### PR TITLE
feat: display offchain spaces treasuries

### DIFF
--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -6,9 +6,9 @@ import {
   PROPOSAL_QUERY,
   VOTES_QUERY
 } from './queries';
-import { enabledNetworks } from '@/networks';
 import { PaginationOpts, SpacesFilter, NetworkApi } from '@/networks/types';
 import { getNames } from '@/helpers/stamp';
+import { CHAIN_IDS } from '@/helpers/constants';
 import {
   Space,
   Proposal,
@@ -23,6 +23,10 @@ import { DEFAULT_VOTING_DELAY } from '../constants';
 
 const DEFAULT_AUTHENTICATOR = 'OffchainAuthenticator';
 
+const TREASURY_NETWORKS = new Map(
+  Object.entries(CHAIN_IDS).map(([networkId, chainId]) => [chainId, networkId as NetworkID])
+);
+
 function getProposalState(proposal: ApiProposal): ProposalState {
   if (proposal.state === 'closed') {
     if (proposal.scores_total < proposal.quorum) return 'rejected';
@@ -35,11 +39,15 @@ function getProposalState(proposal: ApiProposal): ProposalState {
 }
 
 function formatSpace(space: ApiSpace, networkId: NetworkID): Space {
-  // TODO: convert ChainID to ShortName, we might need external mapping to handle
-  // all of those - or just have simple map with limited support
-  const treasuries = space.treasuries.filter(treasury =>
-    enabledNetworks.includes(treasury.network as NetworkID)
-  ) as SpaceMetadataTreasury[];
+  const treasuries = space.treasuries
+    .map(treasury => {
+      return {
+        name: treasury.name,
+        network: TREASURY_NETWORKS.get(parseInt(treasury.network, 10)),
+        address: treasury.address
+      };
+    })
+    .filter(treasury => !!treasury.network) as SpaceMetadataTreasury[];
 
   let validationName = space.validation.name;
   const validationParams = space.validation.params || {};


### PR DESCRIPTION
### Summary

This PR updates the way we process offchain spaces treasuries so they show up in the UI.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/163

**There is limitation with Alchemy API rate limit and sometimes treasuries do not fully load still.**

### How to test

1. Go to http://localhost:8080/#/s:balancer.eth
2. You can click through treasuries.

### Screenshots

<img width="1242" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/b84243db-1ee3-46ba-9477-fd1b94749852">

