### PR TITLE
fix: fix invalid voting period comparison

### DIFF
--- a/apps/ui/src/components/Ui/InputDuration.vue
+++ b/apps/ui/src/components/Ui/InputDuration.vue
@@ -33,18 +33,13 @@ watch(
   <div>
     <div :class="{ 'text-skin-danger': error && dirty }" v-text="definition.title" />
     <div class="flex !mb-0" :class="{ 's-error': error && dirty }">
-      <UiWrapperInput :definition="{ title: 'Days' }" class="flex-1" :error="error" :dirty="dirty">
+      <UiWrapperInput :definition="{ title: 'Days' }" class="flex-1" :dirty="dirty">
         <input v-model="days" class="s-input !rounded-r-none" type="number" min="0" />
       </UiWrapperInput>
-      <UiWrapperInput :definition="{ title: 'Hours' }" class="flex-1" :error="error" :dirty="dirty">
+      <UiWrapperInput :definition="{ title: 'Hours' }" class="flex-1" :dirty="dirty">
         <input v-model="hours" class="s-input !rounded-none !border-l-0" type="number" min="0" />
       </UiWrapperInput>
-      <UiWrapperInput
-        :definition="{ title: 'Minutes' }"
-        class="flex-1"
-        :error="error"
-        :dirty="dirty"
-      >
+      <UiWrapperInput :definition="{ title: 'Minutes' }" class="flex-1" :dirty="dirty">
         <input
           v-model="minutes"
           class="s-input !rounded-l-none !border-l-0"

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -7,7 +7,7 @@ const props = defineProps<{ space: Space }>();
 
 const { setTitle } = useTitle();
 const { web3 } = useWeb3();
-const { getDurationFromCurrent } = useMetaStore();
+const { getDurationFromCurrent, getCurrentFromDuration } = useMetaStore();
 const { setVotingDelay, setMinVotingDuration, setMaxVotingDuration, transferOwnership } =
   useActions();
 
@@ -94,7 +94,7 @@ watchEffect(() => setTitle(`Settings - ${props.space.name}`));
             }"
             :custom-error-validation="
               value =>
-                Number(value) > space.max_voting_period
+                getCurrentFromDuration(space.network, Number(value)) > space.max_voting_period
                   ? 'Must be equal to or lower than max. voting period'
                   : undefined
             "
@@ -118,7 +118,7 @@ watchEffect(() => setTitle(`Settings - ${props.space.name}`));
             }"
             :custom-error-validation="
               value =>
-                Number(value) < space.min_voting_period
+                getCurrentFromDuration(space.network, Number(value)) < space.min_voting_period
                   ? 'Must be equal to or higher than min. voting period'
                   : undefined
             "


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #267

Fix an error where the space min voting period form always show a validation error when a max voting period is set

### How to test

1. Go to a space settings
2. Set a max voting period and save
3. Try to edit the min voting period
4. It should show an error only if min voting period is greater than max voting period
