### PR TITLE
fix: overestimate fee when using nonce

### DIFF
--- a/.changeset/fuzzy-onions-destroy.md
+++ b/.changeset/fuzzy-onions-destroy.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+overestimate fee when using nonce in StarknetTx client

--- a/packages/sx.js/src/clients/starknet/starknet-tx/index.ts
+++ b/packages/sx.js/src/clients/starknet/starknet-tx/index.ts
@@ -1,4 +1,4 @@
-import { Account, CallData, shortString, uint256, hash } from 'starknet';
+import { stark, Account, CallData, shortString, uint256, hash } from 'starknet';
 import { ContractFactory } from '@ethersproject/contracts';
 import { Signer } from '@ethersproject/abstract-signer';
 import { poseidonHashMany } from 'micro-starknet';
@@ -204,7 +204,8 @@ export class StarknetTx {
     const calls = [call];
 
     const fee = opts?.nonce ? await account.estimateFee(calls) : null;
-    return account.execute(calls, undefined, fee ? { maxFee: fee.suggestedMaxFee } : undefined);
+    const maxFee = fee ? stark.estimatedFeeToMaxFee(fee.suggestedMaxFee, 1.5) : undefined;
+    return account.execute(calls, undefined, fee ? { maxFee } : undefined);
   }
 
   async updateProposal(account: Account, envelope: Envelope<UpdateProposal>, opts?: Opts) {
@@ -226,7 +227,8 @@ export class StarknetTx {
     });
 
     const fee = opts?.nonce ? await account.estimateFee(call) : null;
-    return account.execute(call, undefined, fee ? { maxFee: fee.suggestedMaxFee } : undefined);
+    const maxFee = fee ? stark.estimatedFeeToMaxFee(fee.suggestedMaxFee, 1.5) : undefined;
+    return account.execute(call, undefined, fee ? { maxFee } : undefined);
   }
 
   async vote(account: Account, envelope: Envelope<Vote>, opts?: Opts) {
@@ -254,7 +256,8 @@ export class StarknetTx {
     });
 
     const fee = opts?.nonce ? await account.estimateFee(call) : null;
-    return account.execute(call, undefined, fee ? { maxFee: fee.suggestedMaxFee } : undefined);
+    const maxFee = fee ? stark.estimatedFeeToMaxFee(fee.suggestedMaxFee, 1.5) : undefined;
+    return account.execute(call, undefined, fee ? { maxFee } : undefined);
   }
 
   execute({


### PR DESCRIPTION
### Summary

It looks like fees are floating too much so two step estimation is likely to get outdated.

https://www.starknetjs.com/docs/guides/estimate_fees/#fee-limitation

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/304

### How to test

1. Should be able to propose/vote on Starknet with local mana.

