### PR TITLE
fix: enable create proposal button for offchain spaces

### DIFF
--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -123,7 +123,7 @@ watchEffect(() => setTitle(`Proposals - ${props.space.name}`));
           :voting-power-symbol="space.voting_power_symbol"
           :voting-powers="votingPowers"
         />
-        <router-link v-if="!network.readOnly" :to="{ name: 'editor' }">
+        <router-link :to="{ name: 'editor' }">
           <UiTooltip title="New proposal">
             <UiButton class="!px-0 w-[46px]">
               <IH-pencil-alt class="inline-block" />


### PR DESCRIPTION
### Summary

Show the "Create new proposals" button for offchain spaces, in the proposals page

### How to test

1. Go to an offchain spaces, then proposals page (e.g. http://localhost:8080/#/s-tn:wan-test.eth/proposals)
2. The "Create proposal" button should appear on page top right, next to the voting power 

Final result should look like
![Screenshot 2024-02-27 at 23 11 38](https://github.com/snapshot-labs/sx-monorepo/assets/495709/b181df47-9fcb-4b65-a009-0ee266f10287)

