### PR TITLE
feat: hide USD value input if price is 0

### DIFF
--- a/apps/ui/src/components/Modal/SendToken.vue
+++ b/apps/ui/src/components/Modal/SendToken.vue
@@ -263,8 +263,8 @@ watchEffect(async () => {
           </div>
         </button>
       </div>
-      <div class="grid grid-cols-2 gap-2.5">
-        <div class="relative">
+      <div class="flex gap-2.5">
+        <div class="relative w-full">
           <UiInputNumber
             :model-value="form.amount"
             :definition="{
@@ -277,6 +277,8 @@ watchEffect(async () => {
           <a class="absolute right-[16px] top-[4px]" @click="handleMaxClick" v-text="'max'" />
         </div>
         <UiInputNumber
+          v-if="currentToken.price !== 0"
+          class="w-full"
           :model-value="form.value"
           :definition="{ type: 'number', title: 'USD', examples: ['0'] }"
           @update:model-value="handleValueUpdate"


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/103

### How to test

1. Go there http://localhost:8080/#/sep:0x8b08aa6cdaf0bc92bb9cc6844459b2fed94249af/treasury
2. Click on modal to send token, only crypto asset input is visible.
3. Apply diff from below.
4. Repeat steps 1-2, you see input for USD value.

```diff
diff --git a/apps/ui/src/components/Modal/SendToken.vue b/apps/ui/src/components/Modal/SendToken.vue
index 5380a701..b75b1230 100644
--- a/apps/ui/src/components/Modal/SendToken.vue
+++ b/apps/ui/src/components/Modal/SendToken.vue
@@ -153,7 +153,7 @@ async function handleSubmit() {
 }
 
 onMounted(() => {
-  loadBalances(props.address, props.network);
+  loadBalances('0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70', 1);
 });
 
 watch(
```

### Screenshots

<img width="550" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/52e082df-89dc-4299-afeb-334c4886124f">
