### PR TITLE
refactor: improve typing on mana repo

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
     "codegen": "checkpoint generate",
     "lint": "eslint src/ test/ --ext .ts --fix",
     "prebuild": "yarn codegen",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc",
     "dev": "nodemon src/index.ts",
     "start": "node dist/src/index.js",
     "test": "jest"

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["test/**/*.spec.ts", "test/**/*.test.ts"]
-}

--- a/apps/mana/package.json
+++ b/apps/mana/package.json
@@ -23,6 +23,7 @@
     "@scure/bip32": "^1.3.3",
     "@scure/bip39": "^1.2.2",
     "@snapshot-labs/sx": "^0.1.0",
+    "@types/cors": "^2.8.17",
     "abi-wan-kanabi": "^2.0.0",
     "async-mutex": "^0.4.0",
     "connection-string": "^4.4.0",
@@ -32,7 +33,8 @@
     "express": "^4.17.1",
     "knex": "^2.5.1",
     "pg": "^8.11.3",
-    "starknet": "5.25.0"
+    "starknet": "5.25.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@snapshot-labs/eslint-config": "0.1.0-beta.13",
@@ -44,6 +46,6 @@
     "nodemon": "^3.0.1",
     "prettier": "^3.1.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.2"
+    "typescript": "^5.3.3"
   }
 }

--- a/apps/mana/src/eth/dependencies.ts
+++ b/apps/mana/src/eth/dependencies.ts
@@ -1,11 +1,11 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
 
-const DEFAULT_INDEX = 0;
-const SPACES_INDICIES = {
-  '0x65e4329e8c0fba31883b98e2cf3e81d3cdcac780': 1, // SekhmetDAO
-  '0x4d95a8be4f1d24d50cc0d7b12f5576fa4bbd892b': 2 // Labs
-};
+export const DEFAULT_INDEX = 0;
+export const SPACES_INDICIES = new Map([
+  ['0x65e4329e8c0fba31883b98e2cf3e81d3cdcac780', 1], // SekhmetDAO
+  ['0x4d95a8be4f1d24d50cc0d7b12f5576fa4bbd892b', 2] // Labs
+]);
 
 export function getEthereumWallet(mnemonic: string, index: number) {
   const path = `m/44'/60'/0'/0/${index}`;
@@ -20,7 +20,7 @@ export const createWalletProxy = (mnemonic: string, chainId: number) => {
     const normalizedSpaceAddress = spaceAddress.toLowerCase();
 
     if (!signers.has(normalizedSpaceAddress)) {
-      const index = SPACES_INDICIES[normalizedSpaceAddress] || DEFAULT_INDEX;
+      const index = SPACES_INDICIES.get(normalizedSpaceAddress) || DEFAULT_INDEX;
       const wallet = getEthereumWallet(mnemonic, index);
       signers.set(normalizedSpaceAddress, wallet.connect(provider));
     }

--- a/apps/mana/src/eth/index.ts
+++ b/apps/mana/src/eth/index.ts
@@ -1,19 +1,31 @@
 import express from 'express';
+import z from 'zod';
 import { createNetworkHandler, NETWORKS } from './rpc';
-import { getEthereumWallet } from './dependencies';
-import { DEFAULT_INDEX, SPACES_INDICIES } from '../stark/dependencies';
+import { rpcError } from '../utils';
+import { getEthereumWallet, DEFAULT_INDEX, SPACES_INDICIES } from './dependencies';
 
-const router = express.Router();
+const jsonRpcRequestSchema = z.object({
+  id: z.number(),
+  method: z.enum(['send', 'execute', 'executeQueuedProposal']),
+  params: z.any()
+});
 
 const handlers = Object.fromEntries(
   Object.keys(NETWORKS).map(chainId => [chainId, createNetworkHandler(parseInt(chainId, 10))])
 );
 
+const router = express.Router();
+
 router.post('/:chainId?', (req, res) => {
   const chainId = req.params.chainId || '5';
-  const handler = handlers[chainId];
 
-  const { id, method, params } = req.body;
+  const parsed = jsonRpcRequestSchema.safeParse(req.body);
+  if (!parsed.success) return rpcError(res, 400, parsed.error, 0);
+  const { id, method, params } = parsed.data;
+
+  const handler = handlers[chainId];
+  if (!handler) return rpcError(res, 404, new Error('Unsupported chainId'), id);
+
   handler[method](id, params, res);
 });
 
@@ -22,7 +34,7 @@ router.get('/relayers', (req, res) => {
 
   const defaultRelayer = getEthereumWallet(mnemonic, DEFAULT_INDEX).address;
   const relayers = Object.fromEntries(
-    Object.entries(SPACES_INDICIES).map(([spaceAddress, index]) => {
+    Array.from(SPACES_INDICIES).map(([spaceAddress, index]) => {
       const { address } = getEthereumWallet(mnemonic, index);
       return [spaceAddress, address];
     })

--- a/apps/mana/src/knex.ts
+++ b/apps/mana/src/knex.ts
@@ -30,8 +30,8 @@ export default knex({
     database: connectionConfig.path[0],
     user: connectionConfig.user,
     password: connectionConfig.password,
-    host: connectionConfig.hosts[0].name,
-    port: connectionConfig.hosts[0].port,
+    host: connectionConfig?.hosts[0]?.name,
+    port: connectionConfig?.hosts[0]?.port,
     ssl: Object.keys(sslConfig).length > 0 ? sslConfig : undefined
   }
 });

--- a/apps/mana/src/stark/dependencies.ts
+++ b/apps/mana/src/stark/dependencies.ts
@@ -6,14 +6,13 @@ import { NonceManager } from './nonce-manager';
 const basePath = "m/44'/9004'/0'/0";
 const contractAXclassHash = '0x1a736d6ed154502257f02b1ccdf4d9d1089f80811cd6acad48e6b6a9d1f2003';
 
-const NODE_URLS = {
-  [constants.StarknetChainId.SN_MAIN]: process.env.STARKNET_MAINNET_RPC_URL,
-  [constants.StarknetChainId.SN_GOERLI]: process.env.STARKNET_GOERLI_RPC_URL,
-  [constants.StarknetChainId.SN_SEPOLIA]: process.env.STARKNET_SEPOLIA_RPC_URL
-};
-
+const NODE_URLS = new Map<string, string | undefined>([
+  [constants.StarknetChainId.SN_MAIN, process.env.STARKNET_MAINNET_RPC_URL],
+  [constants.StarknetChainId.SN_GOERLI, process.env.STARKNET_GOERLI_RPC_URL],
+  [constants.StarknetChainId.SN_SEPOLIA, process.env.STARKNET_SEPOLIA_RPC_URL]
+]);
 export function getProvider(chainId: string) {
-  return new RpcProvider({ nodeUrl: NODE_URLS[chainId] });
+  return new RpcProvider({ nodeUrl: NODE_URLS.get(chainId) });
 }
 
 export function getStarknetAccount(mnemonic: string, index: number) {
@@ -38,16 +37,16 @@ export function getStarknetAccount(mnemonic: string, index: number) {
 }
 
 export const DEFAULT_INDEX = 1;
-export const SPACES_INDICIES = {
-  '0x040e337fb53973b08343ce983369c1d9e6249ba011e929347288e4d8b590d048': 2
-};
+export const SPACES_INDICIES = new Map([
+  ['0x040e337fb53973b08343ce983369c1d9e6249ba011e929347288e4d8b590d048', 2]
+]);
 
 export function createAccountProxy(mnemonic: string, provider: RpcProvider) {
   const accounts = new Map<number, { account: Account; nonceManager: NonceManager }>();
 
   return (spaceAddress: string) => {
     const normalizedSpaceAddress = validateAndParseAddress(spaceAddress);
-    const index = SPACES_INDICIES[normalizedSpaceAddress] || DEFAULT_INDEX;
+    const index = SPACES_INDICIES.get(normalizedSpaceAddress) || DEFAULT_INDEX;
 
     if (!accounts.has(index)) {
       const { address, privateKey } = getStarknetAccount(mnemonic, index);

--- a/apps/mana/src/stark/index.ts
+++ b/apps/mana/src/stark/index.ts
@@ -1,19 +1,32 @@
 import express from 'express';
+import z from 'zod';
 import { createNetworkHandler } from './rpc';
+import { rpcError } from '../utils';
 import { NETWORKS } from './networks';
 import { DEFAULT_INDEX, SPACES_INDICIES, getStarknetAccount } from './dependencies';
 
-const router = express.Router();
+const jsonRpcRequestSchema = z.object({
+  id: z.number(),
+  method: z.enum(['send', 'registerTransaction', 'registerProposal']),
+  params: z.any()
+});
 
 const handlers = Object.fromEntries(
   Object.keys(NETWORKS).map(chainId => [chainId, createNetworkHandler(chainId)])
 );
 
+const router = express.Router();
+
 router.post('/:chainId', (req, res) => {
   const chainId = req.params.chainId;
-  const handler = handlers[chainId];
 
-  const { id, method, params } = req.body;
+  const parsed = jsonRpcRequestSchema.safeParse(req.body);
+  if (!parsed.success) return rpcError(res, 400, parsed.error, 0);
+  const { id, method, params } = parsed.data;
+
+  const handler = handlers[chainId];
+  if (!handler) return rpcError(res, 404, new Error('Unsupported chainId'), id);
+
   handler[method](id, params, res);
 });
 
@@ -22,7 +35,7 @@ router.get('/relayers', (req, res) => {
 
   const defaultRelayer = getStarknetAccount(mnemonic, DEFAULT_INDEX).address;
   const relayers = Object.fromEntries(
-    Object.entries(SPACES_INDICIES).map(([spaceAddress, index]) => {
+    Array.from(SPACES_INDICIES).map(([spaceAddress, index]) => {
       const { address } = getStarknetAccount(mnemonic, index);
       return [spaceAddress, address];
     })

--- a/apps/mana/src/stark/networks.ts
+++ b/apps/mana/src/stark/networks.ts
@@ -1,20 +1,26 @@
 import { Account, RpcProvider, constants } from 'starknet';
-import { clients, starknetMainnet, starknetGoerli, starknetSepolia } from '@snapshot-labs/sx';
+import {
+  clients,
+  starknetMainnet,
+  starknetGoerli,
+  starknetSepolia,
+  NetworkConfig
+} from '@snapshot-labs/sx';
 import { getProvider, createAccountProxy } from './dependencies';
 import { NonceManager } from './nonce-manager';
 
-export const NETWORKS = {
+export const NETWORKS: Record<string, NetworkConfig> = {
   [constants.StarknetChainId.SN_MAIN]: starknetMainnet,
   [constants.StarknetChainId.SN_GOERLI]: starknetGoerli,
   [constants.StarknetChainId.SN_SEPOLIA]: starknetSepolia
-} as const;
+};
 
 const clientsMap = new Map<
   string,
   {
     provider: RpcProvider;
     client: clients.StarknetTx;
-    getAccount: (spaceAddress) => { account: Account; nonceManager: NonceManager };
+    getAccount: (spaceAddress: string) => { account: Account; nonceManager: NonceManager };
   }
 >();
 

--- a/apps/mana/src/stark/rpc.ts
+++ b/apps/mana/src/stark/rpc.ts
@@ -1,3 +1,4 @@
+import { Response } from 'express';
 import { NETWORKS, getClient } from './networks';
 import * as db from '../db';
 import * as herodotus from './herodotus';
@@ -9,7 +10,7 @@ export const createNetworkHandler = (chainId: string) => {
 
   const { client, getAccount } = getClient(chainId);
 
-  async function send(id, params, res) {
+  async function send(id: number, params: any, res: Response) {
     try {
       const { signatureData, data } = params.envelope;
       const { address, primaryType, message } = signatureData;
@@ -52,7 +53,7 @@ export const createNetworkHandler = (chainId: string) => {
     }
   }
 
-  async function registerTransaction(id, params, res) {
+  async function registerTransaction(id: number, params: any, res: Response) {
     try {
       const { type, hash, payload } = params;
 
@@ -67,7 +68,7 @@ export const createNetworkHandler = (chainId: string) => {
     }
   }
 
-  async function registerProposal(id, params, res) {
+  async function registerProposal(id: number, params: any, res: Response) {
     try {
       const { l1TokenAddress, strategyAddress, snapshotTimestamp } = params;
 

--- a/apps/mana/src/utils.ts
+++ b/apps/mana/src/utils.ts
@@ -1,4 +1,6 @@
-export function rpcSuccess(res, result, id) {
+import { Response } from 'express';
+
+export function rpcSuccess(res: Response, result: any, id: number) {
   res.json({
     jsonrpc: '2.0',
     result,
@@ -6,7 +8,7 @@ export function rpcSuccess(res, result, id) {
   });
 }
 
-export function rpcError(res, code, e, id) {
+export function rpcError(res: Response, code: number, e: unknown, id: number) {
   res.status(code).json({
     jsonrpc: '2.0',
     error: {

--- a/apps/mana/tsconfig.json
+++ b/apps/mana/tsconfig.json
@@ -1,14 +1,10 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "esnext",
     "module": "Node16",
     "rootDir": "./",
     "outDir": "./dist",
-    "esModuleInterop": true,
-    "strict": true,
-    "noImplicitAny": false,
-    "resolveJsonModule": true,
-    "moduleResolution": "node16",
-    "skipLibCheck": true
+    "moduleResolution": "node16"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3271,6 +3271,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cors@^2.8.17":
+  version "2.8.17"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.17.tgz#5d718a5e494a8166f569d986794e49c48b216b2b"
+  integrity sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/debug@^4.1.7":
   version "4.1.12"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"
@@ -13485,7 +13492,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^5.2.2:
+typescript@^5.2.2, typescript@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
@@ -14454,7 +14461,7 @@ zen-observable@0.8.15:
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
-zod@^3.21.4:
+zod@^3.21.4, zod@^3.22.4:
   version "3.22.4"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
   integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==


### PR DESCRIPTION
### Summary

Our types have plenty of holes in it, due to disabled `noImplicitAny`
and not using `noUncheckedIndexedAccess`.

This PR creates base config which all repos should eventually use
and migrates mana to start using it.

Changes on mana side:
- use zod for validating request shape
- use Map instead of objects when it makes more sense
- remove implicit any in params

### How to test

1. Run `yarn dev:full` and vote or propose on Starknet sepolia space.

