### PR TITLE
feat(ux): sort proposals results by weight

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -25,7 +25,7 @@ const labels = {
 const progress = computed(() => Math.min(props.proposal.scores_total / props.proposal.quorum, 1));
 
 const adjustedScores = computed(() =>
-  [props.proposal.scores[0], props.proposal.scores[1], props.proposal.scores[2]].map(score => {
+  props.proposal.scores.map(score => {
     // TODO: sx-api returns number, sx-subgraph returns string
     const parsedTotal = parseFloat(props.proposal.scores_total as unknown as string);
 
@@ -40,7 +40,7 @@ const results = computed(() =>
       score: props.proposal.scores[i],
       progress: score
     }))
-    .sort((a, b) => b.progress - a.progress)
+    .sort((a, b) => (props.proposal.type === 'basic' ? 0 : b.progress - a.progress))
 );
 </script>
 
@@ -73,31 +73,35 @@ const results = computed(() =>
   <template v-else>
     <div v-if="withDetails" class="flex flex-col gap-2">
       <div
-        v-for="(choice, id) in proposal.choices"
-        :key="id"
+        v-for="result in results"
+        :key="result.choice"
         class="flex gap-2 border rounded-lg px-3 py-2.5 last:mb-0 text-skin-link relative overflow-hidden items-center"
-        :class="{ [`_${id + 1} choice-border`]: proposal.type === 'basic' }"
+        :class="{ [`_${result.choice + 1} choice-border`]: proposal.type === 'basic' }"
       >
         <div
           class="absolute bg-skin-border top-0 bottom-0 left-0 pointer-events-none -z-10"
-          :class="{ [`_${id + 1} choice-bg opacity-10`]: proposal.type === 'basic' }"
+          :class="{ [`_${result.choice + 1} choice-bg opacity-10`]: proposal.type === 'basic' }"
           :style="{
-            width: `${((proposal.scores[id] / (proposal.scores_total || Infinity)) * 100).toFixed(
-              2
-            )}%`
+            width: `${result.progress.toFixed(2)}%`
           }"
         />
         <div
           v-if="proposal.type === 'basic'"
           class="rounded-full choice-bg inline-block w-[18px] h-[18px]"
-          :class="`_${id + 1}`"
+          :class="`_${result.choice + 1}`"
         >
-          <IH-check v-if="id === 0" class="text-white w-[14px] h-[14px] mt-0.5 ml-0.5" />
-          <IH-x v-else-if="id === 1" class="text-white w-[14px] h-[14px] mt-0.5 ml-0.5" />
-          <IH-minus-sm v-else-if="id === 2" class="text-white w-[14px] h-[14px] mt-0.5 ml-0.5" />
+          <IH-check v-if="result.choice === 0" class="text-white w-[14px] h-[14px] mt-0.5 ml-0.5" />
+          <IH-x
+            v-else-if="result.choice === 1"
+            class="text-white w-[14px] h-[14px] mt-0.5 ml-0.5"
+          />
+          <IH-minus-sm
+            v-else-if="result.choice === 2"
+            class="text-white w-[14px] h-[14px] mt-0.5 ml-0.5"
+          />
         </div>
-        <div class="truncate grow" v-text="choice" />
-        <div v-text="_p(proposal.scores[id] / (proposal.scores_total || Infinity))" />
+        <div class="truncate grow" v-text="proposal.choices[result.choice - 1]" />
+        <div v-text="_p(result.progress / 100)" />
       </div>
       <div v-if="proposal.privacy === 'shutter'" class="flex flex-col mt-2.5">
         <div class="text-xs">Powered by</div>

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { _n, _p } from '@/helpers/utils';
+import { _p } from '@/helpers/utils';
 import { Proposal as ProposalType } from '@/types';
 
 const props = withDefaults(

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -76,11 +76,11 @@ const results = computed(() =>
         v-for="result in results"
         :key="result.choice"
         class="flex gap-2 border rounded-lg px-3 py-2.5 last:mb-0 text-skin-link relative overflow-hidden items-center"
-        :class="{ [`_${result.choice + 1} choice-border`]: proposal.type === 'basic' }"
+        :class="{ [`_${result.choice} choice-border`]: proposal.type === 'basic' }"
       >
         <div
           class="absolute bg-skin-border top-0 bottom-0 left-0 pointer-events-none -z-10"
-          :class="{ [`_${result.choice + 1} choice-bg opacity-10`]: proposal.type === 'basic' }"
+          :class="{ [`_${result.choice} choice-bg opacity-10`]: proposal.type === 'basic' }"
           :style="{
             width: `${result.progress.toFixed(2)}%`
           }"

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -40,7 +40,7 @@ const results = computed(() =>
       score: props.proposal.scores[i],
       progress: score
     }))
-    .sort((a, b) => (props.proposal.type === 'basic' ? 0 : b.progress - a.progress))
+    .sort((a, b) => b.progress - a.progress)
 );
 </script>
 
@@ -88,15 +88,15 @@ const results = computed(() =>
         <div
           v-if="proposal.type === 'basic'"
           class="rounded-full choice-bg inline-block w-[18px] h-[18px]"
-          :class="`_${result.choice + 1}`"
+          :class="`_${result.choice}`"
         >
-          <IH-check v-if="result.choice === 0" class="text-white w-[14px] h-[14px] mt-0.5 ml-0.5" />
+          <IH-check v-if="result.choice === 1" class="text-white w-[14px] h-[14px] mt-0.5 ml-0.5" />
           <IH-x
-            v-else-if="result.choice === 1"
+            v-else-if="result.choice === 2"
             class="text-white w-[14px] h-[14px] mt-0.5 ml-0.5"
           />
           <IH-minus-sm
-            v-else-if="result.choice === 2"
+            v-else-if="result.choice === 3"
             class="text-white w-[14px] h-[14px] mt-0.5 ml-0.5"
           />
         </div>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #227

Sort proposals results by weight, ~~when type !== basic~~ for all voting type

![Screenshot 2024-04-01 at 10 58 48](https://github.com/snapshot-labs/sx-monorepo/assets/495709/11274af9-bc70-49fe-a47d-1443de5da72d)

![Screenshot 2024-04-01 at 12 26 47](https://github.com/snapshot-labs/sx-monorepo/assets/495709/b83b92d0-b0a6-422c-8ec7-389f5253b704)


### How to test

1. Go to http://localhost:8080/#/s:ens.eth/proposal/0x6ba81cd2997288cc49ae1b95921ec8f107e8ffb9733321d53d488e2b30710b86
2. It should show results in same order as https://snapshot.org/#/ens.eth/proposal/0x6ba81cd2997288cc49ae1b95921ec8f107e8ffb9733321d53d488e2b30710b86
3. Go to http://localhost:8080/#/s:test.wa0x6e.eth/proposal/0x46a984c60c16af8214d8a50dc964cdabfbb39fd57a5d1f9ad5ff62dca4e2f856
4. It should show results in for, against, abstain order
