### PR TITLE
fix: Max 2 decimals for voting power

### DIFF
--- a/apps/ui/src/components/IndicatorVotingPower.vue
+++ b/apps/ui/src/components/IndicatorVotingPower.vue
@@ -25,7 +25,8 @@ const decimals = computed(() =>
 );
 const formattedVotingPower = computed(() => {
   const value = _n(Number(votingPower.value) / 10 ** decimals.value, 'compact', {
-    maximumFractionDigits: 2
+    maximumFractionDigits: 2,
+    formatDust: true
   });
 
   if (props.votingPowerSymbol) {

--- a/apps/ui/src/components/IndicatorVotingPower.vue
+++ b/apps/ui/src/components/IndicatorVotingPower.vue
@@ -24,7 +24,9 @@ const decimals = computed(() =>
   Math.max(...props.votingPowers.map(votingPower => votingPower.decimals), 0)
 );
 const formattedVotingPower = computed(() => {
-  const value = _n(Number(votingPower.value) / 10 ** decimals.value, 'compact');
+  const value = _n(Number(votingPower.value) / 10 ** decimals.value, 'compact', {
+    maximumFractionDigits: 2
+  });
 
   if (props.votingPowerSymbol) {
     return `${value} ${props.votingPowerSymbol}`;

--- a/apps/ui/src/components/Modal/VotingPower.vue
+++ b/apps/ui/src/components/Modal/VotingPower.vue
@@ -51,7 +51,11 @@ const error = computed(() => props.votingPowerStatus === 'error');
             v-text="network.constants.STRATEGIES[strategy.address] || strategy.address"
           />
           <div class="text-skin-link">
-            {{ _n(Number(strategy.value) / 10 ** finalDecimals, 'compact') }}
+            {{
+              _n(Number(strategy.value) / 10 ** finalDecimals, 'compact', {
+                maximumFractionDigits: 2
+              })
+            }}
             {{ votingPowerSymbol }}
           </div>
         </div>

--- a/apps/ui/src/components/Modal/VotingPower.vue
+++ b/apps/ui/src/components/Modal/VotingPower.vue
@@ -53,7 +53,8 @@ const error = computed(() => props.votingPowerStatus === 'error');
           <div class="text-skin-link">
             {{
               _n(Number(strategy.value) / 10 ** finalDecimals, 'compact', {
-                maximumFractionDigits: 2
+                maximumFractionDigits: 2,
+                formatDust: true
               })
             }}
             {{ votingPowerSymbol }}

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -128,9 +128,12 @@ export function getProposalId(proposal: Proposal) {
 export function _n(
   value: any,
   notation: 'standard' | 'compact' = 'standard',
-  { maximumFractionDigits }: { maximumFractionDigits?: number } = {}
+  {
+    maximumFractionDigits,
+    formatDust = false
+  }: { maximumFractionDigits?: number; formatDust?: boolean } = {}
 ) {
-  if (maximumFractionDigits == 2 && value !== 0 && value < 0.01) return '~0';
+  if (formatDust && value > 0 && value < 0.01) return '~0';
 
   const formatter = new Intl.NumberFormat('en', {
     notation,

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -130,7 +130,12 @@ export function _n(
   notation: 'standard' | 'compact' = 'standard',
   { maximumFractionDigits }: { maximumFractionDigits?: number } = {}
 ) {
-  const formatter = new Intl.NumberFormat('en', { notation, maximumFractionDigits });
+  if (maximumFractionDigits == 2 && value !== 0 && value < 0.01) return '~0';
+
+  const formatter = new Intl.NumberFormat('en', {
+    notation,
+    maximumFractionDigits
+  });
   return formatter.format(value).toLowerCase();
 }
 


### PR DESCRIPTION
### Summary
Closes: #309 

### How to test
1. Go to http://localhost:8080/#/sn-sep:0x019fe8e10c15ced8c06a1052ab9632d6e4cfb0b447525a6779906b081d31f5d3/proposals 
2. connect wallet `0xeF8305E140ac520225DAf050e2f71d5fBcC543e7`
3. You should see voting power `~0`
4. Try clicking on voting power, you should see `~0` as voting power

Here are the screenshots to explain how it works on different proposals:
| Screenshots |
| -----------  |
| ![image](https://github.com/snapshot-labs/sx-monorepo/assets/15967809/8a814480-5b03-49ff-881c-f427bf1f12fc) |
| ![image](https://github.com/snapshot-labs/sx-monorepo/assets/15967809/4527562a-d0b3-44ac-98e5-956110572d22) |
| ![image](https://github.com/snapshot-labs/sx-monorepo/assets/15967809/da8da5c7-b50c-4c99-ad46-0648ced7c3ab) |
| ![image](https://github.com/snapshot-labs/sx-monorepo/assets/15967809/c9e6c666-ae2c-49e6-a3e4-dc32b480f378) |

