### PR TITLE
feat: only load votes per-space

### DIFF
--- a/apps/ui/src/App.vue
+++ b/apps/ui/src/App.vue
@@ -6,8 +6,7 @@ const router = useRouter();
 const uiStore = useUiStore();
 const { modalOpen } = useModal();
 const { init, app } = useApp();
-const { web3, web3Account } = useWeb3();
-const { loadVotes, votes } = useAccount();
+const { web3 } = useWeb3();
 const { isSwiping, direction } = useSwipe(el);
 const { createDraft } = useEditor();
 const { spaceKey, network, executionStrategy, transaction, reset } = useWalletConnectTransaction();
@@ -40,11 +39,6 @@ onMounted(async () => {
 watch(scrollDisabled, val => {
   const el = document.body;
   el.classList[val ? 'add' : 'remove']('overflow-hidden');
-});
-
-watch(web3Account, async () => {
-  if (web3Account.value) return await loadVotes();
-  votes.value = {};
 });
 
 watch(route, () => {

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -272,7 +272,7 @@ export function createApi(uri: string, networkId: NetworkID, opts: ApiOptions = 
         query: USER_VOTES_QUERY,
         variables: {
           spaceId,
-          voter: voter.toLowerCase()
+          voter
         }
       });
 

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -267,10 +267,11 @@ export function createApi(uri: string, networkId: NetworkID, opts: ApiOptions = 
         return vote;
       });
     },
-    loadUserVotes: async (voter: string): Promise<{ [key: string]: Vote }> => {
+    loadUserVotes: async (spaceId: string, voter: string): Promise<{ [key: string]: Vote }> => {
       const { data } = await apollo.query({
         query: USER_VOTES_QUERY,
         variables: {
+          spaceId,
           voter: voter.toLowerCase()
         }
       });

--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -183,8 +183,8 @@ export const VOTES_QUERY = gql`
 `;
 
 export const USER_VOTES_QUERY = gql`
-  query ($voter: String) {
-    votes(where: { voter: $voter }) {
+  query ($spaceId: String, $voter: String) {
+    votes(where: { space: $spaceId, voter: $voter }) {
       id
       voter {
         id

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -4,6 +4,7 @@ import {
   SPACE_QUERY,
   PROPOSALS_QUERY,
   PROPOSAL_QUERY,
+  USER_VOTES_QUERY,
   VOTES_QUERY
 } from './queries';
 import { PaginationOpts, SpacesFilter, NetworkApi } from '@/networks/types';
@@ -247,8 +248,18 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
         return formattedVote;
       });
     },
-    loadUserVotes: async (): Promise<{ [key: string]: Vote }> => {
-      return {};
+    loadUserVotes: async (spaceId: string, voter: string): Promise<{ [key: string]: Vote }> => {
+      const { data } = await apollo.query({
+        query: USER_VOTES_QUERY,
+        variables: {
+          spaceId,
+          voter
+        }
+      });
+
+      return Object.fromEntries(
+        data.votes.map(vote => [`${networkId}:${vote.proposal.id}`, formatVote(vote)])
+      );
     },
     loadProposals: async (
       spaceId: string,

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -119,6 +119,24 @@ export const SPACE_QUERY = gql`
   ${SPACE_FRAGMENT}
 `;
 
+export const USER_VOTES_QUERY = gql`
+  query ($spaceId: String, $voter: String) {
+    votes(where: { space: $spaceId, voter: $voter }) {
+      id
+      voter
+      space {
+        id
+      }
+      proposal {
+        id
+      }
+      choice
+      vp
+      created
+    }
+  }
+`;
+
 export const VOTES_QUERY = gql`
   query (
     $first: Int!

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -181,7 +181,7 @@ export type NetworkApi = {
     filter?: 'any' | 'for' | 'against' | 'abstain',
     sortBy?: 'vp-desc' | 'vp-asc' | 'created-desc' | 'created-asc'
   ): Promise<Vote[]>;
-  loadUserVotes(voter: string): Promise<{ [key: string]: Vote }>;
+  loadUserVotes(spaceId: string, voter: string): Promise<{ [key: string]: Vote }>;
   loadProposals(
     spaceId: string,
     paginationOpts: PaginationOpts,

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -11,6 +11,7 @@ const { resolved, address: spaceAddress, networkId } = useResolve(param);
 const { setTitle } = useTitle();
 const proposalsStore = useProposalsStore();
 const { web3 } = useWeb3();
+const { loadVotes } = useAccount();
 const { vote } = useActions();
 
 const sendingType = ref<Choice | null>(null);
@@ -88,6 +89,12 @@ watch(
   },
   { immediate: true }
 );
+
+watchEffect(() => {
+  if (!resolved.value || !networkId.value || !spaceAddress.value) return;
+
+  loadVotes(networkId.value, spaceAddress.value);
+});
 
 watchEffect(() => {
   if (!proposal.value) return;

--- a/apps/ui/src/views/Space.vue
+++ b/apps/ui/src/views/Space.vue
@@ -7,6 +7,7 @@ const { param } = useRouteParser('id');
 const { resolved, address, networkId } = useResolve(param);
 const uiStore = useUiStore();
 const spacesStore = useSpacesStore();
+const { loadVotes } = useAccount();
 
 const space = computed(() => {
   if (!resolved.value) return null;
@@ -25,6 +26,12 @@ watch(
     immediate: true
   }
 );
+
+watchEffect(() => {
+  if (!resolved.value || !networkId.value || !address.value) return;
+
+  loadVotes(networkId.value, address.value);
+});
 
 watchEffect(() => {
   if (!space.value) return setFavicon(null);


### PR DESCRIPTION
### Summary

Before all user votes were loaded for all enabled spaces. Now only single space votes will be loaded as needed.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/162
Depends on: https://github.com/snapshot-labs/sx-monorepo/pull/204

### How to test

1. If you need to test EVM you need to run `yarn dev:full` as we need to format addresses on API.
1. Go to app, check networks - no votes are loaded unless on space/proposal page.
2. Go to proposal you voted on - you don't see button to vote.
3. Disconnect from Web3 wallet - buttons to vote show up again.
