### PR TITLE
feat: format addresses to common format across app

### DIFF
--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -1,6 +1,7 @@
 import { Web3Provider } from '@ethersproject/providers';
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
 import { formatUnits } from '@ethersproject/units';
+import { formatAddress } from '@/helpers/utils';
 import { getNames } from '@/helpers/stamp';
 import networks from '@/helpers/networks.json';
 
@@ -82,9 +83,11 @@ export function useWeb3() {
       }
       handleChainChanged(network.chainId);
       const acc = accounts.length > 0 ? accounts[0] : null;
-      const names = await getNames([acc]);
-      state.account = acc;
-      state.name = names[acc];
+      const formattedAddress = formatAddress(acc);
+
+      const names = await getNames([formattedAddress]);
+      state.account = formattedAddress;
+      state.name = names[formattedAddress];
       state.type = connector;
 
       if (typeof connector === 'undefined') {

--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -1,7 +1,6 @@
 import { Web3Provider } from '@ethersproject/providers';
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
 import { formatUnits } from '@ethersproject/units';
-import { formatAddress } from '@/helpers/utils';
 import { getNames } from '@/helpers/stamp';
 import networks from '@/helpers/networks.json';
 
@@ -83,11 +82,9 @@ export function useWeb3() {
       }
       handleChainChanged(network.chainId);
       const acc = accounts.length > 0 ? accounts[0] : null;
-      const formattedAddress = formatAddress(acc);
-
-      const names = await getNames([formattedAddress]);
-      state.account = formattedAddress;
-      state.name = names[formattedAddress];
+      const names = await getNames([acc]);
+      state.account = acc;
+      state.name = names[acc];
       state.type = connector;
 
       if (typeof connector === 'undefined') {

--- a/apps/ui/src/helpers/stamp.ts
+++ b/apps/ui/src/helpers/stamp.ts
@@ -1,17 +1,22 @@
+import { formatAddress } from './utils';
+
 export async function getNames(addresses: string[]): Promise<Record<string, string>> {
   try {
+    const inputMapping = Object.fromEntries(
+      addresses.map(address => [address, formatAddress(address)])
+    );
+
     const res = await fetch('https://stamp.fyi', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({ method: 'lookup_addresses', params: addresses })
+      body: JSON.stringify({ method: 'lookup_addresses', params: Object.values(inputMapping) })
     });
     const data = (await res.json()).result;
 
-    const dataToLc = Object.fromEntries(Object.entries(data).map(([k, v]) => [k.toLowerCase(), v]));
-    const entries: any = addresses
-      .map(address => [address, dataToLc[address.toLowerCase()] || null])
+    const entries: any = Object.entries(inputMapping)
+      .map(([address, formatted]) => [address, data[formatted] || null])
       .filter(([, name]) => name);
 
     return Object.fromEntries(entries);

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -4,6 +4,7 @@ import updateLocale from 'dayjs/plugin/updateLocale';
 import duration from 'dayjs/plugin/duration';
 import sha3 from 'js-sha3';
 import { sanitizeUrl as baseSanitizeUrl } from '@braintree/sanitize-url';
+import { getAddress } from '@ethersproject/address';
 import { validateAndParseAddress } from 'starknet';
 import networks from '@/helpers/networks.json';
 import pkg from '@/../package.json';
@@ -80,7 +81,9 @@ export function sanitizeUrl(url: string): string | null {
 }
 
 export function shortenAddress(str = '') {
-  return `${str.slice(0, 6)}...${str.slice(str.length - 4)}`;
+  const formatted = formatAddress(str);
+
+  return `${formatted.slice(0, 6)}...${formatted.slice(formatted.length - 4)}`;
 }
 
 export function shorten(str: string, key?: number | 'symbol' | 'name' | 'choice'): string {
@@ -92,6 +95,15 @@ export function shorten(str: string, key?: number | 'symbol' | 'name' | 'choice'
   if (key === 'choice') limit = 12;
   if (limit) return str.length > limit ? `${str.slice(0, limit).trim()}...` : str;
   return shortenAddress(str);
+}
+
+export function formatAddress(address: string) {
+  if (address.length === 42) return getAddress(address);
+  try {
+    return validateAndParseAddress(address);
+  } catch {
+    return address;
+  }
 }
 
 export function explorerUrl(network, str: string, type = 'address'): string {

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -375,7 +375,11 @@ export function getStampUrl(
 
   const cacheParam = hash ? `&cb=${hash}` : '';
 
-  return `https://cdn.stamp.fyi/${type}/${id}${sizeParam}${cacheParam}`;
+  const formattedId = ['avatar', 'space-sx', 'space-cover-sx'].includes(type)
+    ? formatAddress(id)
+    : id;
+
+  return `https://cdn.stamp.fyi/${type}/${formattedId}${sizeParam}${cacheParam}`;
 }
 
 export async function imageUpload(file: File) {


### PR DESCRIPTION
### Summary

Ethereum checksummed addresses and Starknet padded addresses will be used across app.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/67

Not sure if I caught all cases - if there are places where we do not shorten addresses it won't be updated, but I don't recall such places.

### How to test

1. Check across apps, there are no non-checksummed or non-padded addresses.

