### PR TITLE
fix: better markdown code block UI

### DIFF
--- a/apps/ui/src/components/Ui/Markdown.vue
+++ b/apps/ui/src/components/Ui/Markdown.vue
@@ -19,7 +19,6 @@ const props = defineProps<{
   body: string;
 }>();
 
-const uiStore = useUiStore();
 const { copy } = useClipboard();
 
 const remarkable = new Remarkable({
@@ -70,21 +69,35 @@ onMounted(() => {
   if (!body) return;
 
   body.querySelectorAll('pre>code').forEach(code => {
-    const parent = code.parentElement;
+    const parent = code.parentElement!;
+
     const copyButton = document.createElement('button');
-
-    copyButton.classList.add('copy');
+    const copySvg = `<svg viewBox="0 0 24 24" width="20px" height="20px">${icons.icons.duplicate.body}</svg>`;
+    copyButton.classList.add('text-skin-text');
     copyButton.setAttribute('type', 'button');
-    copyButton.innerHTML = `<svg viewBox="0 0 24 24" width="20px" height="20px">${icons.icons.duplicate.body}</svg>`;
-
+    copyButton.innerHTML = copySvg;
     copyButton.addEventListener('click', () => {
       if (parent !== null) {
-        copy(parent.innerText.trim());
-        uiStore.addNotification('success', 'Code copied');
+        copy(code.textContent!);
+
+        copyButton.innerHTML = `<svg viewBox="0 0 24 24" width="20px" height="20px">${icons.icons.check.body}</svg>`;
+        copyButton.classList.add('!text-skin-success');
+        setTimeout(() => {
+          copyButton.innerHTML = copySvg;
+          copyButton.classList.remove('!text-skin-success');
+        }, 1e3);
       }
     });
 
-    code.prepend(copyButton);
+    const titleBar = document.createElement('div');
+    titleBar.classList.add('title-bar');
+
+    const language = document.createElement('div');
+    language.innerHTML = code.getAttribute('class')?.split('language-')[1] || '';
+
+    titleBar.append(language);
+    titleBar.append(copyButton);
+    parent.prepend(titleBar);
   });
 });
 </script>
@@ -286,14 +299,14 @@ html.dark {
   }
 
   pre {
-    @apply m-0 mb-3 p-3 rounded-lg bg-skin-border text-base overflow-auto relative;
+    @apply m-0 mb-3 p-0 rounded-lg border bg-transparent overflow-hidden;
 
-    code {
-      @apply p-0 m-0 bg-transparent border-none;
+    .title-bar {
+      @apply p-2.5 px-3 text-base text-skin-text font-semibold flex justify-between items-center font-serif;
     }
 
-    .copy {
-      @apply absolute right-2.5 top-2.5 text-skin-text bg-skin-border rounded p-1;
+    code {
+      @apply p-3 m-0 bg-skin-border rounded-none border-none overflow-auto block;
     }
   }
 }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #272

Add title bar to markdown code block to show language if available, and copy button

Copy button will now transform to check icon for 1s on click, instead of triggering flash notification

![Screenshot 2024-04-14 at 03 01 56](https://github.com/snapshot-labs/sx-monorepo/assets/495709/0c77bc02-5698-47c3-a121-2914281c19bc)


### How to test

1. Go to any proposal with code block, e.g. http://localhost:8080/#/s:test.wa0x6e.eth/proposal/0xf56083e1fcbdc5c9ad15d9e91f67a72b817bdf83f1589af8db20e27385db95e1
