### PR TITLE
fix(ui): fix shutter message appearing in proposals list

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -46,7 +46,7 @@ const results = computed(() =>
 
 <template>
   <div
-    v-if="!!props.proposal.privacy && !props.proposal.completed"
+    v-if="!!props.proposal.privacy && !props.proposal.completed && withDetails"
     class="text-center py-3.5 leading-5"
   >
     <div


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #222

### How to test

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth/proposals
2. Active basic proposals with shutter enabled will not show the shutter message anymore
