### PR TITLE
feat: add controller input for execution strategies

### DIFF
--- a/apps/ui/src/components/FormStrategies.vue
+++ b/apps/ui/src/components/FormStrategies.vue
@@ -10,6 +10,7 @@ withDefaults(
     title: string;
     description: string;
     availableStrategies: StrategyTemplate[];
+    defaultParams?: Record<string, any>;
   }>(),
   {
     limit: Infinity,
@@ -28,6 +29,7 @@ withDefaults(
       :model-value="model"
       :unique="unique"
       :available-strategies="availableStrategies"
+      :default-params="defaultParams"
       @update:model-value="value => (model = value)"
     />
   </div>

--- a/apps/ui/src/components/StrategiesConfigurator.vue
+++ b/apps/ui/src/components/StrategiesConfigurator.vue
@@ -8,10 +8,12 @@ const props = withDefaults(
     limit?: number;
     unique?: boolean;
     availableStrategies: StrategyTemplate[];
+    defaultParams?: Record<string, any>;
   }>(),
   {
     limit: Infinity,
-    unique: false
+    unique: false,
+    defaultParams: () => ({})
   }
 );
 
@@ -28,7 +30,9 @@ function addStrategy(strategy: StrategyTemplate) {
 
   const strategyConfig = {
     id: crypto.randomUUID(),
-    params: {},
+    params: {
+      ...props.defaultParams
+    },
     ...strategy
   };
 

--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -398,7 +398,7 @@ export function createConstants(networkId: NetworkID) {
         return client.deployAvatarExecution({
           signer,
           params: {
-            controller,
+            controller: params.controller,
             target: params.contractAddress,
             spaces: [spaceAddress],
             quorum: BigInt(params.quorum)
@@ -409,8 +409,14 @@ export function createConstants(networkId: NetworkID) {
         type: 'object',
         title: 'Params',
         additionalProperties: false,
-        required: ['quorum', 'contractAddress'],
+        required: ['controller', 'quorum', 'contractAddress'],
         properties: {
+          controller: {
+            type: 'string',
+            format: 'address',
+            title: 'Controller address',
+            examples: ['0x0000…']
+          },
           quorum: {
             type: 'integer',
             title: 'Quorum',
@@ -444,7 +450,7 @@ export function createConstants(networkId: NetworkID) {
         return client.deployTimelockExecution({
           signer,
           params: {
-            controller,
+            controller: params.controller,
             vetoGuardian: params.vetoGuardian || '0x0000000000000000000000000000000000000000',
             spaces: [spaceAddress],
             timelockDelay: BigInt(params.timelockDelay),
@@ -456,8 +462,14 @@ export function createConstants(networkId: NetworkID) {
         type: 'object',
         title: 'Params',
         additionalProperties: false,
-        required: ['quorum', 'timelockDelay'],
+        required: ['controller', 'quorum', 'timelockDelay'],
         properties: {
+          controller: {
+            type: 'string',
+            format: 'address',
+            title: 'Controller address',
+            examples: ['0x0000…']
+          },
           quorum: {
             type: 'integer',
             title: 'Quorum',

--- a/apps/ui/src/views/Create.vue
+++ b/apps/ui/src/views/Create.vue
@@ -239,6 +239,7 @@ watchEffect(() => setTitle('Create space'));
             v-else-if="currentPage === 'executions'"
             v-model="executionStrategies"
             :available-strategies="selectedNetwork.constants.EDITOR_EXECUTION_STRATEGIES"
+            :default-params="{ controller }"
             title="Execution strategies"
             description="Execution strategies are used to determine the status of a proposal and execute its payload if it's accepted."
           />


### PR DESCRIPTION
### Summary

Currently execution strategy controller is set to space controller, but we should be able to configure it if needed.

With this change we also add `defaultParams` to StrategiesConfigurator so we can add defaults - in this case `controller` defaults to space controller.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/19

### How to test

1. Go to http://localhost:8080/#/explore
2. Sign in
3. Select EVM network.
4. When selecting execution strategy you can input controller (it defaults to space controller).

### To-Do

- [ ]

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
