### PR TITLE
fix: Change discord link in footer

### DIFF
--- a/apps/ui/src/views/Landing.vue
+++ b/apps/ui/src/views/Landing.vue
@@ -12,7 +12,7 @@ const SOCIALS = [
     icon: ICX
   },
   {
-    href: 'https://discord.gg/snapshot',
+    href: 'https://discord.snapshot.org',
     icon: ICDiscord
   },
   {


### PR DESCRIPTION
### Summary

Changes discord link in footer, refer to https://discord.com/channels/955773041898573854/1182427601046884352/1239002513873702933

### How to test

1. go to landing page and click on discord link