### PR TITLE
feat: display total treasury % change

### DIFF
--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -180,8 +180,11 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
             <h4 class="text-skin-link" v-text="treasury.name || shorten(treasury.wallet)" />
             <div class="text-skin-text text-[17px]" v-text="shorten(treasury.wallet)" />
           </div>
-          <div class="flex-col items-end text-right">
-            <h3 v-text="`$${_n(totalQuote.toFixed())}`" />
+          <div v-if="loaded" class="flex-col items-end text-right leading-[22px]">
+            <h4
+              class="text-skin-link"
+              v-text="`$${_n(totalQuote, 'standard', { maximumFractionDigits: 2 })}`"
+            />
             <div v-if="Math.abs(totalChange) > 0.01" class="text-[17px]">
               <div
                 v-if="totalChange > 0"

--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -55,6 +55,17 @@ const totalQuote = computed(() =>
   }, 0)
 );
 
+const totalPreviousQuote = computed(() =>
+  assets.value.reduce((acc, asset) => {
+    return acc + asset.value / (1 + asset.change / 100);
+  }, 0)
+);
+
+const totalChange = computed(() => {
+  if (totalPreviousQuote.value === 0) return 0;
+  return ((totalQuote.value - totalPreviousQuote.value) / totalPreviousQuote.value) * 100;
+});
+
 const sortedAssets = computed(() =>
   (assets || []).value.sort((a, b) => {
     const isEth = (token: Token) => token.contractAddress === ETH_CONTRACT;
@@ -169,7 +180,21 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
             <h4 class="text-skin-link" v-text="treasury.name || shorten(treasury.wallet)" />
             <div class="text-skin-text text-[17px]" v-text="shorten(treasury.wallet)" />
           </div>
-          <h3 v-text="`$${_n(totalQuote.toFixed())}`" />
+          <div class="flex-col items-end text-right">
+            <h3 v-text="`$${_n(totalQuote.toFixed())}`" />
+            <div v-if="Math.abs(totalChange) > 0.01" class="text-[17px]">
+              <div
+                v-if="totalChange > 0"
+                class="text-skin-success"
+                v-text="`+${_n(totalChange, 'standard', { maximumFractionDigits: 2 })}%`"
+              />
+              <div
+                v-if="totalChange < 0"
+                class="text-skin-danger"
+                v-text="`${_n(totalChange, 'standard', { maximumFractionDigits: 2 })}%`"
+              />
+            </div>
+          </div>
         </a>
       </div>
       <div>


### PR DESCRIPTION
### Summary

This PR adds percentage change in total treasury value in 24 hours.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/167

### How to test

1. Go there: http://localhost:8080/#/sep:0xeb8ea538c90d2e009460ed69add7025560e18481/treasury
2. % change is visible (unless it's really close to 0).

### Screenshots

<img width="1245" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/c90daa31-2d79-48f9-9c14-b8b5f94e8e1a">

