### PR TITLE
fix: pass default stamp space avatar address

### DIFF
--- a/apps/ui/src/components/FormProfile.vue
+++ b/apps/ui/src/components/FormProfile.vue
@@ -49,7 +49,7 @@ const definition = computed(() => {
         type: 'string',
         format: 'stamp',
         title: 'Avatar',
-        default: props.id
+        default: props.id || '0x2121212121212121212121212121212121212121212121212121212121212121'
       },
       name: {
         type: 'string',


### PR DESCRIPTION
### Summary

It's usually it's set to space address but when creating new space we don't have space ID yet. Before it was passed as undefined, which worked (ignoring Vue warning), but now it fails as we try to format address.

This PR replaces undefined with valid address.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/144

<img width="960" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/243aa3c5-a3bf-432a-9ac3-bcd6f93f9da1">


### How to test

1. Go to http://localhost:8080/#/create
2. Avatar is visible, no warnings in console.

