### PR TITLE
fix: Messenger overlap on proposal

### DIFF
--- a/apps/ui/src/helpers/intercom.ts
+++ b/apps/ui/src/helpers/intercom.ts
@@ -1,7 +1,7 @@
 const APP_ID = import.meta.env.VITE_INTERCOM_APP_ID;
 
 export function startIntercom() {
-  if (!APP_ID || document.body.clientWidth < 544) return;
+  if (!APP_ID || document.body.clientWidth < 768) return;
 
   const w: any = window;
   w.intercomSettings = {

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -160,7 +160,7 @@ watchEffect(() => {
         <router-view :proposal="proposal" />
       </div>
       <div
-        class="static md:fixed md:top-[72px] md:right-0 w-full md:h-[calc(100vh-72px)] md:max-w-[340px] p-4 border-l-0 md:border-l space-y-4 no-scrollbar overflow-y-scroll"
+        class="static md:fixed md:top-[72px] md:right-0 w-full md:h-[calc(100vh-72px)] md:max-w-[340px] p-4 md:pb-[88px] border-l-0 md:border-l space-y-4 no-scrollbar overflow-y-scroll"
       >
         <div v-if="!proposal.cancelled && ['pending', 'active'].includes(proposal.state)">
           <h4 class="mb-2 eyebrow flex items-center">


### PR DESCRIPTION
### Summary
Fixes suggested in https://github.com/snapshot-labs/sx-monorepo/pull/264#issuecomment-2043090206

- Sidebar to have padding-bottom of 88px
- Default padding on small devices
- Hide intercom messenger if screen width is less than `768` (same as `md`) - Because most of the proposal components are responsive with `md` 

### How to test
- Go to http://localhost:8080/#/s:uniswapgovernance.eth/proposal/0xe7274e00eb2a084cdc3b7510a8b40aa303ac2d7944e9706ad090c974c76e71bf

| Before    | After |
| -------- | ------- |
| <img width="335" alt="Untitled 3" src="https://github.com/snapshot-labs/sx-monorepo/assets/15967809/73752879-bcfb-41d1-ac59-095abad41b59"> | <img width="341" alt="Untitled 2" src="https://github.com/snapshot-labs/sx-monorepo/assets/15967809/44938cb4-3f0e-43c3-9119-8476f6aecda0"> |

- Go to http://localhost:8080/#/s:thanku.eth/proposal/0xada3af8c9e1885ad7c800d966da91d604df9d567000b75c30b1e81a6d71c99d5

| Before    | After |
| -------- | ------- |
| <img width="341" alt="Untitled 6" src="https://github.com/snapshot-labs/sx-monorepo/assets/15967809/b751d0c6-7836-49a7-a694-304135f956ff"> | <img width="342" alt="Untitled 9" src="https://github.com/snapshot-labs/sx-monorepo/assets/15967809/ad0c5197-06d4-42d0-afb9-fe3319710855"> |
| <img width="437" alt="Untitled 4" src="https://github.com/snapshot-labs/sx-monorepo/assets/15967809/6938de22-0e88-47e6-9d4d-40c74bdcd584"> |  <img width="469" alt="Untitled 5" src="https://github.com/snapshot-labs/sx-monorepo/assets/15967809/e6bf2f79-8085-4195-8f10-d3986aee4cf5">  |

