### PR TITLE
feat: configure and store multiple treasuries

### DIFF
--- a/apps/api/src/ipfs.ts
+++ b/apps/api/src/ipfs.ts
@@ -22,6 +22,7 @@ export async function handleSpaceMetadata(space: string, metadataUri: string) {
   spaceMetadataItem.wallet = '';
   spaceMetadataItem.executors = [];
   spaceMetadataItem.executors_types = [];
+  spaceMetadataItem.treasuries = [];
   spaceMetadataItem.delegations = [];
 
   const metadata: any = metadataUri ? await getJSON(metadataUri) : {};
@@ -34,6 +35,11 @@ export async function handleSpaceMetadata(space: string, metadataUri: string) {
   if (metadata.properties) {
     if (metadata.properties.cover) spaceMetadataItem.cover = metadata.properties.cover;
 
+    if (metadata.properties.treasuries) {
+      spaceMetadataItem.treasuries = metadata.properties.treasuries.map((treasury: any) =>
+        JSON.stringify(treasury)
+      );
+    }
     if (metadata.properties.delegations) {
       spaceMetadataItem.delegations = metadata.properties.delegations.map((delegation: any) =>
         JSON.stringify(delegation)
@@ -44,9 +50,6 @@ export async function handleSpaceMetadata(space: string, metadataUri: string) {
     if (metadata.properties.discord) spaceMetadataItem.discord = metadata.properties.discord;
     if (metadata.properties.voting_power_symbol) {
       spaceMetadataItem.voting_power_symbol = metadata.properties.voting_power_symbol;
-    }
-    if (metadata.properties.wallets && metadata.properties.wallets.length > 0) {
-      spaceMetadataItem.wallet = metadata.properties.wallets[0];
     }
     if (
       metadata.properties.execution_strategies &&

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -48,7 +48,8 @@ type SpaceMetadataItem {
   wallet: String!
   executors: [String]!
   executors_types: [String]!
-  executors_strategies: [ExecutionStrategy]!
+  # this is dummy field, we should add support for many-to-many in the future
+  executors_strategies: [ExecutionStrategy]! @derivedFrom(field: "id")
 }
 
 type VotingPowerValidationStrategiesParsedMetadataItem {

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -39,6 +39,7 @@ type SpaceMetadataItem {
   avatar: String!
   cover: String!
   external_url: String!
+  treasuries: [String]!
   delegations: [String]!
   github: String!
   twitter: String!

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -48,6 +48,7 @@ type SpaceMetadataItem {
   wallet: String!
   executors: [String]!
   executors_types: [String]!
+  executors_strategies: [ExecutionStrategy]!
 }
 
 type VotingPowerValidationStrategiesParsedMetadataItem {
@@ -72,6 +73,16 @@ type StrategiesParsedMetadataDataItem {
   symbol: String!
   token: String
   payload: String
+}
+
+type ExecutionStrategy {
+  id: String!
+  type: String!
+  quorum: BigDecimalVP!
+  treasury: String
+  treasury_chain: String
+  timelock_veto_guardian: String
+  timelock_delay: BigInt!
 }
 
 type Proposal {

--- a/apps/subgraph-api/schema.graphql
+++ b/apps/subgraph-api/schema.graphql
@@ -43,6 +43,7 @@ type SpaceMetadata @entity {
   wallet: String!
   executors: [Bytes!]!
   executors_types: [String!]!
+  executors_strategies: [ExecutionStrategy!]!
 }
 
 type StrategiesParsedMetadata @entity {
@@ -73,6 +74,8 @@ type ExecutionStrategy @entity {
   id: ID!
   type: String!
   quorum: BigDecimal!
+  treasury: Bytes
+  treasury_chain: Int
   timelock_veto_guardian: Bytes
   timelock_delay: BigInt!
 }

--- a/apps/subgraph-api/schema.graphql
+++ b/apps/subgraph-api/schema.graphql
@@ -34,6 +34,7 @@ type SpaceMetadata @entity {
   avatar: String!
   cover: String!
   external_url: String!
+  treasuries: [String!]!
   delegations: [String!]!
   github: String!
   twitter: String!

--- a/apps/subgraph-api/src/ipfs.ts
+++ b/apps/subgraph-api/src/ipfs.ts
@@ -74,9 +74,13 @@ export function handleSpaceMetadata(content: Bytes): void {
       spaceMetadata.executors_types = executionStrategiesTypes
         .toArray()
         .map<string>((type) => type.toString())
+      spaceMetadata.executors_strategies = executionStrategies
+        .toArray()
+        .map<string>((strategy) => strategy.toString())
     } else {
       spaceMetadata.executors = []
       spaceMetadata.executors_types = []
+      spaceMetadata.executors_strategies = []
     }
   } else {
     spaceMetadata.cover = ''
@@ -85,6 +89,7 @@ export function handleSpaceMetadata(content: Bytes): void {
     spaceMetadata.discord = ''
     spaceMetadata.executors = []
     spaceMetadata.executors_types = []
+    spaceMetadata.executors_strategies = []
   }
 
   spaceMetadata.save()

--- a/apps/subgraph-api/src/ipfs.ts
+++ b/apps/subgraph-api/src/ipfs.ts
@@ -18,20 +18,35 @@ export function handleSpaceMetadata(content: Bytes): void {
   spaceMetadata.about = description ? description.toString() : ''
   spaceMetadata.avatar = avatar ? avatar.toString() : ''
   spaceMetadata.external_url = externalUrl ? externalUrl.toString() : ''
+  spaceMetadata.wallet = ''
+  spaceMetadata.treasuries = []
   spaceMetadata.delegations = []
 
   if (properties) {
     const propertiesObj = properties.toObject()
 
+    let treasuries = propertiesObj.get('treasuries')
     let delegations = propertiesObj.get('delegations')
     let cover = propertiesObj.get('cover')
     let github = propertiesObj.get('github')
     let twitter = propertiesObj.get('twitter')
     let discord = propertiesObj.get('discord')
     let votingPowerSymbol = propertiesObj.get('voting_power_symbol')
-    let wallets = propertiesObj.get('wallets')
     let executionStrategies = propertiesObj.get('execution_strategies')
     let executionStrategiesTypes = propertiesObj.get('execution_strategies_types')
+
+    if (treasuries) {
+      let jsonObj: JSON.Obj = <JSON.Obj>JSON.parse(content)
+      let jsonPropertiesObj = jsonObj.getObj('properties')
+      if (jsonPropertiesObj) {
+        let jsonTreasuriesArr = jsonPropertiesObj.getArr('treasuries')
+        if (jsonTreasuriesArr) {
+          spaceMetadata.treasuries = jsonTreasuriesArr._arr.map<string>((treasury) =>
+            treasury.toString()
+          )
+        }
+      }
+    }
 
     if (delegations) {
       let jsonObj: JSON.Obj = <JSON.Obj>JSON.parse(content)
@@ -51,8 +66,6 @@ export function handleSpaceMetadata(content: Bytes): void {
     spaceMetadata.twitter = twitter ? twitter.toString() : ''
     spaceMetadata.discord = discord ? discord.toString() : ''
     spaceMetadata.voting_power_symbol = votingPowerSymbol ? votingPowerSymbol.toString() : 'VP'
-    spaceMetadata.wallet =
-      wallets && wallets.toArray().length > 0 ? wallets.toArray()[0].toString() : ''
 
     if (executionStrategies && executionStrategiesTypes) {
       spaceMetadata.executors = executionStrategies
@@ -70,7 +83,6 @@ export function handleSpaceMetadata(content: Bytes): void {
     spaceMetadata.github = ''
     spaceMetadata.twitter = ''
     spaceMetadata.discord = ''
-    spaceMetadata.wallet = ''
     spaceMetadata.executors = []
     spaceMetadata.executors_types = []
   }

--- a/apps/ui/src/components/App/Nav.vue
+++ b/apps/ui/src/components/App/Nav.vue
@@ -24,8 +24,6 @@ const space = computed(() =>
     : null
 );
 
-const { treasury } = useTreasury(space);
-
 const isController = computed(() =>
   space.value ? compareAddresses(space.value.controller, web3.value.account) : false
 );
@@ -47,7 +45,7 @@ const navigationConfig = computed(() => ({
           }
         }
       : undefined),
-    ...(treasury.value
+    ...(space.value?.treasuries?.length
       ? {
           treasury: {
             name: 'Treasury',

--- a/apps/ui/src/components/FormProfile.vue
+++ b/apps/ui/src/components/FormProfile.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 import { MAX_SYMBOL_LENGTH } from '@/helpers/constants';
 import { validateForm } from '@/helpers/validation';
-import { getNetwork, enabledNetworks } from '@/networks';
-import { SpaceMetadataDelegation } from '@/types';
+import { getNetwork } from '@/networks';
+import { SpaceMetadataTreasury, SpaceMetadataDelegation } from '@/types';
 
 const props = withDefaults(
   defineProps<{
     showTitle?: boolean;
     form: any;
+    treasuriesValue: SpaceMetadataTreasury[];
     delegationsValue: SpaceMetadataDelegation[];
     id?: string;
     space?: {
@@ -22,33 +23,28 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: 'errors', value: any);
+  (e: 'treasuries', value: SpaceMetadataTreasury[]);
   (e: 'delegations', value: SpaceMetadataDelegation[]);
   (e: 'pick', field: any);
-  (e: 'no-network');
 }>();
 
-const delegationsModalOpen = ref(false);
+const modalOpen = ref({
+  treasury: false,
+  delegation: false
+});
+
+const editedTreasury = ref<number | null>(null);
+const treasuryInitialState = ref<any | null>(null);
+
 const editedDelegation = ref<number | null>(null);
 const delegationInitialState = ref<SpaceMetadataDelegation | null>(null);
-
-const availableNetworks = enabledNetworks
-  .map(id => {
-    const { name, readOnly } = getNetwork(id);
-
-    return {
-      id,
-      name,
-      readOnly
-    };
-  })
-  .filter(network => !network.readOnly);
 
 const definition = computed(() => {
   return {
     type: 'object',
     title: 'Space',
     additionalProperties: true,
-    required: ['name', 'walletNetwork', 'walletAddress'],
+    required: ['name'],
     properties: {
       avatar: {
         type: 'string',
@@ -97,25 +93,7 @@ const definition = computed(() => {
         maxLength: MAX_SYMBOL_LENGTH,
         title: 'Voting power symbol',
         examples: ['e.g. VP']
-      },
-      walletNetwork: {
-        type: ['string', 'null'],
-        enum: [null, ...availableNetworks.map(network => network.id)],
-        options: [{ id: null, name: 'No treasury' }, ...availableNetworks],
-        title: 'Treasury network',
-        nullable: true
-      },
-      ...(props.form.walletNetwork !== null
-        ? {
-            walletAddress: {
-              type: 'string',
-              title: 'Treasury address',
-              examples: ['0x0000…'],
-              format: 'address',
-              minLength: 1
-            }
-          }
-        : {})
+      }
     }
   };
 });
@@ -123,6 +101,19 @@ const definition = computed(() => {
 const formErrors = computed(() =>
   validateForm(definition.value, props.form, { skipEmptyOptionalFields: true })
 );
+
+function addTreasuryConfig(config: SpaceMetadataTreasury) {
+  const newValue = [...props.treasuriesValue];
+
+  if (editedTreasury.value !== null) {
+    newValue[editedTreasury.value] = config;
+    editedTreasury.value = null;
+  } else {
+    newValue.push(config);
+  }
+
+  emit('treasuries', newValue);
+}
 
 function addDelegationConfig(config: SpaceMetadataDelegation) {
   const newValue = [...props.delegationsValue];
@@ -137,17 +128,40 @@ function addDelegationConfig(config: SpaceMetadataDelegation) {
   emit('delegations', newValue);
 }
 
+function addTreasury() {
+  editedTreasury.value = null;
+  treasuryInitialState.value = null;
+
+  modalOpen.value.treasury = true;
+}
+
 function addDelegation() {
   editedDelegation.value = null;
   delegationInitialState.value = null;
-  delegationsModalOpen.value = true;
+
+  modalOpen.value.delegation = true;
+}
+
+function editTreasury(index: number) {
+  editedTreasury.value = index;
+  treasuryInitialState.value = props.treasuriesValue[index];
+
+  modalOpen.value.treasury = true;
 }
 
 function editDelegation(index: number) {
   editedDelegation.value = index;
   delegationInitialState.value = props.delegationsValue[index];
 
-  delegationsModalOpen.value = true;
+  modalOpen.value.delegation = true;
+}
+
+function deleteTreasury(index: number) {
+  const newValue = [
+    ...props.treasuriesValue.slice(0, index),
+    ...props.treasuriesValue.slice(index + 1)
+  ];
+  emit('treasuries', newValue);
 }
 
 function deleteDelegation(index: number) {
@@ -159,13 +173,6 @@ function deleteDelegation(index: number) {
 }
 
 watch(formErrors, value => emit('errors', value));
-
-watch(
-  () => props.form.walletNetwork,
-  to => {
-    if (to === null) emit('no-network');
-  }
-);
 
 onMounted(() => {
   emit('errors', formErrors.value);
@@ -182,7 +189,26 @@ onMounted(() => {
       :definition="definition"
       @pick="field => emit('pick', field)"
     />
-    <h4 class="eyebrow mb-2">Delegations</h4>
+    <h4 class="eyebrow mb-2">Treasuries</h4>
+    <div
+      v-for="(treasury, i) in props.treasuriesValue"
+      :key="i"
+      class="flex justify-between items-center rounded-lg border px-4 py-3 mb-3 text-skin-link"
+    >
+      <div class="flex min-w-0">
+        <div class="whitespace-nowrap">{{ treasury.name }}</div>
+      </div>
+      <div class="flex gap-3">
+        <a @click="editTreasury(i)">
+          <IH-pencil />
+        </a>
+        <a @click="deleteTreasury(i)">
+          <IH-trash />
+        </a>
+      </div>
+    </div>
+    <UiButton class="w-full" @click="addTreasury">Add treasury</UiButton>
+    <h4 class="eyebrow my-2">Delegations</h4>
     <div
       v-for="(delegation, i) in props.delegationsValue"
       :key="i"
@@ -203,10 +229,16 @@ onMounted(() => {
     <UiButton class="w-full" @click="addDelegation">Add delegation</UiButton>
   </div>
   <teleport to="#modal">
+    <ModalTreasuryConfig
+      :open="modalOpen.treasury"
+      :initial-state="treasuryInitialState ?? undefined"
+      @close="modalOpen.treasury = false"
+      @add="addTreasuryConfig"
+    />
     <ModalDelegationConfig
-      :open="delegationsModalOpen"
+      :open="modalOpen.delegation"
       :initial-state="delegationInitialState ?? undefined"
-      @close="delegationsModalOpen = false"
+      @close="modalOpen.delegation = false"
       @add="addDelegationConfig"
     />
   </teleport>

--- a/apps/ui/src/components/Modal/EditSpace.vue
+++ b/apps/ui/src/components/Modal/EditSpace.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { clone } from '@/helpers/utils';
-import type { Space, SpaceMetadata, NetworkID } from '@/types';
+import type { Space, SpaceMetadata } from '@/types';
 
 const DEFAULT_FORM_STATE: SpaceMetadata = {
   name: '',
@@ -12,8 +12,7 @@ const DEFAULT_FORM_STATE: SpaceMetadata = {
   github: '',
   discord: '',
   votingPowerSymbol: '',
-  walletNetwork: null,
-  walletAddress: null,
+  treasuries: [],
   delegations: []
 };
 
@@ -70,16 +69,8 @@ watch(
     form.discord = props.space.discord;
     form.twitter = props.space.twitter;
     form.votingPowerSymbol = props.space.voting_power_symbol;
+    form.treasuries = props.space.treasuries;
     form.delegations = props.space.delegations;
-
-    const [walletNetwork, walletAddress] = props.space.wallet.split(':');
-    if (walletNetwork && walletAddress) {
-      form.walletNetwork = walletNetwork as NetworkID;
-      form.walletAddress = walletAddress;
-    } else {
-      form.walletNetwork = null;
-      form.walletAddress = null;
-    }
   }
 );
 </script>
@@ -117,10 +108,11 @@ watch(
       :space="space"
       :show-title="false"
       :form="form"
+      :treasuries-value="form.treasuries"
       :delegations-value="form.delegations"
+      @treasuries="v => (form.treasuries = v)"
       @delegations="v => (form.delegations = v)"
       @pick="handlePick"
-      @no-network="form.walletAddress = null"
       @errors="v => (formErrors = v)"
     />
     <template v-if="!showPicker" #footer>

--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -4,8 +4,6 @@ import { getNetwork, evmNetworks } from '@/networks';
 import { ETH_CONTRACT } from '@/helpers/constants';
 import { Space, SpaceMetadataTreasury, Transaction } from '@/types';
 import type { Token } from '@/helpers/alchemy';
-import { strategies } from '@snapshot-labs/sx/dist/utils';
-import { getStrategy } from '@snapshot-labs/sx/dist/strategies/evm';
 
 const props = defineProps<{ space: Space; treasuryData: SpaceMetadataTreasury }>();
 
@@ -41,8 +39,6 @@ const currentNetwork = computed(() => {
 const spaceKey = computed(() => `${props.space.network}:${props.space.id}`);
 
 const isReadOnly = computed(() => {
-  console.log('strat', treasury.value?.network, props.space.executors_strategies);
-
   return !props.space.executors_strategies.find(
     strategy =>
       strategy.treasury &&
@@ -123,38 +119,37 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
   <template v-else>
     <div class="p-4 space-x-2 flex">
       <div class="flex-auto" />
-      <template v-if="!isReadOnly">
-        <UiTooltip
-          v-if="currentNetworkId && evmNetworks.includes(currentNetworkId)"
-          title="Connect to apps"
-        >
-          <UiButton class="!px-0 w-[46px]" @click="modalOpen.walletConnectLink = true">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="480"
-              height="332"
-              viewBox="0 0 480 332"
-              class="inline-block w-[26px] h-[26px]"
-            >
-              <path
-                fill="rgba(var(--link))"
-                d="m126.613 93.9842c62.622-61.3123 164.152-61.3123 226.775 0l7.536 7.3788c3.131 3.066 3.131 8.036 0 11.102l-25.781 25.242c-1.566 1.533-4.104 1.533-5.67 0l-10.371-10.154c-43.687-42.7734-114.517-42.7734-158.204 0l-11.107 10.874c-1.565 1.533-4.103 1.533-5.669 0l-25.781-25.242c-3.132-3.066-3.132-8.036 0-11.102zm280.093 52.2038 22.946 22.465c3.131 3.066 3.131 8.036 0 11.102l-103.463 101.301c-3.131 3.065-8.208 3.065-11.339 0l-73.432-71.896c-.783-.767-2.052-.767-2.835 0l-73.43 71.896c-3.131 3.065-8.208 3.065-11.339 0l-103.4657-101.302c-3.1311-3.066-3.1311-8.036 0-11.102l22.9456-22.466c3.1311-3.065 8.2077-3.065 11.3388 0l73.4333 71.897c.782.767 2.051.767 2.834 0l73.429-71.897c3.131-3.065 8.208-3.065 11.339 0l73.433 71.897c.783.767 2.052.767 2.835 0l73.431-71.895c3.132-3.066 8.208-3.066 11.339 0z"
-              />
-            </svg>
-          </UiButton>
-        </UiTooltip>
-        <UiTooltip title="Copy address">
-          <UiButton class="!px-0 w-[46px]" @click="copy(treasury.wallet)">
-            <IH-duplicate v-if="!copied" class="inline-block" />
-            <IH-check v-else class="inline-block" />
-          </UiButton>
-        </UiTooltip>
-        <UiTooltip :title="page === 'tokens' ? 'Send token' : 'Send NFT'">
-          <UiButton class="!px-0 w-[46px]" @click="openModal(page)">
-            <IH-arrow-sm-right class="inline-block -rotate-45" />
-          </UiButton>
-        </UiTooltip>
-      </template>
+
+      <UiTooltip
+        v-if="currentNetworkId && evmNetworks.includes(currentNetworkId) && !isReadOnly"
+        title="Connect to apps"
+      >
+        <UiButton class="!px-0 w-[46px]" @click="modalOpen.walletConnectLink = true">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="480"
+            height="332"
+            viewBox="0 0 480 332"
+            class="inline-block w-[26px] h-[26px]"
+          >
+            <path
+              fill="rgba(var(--link))"
+              d="m126.613 93.9842c62.622-61.3123 164.152-61.3123 226.775 0l7.536 7.3788c3.131 3.066 3.131 8.036 0 11.102l-25.781 25.242c-1.566 1.533-4.104 1.533-5.67 0l-10.371-10.154c-43.687-42.7734-114.517-42.7734-158.204 0l-11.107 10.874c-1.565 1.533-4.103 1.533-5.669 0l-25.781-25.242c-3.132-3.066-3.132-8.036 0-11.102zm280.093 52.2038 22.946 22.465c3.131 3.066 3.131 8.036 0 11.102l-103.463 101.301c-3.131 3.065-8.208 3.065-11.339 0l-73.432-71.896c-.783-.767-2.052-.767-2.835 0l-73.43 71.896c-3.131 3.065-8.208 3.065-11.339 0l-103.4657-101.302c-3.1311-3.066-3.1311-8.036 0-11.102l22.9456-22.466c3.1311-3.065 8.2077-3.065 11.3388 0l73.4333 71.897c.782.767 2.051.767 2.834 0l73.429-71.897c3.131-3.065 8.208-3.065 11.339 0l73.433 71.897c.783.767 2.052.767 2.835 0l73.431-71.895c3.132-3.066 8.208-3.066 11.339 0z"
+            />
+          </svg>
+        </UiButton>
+      </UiTooltip>
+      <UiTooltip title="Copy address">
+        <UiButton class="!px-0 w-[46px]" @click="copy(treasury.wallet)">
+          <IH-duplicate v-if="!copied" class="inline-block" />
+          <IH-check v-else class="inline-block" />
+        </UiButton>
+      </UiTooltip>
+      <UiTooltip v-if="!isReadOnly" :title="page === 'tokens' ? 'Send token' : 'Send NFT'">
+        <UiButton class="!px-0 w-[46px]" @click="openModal(page)">
+          <IH-arrow-sm-right class="inline-block -rotate-45" />
+        </UiButton>
+      </UiTooltip>
     </div>
     <div class="space-y-3">
       <div>

--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { _n, _c, shorten, sanitizeUrl } from '@/helpers/utils';
+import { _n, _c, shorten, sanitizeUrl, compareAddresses } from '@/helpers/utils';
 import { getNetwork, evmNetworks } from '@/networks';
 import { ETH_CONTRACT } from '@/helpers/constants';
 import { Space, SpaceMetadataTreasury, Transaction } from '@/types';
 import type { Token } from '@/helpers/alchemy';
+import { strategies } from '@snapshot-labs/sx/dist/utils';
+import { getStrategy } from '@snapshot-labs/sx/dist/strategies/evm';
 
 const props = defineProps<{ space: Space; treasuryData: SpaceMetadataTreasury }>();
 
@@ -37,6 +39,19 @@ const currentNetwork = computed(() => {
 });
 
 const spaceKey = computed(() => `${props.space.network}:${props.space.id}`);
+
+const isReadOnly = computed(() => {
+  console.log('strat', treasury.value?.network, props.space.executors_strategies);
+
+  return !props.space.executors_strategies.find(
+    strategy =>
+      strategy.treasury &&
+      strategy.treasury_chain &&
+      treasury.value &&
+      compareAddresses(strategy.treasury, treasury.value.wallet) &&
+      strategy.treasury_chain === treasury.value.network
+  );
+});
 
 const totalQuote = computed(() =>
   assets.value.reduce((acc, asset) => {
@@ -108,36 +123,38 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
   <template v-else>
     <div class="p-4 space-x-2 flex">
       <div class="flex-auto" />
-      <UiTooltip
-        v-if="currentNetworkId && evmNetworks.includes(currentNetworkId)"
-        title="Connect to apps"
-      >
-        <UiButton class="!px-0 w-[46px]" @click="modalOpen.walletConnectLink = true">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="480"
-            height="332"
-            viewBox="0 0 480 332"
-            class="inline-block w-[26px] h-[26px]"
-          >
-            <path
-              fill="rgba(var(--link))"
-              d="m126.613 93.9842c62.622-61.3123 164.152-61.3123 226.775 0l7.536 7.3788c3.131 3.066 3.131 8.036 0 11.102l-25.781 25.242c-1.566 1.533-4.104 1.533-5.67 0l-10.371-10.154c-43.687-42.7734-114.517-42.7734-158.204 0l-11.107 10.874c-1.565 1.533-4.103 1.533-5.669 0l-25.781-25.242c-3.132-3.066-3.132-8.036 0-11.102zm280.093 52.2038 22.946 22.465c3.131 3.066 3.131 8.036 0 11.102l-103.463 101.301c-3.131 3.065-8.208 3.065-11.339 0l-73.432-71.896c-.783-.767-2.052-.767-2.835 0l-73.43 71.896c-3.131 3.065-8.208 3.065-11.339 0l-103.4657-101.302c-3.1311-3.066-3.1311-8.036 0-11.102l22.9456-22.466c3.1311-3.065 8.2077-3.065 11.3388 0l73.4333 71.897c.782.767 2.051.767 2.834 0l73.429-71.897c3.131-3.065 8.208-3.065 11.339 0l73.433 71.897c.783.767 2.052.767 2.835 0l73.431-71.895c3.132-3.066 8.208-3.066 11.339 0z"
-            />
-          </svg>
-        </UiButton>
-      </UiTooltip>
-      <UiTooltip title="Copy address">
-        <UiButton class="!px-0 w-[46px]" @click="copy(treasury.wallet)">
-          <IH-duplicate v-if="!copied" class="inline-block" />
-          <IH-check v-else class="inline-block" />
-        </UiButton>
-      </UiTooltip>
-      <UiTooltip :title="page === 'tokens' ? 'Send token' : 'Send NFT'">
-        <UiButton class="!px-0 w-[46px]" @click="openModal(page)">
-          <IH-arrow-sm-right class="inline-block -rotate-45" />
-        </UiButton>
-      </UiTooltip>
+      <template v-if="!isReadOnly">
+        <UiTooltip
+          v-if="currentNetworkId && evmNetworks.includes(currentNetworkId)"
+          title="Connect to apps"
+        >
+          <UiButton class="!px-0 w-[46px]" @click="modalOpen.walletConnectLink = true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="480"
+              height="332"
+              viewBox="0 0 480 332"
+              class="inline-block w-[26px] h-[26px]"
+            >
+              <path
+                fill="rgba(var(--link))"
+                d="m126.613 93.9842c62.622-61.3123 164.152-61.3123 226.775 0l7.536 7.3788c3.131 3.066 3.131 8.036 0 11.102l-25.781 25.242c-1.566 1.533-4.104 1.533-5.67 0l-10.371-10.154c-43.687-42.7734-114.517-42.7734-158.204 0l-11.107 10.874c-1.565 1.533-4.103 1.533-5.669 0l-25.781-25.242c-3.132-3.066-3.132-8.036 0-11.102zm280.093 52.2038 22.946 22.465c3.131 3.066 3.131 8.036 0 11.102l-103.463 101.301c-3.131 3.065-8.208 3.065-11.339 0l-73.432-71.896c-.783-.767-2.052-.767-2.835 0l-73.43 71.896c-3.131 3.065-8.208 3.065-11.339 0l-103.4657-101.302c-3.1311-3.066-3.1311-8.036 0-11.102l22.9456-22.466c3.1311-3.065 8.2077-3.065 11.3388 0l73.4333 71.897c.782.767 2.051.767 2.834 0l73.429-71.897c3.131-3.065 8.208-3.065 11.339 0l73.433 71.897c.783.767 2.052.767 2.835 0l73.431-71.895c3.132-3.066 8.208-3.066 11.339 0z"
+              />
+            </svg>
+          </UiButton>
+        </UiTooltip>
+        <UiTooltip title="Copy address">
+          <UiButton class="!px-0 w-[46px]" @click="copy(treasury.wallet)">
+            <IH-duplicate v-if="!copied" class="inline-block" />
+            <IH-check v-else class="inline-block" />
+          </UiButton>
+        </UiTooltip>
+        <UiTooltip :title="page === 'tokens' ? 'Send token' : 'Send NFT'">
+          <UiButton class="!px-0 w-[46px]" @click="openModal(page)">
+            <IH-arrow-sm-right class="inline-block -rotate-45" />
+          </UiButton>
+        </UiTooltip>
+      </template>
     </div>
     <div class="space-y-3">
       <div>

--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -1,0 +1,293 @@
+<script setup lang="ts">
+import { _n, _c, shorten, sanitizeUrl } from '@/helpers/utils';
+import { getNetwork, evmNetworks } from '@/networks';
+import { ETH_CONTRACT } from '@/helpers/constants';
+import { Space, SpaceMetadataTreasury, Transaction } from '@/types';
+import type { Token } from '@/helpers/alchemy';
+
+const props = defineProps<{ space: Space; treasuryData: SpaceMetadataTreasury }>();
+
+const { setTitle } = useTitle();
+const router = useRouter();
+const { copy, copied } = useClipboard();
+const { loading, loaded, assets, loadBalances } = useBalances();
+const { loading: nftsLoading, loaded: nftsLoaded, nfts, loadNfts } = useNfts();
+const { treasury } = useTreasury(props.treasuryData);
+const { createDraft } = useEditor();
+
+const page: Ref<'tokens' | 'nfts'> = ref('tokens');
+const modalOpen = ref({
+  tokens: false,
+  nfts: false,
+  walletConnectLink: false
+});
+
+const currentNetworkId = computed(() => {
+  try {
+    return treasury.value?.networkId;
+  } catch (e) {
+    return null;
+  }
+});
+
+const currentNetwork = computed(() => {
+  if (!currentNetworkId.value) return null;
+
+  return getNetwork(currentNetworkId.value);
+});
+
+const spaceKey = computed(() => `${props.space.network}:${props.space.id}`);
+
+const totalQuote = computed(() =>
+  assets.value.reduce((acc, asset) => {
+    return acc + asset.value;
+  }, 0)
+);
+
+const sortedAssets = computed(() =>
+  (assets || []).value.sort((a, b) => {
+    const isEth = (token: Token) => token.contractAddress === ETH_CONTRACT;
+    if (isEth(a)) return -1;
+    if (isEth(b)) return 1;
+    return 0;
+  })
+);
+
+const treasuryExplorerUrl = computed(() => {
+  if (!currentNetwork.value || !treasury.value) return '';
+
+  const url = currentNetwork.value.helpers.getExplorerUrl(treasury.value.wallet, 'address');
+  return sanitizeUrl(url);
+});
+
+const executionStrategy = computed(() => {
+  let executorIndex = props.space.executors.findIndex(
+    executorAddress => executorAddress === treasury.value?.wallet
+  );
+
+  if (executorIndex === -1) {
+    // If the treasury is not an executor, use the first avatar executor
+    executorIndex = props.space.executors_types.findIndex(e => e === 'SimpleQuorumAvatar');
+  }
+
+  if (executorIndex === -1) return null;
+
+  return {
+    address: props.space.executors[executorIndex],
+    type: props.space.executors_types[executorIndex]
+  };
+});
+
+function openModal(type: 'tokens' | 'nfts') {
+  modalOpen.value[type] = true;
+}
+
+function addTx(tx: Transaction) {
+  const draftId = createDraft(spaceKey.value, {
+    execution: [tx],
+    executionStrategy: executionStrategy.value
+  });
+  router.push(`create/${draftId}`);
+}
+
+onMounted(() => {
+  if (!treasury.value) return;
+
+  loadBalances(treasury.value.wallet, treasury.value.network);
+  loadNfts(treasury.value.wallet, treasury.value.network);
+});
+
+watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
+</script>
+
+<template>
+  <div v-if="!treasury || !currentNetwork" class="p-4 flex items-center text-skin-link">
+    <IH-exclamation-circle class="inline-block mr-2" />
+    No treasury configured.
+  </div>
+  <template v-else>
+    <div class="p-4 space-x-2 flex">
+      <div class="flex-auto" />
+      <UiTooltip
+        v-if="currentNetworkId && evmNetworks.includes(currentNetworkId)"
+        title="Connect to apps"
+      >
+        <UiButton class="!px-0 w-[46px]" @click="modalOpen.walletConnectLink = true">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="480"
+            height="332"
+            viewBox="0 0 480 332"
+            class="inline-block w-[26px] h-[26px]"
+          >
+            <path
+              fill="rgba(var(--link))"
+              d="m126.613 93.9842c62.622-61.3123 164.152-61.3123 226.775 0l7.536 7.3788c3.131 3.066 3.131 8.036 0 11.102l-25.781 25.242c-1.566 1.533-4.104 1.533-5.67 0l-10.371-10.154c-43.687-42.7734-114.517-42.7734-158.204 0l-11.107 10.874c-1.565 1.533-4.103 1.533-5.669 0l-25.781-25.242c-3.132-3.066-3.132-8.036 0-11.102zm280.093 52.2038 22.946 22.465c3.131 3.066 3.131 8.036 0 11.102l-103.463 101.301c-3.131 3.065-8.208 3.065-11.339 0l-73.432-71.896c-.783-.767-2.052-.767-2.835 0l-73.43 71.896c-3.131 3.065-8.208 3.065-11.339 0l-103.4657-101.302c-3.1311-3.066-3.1311-8.036 0-11.102l22.9456-22.466c3.1311-3.065 8.2077-3.065 11.3388 0l73.4333 71.897c.782.767 2.051.767 2.834 0l73.429-71.897c3.131-3.065 8.208-3.065 11.339 0l73.433 71.897c.783.767 2.052.767 2.835 0l73.431-71.895c3.132-3.066 8.208-3.066 11.339 0z"
+            />
+          </svg>
+        </UiButton>
+      </UiTooltip>
+      <UiTooltip title="Copy address">
+        <UiButton class="!px-0 w-[46px]" @click="copy(treasury.wallet)">
+          <IH-duplicate v-if="!copied" class="inline-block" />
+          <IH-check v-else class="inline-block" />
+        </UiButton>
+      </UiTooltip>
+      <UiTooltip :title="page === 'tokens' ? 'Send token' : 'Send NFT'">
+        <UiButton class="!px-0 w-[46px]" @click="openModal(page)">
+          <IH-arrow-sm-right class="inline-block -rotate-45" />
+        </UiButton>
+      </UiTooltip>
+    </div>
+    <div class="space-y-3">
+      <div>
+        <UiLabel label="Treasury" sticky />
+        <a
+          :href="treasuryExplorerUrl || '#'"
+          target="_blank"
+          class="flex justify-between items-center mx-4 py-3 border-b"
+          :class="{
+            'pointer-events-none': !treasuryExplorerUrl
+          }"
+        >
+          <UiStamp :id="treasury.wallet" type="avatar" :size="32" class="mr-3" />
+          <div class="flex-1 leading-[22px]">
+            <h4 class="text-skin-link" v-text="shorten(treasury.wallet)" />
+            <div class="text-skin-text text-[17px]" v-text="shorten(treasury.wallet)" />
+          </div>
+          <h3 v-text="`$${_n(totalQuote.toFixed())}`" />
+        </a>
+      </div>
+      <div>
+        <div class="flex pl-4 border-b space-x-3">
+          <button type="button" @click="page = 'tokens'">
+            <UiLink :is-active="page === 'tokens'" text="Tokens" />
+          </button>
+          <button type="button" @click="page = 'nfts'">
+            <UiLink :is-active="page === 'nfts'" text="NFTs" />
+          </button>
+        </div>
+        <div v-if="page === 'tokens'">
+          <UiLoading v-if="loading && !loaded" class="px-4 py-3 block" />
+          <div
+            v-if="loaded && sortedAssets.length === 0"
+            class="px-4 py-3 flex items-center text-skin-link"
+          >
+            <IH-exclamation-circle class="inline-block mr-2" />
+            There are no tokens in treasury.
+          </div>
+          <a
+            v-for="(asset, i) in sortedAssets"
+            :key="i"
+            :href="
+              (asset.contractAddress === ETH_CONTRACT
+                ? treasuryExplorerUrl
+                : sanitizeUrl(
+                    currentNetwork.helpers.getExplorerUrl(asset.contractAddress, 'token')
+                  )) || '#'
+            "
+            target="_blank"
+            class="mx-4 py-3 border-b flex"
+          >
+            <div class="flex-auto flex items-center min-w-0">
+              <UiStampToken
+                :id="`${treasury.networkId}:${asset.contractAddress}`"
+                type="token"
+                :size="32"
+              />
+              <div class="flex flex-col ml-3 leading-[22px] min-w-0 pr-2 md:pr-0">
+                <h4 class="truncate" v-text="asset.symbol" />
+                <div class="text-[17px] truncate text-skin-text" v-text="asset.name" />
+              </div>
+            </div>
+            <div
+              v-if="asset.price"
+              class="flex-col items-end text-right leading-[22px] w-[240px] hidden md:block"
+            >
+              <h4
+                class="text-skin-link"
+                v-text="`$${_n(asset.price, 'standard', { maximumFractionDigits: 2 })}`"
+              />
+              <div v-if="asset.change" class="text-[17px]">
+                <div
+                  v-if="asset.change > 0"
+                  class="text-skin-success"
+                  v-text="`+${_n(asset.change, 'standard', { maximumFractionDigits: 2 })}%`"
+                />
+                <div
+                  v-if="asset.change < 0"
+                  class="text-skin-danger"
+                  v-text="`${_n(asset.change, 'standard', { maximumFractionDigits: 2 })}%`"
+                />
+              </div>
+            </div>
+            <div class="flex-col items-end text-right leading-[22px] w-auto md:w-[240px]">
+              <h4
+                class="text-skin-link truncate"
+                v-text="
+                  `${_c(asset.tokenBalance || 0n, asset.decimals || 0)} ${shorten(
+                    asset.symbol,
+                    'symbol'
+                  )}`
+                "
+              />
+              <div
+                v-if="asset.value"
+                class="text-[17px] text-skin-text"
+                v-text="`$${_n(asset.value, 'standard', { maximumFractionDigits: 2 })}`"
+              />
+            </div>
+          </a>
+        </div>
+        <div v-else-if="page === 'nfts'">
+          <div
+            v-if="nftsLoaded && nfts.length === 0"
+            class="px-4 py-3 flex items-center text-skin-link"
+          >
+            <IH-exclamation-circle class="inline-block mr-2" />
+            There are no NFTs in treasury.
+          </div>
+          <UiLoading v-if="nftsLoading && !nftsLoaded" class="px-4 py-3 block" />
+          <div class="flex flex-row flex-wrap gap-4 p-4">
+            <a
+              v-for="(nft, i) in nfts"
+              :key="i"
+              :href="sanitizeUrl(nft.permalink) || '#'"
+              target="_blank"
+              class="block max-w-[120px]"
+            >
+              <UiNftImage :item="nft" class="w-full" />
+              <div class="mt-2 text-[17px] truncate">{{ nft.displayTitle }}</div>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <teleport to="#modal">
+      <ModalSendToken
+        :open="modalOpen.tokens"
+        :address="treasury.wallet"
+        :network="treasury.network"
+        :network-id="treasury.networkId"
+        @close="modalOpen.tokens = false"
+        @add="addTx"
+      />
+      <ModalSendNft
+        :open="modalOpen.nfts"
+        :address="treasury.wallet"
+        :network="treasury.network"
+        @close="modalOpen.nfts = false"
+        @add="addTx"
+      />
+      <ModalLinkWalletConnect
+        :open="modalOpen.walletConnectLink"
+        :address="treasury.wallet"
+        :network="treasury.network"
+        :network-id="treasury.networkId"
+        :space-key="spaceKey"
+        :execution-strategy="executionStrategy"
+        @close="modalOpen.walletConnectLink = false"
+      />
+    </teleport>
+  </template>
+</template>

--- a/apps/ui/src/composables/useTreasury.ts
+++ b/apps/ui/src/composables/useTreasury.ts
@@ -5,16 +5,16 @@ type NullableSpace = Space | undefined | null;
 
 export function useTreasury(spaceRef: Ref<NullableSpace>) {
   const treasury = computed(() => {
-    if (!spaceRef.value || !spaceRef.value.wallet) return null;
+    const wallet = spaceRef.value?.treasuries?.[0];
+    if (!wallet || !wallet.network || !wallet.address) return null;
 
-    const [networkId, wallet] = spaceRef.value.wallet.split(':');
-    const chainId = CHAIN_IDS[networkId];
+    const chainId = CHAIN_IDS[wallet.network];
     if (!chainId || !wallet) return null;
 
     return {
-      networkId,
+      networkId: wallet.network,
       network: chainId,
-      wallet
+      wallet: wallet.address
     };
   });
 

--- a/apps/ui/src/composables/useTreasury.ts
+++ b/apps/ui/src/composables/useTreasury.ts
@@ -1,20 +1,17 @@
 import { CHAIN_IDS } from '@/helpers/constants';
-import { Space } from '@/types';
+import { SpaceMetadataTreasury } from '@/types';
 
-type NullableSpace = Space | undefined | null;
-
-export function useTreasury(spaceRef: Ref<NullableSpace>) {
+export function useTreasury(treasuryData: SpaceMetadataTreasury) {
   const treasury = computed(() => {
-    const wallet = spaceRef.value?.treasuries?.[0];
-    if (!wallet || !wallet.network || !wallet.address) return null;
+    if (!treasuryData || !treasuryData.network || !treasuryData.address) return null;
 
-    const chainId = CHAIN_IDS[wallet.network];
-    if (!chainId || !wallet) return null;
+    const chainId = CHAIN_IDS[treasuryData.network];
+    if (!chainId || !treasuryData) return null;
 
     return {
-      networkId: wallet.network,
+      networkId: treasuryData.network,
       network: chainId,
-      wallet: wallet.address
+      wallet: treasuryData.address
     };
   });
 

--- a/apps/ui/src/helpers/utils.test.ts
+++ b/apps/ui/src/helpers/utils.test.ts
@@ -47,8 +47,8 @@ describe('utils', () => {
           treasuries: [
             {
               name: 'treasury 1',
-              wallet_network: 'gor',
-              wallet_address: '0x000000000000000000000000000000000000dead'
+              network: 'gor',
+              address: '0x000000000000000000000000000000000000dead'
             }
           ],
           delegations: [

--- a/apps/ui/src/helpers/utils.test.ts
+++ b/apps/ui/src/helpers/utils.test.ts
@@ -15,8 +15,13 @@ describe('utils', () => {
         twitter: 'SnapshotLabs',
         discord: 'snapshot',
         votingPowerSymbol: 'VOTE',
-        walletNetwork: 'gor',
-        walletAddress: '0x000000000000000000000000000000000000dead',
+        treasuries: [
+          {
+            name: 'treasury 1',
+            network: 'gor',
+            address: '0x000000000000000000000000000000000000dead'
+          }
+        ],
         delegations: [
           {
             name: 'sample',
@@ -39,7 +44,13 @@ describe('utils', () => {
           github: 'snapshot-labs',
           twitter: 'SnapshotLabs',
           discord: 'snapshot',
-          wallets: ['gor:0x000000000000000000000000000000000000dead'],
+          treasuries: [
+            {
+              name: 'treasury 1',
+              wallet_network: 'gor',
+              wallet_address: '0x000000000000000000000000000000000000dead'
+            }
+          ],
           delegations: [
             {
               name: 'sample',

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -301,11 +301,6 @@ export function createErc1155Metadata(
   metadata: SpaceMetadata,
   extraProperties?: Record<string, any>
 ) {
-  const wallets: string[] = [];
-  if (metadata.walletNetwork && metadata.walletAddress) {
-    wallets.push(`${metadata.walletNetwork}:${metadata.walletAddress}`);
-  }
-
   return {
     name: metadata.name,
     avatar: metadata.avatar,
@@ -317,7 +312,11 @@ export function createErc1155Metadata(
       github: metadata.github,
       twitter: metadata.twitter,
       discord: metadata.discord,
-      wallets,
+      treasuries: metadata.treasuries.map(treasury => ({
+        name: treasury.name,
+        network: treasury.network,
+        address: treasury.address
+      })),
       delegations: metadata.delegations.map(delegation => ({
         name: delegation.name,
         api_type: delegation.apiType,

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -93,7 +93,15 @@ function formatSpace(space: ApiSpace, networkId: NetworkID): Space {
     twitter: space.metadata.twitter,
     discord: space.metadata.discord,
     voting_power_symbol: space.metadata.voting_power_symbol,
-    wallet: space.metadata.wallet,
+    treasuries: space.metadata.treasuries.map(treasury => {
+      const { name, network, address } = JSON.parse(treasury);
+
+      return {
+        name,
+        network,
+        address
+      };
+    }),
     delegations: space.metadata.delegations.map(delegation => {
       const { name, api_type, api_url, contract } = JSON.parse(delegation);
 

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -117,6 +117,7 @@ function formatSpace(space: ApiSpace, networkId: NetworkID): Space {
     }),
     executors: space.metadata.executors,
     executors_types: space.metadata.executors_types,
+    executors_strategies: space.metadata.executors_strategies,
     voting_power_validation_strategies_parsed_metadata: processStrategiesMetadata(
       space.voting_power_validation_strategies_parsed_metadata
     ),

--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -13,7 +13,7 @@ const SPACE_FRAGMENT = gql`
       twitter
       discord
       voting_power_symbol
-      wallet
+      treasuries
       delegations
       executors
       executors_types

--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -17,6 +17,11 @@ const SPACE_FRAGMENT = gql`
       delegations
       executors
       executors_types
+      executors_strategies {
+        id
+        treasury_chain
+        treasury
+      }
     }
     controller
     voting_delay

--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -19,6 +19,7 @@ const SPACE_FRAGMENT = gql`
       executors_types
       executors_strategies {
         id
+        type
         treasury_chain
         treasury
       }

--- a/apps/ui/src/networks/common/graphqlApi/types.ts
+++ b/apps/ui/src/networks/common/graphqlApi/types.ts
@@ -25,6 +25,11 @@ export type ApiSpace = {
     wallet: string;
     executors: string[];
     executors_types: string[];
+    executors_strategies: {
+      id: string;
+      treasury: string | null;
+      treasury_chain: number | null;
+    }[];
     treasuries: string[];
     delegations: string[];
   };

--- a/apps/ui/src/networks/common/graphqlApi/types.ts
+++ b/apps/ui/src/networks/common/graphqlApi/types.ts
@@ -25,6 +25,7 @@ export type ApiSpace = {
     wallet: string;
     executors: string[];
     executors_types: string[];
+    treasuries: string[];
     delegations: string[];
   };
   controller: string;

--- a/apps/ui/src/networks/common/graphqlApi/types.ts
+++ b/apps/ui/src/networks/common/graphqlApi/types.ts
@@ -27,6 +27,7 @@ export type ApiSpace = {
     executors_types: string[];
     executors_strategies: {
       id: string;
+      type: string;
       treasury: string | null;
       treasury_chain: number | null;
     }[];

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -90,6 +90,7 @@ function formatSpace(space: ApiSpace, networkId: NetworkID): Space {
     authenticators: [DEFAULT_AUTHENTICATOR],
     executors: [],
     executors_types: [],
+    executors_strategies: [],
     strategies: space.strategies.map(strategy => strategy.name),
     strategies_indicies: [],
     strategies_params: space.strategies.map(strategy => strategy),

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -6,9 +6,18 @@ import {
   PROPOSAL_QUERY,
   VOTES_QUERY
 } from './queries';
+import { enabledNetworks } from '@/networks';
 import { PaginationOpts, SpacesFilter, NetworkApi } from '@/networks/types';
 import { getNames } from '@/helpers/stamp';
-import { Space, Proposal, Vote, User, NetworkID, ProposalState } from '@/types';
+import {
+  Space,
+  Proposal,
+  Vote,
+  User,
+  NetworkID,
+  ProposalState,
+  SpaceMetadataTreasury
+} from '@/types';
 import { ApiSpace, ApiProposal, ApiVote } from './types';
 import { DEFAULT_VOTING_DELAY } from '../constants';
 
@@ -28,7 +37,10 @@ function getProposalState(proposal: ApiProposal): ProposalState {
 function formatSpace(space: ApiSpace, networkId: NetworkID): Space {
   // TODO: convert ChainID to ShortName, we might need external mapping to handle
   // all of those - or just have simple map with limited support
-  const wallet = space.treasuries[0] ? `eth:${space.treasuries[0].address}` : '';
+  const treasuries = space.treasuries.filter(treasury =>
+    enabledNetworks.includes(treasury.network as NetworkID)
+  ) as SpaceMetadataTreasury[];
+
   let validationName = space.validation.name;
   const validationParams = space.validation.params || {};
   if (space.validation.name === 'basic') {
@@ -61,7 +73,7 @@ function formatSpace(space: ApiSpace, networkId: NetworkID): Space {
     min_voting_period: space.voting.period ?? DEFAULT_VOTING_DELAY,
     max_voting_period: space.voting.period ?? 0,
     proposal_threshold: '1',
-    wallet,
+    treasuries,
     delegations: space.delegationPortal
       ? [
           {

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -13,6 +13,7 @@ const SPACE_FRAGMENT = gql`
     github
     symbol
     treasuries {
+      name
       network
       address
     }

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -13,6 +13,7 @@ export type ApiSpace = {
   symbol: string;
   treasuries: [
     {
+      name: string;
       network: string;
       address: string;
     }

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -107,6 +107,11 @@ export type Space = {
   authenticators: string[];
   executors: string[];
   executors_types: string[];
+  executors_strategies: {
+    id: string;
+    treasury: string | null;
+    treasury_chain: number | null;
+  }[];
   proposal_count: number;
   vote_count: number;
   created: number;

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -109,6 +109,7 @@ export type Space = {
   executors_types: string[];
   executors_strategies: {
     id: string;
+    type: string;
     treasury: string | null;
     treasury_chain: number | null;
   }[];
@@ -267,3 +268,6 @@ export type ContractCallTransaction = BaseTransaction & {
 };
 
 export type Transaction = SendTokenTransaction | SendNftTransaction | ContractCallTransaction;
+
+// Utils
+export type RequiredProperty<T> = { [P in keyof T]: Required<NonNullable<T[P]>> };

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -32,6 +32,12 @@ export type SelectedStrategy = {
   type: string;
 };
 
+export type SpaceMetadataTreasury = {
+  name: string | null;
+  network: NetworkID | null;
+  address: string | null;
+};
+
 export type SpaceMetadataDelegation = {
   name: string | null;
   apiType: string | null;
@@ -50,8 +56,7 @@ export type SpaceMetadata = {
   github: string;
   discord: string;
   votingPowerSymbol: string;
-  walletNetwork: NetworkID | null;
-  walletAddress: string | null;
+  treasuries: SpaceMetadataTreasury[];
   delegations: SpaceMetadataDelegation[];
 };
 
@@ -79,12 +84,12 @@ export type Space = {
   cover: string;
   about?: string;
   external_url: string;
+  treasuries: SpaceMetadataTreasury[];
   delegations: SpaceMetadataDelegation[];
   twitter: string;
   github: string;
   discord: string;
   voting_power_symbol: string;
-  wallet: string;
   controller: string;
   voting_delay: number;
   min_voting_period: number;

--- a/apps/ui/src/views/Create.vue
+++ b/apps/ui/src/views/Create.vue
@@ -46,8 +46,6 @@ const { predictSpaceAddress } = useActions();
 const { web3 } = useWeb3();
 
 const pagesRefs = ref([] as HTMLElement[]);
-const showPicker = ref(false);
-const searchValue = ref('');
 const sending = ref(false);
 const currentPage: Ref<PageID> = ref('profile');
 const pagesErrors: Ref<Record<PageID, Record<string, string>>> = ref({
@@ -71,8 +69,7 @@ const metadataForm: SpaceMetadata = reactive(
     github: '',
     discord: '',
     votingPowerSymbol: '',
-    walletNetwork: null,
-    walletAddress: null,
+    treasuries: [],
     delegations: []
   })
 );
@@ -131,11 +128,6 @@ function handleNextClick() {
 
   currentPage.value = PAGES[currentIndex + 1].id;
   pagesRefs.value[currentIndex + 1].scrollIntoView();
-}
-
-function handlePickerSelect(value: string) {
-  showPicker.value = false;
-  metadataForm.walletAddress = value;
 }
 
 async function handleSubmit() {
@@ -203,10 +195,10 @@ watchEffect(() => setTitle('Create space'));
           <FormProfile
             v-if="currentPage === 'profile'"
             :form="metadataForm"
+            :treasuries-value="metadataForm.treasuries"
             :delegations-value="metadataForm.delegations"
-            @pick="showPicker = true"
+            @treasuries="v => (metadataForm.treasuries = v)"
             @delegations="v => (metadataForm.delegations = v)"
-            @no-network="metadataForm.walletAddress = null"
             @errors="v => handleErrors('profile', v)"
           />
           <FormNetwork v-else-if="currentPage === 'network'" v-model="selectedNetworkId" />
@@ -270,26 +262,5 @@ watchEffect(() => setTitle('Create space'));
         </UiButton>
       </div>
     </div>
-    <teleport to="#modal">
-      <UiModal :open="showPicker" @close="showPicker = false">
-        <template #header>
-          <h3>Select contact</h3>
-          <a class="absolute left-0 -top-1 p-4 text-color" @click="showPicker = false">
-            <IH-arrow-narrow-left class="mr-2" />
-          </a>
-          <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
-            <IH-search class="mx-2" />
-            <input
-              ref="searchInput"
-              v-model="searchValue"
-              type="text"
-              placeholder="Search"
-              class="flex-auto bg-transparent text-skin-link"
-            />
-          </div>
-        </template>
-        <PickerContact :loading="false" :search-value="searchValue" @pick="handlePickerSelect" />
-      </UiModal>
-    </teleport>
   </div>
 </template>

--- a/apps/ui/src/views/Editor.vue
+++ b/apps/ui/src/views/Editor.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
 import { getNetwork, supportsNullCurrent } from '@/networks';
-import { omit, shortenAddress } from '@/helpers/utils';
+import { compareAddresses, omit } from '@/helpers/utils';
+import { CHAIN_IDS } from '@/helpers/constants';
 import { validateForm } from '@/helpers/validation';
-import { SelectedStrategy, VoteType } from '@/types';
+import { RequiredProperty, SelectedStrategy, VoteType, SpaceMetadataTreasury } from '@/types';
+
+type StrategyWithTreasury = SelectedStrategy & {
+  treasury: RequiredProperty<SpaceMetadataTreasury>;
+};
 
 const TITLE_DEFINITION = {
   type: 'string',
@@ -91,8 +96,36 @@ const supportedExecutionStrategies = computed(() => {
   const networkValue = network.value;
   if (!spaceValue || !networkValue) return null;
 
-  return spaceValue.executors.filter((_, i) =>
-    networkValue.helpers.isExecutorSupported(spaceValue.executors_types[i])
+  return spaceValue.treasuries
+    .map(treasury => {
+      const strategy = spaceValue.executors_strategies.find(strategy => {
+        return (
+          strategy.treasury &&
+          strategy.treasury_chain &&
+          treasury.address &&
+          treasury.network &&
+          compareAddresses(strategy.treasury, treasury.address) &&
+          CHAIN_IDS[treasury.network] === strategy.treasury_chain
+        );
+      });
+
+      if (!strategy) return null;
+
+      return {
+        address: strategy.id,
+        type: strategy.type,
+        treasury: treasury as RequiredProperty<SpaceMetadataTreasury>
+      };
+    })
+    .filter(
+      strategy => strategy && networkValue.helpers.isExecutorSupported(strategy.type)
+    ) as StrategyWithTreasury[];
+});
+const selectedExecutionWithTreasury = computed(() => {
+  if (!executionStrategy.value || !supportedExecutionStrategies.value) return null;
+
+  return supportedExecutionStrategies.value.find(
+    strategy => strategy.address === executionStrategy.value?.address
   );
 });
 const votingTypes = computed(() => {
@@ -351,30 +384,27 @@ export default defineComponent({
         <h4 class="eyebrow mb-2">Execution</h4>
         <div class="border rounded-lg mb-3">
           <ExecutionButton
-            v-for="(executor, i) in supportedExecutionStrategies"
-            :key="executor"
+            v-for="strategy in supportedExecutionStrategies"
+            :key="strategy.address"
             class="flex-auto flex items-center gap-2"
-            @click="
-              handleExecutionStrategySelected({
-                address: executor,
-                type: space.executors_types[i]
-              })
-            "
+            @click="handleExecutionStrategySelected(strategy)"
           >
             <IH-chip />
             <span class="flex-1">
-              {{ network.constants.EXECUTORS[space.executors_types[i]] }}
-              execution strategy
-              <span class="hidden sm:inline-block">({{ shortenAddress(executor) }})</span>
+              {{ strategy.treasury.name }}
+              <span class="hidden sm:inline-block">
+                ({{ network.constants.EXECUTORS[strategy.type] }} execution strategy)
+              </span>
             </span>
-            <IH-check v-if="executionStrategy?.address === executor" />
+            <IH-check v-if="executionStrategy?.address === strategy.address" />
           </ExecutionButton>
         </div>
         <EditorExecution
-          v-if="executionStrategy"
+          v-if="selectedExecutionWithTreasury"
+          :key="selectedExecutionWithTreasury.address"
           v-model="proposal.execution"
-          :selected-execution-strategy="executionStrategy"
           :space="space"
+          :treasury-data="selectedExecutionWithTreasury.treasury"
           class="mb-4"
         />
       </div>

--- a/apps/ui/src/views/Space/Treasury.vue
+++ b/apps/ui/src/views/Space/Treasury.vue
@@ -2,7 +2,7 @@
 import { _n, _c, shorten, sanitizeUrl } from '@/helpers/utils';
 import { getNetwork, evmNetworks } from '@/networks';
 import { ETH_CONTRACT } from '@/helpers/constants';
-import { NetworkID, Space, Transaction } from '@/types';
+import { Space, Transaction } from '@/types';
 import type { Token } from '@/helpers/alchemy';
 
 const props = defineProps<{ space: Space }>();
@@ -23,10 +23,8 @@ const modalOpen = ref({
 });
 
 const currentNetworkId = computed(() => {
-  if (!props.space.wallet) return null;
-
   try {
-    return props.space.wallet.split(':')[0] as NetworkID;
+    return treasury.value?.networkId;
   } catch (e) {
     return null;
   }

--- a/apps/ui/src/views/Space/Treasury.vue
+++ b/apps/ui/src/views/Space/Treasury.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import { Space, SpaceMetadataTreasury } from '@/types';
-
-type RequiredProperty<T> = { [P in keyof T]: Required<NonNullable<T[P]>> };
+import { Space, SpaceMetadataTreasury, RequiredProperty } from '@/types';
 
 const props = defineProps<{ space: Space }>();
 

--- a/apps/ui/src/views/Space/Treasury.vue
+++ b/apps/ui/src/views/Space/Treasury.vue
@@ -1,293 +1,32 @@
 <script setup lang="ts">
-import { _n, _c, shorten, sanitizeUrl } from '@/helpers/utils';
-import { getNetwork, evmNetworks } from '@/networks';
-import { ETH_CONTRACT } from '@/helpers/constants';
-import { Space, Transaction } from '@/types';
-import type { Token } from '@/helpers/alchemy';
+import { Space, SpaceMetadataTreasury } from '@/types';
+
+type RequiredProperty<T> = { [P in keyof T]: Required<NonNullable<T[P]>> };
 
 const props = defineProps<{ space: Space }>();
 
 const { setTitle } = useTitle();
-const router = useRouter();
-const { copy, copied } = useClipboard();
-const { loading, loaded, assets, loadBalances } = useBalances();
-const { loading: nftsLoading, loaded: nftsLoaded, nfts, loadNfts } = useNfts();
-const { treasury } = useTreasury(toRef(props, 'space'));
-const { createDraft } = useEditor();
 
-const page: Ref<'tokens' | 'nfts'> = ref('tokens');
-const modalOpen = ref({
-  tokens: false,
-  nfts: false,
-  walletConnectLink: false
-});
-
-const currentNetworkId = computed(() => {
-  try {
-    return treasury.value?.networkId;
-  } catch (e) {
-    return null;
-  }
-});
-
-const currentNetwork = computed(() => {
-  if (!currentNetworkId.value) return null;
-
-  return getNetwork(currentNetworkId.value);
-});
-
-const spaceKey = computed(() => `${props.space.network}:${props.space.id}`);
-
-const totalQuote = computed(() =>
-  assets.value.reduce((acc, asset) => {
-    return acc + asset.value;
-  }, 0)
+const activeTreasuryId = ref(0);
+const filteredTreasuries = computed(
+  () =>
+    props.space.treasuries.filter(
+      t => t.address && t.network
+    ) as RequiredProperty<SpaceMetadataTreasury>[]
 );
-
-const sortedAssets = computed(() =>
-  (assets || []).value.sort((a, b) => {
-    const isEth = (token: Token) => token.contractAddress === ETH_CONTRACT;
-    if (isEth(a)) return -1;
-    if (isEth(b)) return 1;
-    return 0;
-  })
-);
-
-const treasuryExplorerUrl = computed(() => {
-  if (!currentNetwork.value || !treasury.value) return '';
-
-  const url = currentNetwork.value.helpers.getExplorerUrl(treasury.value.wallet, 'address');
-  return sanitizeUrl(url);
-});
-
-const executionStrategy = computed(() => {
-  let executorIndex = props.space.executors.findIndex(
-    executorAddress => executorAddress === treasury.value?.wallet
-  );
-
-  if (executorIndex === -1) {
-    // If the treasury is not an executor, use the first avatar executor
-    executorIndex = props.space.executors_types.findIndex(e => e === 'SimpleQuorumAvatar');
-  }
-
-  if (executorIndex === -1) return null;
-
-  return {
-    address: props.space.executors[executorIndex],
-    type: props.space.executors_types[executorIndex]
-  };
-});
-
-function openModal(type: 'tokens' | 'nfts') {
-  modalOpen.value[type] = true;
-}
-
-function addTx(tx: Transaction) {
-  const draftId = createDraft(spaceKey.value, {
-    execution: [tx],
-    executionStrategy: executionStrategy.value
-  });
-  router.push(`create/${draftId}`);
-}
-
-onMounted(() => {
-  if (!treasury.value) return;
-
-  loadBalances(treasury.value.wallet, treasury.value.network);
-  loadNfts(treasury.value.wallet, treasury.value.network);
-});
+const treasuryData = computed(() => filteredTreasuries.value[activeTreasuryId.value]);
 
 watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
 </script>
 
 <template>
-  <div v-if="!treasury || !currentNetwork" class="p-4 flex items-center text-skin-link">
-    <IH-exclamation-circle class="inline-block mr-2" />
-    No treasury configured.
+  <div
+    v-if="filteredTreasuries.length !== 1"
+    class="flex px-4 bg-skin-bg border-b sticky top-[71px] lg:top-[72px] z-40 space-x-3"
+  >
+    <a v-for="(treasury, i) in filteredTreasuries" :key="i" @click="activeTreasuryId = i">
+      <UiLink :is-active="activeTreasuryId === i" :text="treasury.name || 'Unnamed treasury'" />
+    </a>
   </div>
-  <template v-else>
-    <div class="p-4 space-x-2 flex">
-      <div class="flex-auto" />
-      <UiTooltip
-        v-if="currentNetworkId && evmNetworks.includes(currentNetworkId)"
-        title="Connect to apps"
-      >
-        <UiButton class="!px-0 w-[46px]" @click="modalOpen.walletConnectLink = true">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="480"
-            height="332"
-            viewBox="0 0 480 332"
-            class="inline-block w-[26px] h-[26px]"
-          >
-            <path
-              fill="rgba(var(--link))"
-              d="m126.613 93.9842c62.622-61.3123 164.152-61.3123 226.775 0l7.536 7.3788c3.131 3.066 3.131 8.036 0 11.102l-25.781 25.242c-1.566 1.533-4.104 1.533-5.67 0l-10.371-10.154c-43.687-42.7734-114.517-42.7734-158.204 0l-11.107 10.874c-1.565 1.533-4.103 1.533-5.669 0l-25.781-25.242c-3.132-3.066-3.132-8.036 0-11.102zm280.093 52.2038 22.946 22.465c3.131 3.066 3.131 8.036 0 11.102l-103.463 101.301c-3.131 3.065-8.208 3.065-11.339 0l-73.432-71.896c-.783-.767-2.052-.767-2.835 0l-73.43 71.896c-3.131 3.065-8.208 3.065-11.339 0l-103.4657-101.302c-3.1311-3.066-3.1311-8.036 0-11.102l22.9456-22.466c3.1311-3.065 8.2077-3.065 11.3388 0l73.4333 71.897c.782.767 2.051.767 2.834 0l73.429-71.897c3.131-3.065 8.208-3.065 11.339 0l73.433 71.897c.783.767 2.052.767 2.835 0l73.431-71.895c3.132-3.066 8.208-3.066 11.339 0z"
-            />
-          </svg>
-        </UiButton>
-      </UiTooltip>
-      <UiTooltip title="Copy address">
-        <UiButton class="!px-0 w-[46px]" @click="copy(treasury.wallet)">
-          <IH-duplicate v-if="!copied" class="inline-block" />
-          <IH-check v-else class="inline-block" />
-        </UiButton>
-      </UiTooltip>
-      <UiTooltip :title="page === 'tokens' ? 'Send token' : 'Send NFT'">
-        <UiButton class="!px-0 w-[46px]" @click="openModal(page)">
-          <IH-arrow-sm-right class="inline-block -rotate-45" />
-        </UiButton>
-      </UiTooltip>
-    </div>
-    <div class="space-y-3">
-      <div>
-        <UiLabel label="Treasury" sticky />
-        <a
-          :href="treasuryExplorerUrl || '#'"
-          target="_blank"
-          class="flex justify-between items-center mx-4 py-3 border-b"
-          :class="{
-            'pointer-events-none': !treasuryExplorerUrl
-          }"
-        >
-          <UiStamp :id="treasury.wallet" type="avatar" :size="32" class="mr-3" />
-          <div class="flex-1 leading-[22px]">
-            <h4 class="text-skin-link" v-text="shorten(treasury.wallet)" />
-            <div class="text-skin-text text-[17px]" v-text="shorten(treasury.wallet)" />
-          </div>
-          <h3 v-text="`$${_n(totalQuote.toFixed())}`" />
-        </a>
-      </div>
-      <div>
-        <div class="flex pl-4 border-b space-x-3">
-          <button type="button" @click="page = 'tokens'">
-            <UiLink :is-active="page === 'tokens'" text="Tokens" />
-          </button>
-          <button type="button" @click="page = 'nfts'">
-            <UiLink :is-active="page === 'nfts'" text="NFTs" />
-          </button>
-        </div>
-        <div v-if="page === 'tokens'">
-          <UiLoading v-if="loading && !loaded" class="px-4 py-3 block" />
-          <div
-            v-if="loaded && sortedAssets.length === 0"
-            class="px-4 py-3 flex items-center text-skin-link"
-          >
-            <IH-exclamation-circle class="inline-block mr-2" />
-            There are no tokens in treasury.
-          </div>
-          <a
-            v-for="(asset, i) in sortedAssets"
-            :key="i"
-            :href="
-              (asset.contractAddress === ETH_CONTRACT
-                ? treasuryExplorerUrl
-                : sanitizeUrl(
-                    currentNetwork.helpers.getExplorerUrl(asset.contractAddress, 'token')
-                  )) || '#'
-            "
-            target="_blank"
-            class="mx-4 py-3 border-b flex"
-          >
-            <div class="flex-auto flex items-center min-w-0">
-              <UiStampToken
-                :id="`${treasury.networkId}:${asset.contractAddress}`"
-                type="token"
-                :size="32"
-              />
-              <div class="flex flex-col ml-3 leading-[22px] min-w-0 pr-2 md:pr-0">
-                <h4 class="truncate" v-text="asset.symbol" />
-                <div class="text-[17px] truncate text-skin-text" v-text="asset.name" />
-              </div>
-            </div>
-            <div
-              v-if="asset.price"
-              class="flex-col items-end text-right leading-[22px] w-[240px] hidden md:block"
-            >
-              <h4
-                class="text-skin-link"
-                v-text="`$${_n(asset.price, 'standard', { maximumFractionDigits: 2 })}`"
-              />
-              <div v-if="asset.change" class="text-[17px]">
-                <div
-                  v-if="asset.change > 0"
-                  class="text-skin-success"
-                  v-text="`+${_n(asset.change, 'standard', { maximumFractionDigits: 2 })}%`"
-                />
-                <div
-                  v-if="asset.change < 0"
-                  class="text-skin-danger"
-                  v-text="`${_n(asset.change, 'standard', { maximumFractionDigits: 2 })}%`"
-                />
-              </div>
-            </div>
-            <div class="flex-col items-end text-right leading-[22px] w-auto md:w-[240px]">
-              <h4
-                class="text-skin-link truncate"
-                v-text="
-                  `${_c(asset.tokenBalance || 0n, asset.decimals || 0)} ${shorten(
-                    asset.symbol,
-                    'symbol'
-                  )}`
-                "
-              />
-              <div
-                v-if="asset.value"
-                class="text-[17px] text-skin-text"
-                v-text="`$${_n(asset.value, 'standard', { maximumFractionDigits: 2 })}`"
-              />
-            </div>
-          </a>
-        </div>
-        <div v-else-if="page === 'nfts'">
-          <div
-            v-if="nftsLoaded && nfts.length === 0"
-            class="px-4 py-3 flex items-center text-skin-link"
-          >
-            <IH-exclamation-circle class="inline-block mr-2" />
-            There are no NFTs in treasury.
-          </div>
-          <UiLoading v-if="nftsLoading && !nftsLoaded" class="px-4 py-3 block" />
-          <div class="flex flex-row flex-wrap gap-4 p-4">
-            <a
-              v-for="(nft, i) in nfts"
-              :key="i"
-              :href="sanitizeUrl(nft.permalink) || '#'"
-              target="_blank"
-              class="block max-w-[120px]"
-            >
-              <UiNftImage :item="nft" class="w-full" />
-              <div class="mt-2 text-[17px] truncate">{{ nft.displayTitle }}</div>
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-    <teleport to="#modal">
-      <ModalSendToken
-        :open="modalOpen.tokens"
-        :address="treasury.wallet"
-        :network="treasury.network"
-        :network-id="treasury.networkId"
-        @close="modalOpen.tokens = false"
-        @add="addTx"
-      />
-      <ModalSendNft
-        :open="modalOpen.nfts"
-        :address="treasury.wallet"
-        :network="treasury.network"
-        @close="modalOpen.nfts = false"
-        @add="addTx"
-      />
-      <ModalLinkWalletConnect
-        :open="modalOpen.walletConnectLink"
-        :address="treasury.wallet"
-        :network="treasury.network"
-        :network-id="treasury.networkId"
-        :space-key="spaceKey"
-        :execution-strategy="executionStrategy"
-        @close="modalOpen.walletConnectLink = false"
-      />
-    </teleport>
-  </template>
+  <SpaceTreasury :key="activeTreasuryId" :space="space" :treasury-data="treasuryData" />
 </template>


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/18

Decisions:
1. We have two sources of truth for treasuries - executions and user configured treasuries on metadata, with this PR treasuries configured in metadata are used as a "whitelist" of executors that should be displayed on UI (in both treasury as well in proposal creation). You can also add treasuries that are not linked to executor to create read only treasury (can't be used in execution).
2. We had to index additional properties on backend to be able to link executors to treasuries.

### Screenshots

UI is temporary as design were not confirmed to be final.

<img width="626" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/3c197d12-f0e3-4658-99af-2caed00ab3d1">
<img width="603" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/fa24e8fb-7120-4c6f-81c7-1b470fa1848b">
<img width="770" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/f59e42b8-a772-4e42-9229-98c0c55fe837">


### How to test

1. Run `VITE_ENABLED_NETWORKS=sep yarn dev:full`. (it can take some time for subgraph to be in sync).
2. Interact with this space as a user (check treasury, try creating proposals): http://localhost:8080/#/sep:0x8b08aa6cdaf0bc92bb9cc6844459b2fed94249af/treasury
2. Create space on Sepolia with execution strategies (can't add them to old spaces as we don't have editor for it).
3. Set treasuries in metadata (so for timelock execution it's just strategy address, for avatar it's avatar's address).

