### PR TITLE
feat: add STARKNET_FEE_ESTIMATE_OVERRIDE env to hardcode fee

### DIFF
--- a/.changeset/selfish-brooms-jog.md
+++ b/.changeset/selfish-brooms-jog.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+add feeEstimateOverride to networkConfig

--- a/apps/mana/src/stark/herodotus.ts
+++ b/apps/mana/src/stark/herodotus.ts
@@ -1,6 +1,5 @@
 import fetch from 'cross-fetch';
 import { constants } from 'starknet';
-import { clients } from '@snapshot-labs/sx';
 import * as db from '../db';
 import { getClient } from './networks';
 
@@ -37,8 +36,6 @@ const HERODOTUS_MAPPING = new Map<string, HerodotusConfig>([
     }
   ]
 ]);
-
-const controller = new clients.HerodotusController();
 
 type ApiProposal = {
   chainId: string;
@@ -168,7 +165,7 @@ export async function processProposal(proposal: DbProposal) {
     }
   }
 
-  const { getAccount } = getClient(proposal.chainId);
+  const { getAccount, herodotusController } = getClient(proposal.chainId);
   const { account, nonceManager } = getAccount('0x0');
   const mapping = HERODOTUS_MAPPING.get(proposal.chainId);
   if (!mapping) throw new Error('Invalid chainId');
@@ -190,7 +187,7 @@ export async function processProposal(proposal: DbProposal) {
     await nonceManager.acquire();
     const nonce = await nonceManager.getNonce();
 
-    const receipt = await controller.cacheTimestamp(
+    const receipt = await herodotusController.cacheTimestamp(
       {
         signer: account,
         contractAddress: proposal.strategyAddress,

--- a/apps/mana/src/stark/herodotus.ts
+++ b/apps/mana/src/stark/herodotus.ts
@@ -200,6 +200,8 @@ export async function processProposal(proposal: DbProposal) {
       { nonce }
     );
 
+    nonceManager.increaseNonce();
+
     console.log('cached proposal', receipt);
 
     await db.markProposalProcessed(proposal.id);

--- a/apps/mana/src/stark/networks.ts
+++ b/apps/mana/src/stark/networks.ts
@@ -20,6 +20,7 @@ const clientsMap = new Map<
   {
     provider: RpcProvider;
     client: clients.StarknetTx;
+    herodotusController: clients.HerodotusController;
     getAccount: (spaceAddress: string) => { account: Account; nonceManager: NonceManager };
   }
 >();
@@ -34,13 +35,18 @@ export function getClient(chainId: string) {
   const ethUrl = ETH_NODE_URLS.get(chainId);
   if (!ethUrl) throw new Error(`Missing ethereum node url for chainId ${chainId}`);
 
+  const networkConfig = NETWORKS.get(chainId);
+  if (!networkConfig) throw new Error(`Missing network config for chainId ${chainId}`);
+
   const client = new clients.StarknetTx({
     starkProvider: provider,
     ethUrl,
-    networkConfig: NETWORKS.get(chainId)
+    networkConfig
   });
 
-  clientsMap.set(chainId, { provider, client, getAccount });
+  const herodotusController = new clients.HerodotusController(networkConfig);
 
-  return { provider, client, getAccount };
+  clientsMap.set(chainId, { provider, client, herodotusController, getAccount });
+
+  return { provider, client, herodotusController, getAccount };
 }

--- a/packages/sx.js/src/clients/starknet/herodotus/index.ts
+++ b/packages/sx.js/src/clients/starknet/herodotus/index.ts
@@ -1,5 +1,6 @@
 import { Account, CairoOption, CairoOptionVariant, CallData, cairo } from 'starknet';
 import { estimateStarknetFee } from '../../../utils/fees';
+import { NetworkConfig } from '../../../types';
 
 type ProofElement = {
   index: number;
@@ -12,6 +13,12 @@ type Opts = {
 };
 
 export class HerodotusController {
+  networkConfig: NetworkConfig;
+
+  constructor(networkConfig: NetworkConfig) {
+    this.networkConfig = networkConfig;
+  }
+
   async cacheTimestamp(
     {
       signer,
@@ -47,7 +54,9 @@ export class HerodotusController {
       })
     };
 
-    const maxFee = opts?.nonce ? await estimateStarknetFee(signer, call) : undefined;
+    const maxFee = opts?.nonce
+      ? await estimateStarknetFee(signer, this.networkConfig, call)
+      : undefined;
     return signer.execute(call, undefined, { ...opts, maxFee });
   }
 }

--- a/packages/sx.js/src/clients/starknet/herodotus/index.ts
+++ b/packages/sx.js/src/clients/starknet/herodotus/index.ts
@@ -1,4 +1,5 @@
 import { Account, CairoOption, CairoOptionVariant, CallData, cairo } from 'starknet';
+import { estimateStarknetFee } from '../../../utils/fees';
 
 type ProofElement = {
   index: number;
@@ -46,7 +47,7 @@ export class HerodotusController {
       })
     };
 
-    const fee = await signer.estimateFee(call);
-    return signer.execute(call, undefined, { ...opts, maxFee: fee.suggestedMaxFee });
+    const maxFee = opts?.nonce ? await estimateStarknetFee(signer, call) : undefined;
+    return signer.execute(call, undefined, { ...opts, maxFee });
   }
 }

--- a/packages/sx.js/src/clients/starknet/starknet-tx/index.ts
+++ b/packages/sx.js/src/clients/starknet/starknet-tx/index.ts
@@ -204,7 +204,9 @@ export class StarknetTx {
 
     const calls = [call];
 
-    const maxFee = opts?.nonce ? await estimateStarknetFee(account, calls) : undefined;
+    const maxFee = opts?.nonce
+      ? await estimateStarknetFee(account, this.config.networkConfig, calls)
+      : undefined;
     return account.execute(calls, undefined, { ...opts, maxFee });
   }
 
@@ -226,7 +228,9 @@ export class StarknetTx {
       metadataUri: envelope.data.metadataUri
     });
 
-    const maxFee = opts?.nonce ? await estimateStarknetFee(account, call) : undefined;
+    const maxFee = opts?.nonce
+      ? await estimateStarknetFee(account, this.config.networkConfig, call)
+      : undefined;
     return account.execute(call, undefined, { ...opts, maxFee });
   }
 
@@ -254,7 +258,9 @@ export class StarknetTx {
       metadataUri: ''
     });
 
-    const maxFee = opts?.nonce ? await estimateStarknetFee(account, call) : undefined;
+    const maxFee = opts?.nonce
+      ? await estimateStarknetFee(account, this.config.networkConfig, call)
+      : undefined;
     return account.execute(call, undefined, { ...opts, maxFee });
   }
 

--- a/packages/sx.js/src/clients/starknet/starknet-tx/index.ts
+++ b/packages/sx.js/src/clients/starknet/starknet-tx/index.ts
@@ -1,4 +1,4 @@
-import { stark, Account, CallData, shortString, uint256, hash } from 'starknet';
+import { Account, CallData, shortString, uint256, hash } from 'starknet';
 import { ContractFactory } from '@ethersproject/contracts';
 import { Signer } from '@ethersproject/abstract-signer';
 import { poseidonHashMany } from 'micro-starknet';
@@ -6,6 +6,7 @@ import randomBytes from 'randombytes';
 import { getStrategiesWithParams } from '../../../utils/strategies';
 import { getAuthenticator } from '../../../authenticators/starknet';
 import { hexPadLeft } from '../../../utils/encoding';
+import { estimateStarknetFee } from '../../../utils/fees';
 import { defaultNetwork } from '../../../networks';
 import SpaceAbi from './abis/Space.json';
 import L1AvatarExecutionStrategyAbi from './abis/L1AvatarExecutionStrategy.json';
@@ -203,9 +204,8 @@ export class StarknetTx {
 
     const calls = [call];
 
-    const fee = opts?.nonce ? await account.estimateFee(calls) : null;
-    const maxFee = fee ? stark.estimatedFeeToMaxFee(fee.suggestedMaxFee, 1.5) : undefined;
-    return account.execute(calls, undefined, fee ? { maxFee } : undefined);
+    const maxFee = opts?.nonce ? await estimateStarknetFee(account, calls) : undefined;
+    return account.execute(calls, undefined, { ...opts, maxFee });
   }
 
   async updateProposal(account: Account, envelope: Envelope<UpdateProposal>, opts?: Opts) {
@@ -226,9 +226,8 @@ export class StarknetTx {
       metadataUri: envelope.data.metadataUri
     });
 
-    const fee = opts?.nonce ? await account.estimateFee(call) : null;
-    const maxFee = fee ? stark.estimatedFeeToMaxFee(fee.suggestedMaxFee, 1.5) : undefined;
-    return account.execute(call, undefined, fee ? { maxFee } : undefined);
+    const maxFee = opts?.nonce ? await estimateStarknetFee(account, call) : undefined;
+    return account.execute(call, undefined, { ...opts, maxFee });
   }
 
   async vote(account: Account, envelope: Envelope<Vote>, opts?: Opts) {
@@ -255,9 +254,8 @@ export class StarknetTx {
       metadataUri: ''
     });
 
-    const fee = opts?.nonce ? await account.estimateFee(call) : null;
-    const maxFee = fee ? stark.estimatedFeeToMaxFee(fee.suggestedMaxFee, 1.5) : undefined;
-    return account.execute(call, undefined, fee ? { maxFee } : undefined);
+    const maxFee = opts?.nonce ? await estimateStarknetFee(account, call) : undefined;
+    return account.execute(call, undefined, { ...opts, maxFee });
   }
 
   execute({

--- a/packages/sx.js/src/starknetNetworks.ts
+++ b/packages/sx.js/src/starknetNetworks.ts
@@ -58,6 +58,7 @@ function createStarknetConfig(networkId: keyof typeof starknetNetworks): Network
     masterSpace: network.Meta.masterSpace,
     starknetCommit: network.Meta.starknetCommit,
     starknetCore: network.Meta.starknetCore,
+    feeEstimateOverride: network.Meta.feeEstimateOverride,
     authenticators,
     strategies
   };
@@ -72,7 +73,8 @@ export const starknetNetworks = {
       spaceFactory: '0x0250e28c97e729842190c3672f9fcf8db0fc78b8080e87a894831dc69e4f4439',
       masterSpace: '0x00f20287bef9f46c6051e425a84094d2436bcc1fef804db353e60f93661961ac',
       starknetCommit: '0xf1ec7b0276aa5af11ecefe56efb0f198a77016e9',
-      starknetCore: '0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4'
+      starknetCore: '0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4',
+      feeEstimateOverride: process.env.STARKNET_MAINNET_FEE_ESTIMATE_OVERRIDE
     },
     Authenticators: {
       Vanilla: '0xc4b0a7d8626638e7dd410b16ccbc48fe36e68f864dec75b23ef41e3732d5d2',
@@ -103,7 +105,8 @@ export const starknetNetworks = {
       spaceFactory: '0x063c62258e1ba4d9ad72eab809ea5c3d1a4545b721bc444d6068ced6246c2f3c',
       masterSpace: '0x00f20287bef9f46c6051e425a84094d2436bcc1fef804db353e60f93661961ac',
       starknetCommit: '0x8bf85537c80becba711447f66a9a4452e3575e29',
-      starknetCore: '0xde29d060D45901Fb19ED6C6e959EB22d8626708e'
+      starknetCore: '0xde29d060D45901Fb19ED6C6e959EB22d8626708e',
+      feeEstimateOverride: process.env.STARKNET_GOERLI_FEE_ESTIMATE_OVERRIDE
     },
     Authenticators: {
       Vanilla: '0x46ad946f22ac4e14e271f24309f14ac36f0fde92c6831a605813fefa46e0893',
@@ -134,7 +137,8 @@ export const starknetNetworks = {
       spaceFactory: '0x302d332e9aceb184e5f301cb62c85181e7fc3b30559935c5736e987de579f6e',
       masterSpace: '0x04b61126a7def0956cb4ff342ba72d850ea6b78b0ddb3e0b45f3a99bc9eb5995',
       starknetCommit: '0xf1ec7b0276aa5af11ecefe56efb0f198a77016e9',
-      starknetCore: '0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057'
+      starknetCore: '0xE2Bb56ee936fd6433DC0F6e7e3b8365C906AA057',
+      feeEstimateOverride: process.env.STARKNET_SEPOLIA_FEE_ESTIMATE_OVERRIDE
     },
     Authenticators: {
       Vanilla: '0x51a4a1eb5ce28fc95edf408a847efccfb030d27314d9fbe82d82cb998ec1a0b',

--- a/packages/sx.js/src/types/networkConfig.ts
+++ b/packages/sx.js/src/types/networkConfig.ts
@@ -66,6 +66,7 @@ export type NetworkConfig = {
   masterSpace: string;
   starknetCommit: string;
   starknetCore: string;
+  feeEstimateOverride?: string;
   herodotusAccumulatesChainId: number;
   authenticators: {
     [key: string]:

--- a/packages/sx.js/src/utils/fees.ts
+++ b/packages/sx.js/src/utils/fees.ts
@@ -1,0 +1,12 @@
+import { Account, Call, stark } from 'starknet';
+
+// Used as workaround due to broken fee estimation in starknet@5 and RPC 0.5
+const FEE_ESTIMATE_OVERRIDE = process.env.VITE_FEE_ESTIMATE_OVERRIDE;
+const FEE_OVERHEAD = 0.5;
+
+export async function estimateStarknetFee(account: Account, calls: Call | Call[]) {
+  if (FEE_ESTIMATE_OVERRIDE) return BigInt(FEE_ESTIMATE_OVERRIDE);
+
+  const fee = await account.estimateFee(calls);
+  return stark.estimatedFeeToMaxFee(fee.suggestedMaxFee, FEE_OVERHEAD);
+}

--- a/packages/sx.js/src/utils/fees.ts
+++ b/packages/sx.js/src/utils/fees.ts
@@ -1,7 +1,7 @@
 import { Account, Call, stark } from 'starknet';
 
 // Used as workaround due to broken fee estimation in starknet@5 and RPC 0.5
-const FEE_ESTIMATE_OVERRIDE = process.env.VITE_FEE_ESTIMATE_OVERRIDE;
+const FEE_ESTIMATE_OVERRIDE = process.env.STARKNET_FEE_ESTIMATE_OVERRIDE;
 const FEE_OVERHEAD = 0.5;
 
 export async function estimateStarknetFee(account: Account, calls: Call | Call[]) {

--- a/packages/sx.js/src/utils/fees.ts
+++ b/packages/sx.js/src/utils/fees.ts
@@ -1,11 +1,14 @@
 import { Account, Call, stark } from 'starknet';
+import { NetworkConfig } from '../types';
 
-// Used as workaround due to broken fee estimation in starknet@5 and RPC 0.5
-const FEE_ESTIMATE_OVERRIDE = process.env.STARKNET_FEE_ESTIMATE_OVERRIDE;
 const FEE_OVERHEAD = 0.5;
 
-export async function estimateStarknetFee(account: Account, calls: Call | Call[]) {
-  if (FEE_ESTIMATE_OVERRIDE) return BigInt(FEE_ESTIMATE_OVERRIDE);
+export async function estimateStarknetFee(
+  account: Account,
+  networkConfig: NetworkConfig,
+  calls: Call | Call[]
+) {
+  if (networkConfig.feeEstimateOverride) return BigInt(networkConfig.feeEstimateOverride);
 
   const fee = await account.estimateFee(calls);
   return stark.estimatedFeeToMaxFee(fee.suggestedMaxFee, FEE_OVERHEAD);


### PR DESCRIPTION
### Summary

This PR adds `VITE_FEE_ESTIMATE_OVERRIDE` that can be used to override fees in `starknet-tx` and `herodotus` clients.
The fees are pretty high on Sepolia right now, over $4 to just propose on Sepolia. We could hardcode it to 10000000000000000 to be safe.

### How to test

1. Uncomment mana filter from `yarn dev` script.
2. Run `STARKNET_SEPOLIA_FEE_ESTIMATE_OVERRIDE=10000000000000000 VITE_MANA_URL=http://localhost:3001 yarn dev`
3. You can propose/vote on Starknet spaces with EthSig/StarkSig.
4. Max fee is hardcoded in transaction.
