### PR TITLE
feat: add space param to offchain voting power strategies

### DIFF
--- a/.changeset/fifty-cats-wait.md
+++ b/.changeset/fifty-cats-wait.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+add space param to offchain voting power strategies

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -554,6 +554,7 @@ export function createActions(
     },
     send: (envelope: any) => ethSigClient.send(envelope),
     getVotingPower: async (
+      spaceId: string,
       strategiesAddresses: string[],
       strategiesParams: any[],
       strategiesMetadata: StrategyParsedMetadata[],

--- a/apps/ui/src/networks/offchain/actions.ts
+++ b/apps/ui/src/networks/offchain/actions.ts
@@ -147,6 +147,7 @@ export function createActions(
     },
     send: (envelope: any) => client.send(envelope),
     getVotingPower: async (
+      spaceId: string,
       strategiesNames: string[],
       strategiesOrValidationParams: any[],
       strategiesMetadata: StrategyParsedMetadata[],
@@ -162,6 +163,7 @@ export function createActions(
       if (!strategy) return [{ address: name, value: 0n, decimals: 0, token: null, symbol: '' }];
 
       const result = await strategy.getVotingPower(
+        spaceId,
         voterAddress,
         strategiesOrValidationParams,
         snapshotInfo

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -441,6 +441,7 @@ export function createActions(
       throw new Error('Not implemented');
     },
     getVotingPower: async (
+      spaceId: string,
       strategiesAddresses: string[],
       strategiesParams: any[],
       strategiesMetadata: StrategyParsedMetadata[],

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -84,6 +84,7 @@ export type VotingPowerStatus = 'loading' | 'success' | 'error';
 
 export type ReadOnlyNetworkActions = {
   getVotingPower(
+    spaceId: string,
     strategiesAddresses: string[],
     strategiesParams: any[],
     strategiesMetadata: StrategyParsedMetadata[],

--- a/apps/ui/src/views/Editor.vue
+++ b/apps/ui/src/views/Editor.vue
@@ -228,6 +228,7 @@ async function getVotingPower() {
     const network = getNetwork(space.value.network);
 
     const votingPowers = await network.actions.getVotingPower(
+      space.value.id,
       space.value.voting_power_validation_strategy_strategies,
       space.value.voting_power_validation_strategy_strategies_params,
       space.value.voting_power_validation_strategies_parsed_metadata,

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -51,6 +51,7 @@ async function getVotingPower() {
   votingPowerStatus.value = 'loading';
   try {
     votingPowers.value = await network.value.actions.getVotingPower(
+      proposal.value.space.id,
       proposal.value.strategies,
       proposal.value.strategies_params,
       proposal.value.space.strategies_parsed_metadata,

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -41,6 +41,7 @@ async function getVotingPower() {
   votingPowerStatus.value = 'loading';
   try {
     votingPowers.value = await network.value.actions.getVotingPower(
+      props.space.id,
       props.space.strategies,
       props.space.strategies_params,
       props.space.strategies_parsed_metadata,

--- a/packages/sx.js/src/clients/offchain/types.ts
+++ b/packages/sx.js/src/clients/offchain/types.ts
@@ -28,7 +28,12 @@ export type SnapshotInfo = {
 
 export type Strategy = {
   type: string;
-  getVotingPower(voterAddress: string, params: any, snapshotInfo: SnapshotInfo): Promise<bigint[]>;
+  getVotingPower(
+    spaceId: string,
+    voterAddress: string,
+    params: any,
+    snapshotInfo: SnapshotInfo
+  ): Promise<bigint[]>;
 };
 
 export type EIP712VoteMessage = {

--- a/packages/sx.js/src/strategies/offchain/only-members.ts
+++ b/packages/sx.js/src/strategies/offchain/only-members.ts
@@ -3,7 +3,7 @@ import { Strategy } from '../../clients/offchain/types';
 export default function createOnlyMembersStrategy(): Strategy {
   return {
     type: 'only-members',
-    async getVotingPower(voterAddress: string, params: any) {
+    async getVotingPower(spaceId: string, voterAddress: string, params: any) {
       const isValid = params[0].addresses
         .map((address: string) => address.toLowerCase())
         .includes(voterAddress.toLowerCase());

--- a/packages/sx.js/src/strategies/offchain/remote-validate.ts
+++ b/packages/sx.js/src/strategies/offchain/remote-validate.ts
@@ -4,11 +4,16 @@ import { Strategy, SnapshotInfo } from '../../clients/offchain/types';
 export default function createRemoteValidateStrategy(type: string): Strategy {
   return {
     type,
-    async getVotingPower(voterAddress: string, params: any, snapshotInfo: SnapshotInfo) {
+    async getVotingPower(
+      spaceId: string,
+      voterAddress: string,
+      params: any,
+      snapshotInfo: SnapshotInfo
+    ) {
       const isValid = await fetchScoreApi('validate', {
         validation: type,
         author: voterAddress,
-        space: '',
+        space: spaceId,
         network: snapshotInfo.chainId,
         snapshot: snapshotInfo.at ?? 'latest',
         params: params[0]

--- a/packages/sx.js/src/strategies/offchain/remote-vp.ts
+++ b/packages/sx.js/src/strategies/offchain/remote-vp.ts
@@ -4,10 +4,15 @@ import { Strategy, SnapshotInfo } from '../../clients/offchain/types';
 export default function createRemoteVpStrategy(): Strategy {
   return {
     type: 'remote-vp',
-    async getVotingPower(voterAddress: string, params: any, snapshotInfo: SnapshotInfo) {
+    async getVotingPower(
+      spaceId: string,
+      voterAddress: string,
+      params: any,
+      snapshotInfo: SnapshotInfo
+    ) {
       const result = await fetchScoreApi('get_vp', {
         address: voterAddress,
-        space: '',
+        space: spaceId,
         strategies: params,
         network: snapshotInfo.chainId,
         snapshot: snapshotInfo.at ?? 'latest'


### PR DESCRIPTION
### Summary

Add new `space` params to `getVotingPower()`, used by offchain strategies

Closes: #147

### How to test

1. To to an offchain space proposals page (e.g. http://localhost:8080/#/s-tn:wan-test.eth/proposals)
2. Open the web dev network tools
3. Inspect the query to https://score.snapshot.org/
4. In the POST payload, it should set the space params to the current space (before, it was just an empty string)

e.g

![Screenshot 2024-03-08 at 00 08 15](https://github.com/snapshot-labs/sx-monorepo/assets/495709/8405720b-edfa-4972-b7d4-c9aba8f04af2)

Repeat the same steps, but for an offchain proposal (e.g. http://localhost:8080/#/s-tn:wan-test.eth/proposal/0x819d95f7e00efa19ec3cc1794ca63d651241d4f82ccf813da24996e4e4ed3d95)
