### PR TITLE
fix: fix ENS domain resolver cache being overwritten

### DIFF
--- a/apps/ui/src/helpers/stamp.ts
+++ b/apps/ui/src/helpers/stamp.ts
@@ -26,7 +26,7 @@ export async function getNames(addresses: string[]): Promise<Record<string, stri
       });
       data = (await res.json()).result;
 
-      Object.values(inputMapping).forEach((formatted: string) => {
+      unresolvedAddresses.forEach((formatted: string) => {
         resolvedAddresses.set(formatted, data[formatted]);
       });
     }


### PR DESCRIPTION
### Summary

Fix issue where ENS domain cache is being overwritten, and always return undefined for previously resolved domains

Closes: #197


### How to test

1. Go to http://localhost:8080/#/s:aave.eth
2. The ENS domain should resolve for one of the proposals' author
3. Navigate to the space's proposals page from the sidebar
4. The same proposal's author with its ENS domain being resolved should also resolve on this page (previously, it only show address instead of resolving)
