### PR TITLE
chore: add Ethereum network for CoinGecko API

### DIFF
--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -10,11 +10,13 @@ export const CHAIN_IDS = {
 };
 
 export const COINGECKO_ASSET_PLATFORMS = {
+  1: 'ethereum',
   137: 'polygon-pos',
   42161: 'arbitrum-one'
 };
 
 export const COINGECKO_BASE_ASSETS = {
+  1: 'ethereum',
   137: 'matic-network',
   42161: 'ethereum'
 };


### PR DESCRIPTION
This is just so we can see dollar value for Ethereum treasuries like here:
https://snapshotx.xyz/#/sn:0x0041ada9121061198b52ae28edeec8ace7c23f2ba8d66938c129af1a2245701c/treasury