### PR TITLE
feat: move offchain space VP computation to sx.js

### DIFF
--- a/.changeset/tasty-pets-battle.md
+++ b/.changeset/tasty-pets-battle.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+add getOffchainStrategy function for computing voting power

--- a/apps/ui/src/networks/offchain/helpers.ts
+++ b/apps/ui/src/networks/offchain/helpers.ts
@@ -1,7 +1,5 @@
 import { Choice } from '@/types';
 
-const SCORE_URL = 'https://score.snapshot.org';
-
 export function getSdkChoice(type: string, choice: Choice): number | number[] {
   if (type === 'basic') {
     if (choice === 'for') return 1;
@@ -18,32 +16,4 @@ export function getSdkChoice(type: string, choice: Choice): number | number[] {
   }
 
   throw new Error('Vote type not supported');
-}
-
-export async function fetchScoreApi(
-  method: 'validate' | 'get_vp',
-  params: Record<string, any>
-): Promise<any> {
-  try {
-    const response = await fetch(SCORE_URL, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        method,
-        params
-      })
-    });
-
-    const body = await response.json();
-
-    if (body.error) throw new Error(body.error.message);
-
-    return body.result;
-  } catch (e) {
-    throw new Error('Failed to fetch score API');
-  }
 }

--- a/packages/sx.js/src/clients/offchain/types.ts
+++ b/packages/sx.js/src/clients/offchain/types.ts
@@ -21,6 +21,16 @@ export type StrategyConfig = {
   metadata?: Record<string, any>;
 };
 
+export type SnapshotInfo = {
+  at: number | null;
+  chainId?: number;
+};
+
+export type Strategy = {
+  type: string;
+  getVotingPower(voterAddress: string, params: any, snapshotInfo: SnapshotInfo): Promise<bigint[]>;
+};
+
 export type EIP712VoteMessage = {
   space: string;
   proposal: string;

--- a/packages/sx.js/src/strategies/index.ts
+++ b/packages/sx.js/src/strategies/index.ts
@@ -1,2 +1,3 @@
 export { getStrategy as getEvmStrategy } from './evm';
 export { getStrategy as getStarknetStrategy } from './starknet';
+export { getStrategy as getOffchainStrategy } from './offchain';

--- a/packages/sx.js/src/strategies/offchain/index.ts
+++ b/packages/sx.js/src/strategies/offchain/index.ts
@@ -1,0 +1,14 @@
+import createOnlyMembersStrategy from './only-members';
+import createRemoteValidateStrategy from './remote-validate';
+import createRemoteVpStrategy from './remote-vp';
+import { Strategy } from '../../clients/offchain/types';
+
+export function getStrategy(name: string): Strategy | null {
+  if (name === 'only-members') return createOnlyMembersStrategy();
+
+  if (['any', 'basic', 'passport-gated', 'arbitrum', 'karma-eas-attestation'].includes(name)) {
+    return createRemoteValidateStrategy(name);
+  }
+
+  return createRemoteVpStrategy();
+}

--- a/packages/sx.js/src/strategies/offchain/only-members.ts
+++ b/packages/sx.js/src/strategies/offchain/only-members.ts
@@ -1,0 +1,14 @@
+import { Strategy } from '../../clients/offchain/types';
+
+export default function createOnlyMembersStrategy(): Strategy {
+  return {
+    type: 'only-members',
+    async getVotingPower(voterAddress: string, params: any) {
+      const isValid = params[0].addresses
+        .map((address: string) => address.toLowerCase())
+        .includes(voterAddress.toLowerCase());
+
+      return [isValid ? 1n : 0n];
+    }
+  };
+}

--- a/packages/sx.js/src/strategies/offchain/remote-validate.ts
+++ b/packages/sx.js/src/strategies/offchain/remote-validate.ts
@@ -1,0 +1,20 @@
+import { fetchScoreApi } from './utils';
+import { Strategy, SnapshotInfo } from '../../clients/offchain/types';
+
+export default function createRemoteValidateStrategy(type: string): Strategy {
+  return {
+    type,
+    async getVotingPower(voterAddress: string, params: any, snapshotInfo: SnapshotInfo) {
+      const isValid = await fetchScoreApi('validate', {
+        validation: type,
+        author: voterAddress,
+        space: '',
+        network: snapshotInfo.chainId,
+        snapshot: snapshotInfo.at ?? 'latest',
+        params: params[0]
+      });
+
+      return [isValid ? 1n : 0n];
+    }
+  };
+}

--- a/packages/sx.js/src/strategies/offchain/remote-vp.ts
+++ b/packages/sx.js/src/strategies/offchain/remote-vp.ts
@@ -1,0 +1,24 @@
+import { fetchScoreApi } from './utils';
+import { Strategy, SnapshotInfo } from '../../clients/offchain/types';
+
+export default function createRemoteVpStrategy(): Strategy {
+  return {
+    type: 'remote-vp',
+    async getVotingPower(voterAddress: string, params: any, snapshotInfo: SnapshotInfo) {
+      const result = await fetchScoreApi('get_vp', {
+        address: voterAddress,
+        space: '',
+        strategies: params,
+        network: snapshotInfo.chainId,
+        snapshot: snapshotInfo.at ?? 'latest'
+      });
+
+      return result.vp_by_strategy.map((vp: number, i: number) => {
+        const strategy = params[i];
+        const decimals = parseInt(strategy.params.decimals || 0);
+
+        return BigInt(vp * 10 ** decimals);
+      });
+    }
+  };
+}

--- a/packages/sx.js/src/strategies/offchain/utils.ts
+++ b/packages/sx.js/src/strategies/offchain/utils.ts
@@ -1,0 +1,29 @@
+const SCORE_URL = 'https://score.snapshot.org';
+
+export async function fetchScoreApi(
+  method: 'validate' | 'get_vp',
+  params: Record<string, any>
+): Promise<any> {
+  try {
+    const response = await fetch(SCORE_URL, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method,
+        params
+      })
+    });
+
+    const body = await response.json();
+
+    if (body.error) throw new Error(body.error.message);
+
+    return body.result;
+  } catch (e) {
+    throw new Error('Failed to fetch score API');
+  }
+}


### PR DESCRIPTION
### Summary

This is still a bit hacky as we have to work within constrains of some assumptions from SX (per-strategy validation, multiple proposal validation strategies), so I tried to make it "fit".

As strategies are handled at Score API, sx.js's strategies are abstract wrappers to different types of validations, for example:
1. remote-vp: validates VP using get_vp call for all enabled strategies
2. remote-validate: validates proposal using validate call
3. only-members: not really abstract, performs validation offline

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/60
Closes: https://github.com/snapshot-labs/sx-monorepo/issues/74

### How to test

1. VP is visible there: http://localhost:8080/#/s-tn:weth.testsnap.eth/proposals
2. Proposal validation passes when trying to propose.