### PR TITLE
fix: reset simulation state when execution is edited

### DIFF
--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -79,9 +79,12 @@ async function handleSimulateClick() {
   }
 }
 
-watch(model.value, () => {
-  simulationState.value = null;
-});
+watch(
+  () => model.value,
+  () => {
+    simulationState.value = null;
+  }
+);
 </script>
 <template>
   <div class="space-y-3">


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/303

### How to test

1. Go to space where you can create execution.
2. Create some execution and simulate it.
3. Edit it.
4. You can simulate it again.
