### PR TITLE
refactor: format addresses with checksum

### DIFF
--- a/apps/subgraph-api/.gitignore
+++ b/apps/subgraph-api/.gitignore
@@ -12,3 +12,5 @@ coverage
 
 # TheGraph
 generated
+tests/.bin
+tests/.latest.json

--- a/apps/subgraph-api/package.json
+++ b/apps/subgraph-api/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.23",
   "scripts": {
+    "test": "graph test",
     "codegen": "graph codegen",
     "build": "graph build",
     "dev": "yarn deploy-local",
@@ -23,5 +24,8 @@
     "@graphprotocol/graph-cli": "0.68.0",
     "@graphprotocol/graph-ts": "0.33.0",
     "assemblyscript-json": "^1.1.0"
+  },
+  "devDependencies": {
+    "matchstick-as": "^0.6.0"
   }
 }

--- a/apps/subgraph-api/src/helpers.ts
+++ b/apps/subgraph-api/src/helpers.ts
@@ -86,9 +86,8 @@ export function updateProposalValidationStrategy(
       space.voting_power_validation_strategy_strategies = getProposalValidationStrategies(
         params
       ).map<Bytes>((strategy) => strategy)
-      space.voting_power_validation_strategy_strategies_params = getProposalValidationStrategiesParams(
-        params
-      ).map<string>((params) => params.toHexString())
+      space.voting_power_validation_strategy_strategies_params =
+        getProposalValidationStrategiesParams(params).map<string>((params) => params.toHexString())
     } else {
       space.proposal_threshold = new BigDecimal(new BigInt(0))
       space.voting_power_validation_strategy_strategies = []

--- a/apps/subgraph-api/src/helpers.ts
+++ b/apps/subgraph-api/src/helpers.ts
@@ -5,6 +5,8 @@ import {
   Address,
   DataSourceContext,
   BigDecimal,
+  crypto,
+  ByteArray,
 } from '@graphprotocol/graph-ts'
 import {
   StrategiesParsedMetadataData as StrategiesParsedMetadataDataTemplate,
@@ -21,6 +23,22 @@ const VOTING_POWER_VALIDATION_STRATEGY = Address.fromString(
   '0x6D9d6D08EF6b26348Bd18F1FC8D953696b7cf311'
 )
 const VOTING_POWER_VALIDATION_STRATEGY_PARAMS_SIGNATURE = '(uint256, (address,bytes)[])'
+
+export function toChecksumAddress(address: string): string {
+  const rawAddress = address.toLowerCase().replace('0x', '')
+  const hash = crypto.keccak256(ByteArray.fromUTF8(rawAddress)).toHexString().replace('0x', '')
+
+  let ret = '0x'
+  for (let i = 0; i < rawAddress.length; i++) {
+    if (parseInt(hash.charAt(i), 16) >= 8) {
+      ret += rawAddress.charAt(i).toUpperCase()
+    } else {
+      ret += rawAddress.charAt(i)
+    }
+  }
+
+  return ret
+}
 
 export function decodeProposalValidationParams(params: Bytes): ethereum.Value | null {
   let paramsBytes = Bytes.fromByteArray(

--- a/apps/subgraph-api/tests/helpers.test.ts
+++ b/apps/subgraph-api/tests/helpers.test.ts
@@ -1,0 +1,46 @@
+import { assert, describe, test } from 'matchstick-as'
+import { toChecksumAddress } from '../src/helpers'
+import { log } from '@graphprotocol/graph-ts'
+
+describe('toChecksumAddress', () => {
+  test('converts all upper addresses to checksum addresses', () => {
+    assert.stringEquals(
+      toChecksumAddress('0x52908400098527886e0f7030069857d2e4169ee7'),
+      '0x52908400098527886E0F7030069857D2E4169EE7'
+    )
+    assert.stringEquals(
+      toChecksumAddress('0x8617e340b3d01fa5f11f306f4090fd50e238070d'),
+      '0x8617E340B3D01FA5F11F306F4090FD50E238070D'
+    )
+  })
+
+  test('converts all lower addresses to checksum addresses', () => {
+    assert.stringEquals(
+      toChecksumAddress('0xde709f2102306220921060314715629080e2fb77'),
+      '0xde709f2102306220921060314715629080e2fb77'
+    )
+    assert.stringEquals(
+      toChecksumAddress('0x27b1fdb04752bbc536007a920d24acb045561c26'),
+      '0x27b1fdb04752bbc536007a920d24acb045561c26'
+    )
+  })
+
+  test('converts regular addresses to checksum addresses', () => {
+    assert.stringEquals(
+      toChecksumAddress('0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed'),
+      '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'
+    )
+    assert.stringEquals(
+      toChecksumAddress('0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359'),
+      '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359'
+    )
+    assert.stringEquals(
+      toChecksumAddress('0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb'),
+      '0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB'
+    )
+    assert.stringEquals(
+      toChecksumAddress('0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb'),
+      '0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb'
+    )
+  })
+})

--- a/package.json
+++ b/package.json
@@ -22,8 +22,14 @@
     "node": ">=18.x"
   },
   "packageManager": "yarn@1.22.19",
-  "workspaces": [
-    "apps/*",
-    "packages/*"
-  ]
+  "workspaces": {
+    "packages": [
+      "apps/*",
+      "packages/*"
+    ],
+    "nohoist": [
+      "**/@graphprotocol/graph-ts",
+      "**/assemblyscript"
+    ]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9286,6 +9286,13 @@ matcher@^3.0.0:
   dependencies:
     escape-string-regexp "^4.0.0"
 
+matchstick-as@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/matchstick-as/-/matchstick-as-0.6.0.tgz#c65296b1f51b1014d605c52067d9b5321ea630e8"
+  integrity sha512-E36fWsC1AbCkBFt05VsDDRoFvGSdcZg6oZJrtIe/YDBbuFh8SKbR5FcoqDhNWqSN+F7bN/iS2u8Md0SM+4pUpw==
+  dependencies:
+    wabt "1.0.24"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -13211,6 +13218,11 @@ w3c-xmlserializer@^4.0.0:
   integrity sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==
   dependencies:
     xml-name-validator "^4.0.0"
+
+wabt@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/wabt/-/wabt-1.0.24.tgz#c02e0b5b4503b94feaf4a30a426ef01c1bea7c6c"
+  integrity sha512-8l7sIOd3i5GWfTWciPL0+ff/FK/deVK2Q6FN+MPz4vfUcD78i2M/49XJTwF6aml91uIiuXJEsLKWMB2cw/mtKg==
 
 wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### Summary

Depends on https://github.com/snapshot-labs/sx-monorepo/pull/203

This PR changes how we store addresses at API to always use checksummed addresses which matches SX/hub.
Subgraph queries are case sensitive so we should use common format everywhere.

### How to test

1. Run `yarn dev:full` (you might be getting rate limited).
2. Go to sepolia space you already voted on.
3. It shows you already voted.
