### PR TITLE
fix: format web3 account address

### DIFF
--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -57,7 +57,7 @@ export function useWeb3() {
         });
         auth.provider.value.on('accountsChanged', async accounts => {
           if (accounts.length !== 0) {
-            state.account = formatAddress(state.account);
+            state.account = formatAddress(accounts[0]);
             await login();
           }
         });

--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -2,6 +2,7 @@ import { Web3Provider } from '@ethersproject/providers';
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
 import { formatUnits } from '@ethersproject/units';
 import { getNames } from '@/helpers/stamp';
+import { formatAddress } from '@/helpers/utils';
 import networks from '@/helpers/networks.json';
 
 networks['starknet'] = {
@@ -56,7 +57,7 @@ export function useWeb3() {
         });
         auth.provider.value.on('accountsChanged', async accounts => {
           if (accounts.length !== 0) {
-            state.account = accounts[0];
+            state.account = formatAddress(state.account);
             await login();
           }
         });
@@ -83,7 +84,7 @@ export function useWeb3() {
       handleChainChanged(network.chainId);
       const acc = accounts.length > 0 ? accounts[0] : null;
       const names = await getNames([acc]);
-      state.account = acc;
+      state.account = formatAddress(acc);
       state.name = names[acc];
       state.type = connector;
 


### PR DESCRIPTION
### Summary

Currently it's not formatted. If it ends up with odd number of digits it will fail to fetch spaces from subgraph.

Long term we probably shouldn't try to fetch EVM spaces with Starknet accounts, but for now let's keep addresess consistent while fixing the issue.

### How to test

1. Sign in with Starknet account.
2. Go to http://localhost:8080/#/settings
3. Spaces you controll will be displayed.
