### PR TITLE
feat: index Axiom execution

### DIFF
--- a/apps/subgraph-api/abis/AxiomExecutionStrategy.json
+++ b/apps/subgraph-api/abis/AxiomExecutionStrategy.json
@@ -1,0 +1,1286 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_quorum",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_axiomV2QueryAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_snapshotAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_snapshotSlot",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_spaceAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_querySchema",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "ArrayLengthMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AuthenticatorNotWhitelisted",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "proposalSpaceHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AxiomProposalAlreadyExists",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "AxiomProposalExists",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AxiomV2QueryAddressIsZero",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CallerMustBeAxiomV2Query",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "startBlock",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "currentBlock",
+        "type": "uint32"
+      }
+    ],
+    "name": "CannotCommitProposalBeforeStartBlock",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "minVotingDuration",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "maxVotingDuration",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "provingTimeAllowance",
+        "type": "uint32"
+      }
+    ],
+    "name": "DurationMustExceedProvingTimeAllownace",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyArray",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ExceedsStrategyLimit",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ExecutionFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FailedToPassProposalValidation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidCaller",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "minVotingDuration",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "maxVotingDuration",
+        "type": "uint32"
+      }
+    ],
+    "name": "InvalidDuration",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "executionPayloadHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "InvalidExecutionPayloadHash",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidPayload",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidProof",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidProposal",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum ProposalStatus",
+        "name": "status",
+        "type": "uint8"
+      }
+    ],
+    "name": "InvalidProposalStatus",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidSpace",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "InvalidStrategyIndex",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoActiveVotingStrategies",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "NotAxiomProposal",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyProver",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "proposalSpaceHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ProposalAlreadyProven",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProposalFinalized",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ProposalNotAccepted",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "proposalSpaceHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ProposalNotCommitted",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "proposalSpaceHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ProposalNotProven",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UserAlreadyVoted",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UserHasNoVotingPower",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VotingDelayHasPassed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VotingPeriodHasEnded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VotingPeriodHasNotStarted",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddress",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "quorum",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "snapshotAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "snapshotSlot",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "spaceAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "querySchema",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AxiomExecutionStrategySetUp",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "enum ProofStatus",
+            "name": "proofStatus",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "payloadHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "offchainVotesFor",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "offchainVotesAgainst",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "offchainVotesAbstain",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct AxiomProposal",
+        "name": "axiomProposal",
+        "type": "tuple"
+      }
+    ],
+    "name": "AxiomProposalCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "executionPayloadHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AxiomProposalExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "sourceChainId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "querySchema",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "queryId",
+        "type": "uint256"
+      }
+    ],
+    "name": "AxiomV2Call",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "sourceChainId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "querySchema",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "queryId",
+        "type": "uint256"
+      }
+    ],
+    "name": "AxiomV2OffchainCall",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "verifierAddress",
+        "type": "address"
+      }
+    ],
+    "name": "AxiomVoteVerifierAddressUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "votesFor",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "votesAgainst",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "votesAbstain",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "payloadHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "OnchainVotesFinalized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "numBlocks",
+        "type": "uint32"
+      }
+    ],
+    "name": "ProvingTimeAllowanceUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "newQuerySchema",
+        "type": "bytes32"
+      }
+    ],
+    "name": "QuerySchemaUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newQuorum",
+        "type": "uint256"
+      }
+    ],
+    "name": "QuorumUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "snapshotAddress",
+        "type": "address"
+      }
+    ],
+    "name": "SnapshotAddressUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "slot",
+        "type": "uint256"
+      }
+    ],
+    "name": "SnapshotSlotUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "space",
+        "type": "address"
+      }
+    ],
+    "name": "SpaceDisabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "space",
+        "type": "address"
+      }
+    ],
+    "name": "SpaceEnabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          },
+          {
+            "internalType": "enum Enum.Operation",
+            "name": "operation",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct MetaTransaction",
+        "name": "transaction",
+        "type": "tuple"
+      }
+    ],
+    "name": "TransactionExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "queryId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "offchainForVotes",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "offchainAgainstVotes",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "offchainAbstainVotes",
+        "type": "uint256"
+      }
+    ],
+    "name": "WriteOffchainVotes",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "axiomProposals",
+    "outputs": [
+      {
+        "internalType": "enum ProofStatus",
+        "name": "proofStatus",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "payloadHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offchainVotesFor",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offchainVotesAgainst",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offchainVotesAbstain",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "sourceChainId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "querySchema",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "queryId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "axiomResults",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "axiomV2Callback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "sourceChainId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "querySchema",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "queryId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "axiomResults",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "axiomV2OffchainCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "axiomV2QueryAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "space",
+        "type": "address"
+      }
+    ],
+    "name": "disableSpace",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "space",
+        "type": "address"
+      }
+    ],
+    "name": "enableSpace",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "author",
+            "type": "address"
+          },
+          {
+            "internalType": "uint32",
+            "name": "startBlockNumber",
+            "type": "uint32"
+          },
+          {
+            "internalType": "contract IExecutionStrategy",
+            "name": "executionStrategy",
+            "type": "address"
+          },
+          {
+            "internalType": "uint32",
+            "name": "minEndBlockNumber",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "maxEndBlockNumber",
+            "type": "uint32"
+          },
+          {
+            "internalType": "enum FinalizationStatus",
+            "name": "finalizationStatus",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "executionPayloadHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "activeVotingStrategies",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Proposal",
+        "name": "proposal",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "votesFor",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "votesAgainst",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "votesAbstain",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "payload",
+        "type": "bytes"
+      }
+    ],
+    "name": "execute",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "payload",
+        "type": "bytes"
+      }
+    ],
+    "name": "executeMergedProposal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getMergedVotes",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getProofStatus",
+    "outputs": [
+      {
+        "internalType": "enum ProofStatus",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "author",
+            "type": "address"
+          },
+          {
+            "internalType": "uint32",
+            "name": "startBlockNumber",
+            "type": "uint32"
+          },
+          {
+            "internalType": "contract IExecutionStrategy",
+            "name": "executionStrategy",
+            "type": "address"
+          },
+          {
+            "internalType": "uint32",
+            "name": "minEndBlockNumber",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "maxEndBlockNumber",
+            "type": "uint32"
+          },
+          {
+            "internalType": "enum FinalizationStatus",
+            "name": "finalizationStatus",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "executionPayloadHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "activeVotingStrategies",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Proposal",
+        "name": "proposal",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "votesFor",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "votesAgainst",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "votesAbstain",
+        "type": "uint256"
+      }
+    ],
+    "name": "getProposalStatus",
+    "outputs": [
+      {
+        "internalType": "enum ProposalStatus",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getStrategyType",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "proposalId",
+        "type": "uint256"
+      }
+    ],
+    "name": "isMergedProposalAccepted",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "space",
+        "type": "address"
+      }
+    ],
+    "name": "isSpaceEnabled",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "querySchema",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "quorum",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_querySchema",
+        "type": "bytes32"
+      }
+    ],
+    "name": "setQuerySchema",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_quorum",
+        "type": "uint256"
+      }
+    ],
+    "name": "setQuorum",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "initializeParams",
+        "type": "bytes"
+      }
+    ],
+    "name": "setUp",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "space",
+    "outputs": [
+      {
+        "internalType": "contract Space",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/apps/subgraph-api/package.json
+++ b/apps/subgraph-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-subgraph",
   "private": true,
-  "version": "0.0.22",
+  "version": "0.0.23",
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",

--- a/apps/subgraph-api/subgraph.yaml
+++ b/apps/subgraph-api/subgraph.yaml
@@ -20,6 +20,8 @@ dataSources:
           file: ./abis/ProxyFactory.json
         - name: AvatarExecutionStrategy
           file: ./abis/AvatarExecutionStrategy.json
+        - name: AxiomExecutionStrategy
+          file: ./abis/AxiomExecutionStrategy.json
         - name: TimelockExecutionStrategy
           file: ./abis/TimelockExecutionStrategy.json
       eventHandlers:


### PR DESCRIPTION
### Summary

With this change axiom strategies will be now indexed.

### How to test

1. Create space with latest axiom strategy (`0xE59405D7d40df064E85FD02a4F2F2C527172a9c1`).
2. Propose, vote, execute.
3. It should show up as executed.

<img width="910" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/f0959ca4-fbc8-4b81-84f3-59261476654c">
