### PR TITLE
feat: network agnostic user profile

### DIFF
--- a/apps/ui/src/components/App/Nav.vue
+++ b/apps/ui/src/components/App/Nav.vue
@@ -95,6 +95,11 @@ const shortcuts = computed(() => {
               name: 'Profile',
               link: { name: 'user', params: { id: web3.value.account } },
               icon: IHUser
+            },
+            settings: {
+              name: 'Settings',
+              link: { name: 'settings' },
+              icon: IHCog
             }
           }
         }

--- a/apps/ui/src/components/App/Nav.vue
+++ b/apps/ui/src/components/App/Nav.vue
@@ -7,6 +7,7 @@ import IHCash from '~icons/heroicons-outline/cash';
 import IHLightningBolt from '~icons/heroicons-outline/lightning-bolt';
 import IHCog from '~icons/heroicons-outline/cog';
 import IHUsers from '~icons/heroicons-outline/users';
+import IHUser from '~icons/heroicons-outline/user';
 import IHStop from '~icons/heroicons-outline/stop';
 import IHGlobe from '~icons/heroicons-outline/globe-americas';
 import IHHome from '~icons/heroicons-outline/home';
@@ -85,6 +86,21 @@ const navigationConfig = computed(() => ({
     }
   }
 }));
+const shortcuts = computed(() => {
+  return {
+    ...(web3.value.account
+      ? {
+          my: {
+            profile: {
+              name: 'Profile',
+              link: { name: 'user', params: { id: web3.value.account } },
+              icon: IHUser
+            }
+          }
+        }
+      : {})
+  };
+});
 const navigationItems = computed(() => navigationConfig.value[currentRouteName.value || '']);
 </script>
 
@@ -104,6 +120,15 @@ const navigationItems = computed(() => navigationConfig.value[currentRouteName.v
         :to="{ name: `${currentRouteName}-${key}` }"
         class="px-4 py-1.5 space-x-2 flex items-center"
         :class="route.name === `${currentRouteName}-${key}` ? 'text-skin-link' : 'text-skin-text'"
+      >
+        <component :is="item.icon" class="inline-block"></component>
+        <span v-text="item.name" />
+      </router-link>
+      <router-link
+        v-for="(item, key) in shortcuts[currentRouteName]"
+        :key="key"
+        :to="item.link"
+        class="px-4 py-1.5 space-x-2 flex items-center text-skin-text"
       >
         <component :is="item.icon" class="inline-block"></component>
         <span v-text="item.name" />

--- a/apps/ui/src/components/App/Nav.vue
+++ b/apps/ui/src/components/App/Nav.vue
@@ -98,7 +98,7 @@ const shortcuts = computed(() => {
             },
             settings: {
               name: 'Settings',
-              link: { name: 'settings' },
+              link: { name: 'settings-spaces' },
               icon: IHCog
             }
           }

--- a/apps/ui/src/components/Modal/Votes.vue
+++ b/apps/ui/src/components/Modal/Votes.vue
@@ -107,7 +107,7 @@ watch(
               :to="{
                 name: 'user',
                 params: {
-                  id: `${proposal.network}:${vote.voter.id}`
+                  id: vote.voter.id
                 }
               }"
               class="grow"

--- a/apps/ui/src/components/ProposalsListItem.vue
+++ b/apps/ui/src/components/ProposalsListItem.vue
@@ -82,7 +82,7 @@ async function handleVoteClick(choice: Choice) {
             class="text-skin-text"
             :to="{
               name: 'user',
-              params: { id: `${proposal.network}:${proposal.author.id}` }
+              params: { id: proposal.author.id }
             }"
           >
             {{ proposal.author.name || shortenAddress(proposal.author.id) }}

--- a/apps/ui/src/stores/users.ts
+++ b/apps/ui/src/stores/users.ts
@@ -3,7 +3,7 @@ import { enabledNetworks as enabledNetworkIds, getNetwork } from '@/networks';
 import { getNames } from '@/helpers/stamp';
 import type { User } from '@/types';
 
-type UserWithName = User & { name: string };
+type UserWithName = User & { name?: string };
 
 type UserRecord = {
   loading: boolean;

--- a/apps/ui/src/stores/users.ts
+++ b/apps/ui/src/stores/users.ts
@@ -47,8 +47,10 @@ export const useUsersStore = defineStore('users', {
         (acc, user) => {
           acc.vote_count += user.vote_count;
           acc.proposal_count += user.proposal_count;
-          if (user.created < acc.created || acc.created === 0) {
-            acc.created = user.created;
+
+          const minCreated = [acc.created, user.created].filter(Number);
+          if (minCreated.length) {
+            acc.created = Math.min(...minCreated);
           }
 
           return acc;

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -189,7 +189,7 @@ onBeforeUnmount(() => destroyAudio());
         <router-link
           :to="{
             name: 'user',
-            params: { id: `${proposal.network}:${proposal.author.id}` }
+            params: { id: proposal.author.id }
           }"
           class="flex items-center py-3"
         >

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -188,7 +188,7 @@ watch([sortBy, choiceFilter], () => {
                   :to="{
                     name: 'user',
                     params: {
-                      id: `${proposal.network}:${vote.voter.id}`
+                      id: vote.voter.id
                     }
                   }"
                 >

--- a/apps/ui/src/views/User.vue
+++ b/apps/ui/src/views/User.vue
@@ -29,7 +29,7 @@ watchEffect(() => setTitle(`${id} user profile`));
           :size="90"
           class="mb-2 border-[4px] border-skin-bg !bg-skin-border"
         />
-        <h1>{{ shortenAddress(user.id) }}</h1>
+        <h1>{{ user.name || shortenAddress(user.id) }}</h1>
         <div>
           <b class="text-skin-link">{{ _n(user.proposal_count) }}</b> proposals ·
           <b class="text-skin-link">{{ _n(user.vote_count) }}</b> votes

--- a/apps/ui/src/views/User.vue
+++ b/apps/ui/src/views/User.vue
@@ -6,11 +6,9 @@ const usersStore = useUsersStore();
 const { setTitle } = useTitle();
 
 const id = route.params.id as string;
-const user = computed(() => (id ? usersStore.getUser(id) : null));
+const user = computed(() => usersStore.getUser(id));
 
-onMounted(() => {
-  usersStore.fetchUser(id);
-});
+onMounted(() => usersStore.fetchUser(id));
 
 watchEffect(() => setTitle(`${id} user profile`));
 </script>

--- a/apps/ui/src/views/User.vue
+++ b/apps/ui/src/views/User.vue
@@ -1,25 +1,18 @@
 <script setup lang="ts">
 import { shortenAddress, _n } from '@/helpers/utils';
 
-const { setTitle } = useTitle();
-const { networkId, address } = useRouteParser('id');
+const route = useRoute();
 const usersStore = useUsersStore();
+const { setTitle } = useTitle();
 
-const user = computed(() => (address.value ? usersStore.getUser(address.value) : null));
+const id = route.params.id as string;
+const user = computed(() => (id ? usersStore.getUser(id) : null));
 
-watch(
-  [networkId, address],
-  () => {
-    if (!address.value || !networkId.value) return;
+onMounted(() => {
+  usersStore.fetchUser(id);
+});
 
-    usersStore.fetchUser(address.value, networkId.value);
-  },
-  {
-    immediate: true
-  }
-);
-
-watchEffect(() => setTitle(`${address.value} user profile`));
+watchEffect(() => setTitle(`${id} user profile`));
 </script>
 
 <template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #291 and #292

User profile should not be scoped by network

### How to test

1. Visit any user profiles, such as  http://localhost:8080/#/profile/0xf9551c66995eD3Ff9bb05C9Fd7ff148Bd75dc99a
2. The user profile link should not include the network ID prefix anymore
3. User profile `proposal_count` and `vote_count` should be the sum of all counters on all enabled networks (offchain spaces still not returning this data, so always `0` for now)
4. User domain should be shown instead of address when available
5. Add links to /settings and /profile/CURRENT_USER in the My sidebar
