### PR TITLE
leaderboard users list rendred fixed

### DIFF
--- a/apps/ui/src/views/Space/Leaderboard.vue
+++ b/apps/ui/src/views/Space/Leaderboard.vue
@@ -154,7 +154,7 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
           <UiLoading class="px-4 py-3 block" />
         </td>
         <template v-else>
-          <tbody v-if="failed || users.length === 0">
+          <tbody v-if="!failed && users.length > 0">
             <tr>
               <td colspan="3">
                 <div class="px-4 py-3 flex items-center">


### PR DESCRIPTION
### Summary
conditional render fixed for listing the users data in the leadboard.

![329852043-6af1fc58-c946-44b4-89f4-b6fa9ef656f0](https://github.com/snapshot-labs/sx-monorepo/assets/66510112/c81016ea-830d-471d-b529-8018ff22e40d)

Closes: #339