### PR TITLE
refactor: use clientConfig ethUrl for evmSlotValue and ozVotesStorageProof

### DIFF
--- a/.changeset/slow-stingrays-smash.md
+++ b/.changeset/slow-stingrays-smash.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+use clientConfig.ethUrl instead of predefined RPC APIs for starknet strategies

--- a/apps/ui/.env
+++ b/apps/ui/.env
@@ -1,5 +1,4 @@
 VITE_ENABLED_NETWORKS=
-VITE_ETH_RPC_URL=https://rpc.snapshotx.xyz
 VITE_MANA_URL=https://mana.pizza
 VITE_HIGHLIGHT_URL=
 VITE_IPFS_GATEWAY=snapshot.4everland.link

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -46,12 +46,10 @@ export function createActions(
   networkId: NetworkID,
   starkProvider: RpcProvider,
   helpers: NetworkHelpers,
-  { l1ChainId }: { l1ChainId: number }
+  { l1ChainId, ethUrl }: { l1ChainId: number; ethUrl: string }
 ): NetworkActions {
   const networkConfig = CONFIGS[networkId];
   if (!networkConfig) throw new Error(`Unsupported network ${networkId}`);
-
-  const ethUrl: string = import.meta.env.VITE_ETH_RPC_URL;
 
   const l1Provider = getProvider(l1ChainId);
 

--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -18,6 +18,7 @@ type Metadata = {
   baseChainId: number;
   baseNetworkId: NetworkID;
   rpcUrl: string;
+  ethRpcUrl: string;
   explorerUrl: string;
   apiUrl: string;
 };
@@ -29,6 +30,7 @@ export const METADATA: Partial<Record<NetworkID, Metadata>> = {
     baseChainId: 1,
     baseNetworkId: 'eth',
     rpcUrl: `https://starknet-mainnet.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
+    ethRpcUrl: `https://mainnet.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
     apiUrl: 'https://api-1.snapshotx.xyz',
     explorerUrl: 'https://starkscan.co'
   },
@@ -38,6 +40,7 @@ export const METADATA: Partial<Record<NetworkID, Metadata>> = {
     baseChainId: 5,
     baseNetworkId: 'gor',
     rpcUrl: `https://starknet-goerli.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
+    ethRpcUrl: `https://goerli.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
     apiUrl: 'https://testnet-api-1.snapshotx.xyz',
     explorerUrl: 'https://testnet.starkscan.co'
   },
@@ -47,6 +50,7 @@ export const METADATA: Partial<Record<NetworkID, Metadata>> = {
     baseChainId: 11155111,
     baseNetworkId: 'sep',
     rpcUrl: `https://starknet-sepolia.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
+    ethRpcUrl: `https://sepolia.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
     apiUrl: 'https://testnet-api-1.snapshotx.xyz',
     explorerUrl: 'https://sepolia.starkscan.co'
   }
@@ -56,7 +60,8 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
   const metadata = METADATA[networkId];
   if (!metadata) throw new Error(`Unsupported network ${networkId}`);
 
-  const { name, chainId, baseChainId, baseNetworkId, rpcUrl, apiUrl, explorerUrl } = metadata;
+  const { name, chainId, baseChainId, baseNetworkId, rpcUrl, ethRpcUrl, apiUrl, explorerUrl } =
+    metadata;
 
   const provider = createProvider(rpcUrl);
   const api = createApi(apiUrl, networkId);
@@ -138,7 +143,10 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
     hasReceive: true,
     supportsSimulation: true,
     managerConnectors: STARKNET_CONNECTORS,
-    actions: createActions(networkId, provider, helpers, { l1ChainId: baseChainId }),
+    actions: createActions(networkId, provider, helpers, {
+      l1ChainId: baseChainId,
+      ethUrl: ethRpcUrl
+    }),
     api,
     constants,
     helpers

--- a/packages/sx.js/src/strategies/starknet/utils.ts
+++ b/packages/sx.js/src/strategies/starknet/utils.ts
@@ -1,23 +1,5 @@
 import { keccak256 } from '@ethersproject/keccak256';
-import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import fetch from 'cross-fetch';
-
-export function getEthRpcUrl(chainId: number) {
-  const apiKey = '46a5dd9727bf48d4a132672d3f376146';
-
-  // TODO: ideally we would use rpc.snapshotx.xyz here but those don't support eth_getProof with past lookup
-  if (chainId === 1) return `https://mainnet.infura.io/v3/${apiKey}`;
-  if (chainId === 5) return `https://goerli.infura.io/v3/${apiKey}`;
-  if (chainId === 11155111) return `https://sepolia.infura.io/v3/${apiKey}`;
-  if (chainId === 137) return `https://polygon-mainnet.infura.io/v3/${apiKey}`;
-  if (chainId === 42161) return `https://arbitrum-mainnet.infura.io/v3/${apiKey}`;
-
-  throw new Error(`Unsupported chainId ${chainId}`);
-}
-
-export function getEthProvider(chainId: number) {
-  return new StaticJsonRpcProvider(getEthRpcUrl(chainId), chainId);
-}
 
 export function getSlotKey(voterAddress: string, slotIndex: number) {
   return keccak256(


### PR DESCRIPTION
### Summary

Predefined mapping was used initially, but as each networkConfig will have each own ethUrl we can use it as well (Starknet Goerli will be mapped to Ethereum goerli etc.).

### How to test

1. Update `VITE_INFURA_API_KEY`.
2. Go to http://localhost:8080/#/sn:0x05702362b68a350c1cae8f2a529d74fdbb502369ddcebfadac7e91da37636947/proposals
3. See that it uses updated API key for Infura calls. 
