### PR TITLE
feat: populate contacts from space treasuries

### DIFF
--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -2,7 +2,7 @@
 import Draggable from 'vuedraggable';
 import { getNetwork } from '@/networks';
 import { simulate } from '@/helpers/tenderly';
-import { Transaction as TransactionType, Space, SpaceMetadataTreasury } from '@/types';
+import { Transaction as TransactionType, Space, SpaceMetadataTreasury, Contact } from '@/types';
 
 const model = defineModel<TransactionType[]>({
   required: true
@@ -11,6 +11,7 @@ const model = defineModel<TransactionType[]>({
 const props = defineProps<{
   space: Space;
   treasuryData: SpaceMetadataTreasury;
+  extraContacts?: Contact[];
 }>();
 
 const uiStore = useUiStore();
@@ -160,6 +161,7 @@ watch(model.value, () => {
         :address="treasury.wallet"
         :network="treasury.network"
         :network-id="treasury.networkId"
+        :extra-contacts="extraContacts"
         :initial-state="modalState.sendToken"
         @close="modalOpen.sendToken = false"
         @add="addTx"
@@ -169,6 +171,7 @@ watch(model.value, () => {
         :open="modalOpen.sendNft"
         :address="treasury.wallet"
         :network="treasury.network"
+        :extra-contacts="extraContacts"
         :initial-state="modalState.sendNft"
         @close="modalOpen.sendNft = false"
         @add="addTx"
@@ -177,6 +180,7 @@ watch(model.value, () => {
         v-if="treasury"
         :open="modalOpen.contractCall"
         :network="treasury.network"
+        :extra-contacts="extraContacts"
         :initial-state="modalState.contractCall"
         @close="modalOpen.contractCall = false"
         @add="addTx"

--- a/apps/ui/src/components/Modal/SendNft.vue
+++ b/apps/ui/src/components/Modal/SendNft.vue
@@ -2,6 +2,7 @@
 import { createSendNftTransaction } from '@/helpers/transactions';
 import { clone } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
+import { Contact } from '@/types';
 
 const DEFAULT_FORM_STATE = {
   to: '',
@@ -20,6 +21,7 @@ const props = defineProps<{
   open: boolean;
   address: string;
   network: number;
+  extraContacts?: Contact[];
   initialState?: any;
 }>();
 
@@ -151,6 +153,7 @@ watchEffect(async () => {
         v-else-if="pickerType === 'contact'"
         :loading="false"
         :search-value="searchValue"
+        :extra-contacts="extraContacts"
         @pick="
           form.to = $event;
           showPicker = false;

--- a/apps/ui/src/components/Modal/SendToken.vue
+++ b/apps/ui/src/components/Modal/SendToken.vue
@@ -6,7 +6,7 @@ import { ETH_CONTRACT } from '@/helpers/constants';
 import { clone } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
 import { Token } from '@/helpers/alchemy';
-import { Transaction } from '@/types';
+import { Contact, Transaction } from '@/types';
 
 const DEFAULT_FORM_STATE = {
   to: '',
@@ -38,6 +38,7 @@ const props = defineProps<{
   address: string;
   network: number;
   networkId: string;
+  extraContacts?: Contact[];
   initialState?: any;
 }>();
 
@@ -233,6 +234,7 @@ watchEffect(async () => {
         v-else-if="pickerType === 'contact'"
         :loading="false"
         :search-value="searchValue"
+        :extra-contacts="extraContacts"
         @pick="
           form.to = $event;
           showPicker = false;

--- a/apps/ui/src/components/Modal/Transaction.vue
+++ b/apps/ui/src/components/Modal/Transaction.vue
@@ -7,6 +7,7 @@ import { abiToDefinition, clone } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
 import { getProvider } from '@/helpers/provider';
 import { resolver } from '@/helpers/resolver';
+import { Contact } from '@/types';
 
 const DEFAULT_FORM_STATE = {
   to: '',
@@ -19,6 +20,7 @@ const DEFAULT_FORM_STATE = {
 const props = defineProps<{
   open: boolean;
   network: number;
+  extraContacts?: Contact[];
   initialState?: any;
 }>();
 
@@ -269,7 +271,12 @@ watchEffect(async () => {
       </template>
     </template>
     <template v-if="showPicker">
-      <PickerContact :loading="false" :search-value="searchValue" @pick="handlePickerSelect" />
+      <PickerContact
+        :loading="false"
+        :search-value="searchValue"
+        :extra-contacts="extraContacts"
+        @pick="handlePickerSelect"
+      />
     </template>
     <div
       v-show="

--- a/apps/ui/src/components/PickerContact.vue
+++ b/apps/ui/src/components/PickerContact.vue
@@ -1,10 +1,17 @@
 <script setup lang="ts">
 import { shorten, shortenAddress } from '@/helpers/utils';
+import { Contact } from '@/types';
 
-const props = defineProps<{
-  searchValue: string;
-  loading: boolean;
-}>();
+const props = withDefaults(
+  defineProps<{
+    searchValue: string;
+    loading: boolean;
+    extraContacts?: Contact[];
+  }>(),
+  {
+    extraContacts: () => []
+  }
+);
 
 const emit = defineEmits<{
   (e: 'pick', value: string);
@@ -24,7 +31,8 @@ const allContacts = computed(() => {
       name: 'You',
       address: account
     },
-    ...contactsStore.contacts
+    ...contactsStore.contacts,
+    ...props.extraContacts
   ];
 });
 

--- a/apps/ui/src/components/PickerContact.vue
+++ b/apps/ui/src/components/PickerContact.vue
@@ -21,9 +21,11 @@ const { account } = useAccount();
 const contactsStore = useContactsStore();
 
 const allContacts = computed(() => {
-  if (!account) return contactsStore.contacts;
+  const contactsList = [...contactsStore.contacts, ...props.extraContacts];
+
+  if (!account) return contactsList;
   if (contactsStore.contacts.find(contact => contact.address === account)) {
-    return contactsStore.contacts;
+    return contactsList;
   }
 
   return [
@@ -31,8 +33,7 @@ const allContacts = computed(() => {
       name: 'You',
       address: account
     },
-    ...contactsStore.contacts,
-    ...props.extraContacts
+    ...contactsList
   ];
 });
 

--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -2,10 +2,14 @@
 import { _n, _c, shorten, sanitizeUrl, compareAddresses } from '@/helpers/utils';
 import { getNetwork, evmNetworks } from '@/networks';
 import { ETH_CONTRACT } from '@/helpers/constants';
-import { Space, SpaceMetadataTreasury, Transaction } from '@/types';
+import { Contact, Space, SpaceMetadataTreasury, Transaction } from '@/types';
 import type { Token } from '@/helpers/alchemy';
 
-const props = defineProps<{ space: Space; treasuryData: SpaceMetadataTreasury }>();
+const props = defineProps<{
+  space: Space;
+  treasuryData: SpaceMetadataTreasury;
+  extraContacts?: Contact[];
+}>();
 
 const { setTitle } = useTitle();
 const router = useRouter();
@@ -313,6 +317,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
         :address="treasury.wallet"
         :network="treasury.network"
         :network-id="treasury.networkId"
+        :extra-contacts="extraContacts"
         @close="modalOpen.tokens = false"
         @add="addTx"
       />
@@ -320,6 +325,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
         :open="modalOpen.nfts"
         :address="treasury.wallet"
         :network="treasury.network"
+        :extra-contacts="extraContacts"
         @close="modalOpen.nfts = false"
         @add="addTx"
       />

--- a/apps/ui/src/helpers/stamp.ts
+++ b/apps/ui/src/helpers/stamp.ts
@@ -32,10 +32,7 @@ export async function getNames(addresses: string[]): Promise<Record<string, stri
     }
 
     const entries: any = Object.entries(inputMapping)
-      .map(([address, formatted]) => [
-        address,
-        resolvedAddresses.get(formatted) || null
-      ])
+      .map(([address, formatted]) => [address, resolvedAddresses.get(formatted) || null])
       .filter(([, name]) => name);
 
     return Object.fromEntries(entries);

--- a/apps/ui/src/views/Editor.vue
+++ b/apps/ui/src/views/Editor.vue
@@ -3,7 +3,7 @@ import { getNetwork, supportsNullCurrent } from '@/networks';
 import { compareAddresses, omit } from '@/helpers/utils';
 import { CHAIN_IDS } from '@/helpers/constants';
 import { validateForm } from '@/helpers/validation';
-import { RequiredProperty, SelectedStrategy, SpaceMetadataTreasury } from '@/types';
+import { Contact, RequiredProperty, SelectedStrategy, SpaceMetadataTreasury } from '@/types';
 
 type StrategyWithTreasury = SelectedStrategy & {
   treasury: RequiredProperty<SpaceMetadataTreasury>;
@@ -127,6 +127,11 @@ const selectedExecutionWithTreasury = computed(() => {
   return supportedExecutionStrategies.value.find(
     strategy => strategy.address === executionStrategy.value?.address
   );
+});
+const extraContacts = computed(() => {
+  if (!space.value) return [];
+
+  return space.value.treasuries as Contact[];
 });
 const votingTypes = computed(() => {
   const networkValue = network.value;
@@ -410,6 +415,7 @@ export default defineComponent({
           v-model="proposal.execution"
           :space="space"
           :treasury-data="selectedExecutionWithTreasury.treasury"
+          :extra-contacts="extraContacts"
           class="mb-4"
         />
       </div>

--- a/apps/ui/src/views/Space/Treasury.vue
+++ b/apps/ui/src/views/Space/Treasury.vue
@@ -30,5 +30,10 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
       />
     </a>
   </div>
-  <SpaceTreasury :key="activeTreasuryId" :space="space" :treasury-data="treasuryData" />
+  <SpaceTreasury
+    :key="activeTreasuryId"
+    :space="space"
+    :treasury-data="treasuryData"
+    :extra-contacts="filteredTreasuries"
+  />
 </template>


### PR DESCRIPTION
### Summary

This PR adds space treasuries in address pickers when creating execution

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/164

### How to test

1. Go to treasury: http://localhost:8080/#/sep:0x8b08aa6cdaf0bc92bb9cc6844459b2fed94249af/treasury
2. Start Send token or Send NFT modal.
3. Pick address, treasuries are listed.
4. Go to editor http://localhost:8080/#/sep:0x8b08aa6cdaf0bc92bb9cc6844459b2fed94249af/create
5. Pick execution strategy, open Send token, Send NFT, Send transaction modal.
6. Pick address, treasuries are listed.

### Screenshots

<img width="532" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/3efdd353-f30b-47bf-94bf-5c7f05a54be2">
<img width="589" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/807a0500-e0d7-4398-8a9b-08b11f1e93ef">
