### PR TITLE
fix(ui): fix stuck tooltip after modal open on mobile

### DIFF
--- a/apps/ui/src/components/IndicatorVotingPower.vue
+++ b/apps/ui/src/components/IndicatorVotingPower.vue
@@ -49,7 +49,7 @@ function handleModalOpen() {
       :formatted-voting-power="formattedVotingPower"
       :on-click="handleModalOpen"
     >
-      <UiTooltip title="Your voting power">
+      <UiTooltip title="Your voting power" :touch="false">
         <UiButton
           v-if="web3.account && !(evmNetworks.includes(networkId) && web3.type === 'argentx')"
           :loading="loading"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #334 

Fix "Your voting power" tooltip persisting, after opening the voting power modal on mobile.

This is a know issue, and only way to fix this is to disable the tooltip for mobile device, like for the sidebar tooltip

### How to test

1. Go to space overview on mobile
2. Tap on the voting power
3. It should not show the tooltip anymore
