### PR TITLE
fix: hide shutter badge on on results page

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -158,7 +158,7 @@ const results = computed(() =>
         />
       </div>
     </div>
-    <div v-if="proposal.privacy === 'shutter'" class="flex flex-col mt-2.5">
+    <div v-if="proposal.privacy === 'shutter' && withDetails" class="flex flex-col mt-2.5">
       <div class="text-xs">Powered by</div>
       <div class="flex items-center">
         <a


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/211

### How to test

1. Not visible there: http://localhost:8080/#/s:shutterdao0x36.eth
2. Visible there: http://localhost:8080/#/s:shutterdao0x36.eth/proposal/0xfbd94f8b30df1581b0b7a8790ecb55cf13e260b075bb6a1d06c73aa22cbe768a

