### PR TITLE
fix: Sidebar doesn't work where there is no content

### DIFF
--- a/apps/ui/src/App.vue
+++ b/apps/ui/src/App.vue
@@ -65,7 +65,7 @@ watch(isSwiping, () => {
 </script>
 
 <template>
-  <div ref="el" :class="{ 'overflow-hidden': scrollDisabled }">
+  <div ref="el" class="h-screen" :class="{ 'overflow-hidden': scrollDisabled }">
     <UiLoading v-if="app.loading || !app.init" class="overlay big" />
     <div v-else class="pb-6 flex">
       <AppSidebar class="lg:visible" :class="{ invisible: !uiStore.sidebarOpen }" />

--- a/apps/ui/src/style.scss
+++ b/apps/ui/src/style.scss
@@ -199,10 +199,6 @@ input {
   }
 }
 
-#app {
-  height: 100%;
-}
-
 ::placeholder {
   color: rgba(var(--text)) !important;
   opacity: 0.6 !important;


### PR DESCRIPTION
### Summary

Closes: #329 

- Fix sliding when there is no content
- Remove unwanted style on `app`

### How to test

- Go to http://localhost:8080/#/s:opcollective.eth/leaderboard
- Try to slide on where there is no content (below: "This space does not have any activities yet.") refer to video [here](https://github.com/snapshot-labs/sx-monorepo/issues/329) 
- Slider should open irrespective of where you slide
- Everything should work same as before
