### PR TITLE
feat: support Starknet delegation from UI

### DIFF
--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -18,8 +18,10 @@ const { loading, loadingMore, loaded, failed, hasMore, delegates, fetch, fetchMo
   useDelegates(props.delegation.apiUrl as string);
 
 const currentNetwork = computed(() => {
+  if (!props.delegation.contractNetwork) return null;
+
   try {
-    return getNetwork(props.space.network);
+    return getNetwork(props.delegation.contractNetwork);
   } catch (e) {
     return null;
   }

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -16,7 +16,7 @@ import {
   createStrategyPicker
 } from '@/networks/common/helpers';
 import { EVM_CONNECTORS, STARKNET_CONNECTORS } from '@/networks/common/constants';
-import type { RpcProvider } from 'starknet';
+import { CallData, type Account, type RpcProvider } from 'starknet';
 import type { MetaTransaction } from '@snapshot-labs/sx/dist/utils/encoding/execution-hash';
 import type {
   Connector,
@@ -437,8 +437,24 @@ export function createActions(
         }
       });
     },
-    delegate: () => {
-      throw new Error('Not implemented');
+    delegate: async (
+      web3: any,
+      space: Space,
+      networkId: NetworkID,
+      delegatee: string,
+      delegationContract: string
+    ) => {
+      const [, contractAddress] = delegationContract.split(':');
+
+      const { account }: { account: Account } = web3.provider;
+
+      return account.execute({
+        contractAddress,
+        entrypoint: 'delegate',
+        calldata: CallData.compile({
+          delegatee
+        })
+      });
     },
     getVotingPower: async (
       spaceId: string,


### PR DESCRIPTION
### Summary

You can now delegate Starknet tokens from UI.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/153

### How to test

1. Go to space with Starknet delegation: http://localhost:8080/#/sep:0x8b08aa6cdaf0bc92bb9cc6844459b2fed94249af/delegates
2. OR set up your own (contract network Starknet, address `0x0782f0ddca11d9950bc3220e35ac82cf868778edb67a5e58b39838544bc4cd0f`, API URL: https://starknet-delegates.checkpoint.fyi/)
3. Get vSTRK (check linked issue for instructions).
4. Try delegating.

