### PR TITLE
feat: add tooltips with space names on sidebar

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -74,6 +74,7 @@
     "scrollmonitor": "^1.2.11",
     "starknet": "5.25.0",
     "stream-browserify": "^3.0.0",
+    "tippy.js": "^6.3.7",
     "unplugin-auto-import": "^0.16.6",
     "util": "^0.12.5",
     "vue": "^3.4.15",

--- a/apps/ui/src/components/App/Sidebar.vue
+++ b/apps/ui/src/components/App/Sidebar.vue
@@ -27,7 +27,7 @@ const spacesStore = useSpacesStore();
           class="block"
           @click="uiStore.sidebarOpen = false"
         >
-          <UiTooltip :title="element.name" placement="right">
+          <UiTooltip :title="element.name" placement="right" :touch="false">
             <SpaceAvatar :space="element" :size="32" class="!rounded-[4px]" />
           </UiTooltip>
         </router-link>

--- a/apps/ui/src/components/App/Sidebar.vue
+++ b/apps/ui/src/components/App/Sidebar.vue
@@ -27,7 +27,9 @@ const spacesStore = useSpacesStore();
           class="block"
           @click="uiStore.sidebarOpen = false"
         >
-          <SpaceAvatar :space="element" :size="32" class="!rounded-[4px]" />
+          <UiTooltip :title="element.name" placement="right">
+            <SpaceAvatar :space="element" :size="32" class="!rounded-[4px]" />
+          </UiTooltip>
         </router-link>
       </template>
     </draggable>

--- a/apps/ui/src/components/Ui/Tooltip.vue
+++ b/apps/ui/src/components/Ui/Tooltip.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
+import type { Placement } from 'tippy.js';
+
 defineProps<{
   title: string;
+  placement?: Placement;
 }>();
 </script>
 
 <template>
-  <div v-tippy="{ content: title }" class="inline-block relative">
+  <div v-tippy="{ content: title, placement }" class="inline-block relative">
     <slot />
   </div>
 </template>

--- a/apps/ui/src/components/Ui/Tooltip.vue
+++ b/apps/ui/src/components/Ui/Tooltip.vue
@@ -1,14 +1,21 @@
 <script setup lang="ts">
-import type { Placement } from 'tippy.js';
+import type { Props } from 'tippy.js';
 
-defineProps<{
-  title: string;
-  placement?: Placement;
-}>();
+withDefaults(
+  defineProps<{
+    title: string;
+    placement?: Props['placement'];
+    touch?: Props['touch'];
+  }>(),
+  {
+    placement: 'top',
+    touch: true
+  }
+);
 </script>
 
 <template>
-  <div v-tippy="{ content: title, placement }" class="inline-block relative">
+  <div v-tippy="{ content: title, placement, touch }" class="inline-block relative">
     <slot />
   </div>
 </template>


### PR DESCRIPTION
### Summary

Unless recognizable avatar is used it's hard to tell which space is which on the sidebar without visting it manually.

This PR adds tooltips with space names.


### How to test

1. Add space to favorites.
2. When hovering it in sidebar you see space name.

### Screenshots

<img width="479" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/a5593e18-74cb-4746-a0f6-69d79085fac1">

