### PR TITLE
fix: bump @checkpoint-labs/checkpoint to prevent duplicate writes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,7 +23,7 @@
     "@ethersproject/providers": "^5.7.2",
     "@ethersproject/units": "^5.6.1",
     "@faker-js/faker": "^7.4.0",
-    "@snapshot-labs/checkpoint": "^0.1.0-beta.28",
+    "@snapshot-labs/checkpoint": "^0.1.0-beta.29",
     "@snapshot-labs/sx": "^0.1.0",
     "@types/bn.js": "^5.1.0",
     "@types/mysql": "^2.15.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,10 +2408,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
-"@snapshot-labs/checkpoint@^0.1.0-beta.28":
-  version "0.1.0-beta.28"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/checkpoint/-/checkpoint-0.1.0-beta.28.tgz#20e6d009cfc7f61435ca6a1ea8a20d24c7e55f4c"
-  integrity sha512-qjbFRLrRAWHmJTm0UOc0umfgRWMm5UPX6TDIo4tdQ3ueNc5B7gaD0t5NsmBNUE+ClKX8GBssHdeLOYoYBYUy5g==
+"@snapshot-labs/checkpoint@^0.1.0-beta.29":
+  version "0.1.0-beta.29"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/checkpoint/-/checkpoint-0.1.0-beta.29.tgz#45f9916d6cae42ee12838bcbd008b69d9005e069"
+  integrity sha512-YORn4OcMXKmul2XYJDQuvpjGubOarMj/ifZsIyRD/NN0oNwbOa+6gwxUSGQsX2ueztdFezcC+f2unZfrANpHyA==
   dependencies:
     "@graphql-tools/schema" "^8.5.1"
     bluebird "^3.7.2"


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/80

This is not something that can really be tested, but once we merge this and server syncs up we should no longer see duplicate writes (causing issues with unique constraints or settings getting out of sync).