### PR TITLE
feat: show info message if Herodotus voting power is not available yet on a proposal

### DIFF
--- a/.changeset/calm-pens-leave.md
+++ b/.changeset/calm-pens-leave.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+migrate to new herodotus indexer

--- a/.changeset/sixty-otters-judge.md
+++ b/.changeset/sixty-otters-judge.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+throw VotingPowerDetailsError in herodotus strategies with NOT_READY_YET memo

--- a/apps/api/src/overrrides.ts
+++ b/apps/api/src/overrrides.ts
@@ -5,6 +5,8 @@ export const networkNodeUrl =
   process.env.NETWORK_NODE_URL ||
   'https://starknet-goerli.infura.io/v3/46a5dd9727bf48d4a132672d3f376146';
 
+export const manaRpcUrl = process.env.VITE_MANA_URL || 'https://mana.pizza';
+
 const createConfig = (
   networkId: keyof typeof starknetNetworks,
   { startBlock }: { startBlock: number }
@@ -12,7 +14,7 @@ const createConfig = (
   const config = starknetNetworks[networkId];
 
   return {
-    manaRpcUrl: `https://mana.pizza/stark_rpc/${config.Meta.eip712ChainId}`,
+    manaRpcUrl: `${manaRpcUrl}/stark_rpc/${config.Meta.eip712ChainId}`,
     factoryAddress: config.Meta.spaceFactory,
     propositionPowerValidationStrategyAddress: config.ProposalValidations.VotingPower,
     herodotusStrategies: [

--- a/apps/mana/src/stark/herodotus.ts
+++ b/apps/mana/src/stark/herodotus.ts
@@ -176,7 +176,7 @@ export async function processProposal(proposal: DbProposal) {
   const { DESTINATION_CHAIN_ID, ACCUMULATES_CHAIN_ID } = mapping;
 
   const res = await fetch(
-    `https://ds-indexer.api.herodotus.cloud/binsearch-path?timestamp=${proposal.timestamp}&deployed_on_chain=${DESTINATION_CHAIN_ID}&accumulates_chain=${ACCUMULATES_CHAIN_ID}`,
+    `https://rs-indexer.api.herodotus.cloud/remappers/binsearch-path?timestamp=${proposal.timestamp}&deployed_on_chain=${DESTINATION_CHAIN_ID}&accumulates_chain=${ACCUMULATES_CHAIN_ID}`,
     {
       headers: {
         accept: 'application/json'

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -173,16 +173,15 @@ watchEffect(() => {
             class="mb-2 flex items-center"
             @get-voting-power="getVotingPower"
           >
-            <UiAlert
+            <div
               v-if="
                 votingPowerDetailsError?.details === 'NOT_READY_YET' &&
                 ['evmSlotValue', 'ozVotesStorageProof'].includes(votingPowerDetailsError.source)
               "
               class="mt-2"
-              type="warning"
             >
               Please allow few minutes for the voting power to be collected from Ethereum.
-            </UiAlert>
+            </div>
             <template v-else>
               <span class="mr-1.5">Voting power:</span>
               <a @click="props.onClick">

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -180,6 +180,9 @@ watchEffect(() => {
               "
               class="mt-2"
             >
+              <span class="inline-flex align-top h-[27px] items-center">
+                <IH-exclamation-circle class="mr-1" />
+              </span>
               Please allow few minutes for the voting power to be collected from Ethereum.
             </div>
             <template v-else>

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { utils } from '@snapshot-labs/sx';
 import { getNetwork, offchainNetworks } from '@/networks';
 import { getStampUrl, getCacheHash, sanitizeUrl } from '@/helpers/utils';
 import { Choice } from '@/types';
@@ -17,6 +18,7 @@ const { vote } = useActions();
 const sendingType = ref<Choice | null>(null);
 const votingPowers = ref([] as VotingPower[]);
 const votingPowerStatus = ref<VotingPowerStatus>('loading');
+const votingPowerDetailsError = ref<utils.errors.VotingPowerDetailsError | null>(null);
 
 const network = computed(() => (networkId.value ? getNetwork(networkId.value) : null));
 const id = computed(() => route.params.id as string);
@@ -43,6 +45,8 @@ const votingPowerDecimals = computed(() => {
 async function getVotingPower() {
   if (!network.value) return;
 
+  votingPowerDetailsError.value = null;
+
   if (!web3.value.account || !proposal.value) {
     votingPowers.value = [];
     votingPowerStatus.value = 'success';
@@ -60,8 +64,13 @@ async function getVotingPower() {
       { at: proposal.value.snapshot, chainId: proposal.value.space.snapshot_chain_id }
     );
     votingPowerStatus.value = 'success';
-  } catch (e) {
-    console.warn('Failed to load voting power', e);
+  } catch (e: unknown) {
+    if (e instanceof utils.errors.VotingPowerDetailsError) {
+      votingPowerDetailsError.value = e;
+    } else {
+      console.warn('Failed to load voting power', e);
+    }
+
     votingPowers.value = [];
     votingPowerStatus.value = 'error';
   }
@@ -164,15 +173,27 @@ watchEffect(() => {
             class="mb-2 flex items-center"
             @get-voting-power="getVotingPower"
           >
-            <span class="mr-1.5">Voting power:</span>
-            <a @click="props.onClick">
-              <UiLoading v-if="votingPowerStatus === 'loading'" />
-              <IH-exclamation
-                v-else-if="votingPowerStatus === 'error'"
-                class="inline-block text-rose-500"
-              />
-              <span v-else class="text-skin-link" v-text="props.formattedVotingPower" />
-            </a>
+            <UiAlert
+              v-if="
+                votingPowerDetailsError?.details === 'NOT_READY_YET' &&
+                ['evmSlotValue', 'ozVotesStorageProof'].includes(votingPowerDetailsError.source)
+              "
+              class="mt-2"
+              type="warning"
+            >
+              Please allow few minutes for the voting power to be collected from Ethereum.
+            </UiAlert>
+            <template v-else>
+              <span class="mr-1.5">Voting power:</span>
+              <a @click="props.onClick">
+                <UiLoading v-if="votingPowerStatus === 'loading'" />
+                <IH-exclamation
+                  v-else-if="votingPowerStatus === 'error'"
+                  class="inline-block text-rose-500"
+                />
+                <span v-else class="text-skin-link" v-text="props.formattedVotingPower" />
+              </a>
+            </template>
           </IndicatorVotingPower>
           <ProposalVote v-if="proposal" :proposal="proposal">
             <ProposalVoteBasic

--- a/packages/sx.js/src/clients/starknet/herodotus/index.ts
+++ b/packages/sx.js/src/clients/starknet/herodotus/index.ts
@@ -31,14 +31,14 @@ export class HerodotusController {
       calldata: CallData.compile({
         timestamp,
         tree: {
-          mapped_id: binaryTree.remapper.onchainRemapperId,
+          mapped_id: binaryTree.remapper.onchain_remapper_id,
           last_pos: 3,
-          peaks: binaryTree.proofs[0].peaksHashes,
+          peaks: binaryTree.proofs[0].peaks_hashes,
           proofs: binaryTree.proofs.map((proof: any) => {
             return {
-              index: proof.elementIndex,
-              value: cairo.uint256(proof.elementHash),
-              proof: proof.siblingsHashes
+              index: proof.element_index,
+              value: cairo.uint256(proof.element_hash),
+              proof: proof.siblings_hashes
             };
           }),
           left_neighbor: new CairoOption<ProofElement>(CairoOptionVariant.None)

--- a/packages/sx.js/src/strategies/starknet/evmSlotValue.ts
+++ b/packages/sx.js/src/strategies/starknet/evmSlotValue.ts
@@ -73,7 +73,7 @@ export default function createEvmSlotValueStrategy({
       const { contractAddress, slotIndex } = metadata;
 
       const tree = await getBinaryTree(deployedOnChain, startTimestamp, chainId);
-      const l1BlockNumber = tree.path[1].blockNumber;
+      const l1BlockNumber = tree.path[1].block_number;
 
       const storageProof = await getProof(
         contractAddress,
@@ -118,7 +118,7 @@ export default function createEvmSlotValueStrategy({
       const contract = new Contract(EVMSlotValue, strategyAddress, clientConfig.starkProvider);
 
       const tree = await getBinaryTree(deployedOnChain, timestamp, chainId);
-      const l1BlockNumber = tree.path[1].blockNumber;
+      const l1BlockNumber = tree.path[1].block_number;
 
       const storageProof = await getProof(
         contractAddress,

--- a/packages/sx.js/src/strategies/starknet/evmSlotValue.ts
+++ b/packages/sx.js/src/strategies/starknet/evmSlotValue.ts
@@ -120,12 +120,11 @@ export default function createEvmSlotValueStrategy({
 
       const contract = new Contract(EVMSlotValue, strategyAddress, clientConfig.starkProvider);
 
-      let tree;
-      try {
-        tree = await getBinaryTree(deployedOnChain, timestamp, chainId);
-      } catch (e: unknown) {
+      const tree = await getBinaryTree(deployedOnChain, timestamp, chainId);
+      if (tree.message === 'No blocks found for binsearch') {
         throw new VotingPowerDetailsError('Failed to get binary tree', type, 'NOT_READY_YET');
       }
+
       const l1BlockNumber = tree.path[1].block_number;
 
       const storageProof = await getProof(

--- a/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
+++ b/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
@@ -142,12 +142,11 @@ export default function createOzVotesStorageProofStrategy({
 
       const contract = new Contract(OZVotesStorageProof, strategyAddress, starkProvider);
 
-      let tree;
-      try {
-        tree = await getBinaryTree(deployedOnChain, timestamp, chainId);
-      } catch (e: unknown) {
+      const tree = await getBinaryTree(deployedOnChain, timestamp, chainId);
+      if (tree.message === 'No blocks found for binsearch') {
         throw new VotingPowerDetailsError('Failed to get binary tree', type, 'NOT_READY_YET');
       }
+
       const l1BlockNumber = tree.path[1].block_number;
 
       const { proofs, checkpointIndex } = await getProofs(

--- a/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
+++ b/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
@@ -92,7 +92,7 @@ export default function createOzVotesStorageProofStrategy({
       const startTimestamp = proposalStruct.start_timestamp;
 
       const tree = await getBinaryTree(deployedOnChain, startTimestamp, chainId);
-      const l1BlockNumber = tree.path[1].blockNumber;
+      const l1BlockNumber = tree.path[1].block_number;
 
       const { proofs, checkpointIndex } = await getProofs(
         contractAddress,
@@ -140,7 +140,7 @@ export default function createOzVotesStorageProofStrategy({
       const contract = new Contract(OZVotesStorageProof, strategyAddress, starkProvider);
 
       const tree = await getBinaryTree(deployedOnChain, timestamp, chainId);
-      const l1BlockNumber = tree.path[1].blockNumber;
+      const l1BlockNumber = tree.path[1].block_number;
 
       const { proofs, checkpointIndex } = await getProofs(
         contractAddress,

--- a/packages/sx.js/src/strategies/starknet/utils.ts
+++ b/packages/sx.js/src/strategies/starknet/utils.ts
@@ -13,7 +13,7 @@ export async function getBinaryTree(
   chainId: number
 ) {
   const res = await fetch(
-    `https://ds-indexer.api.herodotus.cloud/binsearch-path?timestamp=${snapshotTimestamp}&deployed_on_chain=${deployedOnChain}&accumulates_chain=${chainId}`,
+    `https://rs-indexer.api.herodotus.cloud/remappers/binsearch-path?timestamp=${snapshotTimestamp}&deployed_on_chain=${deployedOnChain}&accumulates_chain=${chainId}`,
     {
       headers: {
         accept: 'application/json'

--- a/packages/sx.js/src/utils/errors.ts
+++ b/packages/sx.js/src/utils/errors.ts
@@ -1,0 +1,13 @@
+export type VotingPowerDetailsErrorDetails = 'NOT_READY_YET';
+
+export class VotingPowerDetailsError extends Error {
+  source: string;
+  details: VotingPowerDetailsErrorDetails;
+
+  constructor(message: string, source: string, details: VotingPowerDetailsErrorDetails) {
+    super(message);
+    this.name = 'VotingPowerDetailsError';
+    this.source = source;
+    this.details = details;
+  }
+}

--- a/packages/sx.js/src/utils/index.ts
+++ b/packages/sx.js/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * as bytes from './bytes';
+export * as errors from './errors';
 export * as intsSequence from './ints-sequence';
 export * as merkle from './merkletree';
 export * as splitUint256 from './split-uint256';


### PR DESCRIPTION
### Summary

This PR updates Herodotus to use new indexer API and display message if Herodotus is not processed yet.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/154
Closes: https://github.com/snapshot-labs/sx-monorepo/issues/207

**Note: Currently new indexer has CORS issue so all requests fail showing this message, waiting for fix from Herodotus.**

### How to test

1. Run `yarn dev:full` (might be good idea not to run subgraph and set Sepolia start block later to prevent rate limits).
2. Create space with ozvotes/evmslotvalue strategy (can you this token: `0x6fd821e79cdf212ad8b06c59b28fe8c2185291d4`, slot index 0 for EVM slot value, 8 for OZ Votes).
3. Create proposal.
4. It shows this message until confirmed.

### Screenshots

Newer design:
<img width="361" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/933666bb-babe-4c55-bd4d-80295d7f6af9">


New design:
<img width="930" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/c63121ff-7559-4554-9af8-c9c25fb3578c">


Previous design:
<img width="992" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/46dadd0c-fe6d-41be-a31a-cd350e37af32">
