### PR TITLE
feat(mana): do not retry herodotus batch when failed on some errors

### DIFF
--- a/apps/mana/src/stark/herodotus.ts
+++ b/apps/mana/src/stark/herodotus.ts
@@ -49,7 +49,8 @@ async function getStatus(id: string) {
     `https://api.herodotus.cloud/batch-query-status?apiKey=${HERODOTUS_API_KEY}&batchQueryId=${id}`
   );
 
-  const { queryStatus } = await res.json();
+  const { queryStatus, error } = await res.json();
+  if (error) throw new Error(error);
 
   return queryStatus;
 }
@@ -89,8 +90,13 @@ async function submitBatch(proposal: ApiProposal) {
 
   const result = await res.json();
 
-  if (!result.internalId) {
-    throw new Error('registration failed');
+  if (result.error) {
+    if (result.error.startsWith('Invalid account address or ENS')) {
+      console.log('invalid herodotus batch', result.error);
+      return db.markProposalProcessed(getId(proposal));
+    }
+
+    throw new Error(result.error);
   }
 
   console.log('herodotus internalId', result.internalId);
@@ -127,18 +133,23 @@ export async function processProposal(proposal: DbProposal) {
   if (!proposal.herodotusId) {
     const [, l1TokenAddress] = proposal.id.split('-');
 
-    await submitBatch({
+    return submitBatch({
       ...proposal,
       l1TokenAddress
     });
-
-    return;
   }
 
-  const status = await getStatus(proposal.herodotusId);
-  if (status !== 'DONE') {
-    console.log('proposal is not ready yet', proposal.herodotusId, status);
-    return;
+  try {
+    const status = await getStatus(proposal.herodotusId);
+    if (status !== 'DONE') {
+      console.log('proposal is not ready yet', proposal.herodotusId, status);
+      return;
+    }
+  } catch (e: unknown) {
+    if (e instanceof Error && e.message === 'No query found') {
+      console.log('query does not exist', proposal.herodotusId);
+      return db.markProposalProcessed(proposal.id);
+    }
   }
 
   const { getAccount } = getClient(proposal.chainId);


### PR DESCRIPTION
### Summary

Handling some errors we are seeing in the wild and preventing retries on non-recoverable ones to avoid DoSing Herodotus APIs.

### How to test

1. I tested it by connecting to prod DB can do the same if new case shows up.
2. Otherwise create sn-sep space with this address for EVM slot value: address `0xe8e4dcd310f157f3a8a71464d84cf5f3999066d` and slotIndex `0`
3. Run local sx-api pointing to local mana.
4. Create proposal.
5. It will try to process this proposal, `invalid herodotus batch` will show up once.
