### PR TITLE
fix: handle app nav on settings page

### DIFF
--- a/apps/ui/src/App.vue
+++ b/apps/ui/src/App.vue
@@ -17,7 +17,9 @@ provide('web3', web3);
 
 const scrollDisabled = computed(() => modalOpen.value || uiStore.sidebarOpen);
 
-const hasAppNav = computed(() => ['space', 'my'].includes(String(route.matched[0]?.name)));
+const hasAppNav = computed(() =>
+  ['space', 'my', 'settings'].includes(String(route.matched[0]?.name))
+);
 
 function handleTransactionAccept() {
   if (!spaceKey.value || !executionStrategy.value || !transaction.value) return;

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -16,6 +16,9 @@ const searchValue = ref('');
 
 const { focused } = useFocus(searchInput);
 
+const hasAppNav = computed(() =>
+  ['space', 'my', 'settings'].includes(String(route.matched[0]?.name))
+);
 const hasSearch = computed(() => ['space', 'my'].includes(String(route.matched[0]?.name)));
 
 async function handleLogin(connector) {
@@ -51,8 +54,8 @@ watch(route, to => {
     <div
       class="flex items-center justify-between h-[71px] px-4 bg-skin-bg"
       :class="{
-        'lg:ml-[240px]': hasSearch,
-        'translate-x-[240px] lg:translate-x-0': uiStore.sidebarOpen && hasSearch
+        'lg:ml-[240px]': hasAppNav,
+        'translate-x-[240px] lg:translate-x-0': uiStore.sidebarOpen && hasAppNav
       }"
     >
       <div class="flex flex-grow items-center h-full">


### PR DESCRIPTION
### Summary

This PR fixes display of app nav on settings page.

Before:
<img width="311" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/1a416ad7-a423-4548-9009-321d2828655e">


After:
<img width="306" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/d20d6dd6-2a78-4e23-8edd-6e05779683ab">


### How to test

1. Go to http://localhost:8080/#/settings
2. Make window smaller
3. Open app nav via hamburger menu
4. Background is properly shifted.

