### PR TITLE
fix(ux): do not save empty proposals in draft

### DIFF
--- a/apps/ui/src/composables/useEditor.ts
+++ b/apps/ui/src/composables/useEditor.ts
@@ -6,10 +6,11 @@ const proposals = reactive<Drafts>(lsGet('proposals', {}));
 
 function removeEmpty(proposals: Drafts): Drafts {
   return Object.entries(proposals).reduce((acc, [id, proposal]) => {
-    const { execution, ...rest } = omit(proposal, ['updatedAt']);
+    const { execution, type, choices, ...rest } = omit(proposal, ['updatedAt']);
     const hasFormValues = Object.values(rest).some(val => !!val);
+    const hasFormChoices = type !== 'basic' && choices.some(val => !!val);
 
-    if (execution.length === 0 && !hasFormValues) {
+    if (execution.length === 0 && !hasFormValues && !hasFormChoices) {
       return acc;
     }
 


### PR DESCRIPTION
### Summary

Fix issue where empty proposals were saved in the drafts, which was probably introduced when adding support for more voting type.

This PR add an additional check when detecting "empty" proposals, by taking into account the voting type and choices properties.

This PR also fix the current issue where it'll adda new draft instead of deleting it, when clicking on the "DELETE" icon in the drafts list

Closes: #183 

### How to test

1. Go to an offchain proposals (http://localhost:8080/#/s-tn:wan-test.eth/create/ys2ab)
2. Fill some fields / change the voting type + fill in some choices
3. It should save the draft (confirm in the draft list)
4. Empty the form
5. The draft should disappear from the drafts list

NOTE: A draft is NOT empty only when:
- some of the string input are filled
- voting type is not basic and there is at least a non-empty choice
