### PR TITLE
refactor: Rename Apps to Plugins

### DIFF
--- a/apps/ui/src/components/PluginsListItem.vue
+++ b/apps/ui/src/components/PluginsListItem.vue
@@ -4,7 +4,7 @@ defineProps<{ app: any }>();
 
 <template>
   <router-link
-    :to="{ name: 'app', params: { id: app.id } }"
+    :to="{ name: 'plugin', params: { id: app.id } }"
     class="border rounded-lg p-3 leading-6"
   >
     <img :src="app.avatar" class="w-[32px] h-[32px] rounded-lg mb-2" />

--- a/apps/ui/src/components/PluginsListItem.vue
+++ b/apps/ui/src/components/PluginsListItem.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
-defineProps<{ app: any }>();
+defineProps<{ plugin: any }>();
 </script>
 
 <template>
   <router-link
-    :to="{ name: 'plugin', params: { id: app.id } }"
+    :to="{ name: 'plugin', params: { id: plugin.id } }"
     class="border rounded-lg p-3 leading-6"
   >
-    <img :src="app.avatar" class="w-[32px] h-[32px] rounded-lg mb-2" />
-    <h4 v-text="app.name" />
-    <div class="text-skin-text text-sm" v-text="app.category" />
+    <img :src="plugin.avatar" class="w-[32px] h-[32px] rounded-lg mb-2" />
+    <h4 v-text="plugin.name" />
+    <div class="text-skin-text text-sm" v-text="plugin.category" />
   </router-link>
 </template>

--- a/apps/ui/src/composables/usePlugins.ts
+++ b/apps/ui/src/composables/usePlugins.ts
@@ -1,7 +1,7 @@
 // URL: https://docs.google.com/spreadsheets/d/1R1qmDuKTp8WYiy-QWG0WQpu-pfoi-4TTUQKz1XdFZ1o
-const APPS_SHEET_ID =
+const PLUGINS_SHEET_ID =
   '2PACX-1vSyMqd0Ql198UtPMWO1RQmnzx-rfggEIT3Yieg8mOSf8tyNksUSLKXMpBkO1DLC8yoLqx0stynSk1Us';
-const APPS_SHEET_GID = '0';
+const PLUGINS_SHEET_GID = '0';
 
 async function getSpreadsheet(id: string, gid: string = '0'): Promise<any[]> {
   const res = await fetch(
@@ -24,38 +24,38 @@ function csvToJson(csv: string): any[] {
     .map(line => Object.fromEntries(header.map((key, i) => [key, line[i] || ''])));
 }
 
-const apps: Ref<any[]> = ref([]);
+const plugins: Ref<any[]> = ref([]);
 const categories: Ref<string[]> = ref([]);
 const loading: Ref<boolean> = ref(false);
 const loaded: Ref<boolean> = ref(false);
 
-export function useApps() {
+export function usePlugins() {
   async function load() {
     if (loading.value || loaded.value) return;
 
     loading.value = true;
 
-    apps.value = await getSpreadsheet(APPS_SHEET_ID, APPS_SHEET_GID);
-    categories.value = [...new Set(apps.value.map(({ category }) => category))];
+    plugins.value = await getSpreadsheet(PLUGINS_SHEET_ID, PLUGINS_SHEET_GID);
+    categories.value = [...new Set(plugins.value.map(({ category }) => category))];
 
     loading.value = false;
     loaded.value = true;
   }
 
   function get(id: string) {
-    return apps.value.find(app => app.id === id) || {};
+    return plugins.value.find(plugin => plugin.id === id) || {};
   }
 
   function search(q: string) {
-    return apps.value.filter(app => {
+    return plugins.value.filter(plugin => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { overview, ...appWithoutOverview } = app;
+      const { overview, ...appWithoutOverview } = plugin;
       return JSON.stringify(appWithoutOverview).toLowerCase().includes(q.toLowerCase());
     });
   }
 
   return {
-    apps,
+    plugins,
     categories,
     loading,
     loaded,

--- a/apps/ui/src/router.ts
+++ b/apps/ui/src/router.ts
@@ -18,8 +18,8 @@ import Settings from '@/views/Settings.vue';
 import Contacts from '@/views/Settings/Contacts.vue';
 import Explore from '@/views/Explore.vue';
 import SettingsSpaces from '@/views/Settings/Spaces.vue';
-import Apps from '@/views/Apps.vue';
-import App from '@/views/App.vue';
+import Plugins from '@/views/Plugins.vue';
+import Plugin from '@/views/Plugin.vue';
 
 const { mixpanel } = useMixpanel();
 
@@ -65,8 +65,8 @@ const routes: any[] = [
     ]
   },
   { path: '/explore', name: 'explore', component: Explore },
-  { path: '/apps', name: 'apps', component: Apps },
-  { path: '/apps/:id', name: 'app', component: App }
+  { path: '/plugins', name: 'plugins', component: Plugins },
+  { path: '/plugins/:id', name: 'plugin', component: Plugin }
 ];
 
 const router = createRouter({

--- a/apps/ui/src/views/Plugin.vue
+++ b/apps/ui/src/views/Plugin.vue
@@ -16,7 +16,7 @@ onMounted(() => load());
       <UiLoading v-if="loading && !loaded" class="block" />
       <div v-else>
         <div class="flex space-x-1 items-center text-sm mb-4">
-          <router-link :to="{ name: 'apps' }" class="flex items-center">
+          <router-link :to="{ name: 'plugins' }" class="flex items-center">
             <IH-view-grid class="mr-1" />
             Apps
           </router-link>

--- a/apps/ui/src/views/Plugin.vue
+++ b/apps/ui/src/views/Plugin.vue
@@ -2,10 +2,10 @@
 import { simplifyURL } from '@/helpers/utils';
 
 const route = useRoute();
-const { load, get, loading, loaded } = useApps();
+const { load, get, loading, loaded } = usePlugins();
 
 const id = route.params.id as string;
-const app = computed(() => get(id));
+const plugin = computed(() => get(id));
 
 onMounted(() => load());
 </script>
@@ -21,17 +21,17 @@ onMounted(() => load());
             Apps
           </router-link>
           <IH-chevron-right class="w-[14px] h-[14px]" />
-          <div v-text="app.name" />
+          <div v-text="plugin.name" />
         </div>
         <div class="md:flex items-center mb-5">
           <div class="flex items-center flex-1 mb-3 md:mb-0">
-            <img class="w-[80px] h-[80px] rounded-lg mr-3" :src="app.avatar" />
+            <img class="w-[80px] h-[80px] rounded-lg mr-3" :src="plugin.avatar" />
             <div class="flex-1 leading-5 mb-1">
-              <h1 v-text="app.name" />
-              <div v-text="app.category" />
+              <h1 v-text="plugin.name" />
+              <div v-text="plugin.category" />
             </div>
           </div>
-          <a v-if="app.link" :href="app.link" target="_blank">
+          <a v-if="plugin.link" :href="plugin.link" target="_blank">
             <UiButton class="primary w-full">Use integration</UiButton>
           </a>
         </div>
@@ -39,40 +39,40 @@ onMounted(() => load());
           <div class="space-y-5 p-4 border rounded-lg h-fit mb-4">
             <div>
               <div class="eyebrow mb-2">Overview</div>
-              <div class="text-md text-skin-link" v-text="app.overview" />
+              <div class="text-md text-skin-link" v-text="plugin.overview" />
             </div>
-            <div v-if="app.how">
+            <div v-if="plugin.how">
               <div class="eyebrow mb-2">How it works</div>
-              <div class="text-md text-skin-link" v-text="app.how" />
+              <div class="text-md text-skin-link" v-text="plugin.how" />
             </div>
-            <div v-if="app.start">
+            <div v-if="plugin.start">
               <div class="eyebrow mb-2">Get started</div>
-              <div class="text-md text-skin-link" v-text="app.start" />
+              <div class="text-md text-skin-link" v-text="plugin.start" />
             </div>
           </div>
           <div class="border rounded-lg md:w-[300px] shrink-0 h-fit p-4 space-y-3 mb-4">
             <div>
               <h4 class="eyebrow" v-text="'Built by'" />
-              {{ app.author }}
+              {{ plugin.author }}
             </div>
-            <div v-if="app.website">
+            <div v-if="plugin.website">
               <h4 class="eyebrow" v-text="'Website'" />
-              <a :href="app.website" target="_blank">
-                {{ simplifyURL(app.website) }}
+              <a :href="plugin.website" target="_blank">
+                {{ simplifyURL(plugin.website) }}
                 <IH-arrow-sm-right class="inline-block -rotate-45" />
               </a>
             </div>
-            <div v-if="app.x">
+            <div v-if="plugin.x">
               <h4 class="eyebrow" v-text="'X (Twitter)'" />
-              <a :href="`https://twitter.com/${app.x}`" target="_blank">
-                {{ app.x }}
+              <a :href="`https://twitter.com/${plugin.x}`" target="_blank">
+                {{ plugin.x }}
                 <IH-arrow-sm-right class="inline-block -rotate-45" />
               </a>
             </div>
-            <div v-if="app.github">
+            <div v-if="plugin.github">
               <h4 class="eyebrow" v-text="'Source code'" />
-              <a :href="app.github" target="_blank">
-                {{ simplifyURL(app.github) }}
+              <a :href="plugin.github" target="_blank">
+                {{ simplifyURL(plugin.github) }}
                 <IH-arrow-sm-right class="inline-block -rotate-45" />
               </a>
             </div>

--- a/apps/ui/src/views/Plugins.vue
+++ b/apps/ui/src/views/Plugins.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 const router = useRouter();
 const route = useRoute();
-const { apps, load, search, categories, loading, loaded } = useApps();
+const { plugins, load, search, categories, loading, loaded } = usePlugins();
 
 const q: Ref<string> = ref((route.query.q as string) || '');
 
-const results = computed(() => search(q.value));
+const filteredPlugins = computed(() => search(q.value));
 
 onMounted(() => load());
 
@@ -31,12 +31,12 @@ watch(
     <UiContainer class="!max-w-screen-lg space-y-4">
       <UiLoading v-if="loading && !loaded" class="block" />
       <div v-else-if="q">
-        <UiLink :count="results.length" text="Result(s)" class="inline-block" />
+        <UiLink :count="filteredPlugins.length" text="Result(s)" class="inline-block" />
         <div
-          v-if="results.length"
+          v-if="filteredPlugins.length"
           class="flex grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 mb-4"
         >
-          <PluginsListItem v-for="(app, i) in results" :key="i" :app="app" />
+          <PluginsListItem v-for="(plugin, i) in filteredPlugins" :key="i" :plugin="plugin" />
         </div>
         <div v-else class="flex items-center text-skin-link">
           <IH-exclamation-circle class="inline-block mr-2" />
@@ -47,22 +47,22 @@ watch(
         <UiLink text="Featured" class="inline-block" />
         <div class="flex grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 mb-4">
           <PluginsListItem
-            v-for="(app, i) in apps.filter(({ featured }) => featured)"
+            v-for="(plugin, i) in plugins.filter(({ featured }) => featured)"
             :key="i"
-            :app="app"
+            :plugin="plugin"
           />
         </div>
         <div v-for="(category, i) in categories" :key="i">
           <UiLink
-            :count="apps.filter(app => category === app.category).length"
+            :count="plugins.filter(plugin => category === plugin.category).length"
             :text="category"
             class="inline-block"
           />
           <div class="flex grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 mb-4">
             <PluginsListItem
-              v-for="(app, j) in apps.filter(app => category === app.category)"
+              v-for="(plugin, j) in plugins.filter(plugin => category === plugin.category)"
               :key="j"
-              :app="app"
+              :plugin="plugin"
             />
           </div>
         </div>

--- a/apps/ui/src/views/Plugins.vue
+++ b/apps/ui/src/views/Plugins.vue
@@ -36,7 +36,7 @@ watch(
           v-if="results.length"
           class="flex grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 mb-4"
         >
-          <App v-for="(app, i) in results" :key="i" :app="app" />
+          <PluginsListItem v-for="(app, i) in results" :key="i" :app="app" />
         </div>
         <div v-else class="flex items-center text-skin-link">
           <IH-exclamation-circle class="inline-block mr-2" />
@@ -46,7 +46,11 @@ watch(
       <div v-else>
         <UiLink text="Featured" class="inline-block" />
         <div class="flex grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 mb-4">
-          <App v-for="(app, i) in apps.filter(({ featured }) => featured)" :key="i" :app="app" />
+          <PluginsListItem
+            v-for="(app, i) in apps.filter(({ featured }) => featured)"
+            :key="i"
+            :app="app"
+          />
         </div>
         <div v-for="(category, i) in categories" :key="i">
           <UiLink
@@ -55,7 +59,7 @@ watch(
             class="inline-block"
           />
           <div class="flex grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 mb-4">
-            <App
+            <PluginsListItem
               v-for="(app, j) in apps.filter(app => category === app.category)"
               :key="j"
               :app="app"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Part of https://github.com/snapshot-labs/sx-monorepo/issues/9

Renaming Apps, App and another App to `Plugins`, `Plugin` and `PluginsListItem` to avoid confusions and naming conflicts 

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
