### PR TITLE
feat: add swap link for strategies

### DIFF
--- a/apps/ui/src/components/Modal/VotingPower.vue
+++ b/apps/ui/src/components/Modal/VotingPower.vue
@@ -55,16 +55,28 @@ const error = computed(() => props.votingPowerStatus === 'error');
           </div>
         </div>
         <div class="flex justify-between">
-          <a
-            v-if="strategy.token"
-            :href="baseNetwork.helpers.getExplorerUrl(strategy.token, 'contract', strategy.chainId)"
-            target="_blank"
-            class="flex items-center text-skin-text"
-          >
-            <UiStamp :id="strategy.token" type="avatar" :size="18" class="mr-2 rounded-sm" />
-            {{ shorten(strategy.token) }}
-            <IH-arrow-sm-right class="ml-1 -rotate-45" />
-          </a>
+          <div v-if="strategy.token" class="flex items-center gap-2">
+            <a
+              :href="
+                baseNetwork.helpers.getExplorerUrl(strategy.token, 'contract', strategy.chainId)
+              "
+              target="_blank"
+              class="flex items-center text-skin-text"
+            >
+              <UiStamp :id="strategy.token" type="avatar" :size="18" class="mr-2 rounded-sm" />
+              {{ shorten(strategy.token) }}
+              <IH-arrow-sm-right class="ml-1 -rotate-45" />
+            </a>
+            <a
+              v-if="strategy.swapLink"
+              :href="strategy.swapLink"
+              target="_blank"
+              class="flex items-center text-skin-text"
+            >
+              Buy
+              <IH-arrow-sm-right class="ml-1 -rotate-45" />
+            </a>
+          </div>
           <div v-else />
           <div>
             {{ _n(Number(strategy.value) / 10 ** strategy.decimals) }}

--- a/apps/ui/src/helpers/link.ts
+++ b/apps/ui/src/helpers/link.ts
@@ -1,0 +1,35 @@
+const UNISWAP_CHAINS_BY_NETWORK = {
+  '1': 'mainnet',
+  '42161': 'arbitrum',
+  '10': 'optimism',
+  '137': 'polygon',
+  '8453': 'base',
+  '56': 'bnb',
+  '43114': 'avalanche',
+  '42220': 'celo',
+  '11155111': 'sepolia',
+  '5': 'goerli'
+};
+
+export function getSwapLink(strategy: string, address: string, chainId?: number) {
+  if (
+    strategy &&
+    address &&
+    chainId &&
+    [
+      'comp',
+      'ozVotes',
+      'erc20-balance-of',
+      'erc20-votes',
+      'comp-like-votes',
+      'uni',
+      'erc20-balance-of-with-delegation'
+    ].includes(strategy)
+  ) {
+    const chain = UNISWAP_CHAINS_BY_NETWORK[chainId];
+
+    return `https://app.uniswap.org/swap?inputCurrency=ETH&outputCurrency=${address}&chain=${chain}&ref=snapshot`;
+  }
+
+  return;
+}

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -41,6 +41,7 @@ import type {
   Choice,
   NetworkID
 } from '@/types';
+import { getSwapLink } from '@/helpers/link';
 
 const CONFIGS: Record<number, EvmNetworkConfig> = {
   137: evmPolygon,
@@ -585,7 +586,8 @@ export function createActions(
             value,
             decimals: strategiesMetadata[i]?.decimals ?? 0,
             symbol: strategiesMetadata[i]?.symbol ?? '',
-            token
+            token,
+            swapLink: getSwapLink(strategy.type, address, chainId)
           };
         })
       );

--- a/apps/ui/src/networks/offchain/actions.ts
+++ b/apps/ui/src/networks/offchain/actions.ts
@@ -3,6 +3,7 @@ import { fetchScoreApi, getSdkChoice } from './helpers';
 import { EDITOR_APP_NAME, EDITOR_SNAPSHOT_OFFSET, PROPOSAL_VALIDATIONS } from './constants';
 import { getUrl } from '@/helpers/utils';
 import { getProvider } from '@/helpers/provider';
+import { getSwapLink } from '@/helpers/link';
 import type { Web3Provider } from '@ethersproject/providers';
 import type { StrategyParsedMetadata, Choice, Proposal, Space, VoteType } from '@/types';
 import type {
@@ -190,7 +191,8 @@ export function createActions(
           decimals,
           symbol: strategy.params.symbol,
           token: strategy.params.address,
-          chainId: strategy.network ? parseInt(strategy.network) : undefined
+          chainId: strategy.network ? parseInt(strategy.network) : undefined,
+          swapLink: getSwapLink(strategy.name, strategy.params.address, strategy.network)
         } as VotingPower;
       });
     }

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -75,6 +75,7 @@ export type VotingPower = {
   token: string | null;
   symbol: string;
   chainId?: number;
+  swapLink?: string;
 };
 
 export type VotingPowerStatus = 'loading' | 'success' | 'error';


### PR DESCRIPTION
Add an external link "Buy" that redirect to Uniswap swap page on voting power modal for compatible strategies

<img width="519" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/16245250/99c94281-7b67-428a-8acd-e311a5b96b37">

You can test it here: http://localhost:8080/#/s:ens.eth/proposals
Or here: http://localhost:8080/#/s:stgdao.eth/proposals

Later we could improve that and integrate swap directly in our UI.