### PR TITLE
feat: show quorum progress

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { _p } from '@/helpers/utils';
+import { quorumLabel, quorumProgress, quorumChoiceProgress } from '@/helpers/quorum';
 import { Proposal as ProposalType } from '@/types';
 
 const props = withDefaults(
@@ -22,9 +23,7 @@ const labels = {
   2: 'Abstain'
 };
 
-const totalProgress = computed(() =>
-  Math.min(props.proposal.scores_total / props.proposal.quorum, 1)
-);
+const totalProgress = computed(() => quorumProgress(props.proposal));
 
 const results = computed(() => {
   // TODO: sx-api returns number, sx-subgraph returns string
@@ -36,8 +35,7 @@ const results = computed(() => {
 
       return {
         choice: i + 1,
-        progress,
-        adjustedProgress: progress * totalProgress.value
+        progress
       };
     })
     .sort((a, b) => b.progress - a.progress);
@@ -103,6 +101,10 @@ const results = computed(() => {
         <div class="truncate grow" v-text="proposal.choices[result.choice - 1]" />
         <div v-text="_p(result.progress / 100)" />
       </div>
+      <div v-if="proposal.quorum">
+        {{ quorumLabel(proposal.quorum_type) }}:
+        <span class="text-skin-link">{{ _p(totalProgress) }}</span>
+      </div>
       <div v-if="proposal.privacy === 'shutter'" class="flex flex-col mt-2.5">
         <div class="text-xs">Powered by</div>
         <div class="flex items-center">
@@ -128,7 +130,7 @@ const results = computed(() => {
           :title="labels[result.choice - 1]"
           class="choice-bg float-left h-full"
           :style="{
-            width: `${result.adjustedProgress.toFixed(3)}%`
+            width: `${quorumChoiceProgress(props.proposal.quorum_type, result, totalProgress).toFixed(3)}%`
           }"
           :class="`_${result.choice}`"
         />

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -66,6 +66,11 @@ const results = computed(() => {
       >
         <IC-Shutter class="w-[80px] text-skin-text inline-block" />
       </a>
+
+      <div v-if="proposal.quorum" class="mt-3.5">
+        {{ quorumLabel(proposal.quorum_type) }}:
+        <span class="text-skin-link">{{ _p(totalProgress) }}</span>
+      </div>
     </div>
   </div>
   <template v-else>

--- a/apps/ui/src/components/ProposalsListItem.vue
+++ b/apps/ui/src/components/ProposalsListItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { _rt, _n, shortenAddress, getProposalId } from '@/helpers/utils';
+import { quorumLabel, quorumProgress } from '@/helpers/quorum';
+import { _rt, _n, _p, shortenAddress, getProposalId } from '@/helpers/utils';
 import type { Proposal as ProposalType, Choice } from '@/types';
 
 const props = defineProps<{ proposal: ProposalType }>();
@@ -10,6 +11,8 @@ const { vote } = useActions();
 const { votes } = useAccount();
 const modalOpenTimeline = ref(false);
 const sendingType = ref<Choice | null>(null);
+
+const totalProgress = computed(() => quorumProgress(props.proposal));
 
 async function handleVoteClick(choice: Choice) {
   sendingType.value = choice;
@@ -72,6 +75,10 @@ async function handleVoteClick(choice: Choice) {
             @click="modalOpenTimeline = true"
             v-text="_rt(getTsFromCurrent(proposal.network, proposal.max_end))"
           />
+          <span v-if="proposal.quorum">
+            · {{ quorumLabel(proposal.quorum_type) }}:
+            <span class="text-skin-link">{{ _p(totalProgress) }}</span>
+          </span>
         </span>
       </div>
       <div class="hidden md:block">

--- a/apps/ui/src/components/ProposalsListItem.vue
+++ b/apps/ui/src/components/ProposalsListItem.vue
@@ -69,15 +69,15 @@ async function handleVoteClick(choice: Choice) {
             · {{ _n(proposal.vote_count, 'compact') }}
             {{ proposal.vote_count !== 1 ? 'votes' : 'vote' }}
           </template>
+          <span v-if="proposal.quorum" class="lowercase">
+            · {{ _p(totalProgress) }} {{ quorumLabel(proposal.quorum_type) }}
+          </span>
           ·
           <a
             class="text-skin-text"
             @click="modalOpenTimeline = true"
             v-text="_rt(getTsFromCurrent(proposal.network, proposal.max_end))"
           />
-          <span v-if="proposal.quorum" class="lowercase">
-            · {{ _p(totalProgress) }} {{ quorumLabel(proposal.quorum_type) }}
-          </span>
         </span>
       </div>
       <div class="hidden md:block">

--- a/apps/ui/src/components/ProposalsListItem.vue
+++ b/apps/ui/src/components/ProposalsListItem.vue
@@ -75,9 +75,8 @@ async function handleVoteClick(choice: Choice) {
             @click="modalOpenTimeline = true"
             v-text="_rt(getTsFromCurrent(proposal.network, proposal.max_end))"
           />
-          <span v-if="proposal.quorum">
-            · {{ quorumLabel(proposal.quorum_type) }}:
-            <span class="text-skin-link">{{ _p(totalProgress) }}</span>
+          <span v-if="proposal.quorum" class="lowercase">
+            · {{ _p(totalProgress) }} {{ quorumLabel(proposal.quorum_type) }}
           </span>
         </span>
       </div>

--- a/apps/ui/src/helpers/quorum.ts
+++ b/apps/ui/src/helpers/quorum.ts
@@ -1,0 +1,28 @@
+import { Proposal } from '@/types';
+
+const REJECTION_QUORUM_CHOICE_INDEX = 1;
+
+export function quorumProgress(proposal: Proposal): number {
+  const totalScore =
+    proposal.quorum_type === 'rejection'
+      ? proposal.scores
+          .filter((c, i) => i === REJECTION_QUORUM_CHOICE_INDEX)
+          .reduce((a, b) => a + b, 0)
+      : proposal.scores_total;
+
+  return Math.min(totalScore / proposal.quorum, 1);
+}
+
+export function quorumChoiceProgress(
+  quorumType: Proposal['quorum_type'],
+  result: { choice: number; progress: number },
+  quorumProgress: number
+): number {
+  if (quorumType !== 'rejection') return result.progress * quorumProgress;
+
+  return result.choice - 1 === REJECTION_QUORUM_CHOICE_INDEX ? quorumProgress * 100 : 0;
+}
+
+export function quorumLabel(quorumType: Proposal['quorum_type']): string {
+  return `Quorum${quorumType === 'rejection' ? ' of reject' : ''}`;
+}

--- a/apps/ui/src/helpers/quorum.ts
+++ b/apps/ui/src/helpers/quorum.ts
@@ -5,9 +5,7 @@ const REJECTION_QUORUM_CHOICE_INDEX = 1;
 export function quorumProgress(proposal: Proposal): number {
   const totalScore =
     proposal.quorum_type === 'rejection'
-      ? proposal.scores
-          .filter((c, i) => i === REJECTION_QUORUM_CHOICE_INDEX)
-          .reduce((a, b) => a + b, 0)
+      ? proposal.scores[REJECTION_QUORUM_CHOICE_INDEX] ?? 0
       : proposal.scores_total;
 
   return totalScore / proposal.quorum;

--- a/apps/ui/src/helpers/quorum.ts
+++ b/apps/ui/src/helpers/quorum.ts
@@ -10,7 +10,7 @@ export function quorumProgress(proposal: Proposal): number {
           .reduce((a, b) => a + b, 0)
       : proposal.scores_total;
 
-  return Math.min(totalScore / proposal.quorum, 1);
+  return totalScore / proposal.quorum;
 }
 
 export function quorumChoiceProgress(
@@ -18,9 +18,11 @@ export function quorumChoiceProgress(
   result: { choice: number; progress: number },
   quorumProgress: number
 ): number {
-  if (quorumType !== 'rejection') return result.progress * quorumProgress;
+  const cappedQuorumProgress = Math.min(quorumProgress, 1);
 
-  return result.choice - 1 === REJECTION_QUORUM_CHOICE_INDEX ? quorumProgress * 100 : 0;
+  if (quorumType !== 'rejection') return result.progress * cappedQuorumProgress;
+
+  return result.choice - 1 === REJECTION_QUORUM_CHOICE_INDEX ? cappedQuorumProgress * 100 : 0;
 }
 
 export function quorumLabel(quorumType: Proposal['quorum_type']): string {

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -158,7 +158,8 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID, current: nu
     has_execution_window_opened: proposal.min_end <= current,
     state: getProposalState(proposal, current),
     network: networkId,
-    privacy: null
+    privacy: null,
+    quorum: +proposal.quorum
   };
 }
 

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -136,6 +136,7 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     max_end: proposal.end,
     snapshot: proposal.snapshot,
     quorum: proposal.quorum,
+    quorum_type: proposal.quorumType,
     choices: proposal.choices,
     scores: proposal.scores,
     scores_total: proposal.scores_total,

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -67,6 +67,7 @@ const PROPOSAL_FRAGMENT = gql`
     discussion
     author
     quorum
+    quorumType
     start
     end
     snapshot

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -62,6 +62,7 @@ export type ApiProposal = {
   discussion: string;
   author: string;
   quorum: number;
+  quorumType?: 'default' | 'rejection';
   start: number;
   end: number;
   snapshot: number;

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -131,6 +131,7 @@ export type Proposal = {
   network: NetworkID;
   type: VoteType;
   quorum: number;
+  quorum_type?: 'default' | 'rejection';
   space: {
     id: string;
     name: string;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #279 

Show quorum progress below proposal results, and in proposalListItem

![Screenshot 2024-04-16 at 14 00 17](https://github.com/snapshot-labs/sx-monorepo/assets/495709/904b2174-0ac5-498e-bc47-1afe4f5d46b0)


![Screenshot 2024-04-16 at 02 23 26](https://github.com/snapshot-labs/sx-monorepo/assets/495709/6a920609-c219-4e58-974e-8c5beac29883)

![Screenshot 2024-04-16 at 02 27 55](https://github.com/snapshot-labs/sx-monorepo/assets/495709/df94f76d-0b4d-4d3b-a394-0604e96ab9d8)

On quorum of reject, the result progress bar only show progress of the rejection choice

![Screenshot 2024-04-16 at 14 00 50](https://github.com/snapshot-labs/sx-monorepo/assets/495709/cd4ee161-9aa0-41fa-bbe6-b23c30ded80d)


NOTE: on active shutter proposals, the progress of all proposals using quorum of rejection will always be 0%, as choices are hidden until proposal is closed.

### How to test

1. You can see some tests proposals with default and rejection quorum on http://localhost:8080/#/s:test.wa0x6e.eth
2. You can also create some proposals with default and rejection quorum, and see the progress after voting
