### PR TITLE
feat: index Leaderboard and proposer/voter counts

### DIFF
--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -27,6 +27,8 @@ type Space {
     @derivedFrom(field: "space")
   proposal_count: Int!
   vote_count: Int!
+  proposer_count: Int!
+  voter_count: Int!
   created: Int!
   tx: String!
   proposals: [Proposal]! @derivedFrom(field: "space")
@@ -148,4 +150,12 @@ type User {
   created: Int!
   proposals: [Proposal]! @derivedFrom(field: "author")
   votes: [Vote]! @derivedFrom(field: "voter")
+}
+
+type LeaderboardItem {
+  id: String!
+  space: Space!
+  user: User!
+  proposal_count: Int!
+  vote_count: Int!
 }

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -152,7 +152,7 @@ type User {
   votes: [Vote]! @derivedFrom(field: "voter")
 }
 
-type LeaderboardItem {
+type Leaderboard {
   id: String!
   space: Space!
   user: User!

--- a/apps/api/src/utils.ts
+++ b/apps/api/src/utils.ts
@@ -1,5 +1,13 @@
 import fetch from 'cross-fetch';
-import { BigNumberish, CallData, Contract, Provider, hash, shortString } from 'starknet';
+import {
+  BigNumberish,
+  CallData,
+  Contract,
+  Provider,
+  hash,
+  shortString,
+  validateAndParseAddress
+} from 'starknet';
 import { Contract as EthContract } from '@ethersproject/contracts';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { faker } from '@faker-js/faker';
@@ -91,6 +99,14 @@ export function findVariant(value: { variant: Record<string, any> }) {
     key: result[0],
     value: result[1]
   };
+}
+
+export function formatAddressVariant({ key, value }: { key: string; value: string }) {
+  return key === 'Starknet'
+    ? validateAndParseAddress(value)
+    : key === 'Ethereum'
+      ? getAddress(value)
+      : value;
 }
 
 export function getVoteValue(label: string) {

--- a/apps/api/src/writer.ts
+++ b/apps/api/src/writer.ts
@@ -1,6 +1,6 @@
 import { validateAndParseAddress } from 'starknet';
 import { CheckpointWriter } from '@snapshot-labs/checkpoint';
-import { Space, Vote, User, Proposal, LeaderboardItem } from '../.checkpoint/models';
+import { Space, Vote, User, Proposal, Leaderboard } from '../.checkpoint/models';
 import { handleProposalMetadata, handleSpaceMetadata } from './ipfs';
 import { networkProperties } from './overrrides';
 import {
@@ -370,9 +370,9 @@ export const handlePropose: CheckpointWriter = async ({ block, tx, rawEvent, eve
     await user.save();
   }
 
-  let leaderboardItem = await LeaderboardItem.loadEntity(`${spaceId}/${author}`);
+  let leaderboardItem = await Leaderboard.loadEntity(`${spaceId}/${author}`);
   if (!leaderboardItem) {
-    leaderboardItem = new LeaderboardItem(`${spaceId}/${author}`);
+    leaderboardItem = new Leaderboard(`${spaceId}/${author}`);
     leaderboardItem.space = spaceId;
     leaderboardItem.user = author;
     leaderboardItem.vote_count = 0;
@@ -518,9 +518,9 @@ export const handleVote: CheckpointWriter = async ({ block, tx, rawEvent, event 
     await user.save();
   }
 
-  let leaderboardItem = await LeaderboardItem.loadEntity(`${spaceId}/${voter}`);
+  let leaderboardItem = await Leaderboard.loadEntity(`${spaceId}/${voter}`);
   if (!leaderboardItem) {
-    leaderboardItem = new LeaderboardItem(`${spaceId}/${voter}`);
+    leaderboardItem = new Leaderboard(`${spaceId}/${voter}`);
     leaderboardItem.space = spaceId;
     leaderboardItem.user = voter;
     leaderboardItem.vote_count = 0;

--- a/apps/api/src/writer.ts
+++ b/apps/api/src/writer.ts
@@ -1,7 +1,6 @@
 import { validateAndParseAddress } from 'starknet';
-import { getAddress } from '@ethersproject/address';
 import { CheckpointWriter } from '@snapshot-labs/checkpoint';
-import { Space, Vote, User, Proposal } from '../.checkpoint/models';
+import { Space, Vote, User, Proposal, LeaderboardItem } from '../.checkpoint/models';
 import { handleProposalMetadata, handleSpaceMetadata } from './ipfs';
 import { networkProperties } from './overrrides';
 import {
@@ -13,7 +12,8 @@ import {
   handleStrategiesMetadata,
   longStringToText,
   updateProposaValidationStrategy,
-  registerProposal
+  registerProposal,
+  formatAddressVariant
 } from './utils';
 
 type Strategy = {
@@ -62,6 +62,8 @@ export const handleSpaceCreated: CheckpointWriter = async ({ block, tx, event })
   space.authenticators = event.authenticators;
   space.proposal_count = 0;
   space.vote_count = 0;
+  space.proposer_count = 0;
+  space.voter_count = 0;
   space.created = block?.timestamp ?? getCurrentTimestamp();
   space.tx = tx.transaction_hash;
 
@@ -305,7 +307,7 @@ export const handlePropose: CheckpointWriter = async ({ block, tx, rawEvent, eve
   if (!space) return;
 
   const proposalId = parseInt(BigInt(event.proposal_id).toString());
-  const author = findVariant(event.author).value;
+  const author = formatAddressVariant(findVariant(event.author));
 
   const created = block?.timestamp ?? getCurrentTimestamp();
 
@@ -358,8 +360,6 @@ export const handlePropose: CheckpointWriter = async ({ block, tx, rawEvent, eve
     console.log(JSON.stringify(e).slice(0, 256));
   }
 
-  space.proposal_count += 1;
-
   const existingUser = await User.loadEntity(author);
   if (existingUser) {
     existingUser.proposal_count += 1;
@@ -369,6 +369,21 @@ export const handlePropose: CheckpointWriter = async ({ block, tx, rawEvent, eve
     user.created = created;
     await user.save();
   }
+
+  let leaderboardItem = await LeaderboardItem.loadEntity(`${spaceId}/${author}`);
+  if (!leaderboardItem) {
+    leaderboardItem = new LeaderboardItem(`${spaceId}/${author}`);
+    leaderboardItem.space = spaceId;
+    leaderboardItem.user = author;
+    leaderboardItem.vote_count = 0;
+    leaderboardItem.proposal_count = 0;
+  }
+
+  leaderboardItem.proposal_count += 1;
+  await leaderboardItem.save();
+
+  if (leaderboardItem.proposal_count === 1) space.proposer_count += 1;
+  space.proposal_count += 1;
 
   const herodotusStrategiesIndicies = space.strategies
     .map((strategy, i) => [strategy, i] as const)
@@ -477,17 +492,11 @@ export const handleVote: CheckpointWriter = async ({ block, tx, rawEvent, event 
 
   const spaceId = validateAndParseAddress(rawEvent.from_address);
   const proposalId = parseInt(event.proposal_id);
-  const voterVariant = findVariant(event.voter);
   const choice = getVoteValue(findVariant(event.choice).key);
   const vp = BigInt(event.voting_power);
 
   const created = block?.timestamp ?? getCurrentTimestamp();
-  const voter =
-    voterVariant.key === 'Starknet'
-      ? validateAndParseAddress(voterVariant.value)
-      : voterVariant.key === 'Ethereum'
-        ? getAddress(voterVariant.value)
-        : voterVariant.value;
+  const voter = formatAddressVariant(findVariant(event.voter));
 
   const vote = new Vote(`${spaceId}/${proposalId}/${voter}`);
   vote.space = spaceId;
@@ -509,9 +518,23 @@ export const handleVote: CheckpointWriter = async ({ block, tx, rawEvent, event 
     await user.save();
   }
 
+  let leaderboardItem = await LeaderboardItem.loadEntity(`${spaceId}/${voter}`);
+  if (!leaderboardItem) {
+    leaderboardItem = new LeaderboardItem(`${spaceId}/${voter}`);
+    leaderboardItem.space = spaceId;
+    leaderboardItem.user = voter;
+    leaderboardItem.vote_count = 0;
+    leaderboardItem.proposal_count = 0;
+  }
+
+  leaderboardItem.vote_count += 1;
+  await leaderboardItem.save();
+
   const space = await Space.loadEntity(spaceId);
   if (space) {
     space.vote_count += 1;
+    if (leaderboardItem.vote_count === 1) space.voter_count += 1;
+
     await space.save();
   }
 

--- a/apps/subgraph-api/schema.graphql
+++ b/apps/subgraph-api/schema.graphql
@@ -23,6 +23,8 @@ type Space @entity {
     @derivedFrom(field: "space")
   proposal_count: Int!
   vote_count: Int!
+  proposer_count: Int!
+  voter_count: Int!
   created: Int!
   tx: Bytes!
 }
@@ -145,4 +147,12 @@ type User @entity {
   proposal_count: Int!
   vote_count: Int!
   created: Int!
+}
+
+type LeaderboardItem @entity {
+  id: String!
+  space: Space!
+  user: User!
+  proposal_count: Int!
+  vote_count: Int!
 }

--- a/apps/subgraph-api/schema.graphql
+++ b/apps/subgraph-api/schema.graphql
@@ -149,7 +149,7 @@ type User @entity {
   created: Int!
 }
 
-type LeaderboardItem @entity {
+type Leaderboard @entity {
   id: String!
   space: Space!
   user: User!

--- a/apps/subgraph-api/src/mapping.ts
+++ b/apps/subgraph-api/src/mapping.ts
@@ -1,11 +1,4 @@
-import {
-  Address,
-  BigDecimal,
-  BigInt,
-  Bytes,
-  DataSourceContext,
-  dataSource,
-} from '@graphprotocol/graph-ts'
+import { Address, BigDecimal, BigInt, Bytes, dataSource } from '@graphprotocol/graph-ts'
 import { ProxyDeployed } from '../generated/ProxyFactory/ProxyFactory'
 import { AvatarExecutionStrategy } from '../generated/ProxyFactory/AvatarExecutionStrategy'
 import { AxiomExecutionStrategy } from '../generated/ProxyFactory/AxiomExecutionStrategy'
@@ -38,7 +31,15 @@ import {
   SpaceMetadata as SpaceMetadataTemplate,
   ProposalMetadata as ProposalMetadataTemplate,
 } from '../generated/templates'
-import { Space, ExecutionStrategy, ExecutionHash, Proposal, Vote, User } from '../generated/schema'
+import {
+  Space,
+  ExecutionStrategy,
+  ExecutionHash,
+  Proposal,
+  Vote,
+  User,
+  LeaderboardItem,
+} from '../generated/schema'
 import { updateStrategiesParsedMetadata, updateProposalValidationStrategy } from './helpers'
 
 const MASTER_SPACE = Address.fromString('0xC3031A7d3326E47D49BfF9D374d74f364B29CE4D')
@@ -142,6 +143,8 @@ export function handleSpaceCreated(event: SpaceCreated): void {
   space.authenticators = event.params.input.authenticators.map<Bytes>((address) => address)
   space.proposal_count = 0
   space.vote_count = 0
+  space.proposer_count = 0
+  space.voter_count = 0
   space.created = event.block.timestamp.toI32()
   space.tx = event.transaction.hash
 
@@ -223,19 +226,31 @@ export function handleProposalCreated(event: ProposalCreated): void {
 
   proposal.save()
 
-  space.proposal_count += 1
-  space.save()
-
   let user = User.load(event.params.author.toHexString())
   if (user == null) {
     user = new User(event.params.author.toHexString())
     user.proposal_count = 0
     user.vote_count = 0
     user.created = event.block.timestamp.toI32()
-    user.save()
   }
   user.proposal_count += 1
   user.save()
+
+  let leaderboardItem = LeaderboardItem.load(`${space.id}/${user.id}`)
+  if (!leaderboardItem) {
+    leaderboardItem = new LeaderboardItem(`${space.id}/${user.id}`)
+    leaderboardItem.space = space.id
+    leaderboardItem.user = user.id
+    leaderboardItem.proposal_count = 0
+    leaderboardItem.vote_count = 0
+  }
+
+  leaderboardItem.proposal_count += 1
+  leaderboardItem.save()
+
+  if (leaderboardItem.proposal_count === 1) space.proposer_count += 1
+  space.proposal_count += 1
+  space.save()
 }
 
 export function handleProposalUpdated(event: ProposalUpdated): void {
@@ -346,9 +361,6 @@ export function handleVoteCreated(event: VoteCast): void {
   vote.tx = event.transaction.hash
   vote.save()
 
-  space.vote_count += 1
-  space.save()
-
   let proposal = Proposal.load(`${space.id}/${event.params.proposalId}`)
   if (proposal !== null) {
     proposal.setBigDecimal(
@@ -366,10 +378,26 @@ export function handleVoteCreated(event: VoteCast): void {
     user.proposal_count = 0
     user.vote_count = 0
     user.created = event.block.timestamp.toI32()
-    user.save()
   }
+
   user.vote_count += 1
   user.save()
+
+  let leaderboardItem = LeaderboardItem.load(`${space.id}/${vote.voter}`)
+  if (!leaderboardItem) {
+    leaderboardItem = new LeaderboardItem(`${space.id}/${vote.voter}`)
+    leaderboardItem.space = space.id
+    leaderboardItem.user = vote.voter
+    leaderboardItem.proposal_count = 0
+    leaderboardItem.vote_count = 0
+  }
+
+  leaderboardItem.vote_count += 1
+  leaderboardItem.save()
+
+  if (leaderboardItem.vote_count === 1) space.voter_count += 1
+  space.vote_count += 1
+  space.save()
 }
 
 export function handleMetadataUriUpdated(event: MetadataURIUpdated): void {

--- a/apps/subgraph-api/src/mapping.ts
+++ b/apps/subgraph-api/src/mapping.ts
@@ -38,7 +38,7 @@ import {
   Proposal,
   Vote,
   User,
-  LeaderboardItem,
+  Leaderboard,
 } from '../generated/schema'
 import { updateStrategiesParsedMetadata, updateProposalValidationStrategy } from './helpers'
 
@@ -236,9 +236,9 @@ export function handleProposalCreated(event: ProposalCreated): void {
   user.proposal_count += 1
   user.save()
 
-  let leaderboardItem = LeaderboardItem.load(`${space.id}/${user.id}`)
+  let leaderboardItem = Leaderboard.load(`${space.id}/${user.id}`)
   if (!leaderboardItem) {
-    leaderboardItem = new LeaderboardItem(`${space.id}/${user.id}`)
+    leaderboardItem = new Leaderboard(`${space.id}/${user.id}`)
     leaderboardItem.space = space.id
     leaderboardItem.user = user.id
     leaderboardItem.proposal_count = 0
@@ -383,9 +383,9 @@ export function handleVoteCreated(event: VoteCast): void {
   user.vote_count += 1
   user.save()
 
-  let leaderboardItem = LeaderboardItem.load(`${space.id}/${vote.voter}`)
+  let leaderboardItem = Leaderboard.load(`${space.id}/${vote.voter}`)
   if (!leaderboardItem) {
-    leaderboardItem = new LeaderboardItem(`${space.id}/${vote.voter}`)
+    leaderboardItem = new Leaderboard(`${space.id}/${vote.voter}`)
     leaderboardItem.space = space.id
     leaderboardItem.user = vote.voter
     leaderboardItem.proposal_count = 0


### PR DESCRIPTION
### Summary

This PR adds new `Leaderboard` entity as well as `proposer_count` and `voter_count` to space entity.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/48
Closes: https://github.com/snapshot-labs/sx-monorepo/issues/157

### How to test

1. Run `yarn dev:full`. Wait for subgraph/checkpoint to fetch some data.
2. Run this queries and it should make sense:

```gql
{
  spaces {
    id
    vote_count
    voter_count
    proposal_count
    proposer_count
  }
  leaderboards {
    id
    user {
	id
    }
    space {
      id
    }
    vote_count
    proposal_count
  }
}
```