### PR TITLE
fix(ui): fix tooltip position not matching content length

### DIFF
--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -223,7 +223,7 @@ watch([sortBy, choiceFilter], () => {
               <div v-else>
                 <UiTooltip
                   v-if="proposal.type !== 'basic'"
-                  class="truncate !block"
+                  class="max-w-[100%] truncate !inline-block"
                   :title="getChoiceText(proposal.choices, vote.choice)"
                 >
                   {{ getChoiceText(proposal.choices, vote.choice) }}


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #316

### How to test

1. Go to http://localhost:8080/#/s:pistachiodao.eth/proposal/0xf93f1ac80e22cc930b1eef1d20bd34671ccc33b88b04695479c9de364451d77f/votes
2. Hover some vote choice
3. The tooltip should always be centered on the text, and matching the text length, instead of centered on the table cell
