### PR TITLE
fix: center align results bar on proposal list

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -70,7 +70,7 @@ const results = computed(() =>
       </a>
     </div>
   </div>
-  <div v-else>
+  <template v-else>
     <div v-if="proposal.type !== 'basic'" class="flex flex-col gap-2">
       <div
         v-for="(choice, id) in proposal.choices"
@@ -94,7 +94,7 @@ const results = computed(() =>
     <div
       v-else
       :class="{
-        'flex items-center': !withDetails
+        'h-full flex items-center': !withDetails
       }"
     >
       <div v-if="withDetails" class="text-skin-link mb-3">
@@ -169,5 +169,5 @@ const results = computed(() =>
         </a>
       </div>
     </div>
-  </div>
+  </template>
 </template>


### PR DESCRIPTION
### Summary

After https://github.com/snapshot-labs/sx-monorepo/pull/166 there is an issue with displaying results bar:

Before:
<img width="1376" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/7e2f8201-69c8-4a47-9e8a-df3ee2be5fe1">


After:
<img width="1375" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/46230c3c-8d06-4650-9145-68069e78aeb9">

### How to test

1. Vote on this space: https://testnet.snapshotx.xyz/#/sep:0xeb8ea538c90d2e009460ed69add7025560e18481
2. Results bar is properly aligned.
3. UI there wasn't impacted:
  - [before](https://snapshotx.xyz/#/s:test.wa0x6e.eth/proposal/0x9623af39201332732f38227e75deced57fa4cc53f6bbb5380d0bdce40172d0e0) - [after](http://localhost:8080/#/s:test.wa0x6e.eth/proposal/0x9623af39201332732f38227e75deced57fa4cc53f6bbb5380d0bdce40172d0e0)
  - [before](https://snapshotx.xyz/#/s:test.wa0x6e.eth/proposal/0x5ddbe81f1870a5154bd7b120bdc2c1755315157e7b230d38c74544ddd1ac62ef) - [after](http://localhost:8080/#/s:test.wa0x6e.eth/proposal/0x5ddbe81f1870a5154bd7b120bdc2c1755315157e7b230d38c74544ddd1ac62ef)

