### PR TITLE
fix: shorten proposals ID with IPFS hash format

### DIFF
--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -114,8 +114,12 @@ export function explorerUrl(network, str: string, type = 'address'): string {
 export function getProposalId(proposal: Proposal) {
   const proposalId = proposal.proposal_id.toString();
 
-  if (proposalId.startsWith('0x') || [46, 59].includes(proposalId.length)) {
+  if (proposalId.startsWith('0x')) {
     return `#${proposalId.slice(2, 7)}`;
+  }
+
+  if ([46, 59].includes(proposalId.length)) {
+    return `#${proposalId.slice(-5)}`;
   }
 
   return `#${proposalId}`;

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -114,7 +114,10 @@ export function explorerUrl(network, str: string, type = 'address'): string {
 export function getProposalId(proposal: Proposal) {
   const proposalId = proposal.proposal_id.toString();
 
-  if (proposalId.startsWith('0x')) return `#${proposalId.slice(2, 7)}`;
+  if (proposalId.startsWith('0x') || [46, 59].includes(proposalId.length)) {
+    return `#${proposalId.slice(2, 7)}`;
+  }
+
   return `#${proposalId}`;
 }
 


### PR DESCRIPTION
### Summary

Shorten proposal ID when it's not only an eth address, but also IPFS hashes

Closes: #205

### How to test

1. Go to http://localhost:8080/#/s:ens.eth/proposals
2. Scroll to the oldest proposals
3. All IDs should be shortened
