### PR TITLE
fear(ui): add fallback space cover from space avatar

### DIFF
--- a/apps/ui/src/components/FormProfile.vue
+++ b/apps/ui/src/components/FormProfile.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { MAX_SYMBOL_LENGTH } from '@/helpers/constants';
 import { validateForm } from '@/helpers/validation';
-import { SpaceMetadataTreasury, SpaceMetadataDelegation } from '@/types';
+import { SpaceMetadataTreasury, SpaceMetadataDelegation, NetworkID } from '@/types';
 
 const props = withDefaults(
   defineProps<{
@@ -13,6 +13,8 @@ const props = withDefaults(
     space?: {
       id: string;
       cover: string;
+      avatar: string;
+      network: NetworkID;
     };
   }>(),
   {

--- a/apps/ui/src/components/SpaceCover.vue
+++ b/apps/ui/src/components/SpaceCover.vue
@@ -29,7 +29,7 @@ const cb = computed(() =>
       'background-image': `url(${getStampUrl(
         offchainNetworks.includes(space.network) ? 'space' : 'space-sx',
         space.id,
-        { width: 500, height: 156 },
+        50,
         getCacheHash(space.avatar)
       )}`
     }"

--- a/apps/ui/src/components/SpaceCover.vue
+++ b/apps/ui/src/components/SpaceCover.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import sha3 from 'js-sha3';
+import { offchainNetworks } from '@/networks';
+import { getCacheHash, getStampUrl } from '@/helpers/utils';
+import { NetworkID } from '@/types';
 
 const props = defineProps<{
-  space: { id: string; cover: string };
+  space: { id: string; cover: string; avatar: string; network: NetworkID };
 }>();
 
 const cb = computed(() =>
@@ -11,5 +14,34 @@ const cb = computed(() =>
 </script>
 
 <template>
-  <UiStamp :id="space.id" :width="1500" :height="156" :cb="cb" type="space-cover-sx" />
+  <UiStamp
+    v-if="space.cover"
+    :id="space.id"
+    :width="1500"
+    :height="156"
+    :cb="cb"
+    type="space-cover-sx"
+  />
+  <div
+    v-else
+    class="space-fallback-cover"
+    :style="{
+      'background-image': `url(${getStampUrl(
+        offchainNetworks.includes(space.network) ? 'space' : 'space-sx',
+        space.id,
+        { width: 500, height: 156 },
+        getCacheHash(space.avatar)
+      )}`,
+      color: 'white'
+    }"
+  ></div>
 </template>
+
+<style scoped>
+.space-fallback-cover {
+  background-size: cover;
+  background-position: center;
+  filter: blur(50px) contrast(0.9) saturate(1.3);
+  transform: scale(1.5);
+}
+</style>

--- a/apps/ui/src/components/SpaceCover.vue
+++ b/apps/ui/src/components/SpaceCover.vue
@@ -38,8 +38,7 @@ const cb = computed(() =>
 
 <style lang="scss" scoped>
 .space-fallback-cover {
-  background-size: cover;
-  background-position: center;
+  object-fit: cover;
 
   &::after {
     content: '';

--- a/apps/ui/src/components/SpaceCover.vue
+++ b/apps/ui/src/components/SpaceCover.vue
@@ -37,7 +37,7 @@ const cb = computed(() =>
   ></div>
 </template>
 
-<style scoped>
+<style lang="scss" scoped>
 .space-fallback-cover {
   background-size: cover;
   background-position: center;

--- a/apps/ui/src/components/SpaceCover.vue
+++ b/apps/ui/src/components/SpaceCover.vue
@@ -31,8 +31,7 @@ const cb = computed(() =>
         space.id,
         { width: 500, height: 156 },
         getCacheHash(space.avatar)
-      )}`,
-      color: 'white'
+      )}`
     }"
   ></div>
 </template>

--- a/apps/ui/src/components/SpaceCover.vue
+++ b/apps/ui/src/components/SpaceCover.vue
@@ -41,7 +41,14 @@ const cb = computed(() =>
 .space-fallback-cover {
   background-size: cover;
   background-position: center;
-  filter: blur(50px) contrast(0.9) saturate(1.3);
-  transform: scale(1.5);
+
+  &::after {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    backdrop-filter: blur(50px) contrast(0.9) saturate(1.3);
+    pointer-events: none;
+  }
 }
 </style>

--- a/apps/ui/src/components/SpacesListItem.vue
+++ b/apps/ui/src/components/SpacesListItem.vue
@@ -12,7 +12,7 @@ const spacesStore = useSpacesStore();
     :to="{ name: 'space-overview', params: { id: `${space.network}:${space.id}` } }"
     class="text-skin-text border rounded-lg block h-[280px] relative group overflow-hidden"
   >
-    <SpaceCover :space="props.space" class="!rounded-none w-full h-[68px] object-cover absolute" />
+    <SpaceCover :space="props.space" class="!rounded-none w-full h-[68px] absolute" />
     <div class="relative inline-block mx-4 mt-[34px]">
       <UiNetworkBadge :id="space.network" class="mb-2">
         <SpaceAvatar

--- a/apps/ui/src/components/SpacesListItem.vue
+++ b/apps/ui/src/components/SpacesListItem.vue
@@ -12,12 +12,7 @@ const spacesStore = useSpacesStore();
     :to="{ name: 'space-overview', params: { id: `${space.network}:${space.id}` } }"
     class="text-skin-text border rounded-lg block h-[280px] relative group overflow-hidden"
   >
-    <SpaceCover
-      v-if="props.space.cover"
-      :space="props.space"
-      class="!rounded-none w-full h-[68px] object-cover absolute"
-    />
-    <div v-else class="!rounded-none w-full h-[68px] absolute bg-skin-border" />
+    <SpaceCover :space="props.space" class="!rounded-none w-full h-[68px] object-cover absolute" />
     <div class="relative inline-block mx-4 mt-[34px]">
       <UiNetworkBadge :id="space.network" class="mb-2">
         <SpaceAvatar

--- a/apps/ui/src/components/Ui/InputStampCover.vue
+++ b/apps/ui/src/components/Ui/InputStampCover.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { getUrl, imageUpload } from '@/helpers/utils';
+import { NetworkID } from '@/types';
 
 const model = defineModel<string | null>();
 
@@ -7,6 +8,8 @@ const props = defineProps<{
   space?: {
     id: string;
     cover: string;
+    avatar: string;
+    network: NetworkID;
   };
   error?: string;
 }>();

--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -52,11 +52,7 @@ watchEffect(() => setTitle(props.space.name));
   <div>
     <div class="relative bg-skin-border h-[156px] md:h-[140px] -mb-[86px] md:-mb-[70px] top-[-1px]">
       <div class="w-full h-full overflow-hidden">
-        <SpaceCover
-          v-if="props.space.cover"
-          :space="props.space"
-          class="!rounded-none w-full min-h-full object-cover"
-        />
+        <SpaceCover :space="props.space" class="!rounded-none w-full min-h-full object-cover" />
       </div>
       <div class="relative bg-skin-bg h-[16px] top-[-16px] rounded-t-[16px] md:hidden" />
       <div class="absolute right-4 top-4 space-x-2">

--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -52,7 +52,7 @@ watchEffect(() => setTitle(props.space.name));
   <div>
     <div class="relative bg-skin-border h-[156px] md:h-[140px] -mb-[86px] md:-mb-[70px] top-[-1px]">
       <div class="w-full h-full overflow-hidden">
-        <SpaceCover :space="props.space" class="!rounded-none w-full min-h-full object-cover" />
+        <SpaceCover :space="props.space" class="!rounded-none w-full min-h-full" />
       </div>
       <div class="relative bg-skin-bg h-[16px] top-[-16px] rounded-t-[16px] md:hidden" />
       <div class="absolute right-4 top-4 space-x-2">


### PR DESCRIPTION
### Summary

Add a space fallback cover image, generated from the space avatar (using CSS)

Closes: #184 

NOTE: not using the `scale(1.5)` as suggested in the issue, since the blur is overflowing, and using a additional div to hide the overflow is messing up the position absolute on the explore page.

### How to test

1. Go to a space without cover image
2. It should show a cover image generated from the space avatar, and looks like this

![localhost_8080_](https://github.com/snapshot-labs/sx-monorepo/assets/495709/e194095a-893b-4fc4-ab05-1e15a44b38b3)

The explore page should look like this

![Screenshot 2024-03-22 at 00 17 37](https://github.com/snapshot-labs/sx-monorepo/assets/495709/87086793-12a3-498a-b43e-bb6655e67270)
