### PR TITLE
fix(ui): fix wrong placeholder style

### DIFF
--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -119,18 +119,15 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
           </td>
           <template v-else>
             <tbody>
-              <td
-                v-if="loaded && delegates.length === 0"
-                class="px-4 py-3 flex items-center"
-                colspan="3"
-              >
-                <IH-exclamation-circle class="inline-block mr-2" />
-                There are no delegates.
-              </td>
-              <td v-else-if="loaded && failed" class="px-4 py-3 flex items-center" colspan="3">
-                <IH-exclamation-circle class="inline-block mr-2" />
-                Failed to load delegates.
-              </td>
+              <tr v-if="loaded && (delegates.length === 0 || failed)">
+                <td colspan="3">
+                  <div class="px-4 py-3 flex items-center">
+                    <IH-exclamation-circle class="inline-block mr-2" />
+                    <template v-if="delegates.length === 0">There are no delegates.</template>
+                    <template v-else-if="failed">Failed to load delegates.</template>
+                  </div>
+                </td>
+              </tr>
               <UiContainerInfiniteScroll
                 :loading-more="loadingMore"
                 @end-reached="handleEndReached"

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -159,10 +159,14 @@ watch([sortBy, choiceFilter], () => {
     </td>
     <template v-else>
       <tbody>
-        <td v-if="votes.length === 0" class="px-4 py-3 flex items-center" colspan="5">
-          <IH-exclamation-circle class="inline-block mr-2" />
-          <span v-text="'There are no votes here.'" />
-        </td>
+        <tr>
+          <td v-if="votes.length === 0" colspan="5">
+            <div class="px-4 py-3 flex items-center">
+              <IH-exclamation-circle class="inline-block mr-2" />
+              <span v-text="'There are no votes here.'" />
+            </div>
+          </td>
+        </tr>
         <UiContainerInfiniteScroll :loading-more="loadingMore" @end-reached="handleEndReached">
           <template #loading>
             <td colspan="5">

--- a/apps/ui/src/views/Space/Leaderboard.vue
+++ b/apps/ui/src/views/Space/Leaderboard.vue
@@ -154,15 +154,18 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
           <UiLoading class="px-4 py-3 block" />
         </td>
         <template v-else>
-          <tbody>
-            <td v-if="failed" class="px-4 py-3 flex items-center" colspan="3">
-              <IH-exclamation-circle class="inline-block mr-2" />
-              Failed to load the leaderboard.
-            </td>
-            <td v-else-if="users.length === 0" class="px-4 py-3 flex items-center" colspan="3">
-              <IH-exclamation-circle class="inline-block mr-2" />
-              This space does not have any activities yet.
-            </td>
+          <tbody v-if="failed || users.length === 0">
+            <tr>
+              <td colspan="3">
+                <div class="px-4 py-3 flex items-center">
+                  <IH-exclamation-circle class="inline-block mr-2" />
+                  <template v-if="failed">Failed to load the leaderboard.</template>
+                  <template v-else-if="users.length === 0"
+                    >This space does not have any activities yet.</template
+                  >
+                </div>
+              </td>
+            </tr>
             <UiContainerInfiniteScroll :loading-more="loadingMore" @end-reached="handleEndReached">
               <tr v-for="(user, i) in users" :key="i" class="border-b relative">
                 <td class="text-left flex items-center pl-4 py-3">


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #326

Fix an issue affecting all placeholder message inside TABLE element.

### How to test

1. Go to a proposal without votes
2. Go to votes table
3. The placeholder message should take the full width 

Do the same for space delegates and leaderboard page 
