### PR TITLE
style: minor style improvements

### DIFF
--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -139,7 +139,10 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
                   <td class="text-left flex items-center pl-4 py-3">
                     <UiStamp :id="delegate.id" :size="32" class="mr-3" />
                     <div class="overflow-hidden">
-                      <a :href="currentNetwork.helpers.getExplorerUrl(delegate.id, 'address')">
+                      <a
+                        :href="currentNetwork.helpers.getExplorerUrl(delegate.id, 'address')"
+                        target="_blank"
+                      >
                         <div class="leading-[22px]">
                           <h4
                             class="text-skin-link truncate"

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -161,12 +161,11 @@ watchEffect(() => {
                 class="text-skin-link text-lg flex items-center"
                 @click="props.onClick"
               >
-                <IH-lightning-bolt class="inline-block" />
                 <IH-exclamation
                   v-if="votingPowerStatus === 'error'"
-                  class="inline-block ml-1 text-rose-500"
+                  class="inline-block text-rose-500"
                 />
-                <span v-else class="ml-2" v-text="props.formattedVotingPower" />
+                <span v-else v-text="props.formattedVotingPower" />
               </button>
             </div>
           </IndicatorVotingPower>

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -185,9 +185,9 @@ async function handleAiSummaryClick() {
         <div class="flex gap-2 items-center">
           <UiTooltip
             v-if="
-              props.proposal.body.length > 500 && offchainNetworks.includes(props.proposal.network)
+              offchainNetworks.includes(props.proposal.network) && props.proposal.body.length > 500
             "
-            :title="aiSummaryOpen ? 'Hide AI summary' : 'Show AI summary'"
+            :title="'AI summary'"
           >
             <UiButton class="!p-0 border-0 !h-[auto]" @click="handleAiSummaryClick">
               <UiLoading v-if="aiSummaryLoading" />
@@ -240,11 +240,15 @@ async function handleAiSummaryClick() {
           </UiDropdown>
         </div>
       </div>
-      <div v-if="aiSummaryOpen" class="mb-4 border rounded-lg">
-        <div class="p-4 text-md text-skin-link">{{ aiSummaryBody }}</div>
-        <div class="bg-skin-border p-4 py-2 flex gap-2 items-center text-sm">
+      <div v-if="aiSummaryOpen" class="mb-6">
+        <h4 class="mb-2 eyebrow flex items-center">
+          <IH-sparkles class="inline-block mr-2" />
+          <span>AI summary</span>
+        </h4>
+        <div class="text-md text-skin-link mb-2">{{ aiSummaryBody }}</div>
+        <div class="flex gap-2 items-center text-sm">
           <IH-exclamation />
-          AI summary can be inaccurate or misleading.
+          AI can be inaccurate or misleading.
         </div>
       </div>
       <UiMarkdown v-if="proposal.body" class="mb-4" :body="proposal.body" />

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -171,7 +171,7 @@ watch([sortBy, choiceFilter], () => {
           </template>
           <tr v-for="(vote, i) in votes" :key="i" class="border-b relative align-middle">
             <div
-              class="absolute top-0 -bottom-[1px] right-0 pointer-events-none"
+              class="absolute top-0 -bottom-[1px] left-0 pointer-events-none"
               :style="{
                 width: `${((100 / proposal.scores_total) * vote.vp).toFixed(2)}%`
               }"

--- a/apps/ui/src/views/Space/Delegates.vue
+++ b/apps/ui/src/views/Space/Delegates.vue
@@ -14,14 +14,16 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
 <template>
   <div
     v-if="space.delegations.length !== 1"
-    class="flex px-4 bg-skin-bg border-b sticky top-[71px] lg:top-[72px] z-40 space-x-3"
+    class="overflow-y-scroll no-scrollbar z-40 sticky top-[71px] lg:top-[72px]"
   >
-    <a v-for="(delegation, i) in space.delegations" :key="i" @click="activeDelegationId = i">
-      <UiLink
-        :is-active="activeDelegationId === i"
-        :text="delegation.name || 'Unnamed delegation'"
-      />
-    </a>
+    <div class="flex px-4 space-x-3 bg-skin-bg border-b min-w-max">
+      <a v-for="(delegation, i) in space.delegations" :key="i" @click="activeDelegationId = i">
+        <UiLink
+          :is-active="activeDelegationId === i"
+          :text="delegation.name || `Delegates ${i + 1}`"
+        />
+      </a>
+    </div>
   </div>
   <SpaceDelegates
     v-if="delegateData"

--- a/apps/ui/src/views/Space/Treasury.vue
+++ b/apps/ui/src/views/Space/Treasury.vue
@@ -21,14 +21,16 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
 <template>
   <div
     v-if="filteredTreasuries.length !== 1"
-    class="flex px-4 bg-skin-bg border-b sticky top-[71px] lg:top-[72px] z-40 space-x-3"
+    class="overflow-y-scroll no-scrollbar z-40 sticky top-[71px] lg:top-[72px]"
   >
-    <a v-for="(treasury, i) in filteredTreasuries" :key="i" @click="activeTreasuryId = i">
-      <UiLink
-        :is-active="activeTreasuryId === i"
-        :text="treasury.name || shorten(treasury.address)"
-      />
-    </a>
+    <div class="flex px-4 space-x-3 bg-skin-bg border-b min-w-max">
+      <a v-for="(treasury, i) in filteredTreasuries" :key="i" @click="activeTreasuryId = i">
+        <UiLink
+          :is-active="activeTreasuryId === i"
+          :text="treasury.name || shorten(treasury.address)"
+        />
+      </a>
+    </div>
   </div>
   <SpaceTreasury
     :key="activeTreasuryId"


### PR DESCRIPTION
Here are the changes of the PR:

- Move percent background to left:
<img width="1469" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/16245250/a717ff73-9879-4ea0-a9ca-3fa4aa2a04b5">

- Make delegates and treasury select bar scrollable:
<img width="376" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/16245250/a69d6edd-53f6-4617-a4f6-5cf62a25b993">
Can try here: http://localhost:8080/#/sn:0x0041ada9121061198b52ae28edeec8ace7c23f2ba8d66938c129af1a2245701c/treasury
And here: http://localhost:8080/#/sn:0x05702362b68a350c1cae8f2a529d74fdbb502369ddcebfadac7e91da37636947/delegates

- Remove zap icon for voting power on proposal page
- Open new tab for delegate links

- Improve summary display:

<img width="1469" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/16245250/8df4d5c9-ecd9-4bc8-9acb-8800137a6224">

Also fix an issue with AI summary where SX proposal are not visible 