### PR TITLE
refactor: use wrapPromise for every non-deploy action

### DIFF
--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -91,6 +91,8 @@ export function useActions() {
 
       hash && uiStore.addPendingTransaction(hash, networkId);
     } else {
+      console.log('Receipt', envelope);
+
       uiStore.addPendingTransaction(envelope.transaction_hash || envelope.hash, networkId);
     }
   }
@@ -179,10 +181,7 @@ export function useActions() {
       throw new Error(`${web3.value.type} is not supported for this actions`);
     }
 
-    const receipt = await network.actions.setMetadata(auth.web3, space, metadata);
-
-    console.log('Receipt', receipt);
-    uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, space.network);
+    await wrapPromise(space.network, network.actions.setMetadata(auth.web3, space, metadata));
   }
 
   async function vote(proposal: Proposal, choice: Choice) {
@@ -320,12 +319,7 @@ export function useActions() {
       throw new Error(`${web3.value.type} is not supported for this actions`);
     }
 
-    const receipt = await network.actions.cancelProposal(auth.web3, proposal);
-    console.log('Receipt', receipt);
-
-    if (handleSafeEnvelope(receipt)) return;
-
-    uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, proposal.network);
+    await wrapPromise(proposal.network, network.actions.cancelProposal(auth.web3, proposal));
   }
 
   async function finalizeProposal(proposal: Proposal) {
@@ -334,10 +328,7 @@ export function useActions() {
 
     const network = getReadWriteNetwork(proposal.network);
 
-    const receipt = await network.actions.finalizeProposal(auth.web3, proposal);
-
-    console.log('Receipt', receipt);
-    uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, proposal.network);
+    await wrapPromise(proposal.network, network.actions.finalizeProposal(auth.web3, proposal));
   }
 
   async function receiveProposal(proposal: Proposal) {
@@ -347,10 +338,7 @@ export function useActions() {
     const network = getReadWriteNetwork(proposal.network);
     if (!network.hasReceive) throw new Error('Receive on this network is not supported');
 
-    const receipt = await network.actions.receiveProposal(auth.web3, proposal);
-    console.log('Receipt', receipt);
-
-    uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, 'gor');
+    await wrapPromise('gor', network.actions.receiveProposal(auth.web3, proposal));
   }
 
   async function executeTransactions(proposal: Proposal) {
@@ -359,10 +347,7 @@ export function useActions() {
 
     const network = getReadWriteNetwork(proposal.network);
 
-    const receipt = await network.actions.executeTransactions(auth.web3, proposal);
-    console.log('Receipt', receipt);
-
-    uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, proposal.network);
+    await wrapPromise(proposal.network, network.actions.executeTransactions(auth.web3, proposal));
   }
 
   async function executeQueuedProposal(proposal: Proposal) {
@@ -371,10 +356,7 @@ export function useActions() {
 
     const network = getReadWriteNetwork(proposal.network);
 
-    const receipt = await network.actions.executeQueuedProposal(auth.web3, proposal);
-    console.log('Receipt', receipt);
-
-    uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, proposal.network);
+    await wrapPromise(proposal.network, network.actions.executeQueuedProposal(auth.web3, proposal));
   }
 
   async function vetoProposal(proposal: Proposal) {
@@ -383,10 +365,7 @@ export function useActions() {
 
     const network = getReadWriteNetwork(proposal.network);
 
-    const receipt = await network.actions.vetoProposal(auth.web3, proposal);
-    console.log('Receipt', receipt);
-
-    uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, proposal.network);
+    await wrapPromise(proposal.network, network.actions.vetoProposal(auth.web3, proposal));
   }
 
   async function setVotingDelay(space: Space, votingDelay: number) {
@@ -397,16 +376,14 @@ export function useActions() {
       throw new Error(`${web3.value.type} is not supported for this actions`);
     }
 
-    const receipt = await network.actions.setVotingDelay(
-      auth.web3,
-      space,
-      getCurrentFromDuration(space.network, votingDelay)
+    await wrapPromise(
+      space.network,
+      network.actions.setVotingDelay(
+        auth.web3,
+        space,
+        getCurrentFromDuration(space.network, votingDelay)
+      )
     );
-    console.log('Receipt', receipt);
-
-    if (handleSafeEnvelope(receipt)) return;
-
-    uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, space.network);
   }
 
   async function setMinVotingDuration(space: Space, minVotingDuration: number) {
@@ -417,16 +394,14 @@ export function useActions() {
       throw new Error(`${web3.value.type} is not supported for this actions`);
     }
 
-    const receipt = await network.actions.setMinVotingDuration(
-      auth.web3,
-      space,
-      getCurrentFromDuration(space.network, minVotingDuration)
+    await wrapPromise(
+      space.network,
+      network.actions.setMinVotingDuration(
+        auth.web3,
+        space,
+        getCurrentFromDuration(space.network, minVotingDuration)
+      )
     );
-    console.log('Receipt', receipt);
-
-    if (handleSafeEnvelope(receipt)) return;
-
-    uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, space.network);
   }
 
   async function setMaxVotingDuration(space: Space, maxVotingDuration: number) {
@@ -437,16 +412,14 @@ export function useActions() {
       throw new Error(`${web3.value.type} is not supported for this actions`);
     }
 
-    const receipt = await network.actions.setMaxVotingDuration(
-      auth.web3,
-      space,
-      getCurrentFromDuration(space.network, maxVotingDuration)
+    await wrapPromise(
+      space.network,
+      network.actions.setMaxVotingDuration(
+        auth.web3,
+        space,
+        getCurrentFromDuration(space.network, maxVotingDuration)
+      )
     );
-    console.log('Receipt', receipt);
-
-    if (handleSafeEnvelope(receipt)) return;
-
-    uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, space.network);
   }
 
   async function transferOwnership(space: Space, owner: string) {
@@ -457,12 +430,7 @@ export function useActions() {
       throw new Error(`${web3.value.type} is not supported for this actions`);
     }
 
-    const receipt = await network.actions.transferOwnership(auth.web3, space, owner);
-    console.log('Receipt', receipt);
-
-    if (handleSafeEnvelope(receipt)) return;
-
-    uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, space.network);
+    await wrapPromise(space.network, network.actions.transferOwnership(auth.web3, space, owner));
   }
 
   async function updateStrategies(
@@ -480,20 +448,18 @@ export function useActions() {
       throw new Error(`${web3.value.type} is not supported for this actions`);
     }
 
-    const receipt = await network.actions.updateStrategies(
-      auth.web3,
-      space,
-      authenticatorsToAdd,
-      authenticatorsToRemove,
-      votingStrategiesToAdd,
-      votingStrategiesToRemove,
-      validationStrategy
+    await wrapPromise(
+      space.network,
+      network.actions.updateStrategies(
+        auth.web3,
+        space,
+        authenticatorsToAdd,
+        authenticatorsToRemove,
+        votingStrategiesToAdd,
+        votingStrategiesToRemove,
+        validationStrategy
+      )
     );
-    console.log('Receipt', receipt);
-
-    if (handleSafeEnvelope(receipt)) return;
-
-    uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, space.network);
   }
 
   async function delegate(
@@ -506,16 +472,10 @@ export function useActions() {
 
     const network = getReadWriteNetwork(networkId);
 
-    const receipt = await network.actions.delegate(
-      auth.web3,
-      space,
+    await wrapPromise(
       networkId,
-      delegatee,
-      delegationContract
+      network.actions.delegate(auth.web3, space, networkId, delegatee, delegationContract)
     );
-    console.log('Receipt', receipt);
-
-    uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, networkId);
 
     mixpanel.track('Delegate', {
       network: networkId,


### PR DESCRIPTION
### Summary

We can just use wrapPromise for all actions as it can detect if envelope format is used or not.

Omitted createSpace/deployDependency actions as they use different flow (no pending transaction) for now, we will see what we will need in the future.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/89

### How to test

1. Go to space you control.
2. Modify profile.
3. Modify settings.

