### PR TITLE
refactor: migrate to starknet@6

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^18.11.6",
     "cross-fetch": "^4.0.0",
     "dotenv": "^16.0.1",
-    "starknet": "^5.19.3"
+    "starknet": "6.11.0"
   },
   "devDependencies": {
     "@snapshot-labs/eslint-config": "0.1.0-beta.18",

--- a/apps/api/src/utils.ts
+++ b/apps/api/src/utils.ts
@@ -10,7 +10,7 @@ import {
   CallData,
   Contract,
   hash,
-  Provider,
+  RpcProvider,
   shortString,
   validateAndParseAddress
 } from 'starknet';
@@ -34,10 +34,8 @@ export const ethProvider = new JsonRpcProvider(
   process.env.L1_NETWORK_NODE_URL ??
     `https://rpc.brovider.xyz/${networkProperties.baseChainId}`
 );
-const starkProvider = new Provider({
-  rpc: {
-    nodeUrl: networkNodeUrl
-  }
+const starkProvider = new RpcProvider({
+  nodeUrl: networkNodeUrl
 });
 
 const encodersAbi = new CallData(EncodersAbi);

--- a/apps/mana/package.json
+++ b/apps/mana/package.json
@@ -33,7 +33,7 @@
     "express": "^4.17.1",
     "knex": "^2.5.1",
     "pg": "^8.11.3",
-    "starknet": "5.25.0",
+    "starknet": "6.11.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -74,7 +74,7 @@
     "pinia": "^2.1.6",
     "remarkable": "^2.0.1",
     "scrollmonitor": "^1.2.11",
-    "starknet": "5.25.0",
+    "starknet": "6.11.0",
     "starknetkit": "^1.1.9",
     "stream-browserify": "^3.0.0",
     "tippy.js": "^6.3.7",

--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -1,5 +1,6 @@
 import {
   LibraryError,
+  ReceiptTx,
   constants as starknetConstants,
   TransactionExecutionStatus
 } from 'starknet';
@@ -106,7 +107,8 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
             return;
           }
 
-          if (tx.execution_status === TransactionExecutionStatus.SUCCEEDED) {
+          const receiptTx = new ReceiptTx(tx);
+          if (receiptTx.isSuccess()) {
             resolve(tx);
           } else {
             reject(tx);

--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -1,8 +1,7 @@
 import {
   LibraryError,
   ReceiptTx,
-  constants as starknetConstants,
-  TransactionExecutionStatus
+  constants as starknetConstants
 } from 'starknet';
 import { pinPineapple } from '@/helpers/pin';
 import { Network } from '@/networks/types';

--- a/packages/sx.js/package.json
+++ b/packages/sx.js/package.json
@@ -22,7 +22,7 @@
     "prepare": "yarn build",
     "prepublishOnly": "yarn run lint",
     "node:evm": "anvil",
-    "node:starknet": "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES starknet-devnet --seed 1",
+    "node:starknet": "starknet-devnet --seed 1",
     "test": "SEPOLIA_NODE_URL=https://rpc.snapshotx.xyz/11155111 vitest run test/unit",
     "test:integration:starknet": "vitest run test/integration/starknet",
     "test:integration:evm": "vitest run test/integration/evm",

--- a/packages/sx.js/package.json
+++ b/packages/sx.js/package.json
@@ -54,7 +54,7 @@
     "micro-starknet": "^0.2.3",
     "randombytes": "^2.1.0",
     "snake-case": "^3.0.4",
-    "starknet": "5.25.0"
+    "starknet": "6.11.0"
   },
   "devDependencies": {
     "@ethersproject/units": "^5.7.0",

--- a/packages/sx.js/src/clients/starknet/constants.ts
+++ b/packages/sx.js/src/clients/starknet/constants.ts
@@ -1,0 +1,1 @@
+export const ESTIMATE_FEE_OVERHEAD_PERCENT = 50;

--- a/packages/sx.js/src/clients/starknet/ethereum-tx/index.ts
+++ b/packages/sx.js/src/clients/starknet/ethereum-tx/index.ts
@@ -1,7 +1,7 @@
 import { Signer } from '@ethersproject/abstract-signer';
 import { Contract } from '@ethersproject/contracts';
 import { poseidonHashMany } from 'micro-starknet';
-import { CallData, constants, SequencerProvider, shortString } from 'starknet';
+import { CallData, shortString } from 'starknet';
 import StarknetCommitAbi from './abis/StarknetCommit.json';
 import {
   ClientConfig,
@@ -199,12 +199,10 @@ const UPDATE_PROPOSAL_SELECTOR =
   '0x1f93122f646d968b0ce8c1a4986533f8b4ed3f099122381a4f77478a480c2c3';
 
 export class EthereumTx {
-  // TODO: handle sequencerUrl in network config
-  config: ClientConfig & { sequencerUrl: string };
+  config: ClientConfig;
 
-  constructor(opts: ClientOpts & { sequencerUrl?: string }) {
+  constructor(opts: ClientOpts) {
     this.config = {
-      sequencerUrl: opts.sequencerUrl || constants.BaseUrl.SN_SEPOLIA,
       ...opts
     };
   }
@@ -213,11 +211,7 @@ export class EthereumTx {
     l2Address: string,
     payload: string[]
   ): Promise<{ overall_fee: number }> {
-    const sequencerProvider = new SequencerProvider({
-      baseUrl: this.config.sequencerUrl
-    });
-
-    const fees = await sequencerProvider.estimateMessageFee({
+    const fees = await this.config.starkProvider.estimateMessageFee({
       from_address: this.config.networkConfig.starknetCommit,
       to_address: l2Address,
       entry_point_selector: 'commit',

--- a/packages/sx.js/src/clients/starknet/starknet-sig/index.ts
+++ b/packages/sx.js/src/clients/starknet/starknet-sig/index.ts
@@ -84,7 +84,7 @@ export class StarknetSig {
       verifyingContract
     };
 
-    const data: typedData.TypedData = {
+    const data: typeof typedData.TypedData = {
       types,
       primaryType,
       domain,

--- a/packages/sx.js/src/types/index.ts
+++ b/packages/sx.js/src/types/index.ts
@@ -2,7 +2,7 @@ import {
   TypedDataDomain,
   TypedDataField
 } from '@ethersproject/abstract-signer';
-import { BigNumberish, Call, RpcProvider, StarkNetType } from 'starknet';
+import { BigNumberish, Call, RpcProvider, StarknetType } from 'starknet';
 import { NetworkConfig } from './networkConfig';
 import { MetaTransaction } from '../utils/encoding';
 
@@ -151,7 +151,7 @@ export type SignatureData = {
   signature?: string | string[] | null;
   message?: Record<string, any>;
   domain?: TypedDataDomain;
-  types?: Record<string, TypedDataField[] | StarkNetType[]>;
+  types?: Record<string, TypedDataField[] | StarknetType[]>;
   primaryType?: any;
 };
 

--- a/packages/sx.js/src/utils/fees.ts
+++ b/packages/sx.js/src/utils/fees.ts
@@ -1,7 +1,7 @@
 import { Account, Call, stark } from 'starknet';
 import { NetworkConfig } from '../types';
 
-const FEE_OVERHEAD = 0.5;
+const FEE_OVERHEAD = 50;
 
 export async function estimateStarknetFee(
   account: Account,

--- a/packages/sx.js/test/integration/starknet/index.test.ts
+++ b/packages/sx.js/test/integration/starknet/index.test.ts
@@ -1,6 +1,6 @@
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
-import { Account, Provider, uint256 } from 'starknet';
+import { Account, RpcProvider, uint256 } from 'starknet';
 import { beforeAll, describe, expect, it } from 'vitest';
 import ozAccountCasm from './fixtures/openzeppelin_Account.casm.json';
 import ozAccountSierra from './fixtures/openzeppelin_Account.sierra.json';
@@ -25,8 +25,8 @@ import { Choice } from '../../../src/types';
 describe('sx-starknet', () => {
   const ethUrl = 'http://127.0.0.1:8545';
   const entryAddress =
-    '0x7d2f37b75a5e779f7da01c22acee1b66c39e8ba470ee5448f05e1462afcedb4';
-  const entryPrivateKey = '0xcd613e30d8f16adf91b7584a2265b1f5';
+    '0x260a8311b4f1092db620b923e8d7d20e76dedcc615fb4b6fdf28315b81de201';
+  const entryPrivateKey = '0xc10662b7b247c7cecf7e8a30726cff12';
   const ethPrivateKey =
     '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 
@@ -35,11 +35,8 @@ describe('sx-starknet', () => {
     '0x138b5dd1ca094fcaebd669a5d2aa7bb7d13db32d5939939ee66b938ded2f361';
   const privateKey = '0x9c7d498a8f76dc87564274036988f668';
 
-  // RpcProvider doesn't work with starknet-devnet
-  const starkProvider = new Provider({
-    sequencer: {
-      baseUrl: 'http://127.0.0.1:5050'
-    }
+  const starkProvider = new RpcProvider({
+    nodeUrl: 'http://127.0.0.1:5050/rpc'
   });
 
   const provider = new JsonRpcProvider(ethUrl);
@@ -92,8 +89,7 @@ describe('sx-starknet', () => {
     ethTxClient = new EthereumTx({
       starkProvider: starkProvider as any,
       ethUrl,
-      networkConfig: testConfig.networkConfig,
-      sequencerUrl: 'http://127.0.0.1:5050'
+      networkConfig: testConfig.networkConfig
     });
     starkSigClient = new StarknetSig({
       starkProvider: starkProvider as any,
@@ -101,7 +97,7 @@ describe('sx-starknet', () => {
       networkConfig: testConfig.networkConfig,
       manaUrl: 'http://localhost:3000'
     });
-  }, 300_000);
+  }, 500_000);
 
   describe('vanilla authenticator', () => {
     it('StarknetTx.propose()', async () => {
@@ -601,8 +597,7 @@ describe('sx-starknet', () => {
 
     it('should execute on l1', async () => {
       const flushL2Response = await flush();
-      const message_payload =
-        flushL2Response.consumed_messages.from_l2[0].payload;
+      const message_payload = flushL2Response.messages_to_l1[0].payload;
 
       const { executionParams } = getExecutionData(
         'EthRelayer',

--- a/packages/sx.js/test/integration/starknet/utils.ts
+++ b/packages/sx.js/test/integration/starknet/utils.ts
@@ -129,7 +129,7 @@ export async function setup({
   ethereumWallet: Wallet;
   ethUrl: string;
 }): Promise<TestConfig> {
-  await mint(starknetAccount.address, 1000000000000000000000);
+  await mint(starknetAccount.address, 100000000000000000);
 
   const masterSpaceResult = await starknetAccount.declareIfNot({
     contract: sxSpaceSierra as any,
@@ -287,7 +287,7 @@ export async function setup({
   const merkleTreeRoot = generateMerkleRoot(hashes);
 
   const networkConfig: NetworkConfig = {
-    eip712ChainId: '0x534e5f474f45524c49',
+    eip712ChainId: '0x534e5f5345504f4c4941',
     spaceFactory: factoryAddress,
     l1AvatarExecutionStrategyImplementation: masterl1AvatarExecutionStrategy,
     l1AvatarExecutionStrategyFactory,
@@ -531,7 +531,7 @@ export function increaseTime(timeIncrease: number) {
 
 export function loadL1MessagingContract(networkUrl: string, address: string) {
   return postDevnet('postman/load_l1_messaging_contract', {
-    networkUrl,
+    network_url: networkUrl,
     address
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1809,6 +1809,13 @@
   dependencies:
     "@noble/hashes" "1.3.0"
 
+"@noble/curves@~1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.4.0.tgz#f05771ef64da724997f69ee1261b2417a49522d6"
+  integrity sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==
+  dependencies:
+    "@noble/hashes" "1.4.0"
+
 "@noble/hashes@1.2.0", "@noble/hashes@~1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.2.0.tgz#a3150eeb09cc7ab207ebf6d7b9ad311a9bdbed12"
@@ -1828,6 +1835,11 @@
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
   integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
+
+"@noble/hashes@1.4.0", "@noble/hashes@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
+  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
 
 "@noble/secp256k1@1.7.1", "@noble/secp256k1@~1.7.0":
   version "1.7.1"
@@ -2652,6 +2664,11 @@
     "@stablelib/keyagreement" "^1.0.1"
     "@stablelib/random" "^1.0.2"
     "@stablelib/wipe" "^1.0.1"
+
+"@starknet-io/types-js@^0.7.7", "starknet-types-07@npm:@starknet-io/types-js@^0.7.7":
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/@starknet-io/types-js/-/types-js-0.7.7.tgz#444be5e4e585ec6f599d42d3407280d98b2dfdf8"
+  integrity sha512-WLrpK7LIaIb8Ymxu6KF/6JkGW1sso988DweWu7p5QY/3y7waBIiPvzh27D9bX5KIJNRDyOoOVoHVEKYUYWZ/RQ==
 
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
@@ -3931,6 +3948,16 @@ abi-wan-kanabi@^2.0.0:
     fs-extra "^10.0.0"
     rome "^12.1.3"
     typescript "^5.2.2"
+    yargs "^17.7.2"
+
+abi-wan-kanabi@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-2.2.2.tgz#82c48e8fa08d9016cf92d3d81d494cc60e934693"
+  integrity sha512-sTCv2HyNIj1x2WFUoc9oL8ZT9liosrL+GoqEGZJK1kDND096CfA7lwx06vLxLWMocQ41FQXO3oliwoh/UZHYdQ==
+  dependencies:
+    ansicolors "^0.3.2"
+    cardinal "^2.1.1"
+    fs-extra "^10.0.0"
     yargs "^17.7.2"
 
 abitype@0.9.8:
@@ -6946,6 +6973,14 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fetch-cookie@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fetch-cookie/-/fetch-cookie-3.0.1.tgz#6a77f7495e1a639ae019db916a234db8c85d5963"
+  integrity sha512-ZGXe8Y5Z/1FWqQ9q/CrJhkUD73DyBU9VF0hBQmEO/wPHe4A9PKTjplFDLeFX8aOsYypZUcX5Ji/eByn3VCVO3Q==
+  dependencies:
+    set-cookie-parser "^2.4.8"
+    tough-cookie "^4.0.0"
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -7262,6 +7297,13 @@ get-starknet-core@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/get-starknet-core/-/get-starknet-core-3.2.0.tgz#44cabcbd573262340d575cb6b9a38e469a8029ed"
   integrity sha512-SZhxtLlKoPKLZ2H3l9WIU7CiNmkL3qLWGksALmvZdAXa/9PykYfLtvIB5B8A2UZMpf2ojTZlWLfuo1KhgmVobA==
+
+get-starknet-core@^4.0.0-next.3:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/get-starknet-core/-/get-starknet-core-4.0.0.tgz#9a81101b3a4e54e090f76492b566abaa3b5865c7"
+  integrity sha512-6pLmidQZkC3wZsrHY99grQHoGpuuXqkbSP65F8ov1/JsEI8DDLkhsAuLCKFzNOK56cJp+f1bWWfTJ57e9r5eqQ==
+  dependencies:
+    "@starknet-io/types-js" "^0.7.7"
 
 get-stream@^5.1.0:
   version "5.2.0"
@@ -9379,6 +9421,11 @@ lossless-json@^2.0.8:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/lossless-json/-/lossless-json-2.0.11.tgz#3137684c93fd99481c6f99c985efc9c9c5cc76a5"
   integrity sha512-BP0vn+NGYvzDielvBZaFain/wgeJ1hTvURCqtKvhr1SCPePdaaTanmmcplrHfEJSJOUql7hk4FHwToNJjWRY3g==
+
+lossless-json@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lossless-json/-/lossless-json-4.0.1.tgz#d45229e3abb213a0235812780ca894ea8c5b2c6b"
+  integrity sha512-l0L+ppmgPDnb+JGxNLndPtJZGNf6+ZmVaQzoxQm3u6TXmhdnsA+YtdVR8DjzZd/em58686CQhOFDPewfJ4l7MA==
 
 loupe@^2.3.6, loupe@^2.3.7:
   version "2.3.7"
@@ -11783,6 +11830,11 @@ set-blocking@^2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
+set-cookie-parser@^2.4.8:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz#131921e50f62ff1a66a461d7d62d7b21d5d15a51"
+  integrity sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==
+
 set-function-length@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.0.tgz#2f81dc6c16c7059bda5ab7c82c11f03a515ed8e1"
@@ -12065,17 +12117,23 @@ standard-as-callback@^2.1.0:
   resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
   integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
-starknet@5.25.0:
-  version "5.25.0"
-  resolved "https://registry.yarnpkg.com/starknet/-/starknet-5.25.0.tgz#b8cc6992477899385d754ff0b46c8b9dca190826"
-  integrity sha512-ja5pV610voxTCw/MzXhZoZcwe+XZ5RVWkpa/Fhxsy0OP635DxKDbnPQSKCLWXmSi/BkfkpeefXXv4IUvYJo4kw==
+starknet@6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/starknet/-/starknet-6.11.0.tgz#5d7e868e913777e9bf64323e59ed8be86437f291"
+  integrity sha512-u50KrGDi9fbu1Ogu7ynwF/tSeFlp3mzOg1/Y5x50tYFICImo3OfY4lOz9OtYDk404HK4eUujKkhov9tG7GAKlg==
   dependencies:
-    "@noble/curves" "~1.3.0"
+    "@noble/curves" "~1.4.0"
+    "@noble/hashes" "^1.4.0"
     "@scure/base" "~1.1.3"
     "@scure/starknet" "~1.0.0"
+    abi-wan-kanabi "^2.2.2"
+    fetch-cookie "^3.0.0"
+    get-starknet-core "^4.0.0-next.3"
     isomorphic-fetch "^3.0.0"
-    lossless-json "^2.0.8"
+    lossless-json "^4.0.1"
     pako "^2.0.4"
+    starknet-types-07 "npm:@starknet-io/types-js@^0.7.7"
+    ts-mixer "^6.0.3"
     url-join "^4.0.1"
 
 starknet@^5.19.3:
@@ -12650,6 +12708,16 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
+tough-cookie@^4.0.0:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.4.tgz#945f1461b45b5a8c76821c33ea49c3ac192c1b36"
+  integrity sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
 tough-cookie@^4.1.2:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
@@ -12706,6 +12774,11 @@ ts-invariant@^0.10.3:
   integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
   dependencies:
     tslib "^2.1.0"
+
+ts-mixer@^6.0.3:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-6.0.4.tgz#1da39ceabc09d947a82140d9f09db0f84919ca28"
+  integrity sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==
 
 ts-node@^10.9.1:
   version "10.9.2"


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/310
Closes: https://github.com/snapshot-labs/sx-monorepo/issues/304

Upgrading to latest starknet version mitigates issues with:
- fee estimation (https://github.com/snapshot-labs/sx-monorepo/issues/304)
- caching timestamps (https://github.com/snapshot-labs/sx-monorepo/issues/310)

However it requires RPC 0.7 which is currently in RC stage and not supported by Infura.
You would need to test it with other provider: https://starknet-sepolia.public.blastapi.io/rpc/v0_7

### How to test

1. Update URL for mana to use RPC v0.7
2. Try proposing

