### PR TITLE
fix: fix invalid decimal voting power

### DIFF
--- a/.changeset/five-gifts-rest.md
+++ b/.changeset/five-gifts-rest.md
@@ -2,4 +2,4 @@
 "@snapshot-labs/sx": patch
 ---
 
-fix issue with decimal voting power for offchain proposals
+change default decimals for remote-vp strategy to 18

--- a/.changeset/five-gifts-rest.md
+++ b/.changeset/five-gifts-rest.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+fix issue with decimal voting power for offchain proposals

--- a/apps/ui/src/networks/offchain/actions.ts
+++ b/apps/ui/src/networks/offchain/actions.ts
@@ -184,7 +184,7 @@ export function createActions(
 
       return result.map((value: bigint, index: number) => {
         const strategy = strategiesOrValidationParams[index];
-        const decimals = parseInt(strategy.params.decimals || 0);
+        const decimals = parseInt(strategy.params.decimals || 18);
 
         return {
           address: strategy.name,

--- a/packages/sx.js/src/strategies/offchain/remote-vp.ts
+++ b/packages/sx.js/src/strategies/offchain/remote-vp.ts
@@ -20,9 +20,9 @@ export default function createRemoteVpStrategy(): Strategy {
 
       return result.vp_by_strategy.map((vp: number, i: number) => {
         const strategy = params[i];
-        const decimals = parseInt(strategy.params.decimals || 0);
+        const decimals = parseInt(strategy.params.decimals || 18);
 
-        return BigInt(vp * 10 ** decimals);
+        return BigInt(Math.floor(vp * 10 ** decimals));
       });
     }
   };


### PR DESCRIPTION
### Summary

Fix voting power parsing issue, when voting power returned by score-api for offchain space is a decimal number

Closes: #146

### How to test

1. Connect to account with https://guest.so/#/shot.eth
2. Go to http://localhost:8080/#/s:safe.eth/proposal/0x1d65ca5270b4aa1efaa7b7ca4e17976a99b802efcf678ac2909eb836b1662a29
3. It should show the account voting power (2.5M) (Before, it was failing)
