### PR TITLE
fix: use allowed limit Coingecko API

### DIFF
--- a/apps/ui/src/composables/useBalances.ts
+++ b/apps/ui/src/composables/useBalances.ts
@@ -28,9 +28,9 @@ export function useBalances() {
     const [baseTokenData, tokenData] = await Promise.all([
       callCoinGecko(`${COINGECKO_API_URL}/price?ids=${baseToken}${COINGECKO_PARAMS}`),
       callCoinGecko(
-        `${COINGECKO_API_URL}/token_price/${assetPlatform}?contract_addresses=${contractAddresses.join(
-          ','
-        )}${COINGECKO_PARAMS}`
+        `${COINGECKO_API_URL}/token_price/${assetPlatform}?contract_addresses=${contractAddresses
+          .slice(0, 10)
+          .join(',')}${COINGECKO_PARAMS}`
       )
     ]);
 


### PR DESCRIPTION
Currently request to get assets price with Coingecko API failing when there is more than 10 contract address, this is the limit from the free API. Because of this we can't see assets value beside ETH here: https://snapshotx.xyz/#/sn:0x0041ada9121061198b52ae28edeec8ace7c23f2ba8d66938c129af1a2245701c/treasury
This PR add a limit of 10 so the request don't fail. This is a temporary fix, I'll get a paid account for the API that will increase the limit.