### PR TITLE
refactor: move execution actions to useExecutionActions

### DIFF
--- a/apps/ui/src/composables/useExecutionActions.ts
+++ b/apps/ui/src/composables/useExecutionActions.ts
@@ -1,0 +1,84 @@
+import { Proposal } from '@/types';
+
+const STRATEGIES_WITH_FINALIZE = ['Axiom'];
+
+export function useExecutionActions(proposal: Proposal) {
+  const actions = useActions();
+
+  const currentTimestamp = ref(Date.now());
+
+  const finalizeProposalSending = ref(false);
+  const executeProposalSending = ref(false);
+  const executeQueuedProposalSending = ref(false);
+  const vetoProposalSending = ref(false);
+
+  const { pause } = useIntervalFn(() => {
+    if (currentTimestamp.value > proposal.execution_time * 1000) {
+      pause();
+    }
+
+    currentTimestamp.value = Date.now();
+  }, 1000);
+
+  const hasFinalize = computed(
+    () =>
+      STRATEGIES_WITH_FINALIZE.includes(proposal.execution_strategy_type) &&
+      !proposal.execution_ready
+  );
+  const executionCountdown = computed(() => {
+    return Math.max(proposal.execution_time * 1000 - currentTimestamp.value, 0);
+  });
+
+  async function finalizeProposal() {
+    finalizeProposalSending.value = true;
+
+    try {
+      await actions.finalizeProposal(proposal);
+    } finally {
+      finalizeProposalSending.value = false;
+    }
+  }
+
+  async function executeProposal() {
+    executeProposalSending.value = true;
+
+    try {
+      await actions.executeTransactions(proposal);
+    } finally {
+      executeProposalSending.value = false;
+    }
+  }
+
+  async function executeQueuedProposal() {
+    executeQueuedProposalSending.value = true;
+
+    try {
+      await actions.executeQueuedProposal(proposal);
+    } finally {
+      executeQueuedProposalSending.value = false;
+    }
+  }
+
+  async function vetoProposal() {
+    vetoProposalSending.value = true;
+
+    try {
+      await actions.vetoProposal(proposal);
+    } finally {
+      vetoProposalSending.value = false;
+    }
+  }
+
+  return {
+    hasFinalize,
+    finalizeProposalSending,
+    executeProposalSending,
+    executeQueuedProposalSending,
+    vetoProposalSending,
+    executionCountdown,
+    finalizeProposal,
+    executeProposal,
+    executeQueuedProposal,
+    vetoProposal
+  };
+}


### PR DESCRIPTION
### Summary

There is too much logic in ProposalExecutionActions right now as we need to handle some non-standard actions (veto and queued proposals for Timelock, finalize for Axiom). This will get more complex with Starknet L1 execution as well.

It's not really ideal to create separate components for each execution type (at least now), so extracting that logic to composable is good first step.

### How to test

1. Create proposal with execution (for example timelock and Axiom execution).
2. Entire flow works the same as it used to.

### Screenshots

<img width="700" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/1500500a-265c-4e0a-8e55-00d051a57c25">
<img width="694" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/14139d7e-907a-4ef9-affe-fe9baebd8251">
