### PR TITLE
feat: use real storage value to compute VP for ozVotesStorageProof

### DIFF
--- a/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
+++ b/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
@@ -8,7 +8,7 @@ import OzVotesToken from './abis/OzVotesToken.json';
 import OZVotesStorageProof from './abis/OZVotesStorageProof.json';
 import SpaceAbi from '../../clients/starknet/starknet-tx/abis/Space.json';
 import { getUserAddressEnum } from '../../utils/starknet-enums';
-import { getSlotKey, getBinaryTree } from './utils';
+import { getSlotKey, getNestedSlotKey, getBinaryTree } from './utils';
 import { VotingPowerDetailsError } from '../../utils/errors';
 import type { ClientConfig, Envelope, Strategy, Propose, Vote } from '../../types';
 
@@ -133,6 +133,17 @@ export default function createOzVotesStorageProofStrategy({
       const { herodotusAccumulatesChainId: chainId } = networkConfig;
       const { contractAddress, slotIndex } = metadata;
       const provider = new StaticJsonRpcProvider(ethUrl, chainId);
+
+      if (!timestamp) {
+        // this uses 32/224 bit storage layout, instead of official 48/208 from OZ
+        const slotKey = getSlotKey(voterAddress, slotIndex);
+        const length = Number(await provider.getStorageAt(contractAddress, slotKey));
+
+        const nestedSlotKey = getNestedSlotKey(slotKey, length - 1);
+        const storage = await provider.getStorageAt(contractAddress, nestedSlotKey);
+
+        return BigInt(storage.slice(0, -8));
+      }
 
       const tokenContract = new EvmContract(contractAddress, OzVotesToken, provider);
       if (!timestamp) return tokenContract.getVotes(voterAddress);

--- a/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
+++ b/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
@@ -146,7 +146,6 @@ export default function createOzVotesStorageProofStrategy({
       }
 
       const tokenContract = new EvmContract(contractAddress, OzVotesToken, provider);
-      if (!timestamp) return tokenContract.getVotes(voterAddress);
 
       const numCheckpoints: number = await tokenContract.numCheckpoints(voterAddress);
       if (numCheckpoints === 0) return 0n;

--- a/packages/sx.js/src/strategies/starknet/utils.ts
+++ b/packages/sx.js/src/strategies/starknet/utils.ts
@@ -7,6 +7,10 @@ export function getSlotKey(voterAddress: string, slotIndex: number) {
   );
 }
 
+export function getNestedSlotKey(previous: string, index: number) {
+  return `0x${(BigInt(keccak256(`${previous}`)) + BigInt(index)).toString(16)}`;
+}
+
 export async function getBinaryTree(
   deployedOnChain: string,
   snapshotTimestamp: number,


### PR DESCRIPTION
### Summary

Previously we just called getVotes on the contract, but if strategy was misconfigured (wrong slot index was specified) this wouldn't get caught.

With this change current voting power is computed from storage directly.

As a note, this uses 224 trace instead of 208 from OZ, as this is the what contracts support:
https://github.com/snapshot-labs/sx-starknet/blob/fe3c99f0e8e6210bfc1c2e423f9f0feb97a3a450/starknet/src/voting_strategies/oz_votes_storage_proof.cairo#L131-L134

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/301

### How to test

1. VP gets computed on proposals list (as long as correct storage is used by OZ token).