### PR TITLE
chore: disable strictTuples

### DIFF
--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -10,7 +10,11 @@ import { resolver } from '@/helpers/resolver';
 
 type Opts = { skipEmptyOptionalFields: boolean };
 
-const ajv = new Ajv({ allErrors: true });
+const ajv = new Ajv({
+  allErrors: true,
+  // https://github.com/ajv-validator/ajv/issues/1417
+  strictTuples: false
+});
 addFormats(ajv);
 
 const addressValidator = (value: string) => {


### PR DESCRIPTION
### Summary

With draft v7 we don't have a way to define non-homogenous without breaking strict mode, so for now we will just disable it to avoid warnings.

In the future we could go to newer draft version, but v7 is recommended due to its speed.

### How to test

1. Go to editor http://localhost:8080/#/s-tn:weth.testsnap.eth/create
2. Start typing.
3. No errors in console.

