### PR TITLE
refactor(ui): migrate table to div

### DIFF
--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -58,7 +58,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
 <template>
   <div
     v-if="!currentNetwork || !delegation.apiUrl"
-    class="px-4 py-3 flex items-center text-skin-link gap-x-2"
+    class="px-4 py-3 flex items-center text-skin-link space-x-2"
   >
     <IH-exclamation-circle class="inline-block" />
     <span>No delegation API configured.</span>
@@ -75,11 +75,11 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
     <UiLabel label="Delegates" sticky />
     <div class="text-left table-fixed w-full">
       <div
-        class="bg-skin-bg border-b sticky top-[112px] lg:top-[113px] z-40 flex w-full font-medium gap-x-1"
+        class="bg-skin-bg border-b sticky top-[112px] lg:top-[113px] z-40 flex w-full font-medium space-x-1"
       >
         <div class="pl-4 w-[60%] flex items-center truncate">Delegatee</div>
         <button
-          class="hidden md:flex w-[20%] items-center justify-end hover:text-skin-link gap-x-1 truncate"
+          class="hidden md:flex w-[20%] items-center justify-end hover:text-skin-link space-x-1 truncate"
           @click="handleSortChange('tokenHoldersRepresentedAmount')"
         >
           <span>Delegators</span>
@@ -93,7 +93,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
           />
         </button>
         <button
-          class="w-[40%] md:w-[20%] flex justify-end items-center hover:text-skin-link pr-4 gap-x-1 truncate"
+          class="w-[40%] md:w-[20%] flex justify-end items-center hover:text-skin-link pr-4 space-x-1 truncate"
           @click="handleSortChange('delegatedVotes')"
         >
           <span class="truncate">Voting power</span>
@@ -105,14 +105,14 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
       <template v-else>
         <div
           v-if="loaded && (delegates.length === 0 || failed)"
-          class="px-4 py-3 flex items-center gap-x-2"
+          class="px-4 py-3 flex items-center space-x-2"
         >
           <IH-exclamation-circle class="inline-block" />
           <template v-if="delegates.length === 0">There are no delegates.</template>
           <template v-else-if="failed">Failed to load delegates.</template>
         </div>
         <UiContainerInfiniteScroll :loading-more="loadingMore" @end-reached="handleEndReached">
-          <div v-for="(delegate, i) in delegates" :key="i" class="border-b flex gap-x-1">
+          <div v-for="(delegate, i) in delegates" :key="i" class="border-b flex space-x-1">
             <div class="flex items-center w-[60%] pl-4 py-3 gap-x-3 truncate">
               <UiStamp :id="delegate.id" :size="32" />
               <a

--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -75,24 +75,30 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
     <UiLabel label="Delegates" sticky />
     <div class="text-left table-fixed w-full">
       <div
-        class="bg-skin-bg border-b sticky top-[112px] lg:top-[113px] z-40 flex w-full font-medium"
+        class="bg-skin-bg border-b sticky top-[112px] lg:top-[113px] z-40 flex w-full font-medium gap-x-1"
       >
-        <div class="pl-4 w-[60%] flex items-center">Delegatee</div>
+        <div class="pl-4 w-[60%] flex items-center truncate">Delegatee</div>
         <button
-          class="hidden md:flex w-[20%] items-center justify-end font-medium hover:text-skin-link gap-x-1"
+          class="hidden md:flex w-[20%] items-center justify-end font-medium hover:text-skin-link gap-x-1 truncate"
           @click="handleSortChange('tokenHoldersRepresentedAmount')"
         >
           <span>Delegators</span>
-          <IH-arrow-sm-down v-if="sortBy === 'tokenHoldersRepresentedAmount-desc'" />
-          <IH-arrow-sm-up v-else-if="sortBy === 'tokenHoldersRepresentedAmount-asc'" />
+          <IH-arrow-sm-down
+            v-if="sortBy === 'tokenHoldersRepresentedAmount-desc'"
+            class="shrink-0"
+          />
+          <IH-arrow-sm-up
+            v-else-if="sortBy === 'tokenHoldersRepresentedAmount-asc'"
+            class="shrink-0"
+          />
         </button>
         <button
-          class="w-[40%] md:w-[20%] flex justify-end items-center font-medium hover:text-skin-link pr-4 gap-x-1"
+          class="w-[40%] md:w-[20%] flex justify-end items-center font-medium hover:text-skin-link pr-4 gap-x-1 truncate"
           @click="handleSortChange('delegatedVotes')"
         >
           <span class="truncate">Voting power</span>
-          <IH-arrow-sm-down v-if="sortBy === 'delegatedVotes-desc'" />
-          <IH-arrow-sm-up v-else-if="sortBy === 'delegatedVotes-asc'" />
+          <IH-arrow-sm-down v-if="sortBy === 'delegatedVotes-desc'" class="shrink-0" />
+          <IH-arrow-sm-up v-else-if="sortBy === 'delegatedVotes-asc'" class="shrink-0" />
         </button>
       </div>
       <UiLoading v-if="loading" class="px-4 py-3 block" />
@@ -106,8 +112,8 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
           <template v-else-if="failed">Failed to load delegates.</template>
         </div>
         <UiContainerInfiniteScroll :loading-more="loadingMore" @end-reached="handleEndReached">
-          <div v-for="(delegate, i) in delegates" :key="i" class="border-b flex items-center">
-            <div class="flex items-center w-[60%] pl-4 py-3 gap-x-3">
+          <div v-for="(delegate, i) in delegates" :key="i" class="border-b flex gap-x-1">
+            <div class="flex items-center w-[60%] pl-4 py-3 gap-x-3 truncate">
               <UiStamp :id="delegate.id" :size="32" />
               <a
                 :href="currentNetwork.helpers.getExplorerUrl(delegate.id, 'address')"
@@ -121,12 +127,14 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
                 <div class="text-[17px] text-skin-text truncate" v-text="shorten(delegate.id)" />
               </a>
             </div>
-            <div class="hidden md:flex w-[20%] flex-col items-end justify-center leading-[22px]">
+            <div
+              class="hidden md:flex w-[20%] flex-col items-end justify-center leading-[22px] truncate"
+            >
               <h4 class="text-skin-link" v-text="_n(delegate.tokenHoldersRepresentedAmount)" />
               <div class="text-[17px]" v-text="`${delegate.delegatorsPercentage.toFixed(3)}%`" />
             </div>
             <div
-              class="w-[40%] md:w-[20%] flex flex-col items-end justify-center pr-4 leading-[22px]"
+              class="w-[40%] md:w-[20%] flex flex-col items-end justify-center pr-4 leading-[22px] truncate"
             >
               <h4 class="text-skin-link" v-text="_n(delegate.delegatedVotes)" />
               <div class="text-[17px]" v-text="`${delegate.votesPercentage.toFixed(3)}%`" />

--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -56,9 +56,12 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
 </script>
 
 <template>
-  <div v-if="!currentNetwork || !delegation.apiUrl" class="p-4 flex items-center text-skin-link">
-    <IH-exclamation-circle class="inline-block mr-2" />
-    No delegation API configured.
+  <div
+    v-if="!currentNetwork || !delegation.apiUrl"
+    class="px-4 py-3 flex items-center text-skin-link gap-x-2"
+  >
+    <IH-exclamation-circle class="inline-block" />
+    <span>No delegation API configured.</span>
   </div>
   <template v-else>
     <div v-if="delegation.contractAddress" class="p-4 space-x-2 flex">
@@ -69,116 +72,73 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
         </UiButton>
       </UiTooltip>
     </div>
-    <div class="space-y-3">
-      <div>
-        <UiLabel label="Delegates" sticky />
-
-        <table class="text-left table-fixed w-full">
-          <colgroup>
-            <col class="w-auto" />
-            <col class="w-auto md:w-[120px]" />
-            <col class="w-0 md:w-[240px]" />
-          </colgroup>
-          <thead
-            class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 after:border-b after:absolute after:w-full"
-          >
-            <tr>
-              <th class="pl-4 font-medium">
-                <span class="relative bottom-[1px]">Delegatee</span>
-              </th>
-              <th class="hidden md:table-cell">
-                <button
-                  class="relative bottom-[1px] flex items-center justify-end min-w-0 w-full font-medium hover:text-skin-link"
-                  @click="handleSortChange('tokenHoldersRepresentedAmount')"
-                >
-                  <span>Delegators</span>
-                  <IH-arrow-sm-down
-                    v-if="sortBy === 'tokenHoldersRepresentedAmount-desc'"
-                    class="ml-1"
-                  />
-                  <IH-arrow-sm-up
-                    v-else-if="sortBy === 'tokenHoldersRepresentedAmount-asc'"
-                    class="ml-1"
-                  />
-                </button>
-              </th>
-              <th>
-                <button
-                  class="relative bottom-[1px] flex justify-end items-center min-w-0 w-full font-medium hover:text-skin-link pr-4"
-                  @click="handleSortChange('delegatedVotes')"
-                >
-                  <span class="truncate">Voting power</span>
-                  <IH-arrow-sm-down v-if="sortBy === 'delegatedVotes-desc'" class="ml-1" />
-                  <IH-arrow-sm-up v-else-if="sortBy === 'delegatedVotes-asc'" class="ml-1" />
-                </button>
-              </th>
-            </tr>
-          </thead>
-          <td v-if="loading" colspan="3">
-            <UiLoading class="px-4 py-3 block" />
-          </td>
-          <template v-else>
-            <tbody>
-              <tr v-if="loaded && (delegates.length === 0 || failed)">
-                <td colspan="3">
-                  <div class="px-4 py-3 flex items-center">
-                    <IH-exclamation-circle class="inline-block mr-2" />
-                    <template v-if="delegates.length === 0">There are no delegates.</template>
-                    <template v-else-if="failed">Failed to load delegates.</template>
-                  </div>
-                </td>
-              </tr>
-              <UiContainerInfiniteScroll
-                :loading-more="loadingMore"
-                @end-reached="handleEndReached"
-              >
-                <tr v-for="(delegate, i) in delegates" :key="i" class="border-b relative">
-                  <td class="text-left flex items-center pl-4 py-3">
-                    <UiStamp :id="delegate.id" :size="32" class="mr-3" />
-                    <div class="overflow-hidden">
-                      <a
-                        :href="currentNetwork.helpers.getExplorerUrl(delegate.id, 'address')"
-                        target="_blank"
-                      >
-                        <div class="leading-[22px]">
-                          <h4
-                            class="text-skin-link truncate"
-                            v-text="delegate.name || shorten(delegate.id)"
-                          />
-                          <div
-                            class="text-[17px] text-skin-text truncate"
-                            v-text="shorten(delegate.id)"
-                          />
-                        </div>
-                      </a>
-                    </div>
-                  </td>
-                  <td class="hidden md:table-cell align-middle text-right">
-                    <h4
-                      class="text-skin-link"
-                      v-text="_n(delegate.tokenHoldersRepresentedAmount)"
-                    />
-                    <div
-                      class="text-[17px]"
-                      v-text="`${delegate.delegatorsPercentage.toFixed(3)}%`"
-                    />
-                  </td>
-                  <td class="text-right pr-4 align-middle">
-                    <h4 class="text-skin-link" v-text="_n(delegate.delegatedVotes)" />
-                    <div class="text-[17px]" v-text="`${delegate.votesPercentage.toFixed(3)}%`" />
-                  </td>
-                </tr>
-                <template #loading>
-                  <td colspan="3">
-                    <UiLoading class="p-4 block" />
-                  </td>
-                </template>
-              </UiContainerInfiniteScroll>
-            </tbody>
-          </template>
-        </table>
+    <UiLabel label="Delegates" sticky />
+    <div class="text-left table-fixed w-full">
+      <div
+        class="bg-skin-bg border-b sticky top-[112px] lg:top-[113px] z-40 flex w-full font-medium"
+      >
+        <div class="pl-4 w-[60%] flex items-center">Delegatee</div>
+        <button
+          class="hidden md:flex w-[20%] items-center justify-end font-medium hover:text-skin-link gap-x-1"
+          @click="handleSortChange('tokenHoldersRepresentedAmount')"
+        >
+          <span>Delegators</span>
+          <IH-arrow-sm-down v-if="sortBy === 'tokenHoldersRepresentedAmount-desc'" />
+          <IH-arrow-sm-up v-else-if="sortBy === 'tokenHoldersRepresentedAmount-asc'" />
+        </button>
+        <button
+          class="w-[40%] md:w-[20%] flex justify-end items-center font-medium hover:text-skin-link pr-4 gap-x-1"
+          @click="handleSortChange('delegatedVotes')"
+        >
+          <span class="truncate">Voting power</span>
+          <IH-arrow-sm-down v-if="sortBy === 'delegatedVotes-desc'" />
+          <IH-arrow-sm-up v-else-if="sortBy === 'delegatedVotes-asc'" />
+        </button>
       </div>
+      <UiLoading v-if="loading" class="px-4 py-3 block" />
+      <template v-else>
+        <div
+          v-if="loaded && (delegates.length === 0 || failed)"
+          class="px-4 py-3 flex items-center gap-x-2"
+        >
+          <IH-exclamation-circle class="inline-block" />
+          <template v-if="delegates.length === 0">There are no delegates.</template>
+          <template v-else-if="failed">Failed to load delegates.</template>
+        </div>
+        <UiContainerInfiniteScroll :loading-more="loadingMore" @end-reached="handleEndReached">
+          <div v-for="(delegate, i) in delegates" :key="i" class="border-b flex items-center">
+            <div class="flex items-center w-[60%] pl-4 py-3 gap-x-3">
+              <UiStamp :id="delegate.id" :size="32" />
+              <a
+                :href="currentNetwork.helpers.getExplorerUrl(delegate.id, 'address')"
+                target="_blank"
+                class="overflow-hidden leading-[22px]"
+              >
+                <h4
+                  class="text-skin-link truncate"
+                  v-text="delegate.name || shorten(delegate.id)"
+                />
+                <div class="text-[17px] text-skin-text truncate" v-text="shorten(delegate.id)" />
+              </a>
+            </div>
+            <div class="hidden md:flex w-[20%] flex-col items-end justify-center leading-[22px]">
+              <h4 class="text-skin-link" v-text="_n(delegate.tokenHoldersRepresentedAmount)" />
+              <div class="text-[17px]" v-text="`${delegate.delegatorsPercentage.toFixed(3)}%`" />
+            </div>
+            <div
+              class="w-[40%] md:w-[20%] flex flex-col items-end justify-center pr-4 leading-[22px]"
+            >
+              <h4 class="text-skin-link" v-text="_n(delegate.delegatedVotes)" />
+              <div class="text-[17px]" v-text="`${delegate.votesPercentage.toFixed(3)}%`" />
+            </div>
+          </div>
+          <template #loading>
+            <UiLoading class="px-4 py-3 block" />
+          </template>
+        </UiContainerInfiniteScroll>
+      </template>
     </div>
+
     <teleport to="#modal">
       <ModalDelegate
         :open="delegateModalOpen"

--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -79,7 +79,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
       >
         <div class="pl-4 w-[60%] flex items-center truncate">Delegatee</div>
         <button
-          class="hidden md:flex w-[20%] items-center justify-end font-medium hover:text-skin-link gap-x-1 truncate"
+          class="hidden md:flex w-[20%] items-center justify-end hover:text-skin-link gap-x-1 truncate"
           @click="handleSortChange('tokenHoldersRepresentedAmount')"
         >
           <span>Delegators</span>
@@ -93,7 +93,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
           />
         </button>
         <button
-          class="w-[40%] md:w-[20%] flex justify-end items-center font-medium hover:text-skin-link pr-4 gap-x-1 truncate"
+          class="w-[40%] md:w-[20%] flex justify-end items-center hover:text-skin-link pr-4 gap-x-1 truncate"
           @click="handleSortChange('delegatedVotes')"
         >
           <span class="truncate">Voting power</span>

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -90,10 +90,12 @@ watch([sortBy, choiceFilter], () => {
 </script>
 
 <template>
-  <div class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b flex gap-x-1 font-medium">
+  <div
+    class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b flex space-x-1 font-medium"
+  >
     <div class="pl-4 w-[50%] lg:w-[40%] truncate">Voter</div>
     <button
-      class="hidden lg:flex w-[25%] lg:w-[20%] items-center hover:text-skin-link gap-x-1 truncate"
+      class="hidden lg:flex w-[25%] lg:w-[20%] items-center hover:text-skin-link space-x-1 truncate"
       @click="handleSortChange('created')"
     >
       <span>Date</span>
@@ -117,7 +119,7 @@ watch([sortBy, choiceFilter], () => {
         ]"
       >
         <template #button>
-          <div class="flex items-center hover:text-skin-link gap-x-2">
+          <div class="flex items-center hover:text-skin-link space-x-2">
             <span class="truncate">Choice</span>
             <IH-adjustments-vertical class="shrink-0" />
           </div>
@@ -125,7 +127,7 @@ watch([sortBy, choiceFilter], () => {
       </UiSelectDropdown>
     </div>
     <button
-      class="w-[25%] lg:w-[20%] flex justify-end items-center hover:text-skin-link gap-x-1 truncate"
+      class="w-[25%] lg:w-[20%] flex justify-end items-center hover:text-skin-link space-x-1 truncate"
       @click="handleSortChange('vp')"
     >
       <span class="truncate">Voting power</span>
@@ -137,7 +139,7 @@ watch([sortBy, choiceFilter], () => {
 
   <UiLoading v-if="!loaded" class="px-4 py-3 block" />
   <template v-else>
-    <div v-if="votes.length === 0" class="px-4 py-3 flex items-center gap-x-2">
+    <div v-if="votes.length === 0" class="px-4 py-3 flex items-center space-x-2">
       <IH-exclamation-circle class="inline-block" />
       <span>There are no votes here.</span>
     </div>
@@ -145,7 +147,7 @@ watch([sortBy, choiceFilter], () => {
       <template #loading>
         <UiLoading class="px-4 py-3 block" />
       </template>
-      <div v-for="(vote, i) in votes" :key="i" class="border-b relative flex gap-x-1">
+      <div v-for="(vote, i) in votes" :key="i" class="border-b relative flex space-x-1">
         <div
           class="top-0 bottom-0 left-0 -z-10 pointer-events-none absolute"
           :style="{

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -166,10 +166,13 @@ watch([sortBy, choiceFilter], () => {
                 id: vote.voter.id
               }
             }"
-            class="truncate leading-[22px]"
+            class="overflow-hidden leading-[22px]"
           >
-            <h4 v-text="vote.voter.name || shortenAddress(vote.voter.id)" />
-            <div class="text-[17px] text-skin-text" v-text="shortenAddress(vote.voter.id)" />
+            <h4 class="truncate" v-text="vote.voter.name || shortenAddress(vote.voter.id)" />
+            <div
+              class="text-[17px] text-skin-text truncate"
+              v-text="shortenAddress(vote.voter.id)"
+            />
           </router-link>
         </div>
         <div class="hidden leading-[22px] w-[25%] lg:w-[20%] lg:flex flex-col justify-center">

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -90,213 +90,182 @@ watch([sortBy, choiceFilter], () => {
 </script>
 
 <template>
-  <table class="text-left w-full table-fixed">
-    <colgroup>
-      <col class="w-[50%] lg:w-[40%]" />
-      <col class="w-[25%] lg:w-[20%]" />
-      <col class="w-[25%] lg:w-[20%]" />
-      <col class="w-[60px] lg:w-[20%]" />
-      <col class="w-[0px] lg:w-[60px]" />
-    </colgroup>
-    <thead
-      class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 after:border-b after:absolute after:w-full"
+  <div
+    class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b border-skin-border flex gap-x-1 font-medium"
+  >
+    <div class="pl-4 w-[50%] lg:w-[40%]">Voter</div>
+    <button
+      class="hidden lg:flex w-[25%] lg:w-[20%] items-center hover:text-skin-link gap-x-1"
+      @click="handleSortChange('created')"
     >
-      <tr>
-        <th class="pl-4 font-medium">
-          <span class="relative bottom-[1px]">Voter</span>
-        </th>
-        <th class="hidden lg:table-cell">
-          <button
-            class="relative bottom-[1px] flex items-center min-w-0 w-full font-medium hover:text-skin-link"
-            @click="handleSortChange('created')"
-          >
-            <span>Date</span>
-            <IH-arrow-sm-down v-if="sortBy === 'created-desc'" class="ml-1" />
-            <IH-arrow-sm-up v-else-if="sortBy === 'created-asc'" class="ml-1" />
-          </button>
-        </th>
-        <th class="font-medium">
-          <template v-if="offchainNetworks.includes(proposal.network)">Choice</template>
-          <UiSelectDropdown
-            v-else
-            v-model="choiceFilter"
-            class="font-normal"
-            title="Choice"
-            gap="12px"
-            placement="left"
-            :items="[
-              { key: 'any', label: 'Any' },
-              { key: 'for', label: 'For', indicator: 'bg-skin-success' },
-              { key: 'against', label: 'Against', indicator: 'bg-skin-danger' },
-              { key: 'abstain', label: 'Abstain', indicator: 'bg-skin-text' }
-            ]"
-          >
-            <template #button>
-              <div class="relative bottom-[1px] flex items-center min-w-0 hover:text-skin-link">
-                <span class="truncate">Choice</span>
-                <IH-adjustments-vertical class="ml-2" />
-              </div>
-            </template>
-          </UiSelectDropdown>
-        </th>
-        <th>
-          <div class="relative bottom-[1px] flex justify-end">
-            <button
-              class="flex justify-end items-center min-w-0 w-full font-medium hover:text-skin-link"
-              @click="handleSortChange('vp')"
-            >
-              <span class="truncate">Voting power</span>
-              <IH-arrow-sm-down v-if="sortBy === 'vp-desc'" class="ml-1" />
-              <IH-arrow-sm-up v-else-if="sortBy === 'vp-asc'" class="ml-1" />
-            </button>
+      <span>Date</span>
+      <IH-arrow-sm-down v-if="sortBy === 'created-desc'" />
+      <IH-arrow-sm-up v-else-if="sortBy === 'created-asc'" />
+    </button>
+    <div class="w-[25%] lg:w-[20%]">
+      <template v-if="offchainNetworks.includes(proposal.network)">Choice</template>
+      <UiSelectDropdown
+        v-else
+        v-model="choiceFilter"
+        class="font-normal"
+        title="Choice"
+        gap="12px"
+        placement="left"
+        :items="[
+          { key: 'any', label: 'Any' },
+          { key: 'for', label: 'For', indicator: 'bg-skin-success' },
+          { key: 'against', label: 'Against', indicator: 'bg-skin-danger' },
+          { key: 'abstain', label: 'Abstain', indicator: 'bg-skin-text' }
+        ]"
+      >
+        <template #button>
+          <div class="flex items-center min-w-0 hover:text-skin-link gap-x-2">
+            <span class="truncate">Choice</span>
+            <IH-adjustments-vertical />
           </div>
-        </th>
-        <th />
-      </tr>
-    </thead>
-    <td v-if="!loaded" colspan="5">
-      <UiLoading class="px-4 py-3 block" />
-    </td>
-    <template v-else>
-      <tbody>
-        <tr>
-          <td v-if="votes.length === 0" colspan="5">
-            <div class="px-4 py-3 flex items-center">
-              <IH-exclamation-circle class="inline-block mr-2" />
-              <span v-text="'There are no votes here.'" />
+        </template>
+      </UiSelectDropdown>
+    </div>
+    <button
+      class="w-[25%] lg:w-[20%] flex justify-end items-center hover:text-skin-link gap-x-1"
+      @click="handleSortChange('vp')"
+    >
+      <span class="truncate">Voting power</span>
+      <IH-arrow-sm-down v-if="sortBy === 'vp-desc'" />
+      <IH-arrow-sm-up v-else-if="sortBy === 'vp-asc'" />
+    </button>
+    <div class="w-[30px] lg:w-[60px]" />
+  </div>
+
+  <div v-if="!loaded">
+    <UiLoading class="px-4 py-3 block" />
+  </div>
+
+  <template v-else>
+    <div v-if="votes.length === 0" class="px-4 py-3 items-center space-x-2">
+      <IH-exclamation-circle class="inline-block" />
+      <span>There are no votes here.</span>
+    </div>
+    <UiContainerInfiniteScroll :loading-more="loadingMore" @end-reached="handleEndReached">
+      <template #loading>
+        <UiLoading class="px-4 py-3 block" />
+      </template>
+      <div
+        v-for="(vote, i) in votes"
+        :key="i"
+        class="border-b border-skin-border relative flex gap-x-1"
+      >
+        <div
+          class="top-0 bottom-0 left-0 -z-10 pointer-events-none absolute"
+          :style="{
+            width: `${((100 / proposal.scores_total) * vote.vp).toFixed(2)}%`
+          }"
+          :class="
+            proposal.type === 'basic'
+              ? `choice-bg opacity-[0.1] _${vote.choice}`
+              : 'bg-skin-border opacity-40'
+          "
+        />
+        <div class="pl-4 py-3 w-[50%] lg:w-[40%] flex items-center gap-x-3">
+          <UiStamp :id="vote.voter.id" :size="32" />
+          <router-link
+            :to="{
+              name: 'user',
+              params: {
+                id: vote.voter.id
+              }
+            }"
+            class="truncate leading-[22px]"
+          >
+            <h4 v-text="vote.voter.name || shortenAddress(vote.voter.id)" />
+            <div class="text-[17px] text-skin-text" v-text="shortenAddress(vote.voter.id)" />
+          </router-link>
+        </div>
+        <div class="hidden leading-[22px] w-[25%] lg:w-[20%] lg:flex flex-col justify-center">
+          <h4>{{ _rt(vote.created) }}</h4>
+          <div class="text-[17px]">{{ _t(vote.created, 'MMM D, YYYY') }}</div>
+        </div>
+        <div class="w-[25%] lg:w-[20%] flex items-center">
+          <template v-if="!!props.proposal.privacy && !props.proposal.completed">
+            <div class="hidden md:block">
+              <div class="flex gap-1 items-center">
+                <span class="text-skin-heading leading-6">Encrypted choice</span>
+                <IH-lock-closed class="w-[16px] h-[16px] shrink-0" />
+              </div>
             </div>
-          </td>
-        </tr>
-        <UiContainerInfiniteScroll :loading-more="loadingMore" @end-reached="handleEndReached">
-          <template #loading>
-            <td colspan="5">
-              <UiLoading class="px-4 py-3 block" />
-            </td>
+            <UiTooltip title="Encrypted choice" class="cursor-help md:hidden">
+              <IH-lock-closed class="w-[16px] h-[16px]" />
+            </UiTooltip>
           </template>
-          <tr v-for="(vote, i) in votes" :key="i" class="border-b relative align-middle">
-            <div
-              class="absolute top-0 -bottom-[1px] left-0 pointer-events-none"
-              :style="{
-                width: `${((100 / proposal.scores_total) * vote.vp).toFixed(2)}%`
+          <template v-else>
+            <UiTooltip
+              v-if="proposal.type !== 'basic'"
+              class="max-w-[100%] truncate !inline-block"
+              :title="getChoiceText(proposal.choices, vote.choice)"
+            >
+              {{ getChoiceText(proposal.choices, vote.choice) }}
+            </UiTooltip>
+            <UiButton
+              v-else
+              class="!w-[40px] !h-[40px] !px-0 cursor-default bg-transparent"
+              :class="{
+                '!text-skin-success !border-skin-success': vote.choice === 1,
+                '!text-skin-danger !border-skin-danger': vote.choice === 2,
+                '!text-gray-500 !border-gray-500': vote.choice === 3
               }"
-              :class="
-                proposal.type === 'basic'
-                  ? `choice-bg opacity-[0.1] _${vote.choice}`
-                  : 'bg-skin-border opacity-40'
-              "
-            />
-            <td class="relative text-left flex items-center pl-4 py-3">
-              <UiStamp :id="vote.voter.id" :size="32" class="mr-3" />
-              <div class="truncate">
-                <router-link
-                  :to="{
-                    name: 'user',
-                    params: {
-                      id: vote.voter.id
-                    }
-                  }"
+            >
+              <IH-check v-if="vote.choice === 1" class="inline-block" />
+              <IH-x v-else-if="vote.choice === 2" class="inline-block" />
+              <IH-minus-sm v-else class="inline-block" />
+            </UiButton>
+          </template>
+        </div>
+        <div
+          class="text-right leading-[22px] w-[25%] lg:w-[20%] flex flex-col items-end justify-center"
+        >
+          <h4 class="text-skin-link">
+            {{ _n(vote.vp / 10 ** votingPowerDecimals, 'compact') }}
+            {{ proposal.space.voting_power_symbol }}
+          </h4>
+          <div class="text-[17px]">{{ _n((vote.vp / proposal.scores_total) * 100) }}%</div>
+        </div>
+        <div class="w-[30px] lg:w-[60px] flex items-center justify-center">
+          <UiDropdown>
+            <template #button>
+              <IH-dots-vertical class="text-skin-link" />
+            </template>
+            <template #items>
+              <UiDropdownItem v-slot="{ active }">
+                <a
+                  :href="network.helpers.getExplorerUrl(vote.tx, 'transaction')"
+                  target="_blank"
+                  class="flex items-center gap-2"
+                  :class="{ 'opacity-80': active }"
                 >
-                  <div class="leading-[22px]">
-                    <h4 v-text="vote.voter.name || shortenAddress(vote.voter.id)" />
-                    <div
-                      class="text-[17px] text-skin-text"
-                      v-text="shortenAddress(vote.voter.id)"
-                    />
-                  </div>
-                </router-link>
-              </div>
-            </td>
-            <td class="relative hidden lg:table-cell">
-              <div class="leading-[22px]">
-                <h4>{{ _rt(vote.created) }}</h4>
-                <div class="text-[17px]">{{ _t(vote.created, 'MMM D, YYYY') }}</div>
-              </div>
-            </td>
-            <td class="relative">
-              <template v-if="!!props.proposal.privacy && !props.proposal.completed">
-                <div class="hidden md:block">
-                  <div class="flex gap-1 items-center">
-                    <span class="text-skin-heading leading-6">Encrypted choice</span>
-                    <IH-lock-closed class="w-[16px] h-[16px] shrink-0" />
-                  </div>
-                </div>
-                <UiTooltip title="Encrypted choice" class="cursor-help md:hidden">
-                  <IH-lock-closed class="w-[16px] h-[16px]" />
-                </UiTooltip>
-              </template>
-              <div v-else>
-                <UiTooltip
-                  v-if="proposal.type !== 'basic'"
-                  class="max-w-[100%] truncate !inline-block"
-                  :title="getChoiceText(proposal.choices, vote.choice)"
+                  <IH-arrow-sm-right class="-rotate-45" :width="16" />
+                  View on block explorer
+                </a>
+              </UiDropdownItem>
+              <UiDropdownItem v-slot="{ active }">
+                <a
+                  class="flex items-center gap-2"
+                  :class="{ 'opacity-80': active }"
+                  @click.prevent="copy(vote.voter.id)"
                 >
-                  {{ getChoiceText(proposal.choices, vote.choice) }}
-                </UiTooltip>
-                <UiButton
-                  v-else
-                  class="!w-[40px] !h-[40px] !px-0 cursor-default bg-transparent"
-                  :class="{
-                    '!text-skin-success !border-skin-success': vote.choice === 1,
-                    '!text-skin-danger !border-skin-danger': vote.choice === 2,
-                    '!text-gray-500 !border-gray-500': vote.choice === 3
-                  }"
-                >
-                  <IH-check v-if="vote.choice === 1" class="inline-block" />
-                  <IH-x v-else-if="vote.choice === 2" class="inline-block" />
-                  <IH-minus-sm v-else class="inline-block" />
-                </UiButton>
-              </div>
-            </td>
-            <td class="relative pr-2 text-right">
-              <div class="text-skin-link leading-[22px]">
-                <h4>
-                  {{ _n(vote.vp / 10 ** votingPowerDecimals, 'compact') }}
-                  {{ proposal.space.voting_power_symbol }}
-                </h4>
-              </div>
-              <div class="text-[17px]">{{ _n((vote.vp / proposal.scores_total) * 100) }}%</div>
-            </td>
-            <td class="relative">
-              <div class="flex justify-center">
-                <UiDropdown>
-                  <template #button>
-                    <IH-dots-vertical class="text-skin-link" />
+                  <template v-if="!copied">
+                    <IH-duplicate :width="16" />
+                    Copy voter address
                   </template>
-                  <template #items>
-                    <UiDropdownItem v-slot="{ active }">
-                      <a
-                        :href="network.helpers.getExplorerUrl(vote.tx, 'transaction')"
-                        target="_blank"
-                        class="flex items-center gap-2"
-                        :class="{ 'opacity-80': active }"
-                      >
-                        <IH-arrow-sm-right class="-rotate-45" :width="16" />
-                        View on block explorer
-                      </a>
-                    </UiDropdownItem>
-                    <UiDropdownItem v-slot="{ active }">
-                      <a
-                        class="flex items-center gap-2"
-                        :class="{ 'opacity-80': active }"
-                        @click.prevent="copy(vote.voter.id)"
-                      >
-                        <template v-if="!copied">
-                          <IH-duplicate :width="16" />
-                          Copy voter address
-                        </template>
-                        <template v-else>
-                          <IH-check :width="16" />
-                          Copied
-                        </template>
-                      </a>
-                    </UiDropdownItem>
+                  <template v-else>
+                    <IH-check :width="16" />
+                    Copied
                   </template>
-                </UiDropdown>
-              </div>
-            </td>
-          </tr>
-        </UiContainerInfiniteScroll>
-      </tbody>
-    </template>
-  </table>
+                </a>
+              </UiDropdownItem>
+            </template>
+          </UiDropdown>
+        </div>
+      </div>
+    </UiContainerInfiniteScroll>
+  </template>
 </template>

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -90,9 +90,7 @@ watch([sortBy, choiceFilter], () => {
 </script>
 
 <template>
-  <div
-    class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b border-skin-border flex gap-x-1 font-medium"
-  >
+  <div class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b flex gap-x-1 font-medium">
     <div class="pl-4 w-[50%] lg:w-[40%]">Voter</div>
     <button
       class="hidden lg:flex w-[25%] lg:w-[20%] items-center hover:text-skin-link gap-x-1"
@@ -147,11 +145,7 @@ watch([sortBy, choiceFilter], () => {
       <template #loading>
         <UiLoading class="px-4 py-3 block" />
       </template>
-      <div
-        v-for="(vote, i) in votes"
-        :key="i"
-        class="border-b border-skin-border relative flex gap-x-1"
-      >
+      <div v-for="(vote, i) in votes" :key="i" class="border-b relative flex gap-x-1">
         <div
           class="top-0 bottom-0 left-0 -z-10 pointer-events-none absolute"
           :style="{

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -183,7 +183,7 @@ watch([sortBy, choiceFilter], () => {
           <template v-if="!!props.proposal.privacy && !props.proposal.completed">
             <div class="hidden md:block">
               <div class="flex gap-1 items-center">
-                <span class="text-skin-heading leading-6">Encrypted choice</span>
+                <span class="text-skin-heading leading-[22px]">Encrypted choice</span>
                 <IH-lock-closed class="w-[16px] h-[16px] shrink-0" />
               </div>
             </div>

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -137,10 +137,7 @@ watch([sortBy, choiceFilter], () => {
     <div class="w-[30px] lg:w-[60px]" />
   </div>
 
-  <div v-if="!loaded">
-    <UiLoading class="px-4 py-3 block" />
-  </div>
-
+  <UiLoading v-if="!loaded" class="px-4 py-3 block" />
   <template v-else>
     <div v-if="votes.length === 0" class="px-4 py-3 items-center space-x-2">
       <IH-exclamation-circle class="inline-block" />

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -91,16 +91,16 @@ watch([sortBy, choiceFilter], () => {
 
 <template>
   <div class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b flex gap-x-1 font-medium">
-    <div class="pl-4 w-[50%] lg:w-[40%]">Voter</div>
+    <div class="pl-4 w-[50%] lg:w-[40%] truncate">Voter</div>
     <button
-      class="hidden lg:flex w-[25%] lg:w-[20%] items-center hover:text-skin-link gap-x-1"
+      class="hidden lg:flex w-[25%] lg:w-[20%] items-center hover:text-skin-link gap-x-1 truncate"
       @click="handleSortChange('created')"
     >
       <span>Date</span>
-      <IH-arrow-sm-down v-if="sortBy === 'created-desc'" />
-      <IH-arrow-sm-up v-else-if="sortBy === 'created-asc'" />
+      <IH-arrow-sm-down v-if="sortBy === 'created-desc'" class="shrink-0" />
+      <IH-arrow-sm-up v-else-if="sortBy === 'created-asc'" class="shrink-0" />
     </button>
-    <div class="w-[25%] lg:w-[20%]">
+    <div class="w-[25%] lg:w-[20%] truncate">
       <template v-if="offchainNetworks.includes(proposal.network)">Choice</template>
       <UiSelectDropdown
         v-else
@@ -117,27 +117,27 @@ watch([sortBy, choiceFilter], () => {
         ]"
       >
         <template #button>
-          <div class="flex items-center min-w-0 hover:text-skin-link gap-x-2">
+          <div class="flex items-center hover:text-skin-link gap-x-2">
             <span class="truncate">Choice</span>
-            <IH-adjustments-vertical />
+            <IH-adjustments-vertical class="shrink-0" />
           </div>
         </template>
       </UiSelectDropdown>
     </div>
     <button
-      class="w-[25%] lg:w-[20%] flex justify-end items-center hover:text-skin-link gap-x-1"
+      class="w-[25%] lg:w-[20%] flex justify-end items-center hover:text-skin-link gap-x-1 truncate"
       @click="handleSortChange('vp')"
     >
       <span class="truncate">Voting power</span>
-      <IH-arrow-sm-down v-if="sortBy === 'vp-desc'" />
-      <IH-arrow-sm-up v-else-if="sortBy === 'vp-asc'" />
+      <IH-arrow-sm-down v-if="sortBy === 'vp-desc'" class="shrink-0" />
+      <IH-arrow-sm-up v-else-if="sortBy === 'vp-asc'" class="shrink-0" />
     </button>
     <div class="w-[30px] lg:w-[60px]" />
   </div>
 
   <UiLoading v-if="!loaded" class="px-4 py-3 block" />
   <template v-else>
-    <div v-if="votes.length === 0" class="px-4 py-3 items-center space-x-2">
+    <div v-if="votes.length === 0" class="px-4 py-3 flex items-center gap-x-2">
       <IH-exclamation-circle class="inline-block" />
       <span>There are no votes here.</span>
     </div>
@@ -157,7 +157,7 @@ watch([sortBy, choiceFilter], () => {
               : 'bg-skin-border opacity-40'
           "
         />
-        <div class="pl-4 py-3 w-[50%] lg:w-[40%] flex items-center gap-x-3">
+        <div class="pl-4 py-3 w-[50%] lg:w-[40%] flex items-center gap-x-3 truncate">
           <UiStamp :id="vote.voter.id" :size="32" />
           <router-link
             :to="{
@@ -175,11 +175,13 @@ watch([sortBy, choiceFilter], () => {
             />
           </router-link>
         </div>
-        <div class="hidden leading-[22px] w-[25%] lg:w-[20%] lg:flex flex-col justify-center">
+        <div
+          class="hidden leading-[22px] w-[25%] lg:w-[20%] lg:flex flex-col justify-center truncate"
+        >
           <h4>{{ _rt(vote.created) }}</h4>
           <div class="text-[17px]">{{ _t(vote.created, 'MMM D, YYYY') }}</div>
         </div>
-        <div class="w-[25%] lg:w-[20%] flex items-center">
+        <div class="w-[25%] lg:w-[20%] flex items-center truncate">
           <template v-if="!!props.proposal.privacy && !props.proposal.completed">
             <div class="hidden md:block">
               <div class="flex gap-1 items-center">
@@ -215,7 +217,7 @@ watch([sortBy, choiceFilter], () => {
           </template>
         </div>
         <div
-          class="text-right leading-[22px] w-[25%] lg:w-[20%] flex flex-col items-end justify-center"
+          class="text-right leading-[22px] w-[25%] lg:w-[20%] flex flex-col items-end justify-center truncate"
         >
           <h4 class="text-skin-link">
             {{ _n(vote.vp / 10 ** votingPowerDecimals, 'compact') }}

--- a/apps/ui/src/views/Space/Leaderboard.vue
+++ b/apps/ui/src/views/Space/Leaderboard.vue
@@ -113,81 +113,56 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
 
 <template>
   <UiLabel label="Leaderboard" sticky />
-
-  <!-- <colgroup>
-      <col class="w-auto" />
-      <col class="w-auto md:w-[120px]" />
-      <col class="w-0 md:w-[240px]" /> -->
-  <!-- </colgroup> -->
-  <div class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b w-full flex">
-    <div class="pl-4 font-medium">
-      <span class="relative bottom-[1px]">User</span>
-    </div>
-    <div class="hidden md:table-cell w-0 md:w-[120px]">
-      <button
-        class="relative bottom-[1px] flex items-center justify-end min-w-0 w-full font-medium hover:text-skin-link"
-        @click="handleSortChange('proposal_count')"
-      >
-        <span>Proposals</span>
-        <IH-arrow-sm-down v-if="sortBy === 'proposal_count-desc'" class="ml-1" />
-        <IH-arrow-sm-up v-else-if="sortBy === 'proposal_count-asc'" class="ml-1" />
-      </button>
-    </div>
-    <div>
-      <button
-        class="relative bottom-[1px] flex justify-end items-center min-w-0 w-full font-medium hover:text-skin-link pr-4 w-0 md:w-[240px]"
-        @click="handleSortChange('vote_count')"
-      >
-        <span class="truncate">Votes</span>
-        <IH-arrow-sm-down v-if="sortBy === 'vote_count-desc'" class="ml-1" />
-        <IH-arrow-sm-up v-else-if="sortBy === 'vote_count-asc'" class="ml-1" />
-      </button>
-    </div>
+  <div class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b w-full flex font-medium">
+    <div class="pl-4 w-[40%] lg:w-[50%] flex items-center">User</div>
+    <button
+      class="flex w-[30%] lg:w-[25%] items-center justify-end hover:text-skin-link gap-x-1"
+      @click="handleSortChange('proposal_count')"
+    >
+      <span class="truncate">Proposals</span>
+      <IH-arrow-sm-down v-if="sortBy === 'proposal_count-desc'" />
+      <IH-arrow-sm-up v-else-if="sortBy === 'proposal_count-asc'" />
+    </button>
+    <button
+      class="flex justify-end items-center hover:text-skin-link pr-4 w-[30%] lg:w-[25%] gap-x-1"
+      @click="handleSortChange('vote_count')"
+    >
+      <span class="truncate">Votes</span>
+      <IH-arrow-sm-down v-if="sortBy === 'vote_count-desc'" />
+      <IH-arrow-sm-up v-else-if="sortBy === 'vote_count-asc'" />
+    </button>
   </div>
-
-  <div v-if="!loaded">
-    <UiLoading class="px-4 py-3 block" />
-  </div>
-
+  <UiLoading v-if="!loaded" class="px-4 py-3 block" />
   <template v-else>
     <div v-if="failed || users.length === 0">
-      <td>
-        <div class="px-4 py-3 flex items-center">
-          <IH-exclamation-circle class="inline-block mr-2" />
-          <template v-if="failed">Failed to load the leaderboard.</template>
-          <template v-else-if="users.length === 0"
-            >This space does not have any activities yet.</template
-          >
-        </div>
-      </td>
+      <div class="px-4 py-3 flex items-center gap-x-2">
+        <IH-exclamation-circle class="inline-block" />
+        <span v-if="failed">Failed to load the leaderboard.</span>
+        <span v-else-if="users.length === 0"> This space does not have any activities yet. </span>
+      </div>
     </div>
-
     <UiContainerInfiniteScroll :loading-more="loadingMore" @end-reached="handleEndReached">
-      <div v-for="(user, i) in users" :key="i" class="border-b relative flex items-center">
-        <div class="flex items-center pl-4 py-3">
-          <UiStamp :id="user.id" :size="32" class="mr-3" />
-          <div class="overflow-hidden">
-            <router-link
-              class="text-skin-text"
-              :to="{
-                name: 'user',
-                params: { id: user.id }
-              }"
-            >
-              <div class="leading-[22px]">
-                <h4 class="text-skin-link truncate" v-text="user.name || shorten(user.id)" />
-                <div class="text-[17px] text-skin-text truncate" v-text="shorten(user.id)" />
-              </div>
-            </router-link>
-          </div>
+      <div v-for="(user, i) in users" :key="i" class="border-b flex items-center">
+        <div class="flex items-center pl-4 py-3 gap-x-3 leading-[22px] w-[40%] lg:w-[50%]">
+          <UiStamp :id="user.id" :size="32" />
+          <router-link
+            :to="{
+              name: 'user',
+              params: { id: user.id }
+            }"
+            class="overflow-hidden"
+          >
+            <h4 class="text-skin-link truncate" v-text="user.name || shorten(user.id)" />
+            <div class="text-[17px] text-skin-text truncate" v-text="shorten(user.id)" />
+          </router-link>
         </div>
-        <div class="hidden md:table-cell text-right">
+        <div class="flex flex-col items-end justify-center leading-[22px] w-[30%] lg:w-[25%]">
           <h4 class="text-skin-link" v-text="_n(user.proposal_count)" />
           <div class="text-[17px]">
             {{ _p(user.proposal_count / space.proposal_count) }}
           </div>
         </div>
-        <div class="text-right pr-4">
+        <div class="flex flex-col items-end justify-center pr-4 leading-[22px] w-[30%] lg:w-[25%]">
           <h4 class="text-skin-link" v-text="_n(user.vote_count)" />
           <div class="text-[17px]">
             {{ _p(user.vote_count / space.vote_count) }}
@@ -195,7 +170,7 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
         </div>
       </div>
       <template #loading>
-        <UiLoading class="p-4 block" />
+        <UiLoading class="px-4 py-3 block" />
       </template>
     </UiContainerInfiniteScroll>
   </template>

--- a/apps/ui/src/views/Space/Leaderboard.vue
+++ b/apps/ui/src/views/Space/Leaderboard.vue
@@ -114,11 +114,11 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
 <template>
   <UiLabel label="Leaderboard" sticky />
   <div
-    class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b w-full flex font-medium gap-x-1"
+    class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b w-full flex font-medium space-x-1"
   >
     <div class="pl-4 w-[40%] lg:w-[50%] flex items-center truncate">User</div>
     <button
-      class="flex w-[30%] lg:w-[25%] items-center justify-end hover:text-skin-link gap-x-1 truncate"
+      class="flex w-[30%] lg:w-[25%] items-center justify-end hover:text-skin-link space-x-1 truncate"
       @click="handleSortChange('proposal_count')"
     >
       <span class="truncate">Proposals</span>
@@ -126,7 +126,7 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
       <IH-arrow-sm-up v-else-if="sortBy === 'proposal_count-asc'" class="shrink-0" />
     </button>
     <button
-      class="flex justify-end items-center hover:text-skin-link pr-4 w-[30%] lg:w-[25%] gap-x-1 truncate"
+      class="flex justify-end items-center hover:text-skin-link pr-4 w-[30%] lg:w-[25%] space-x-1 truncate"
       @click="handleSortChange('vote_count')"
     >
       <span class="truncate">Votes</span>
@@ -136,13 +136,13 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
   </div>
   <UiLoading v-if="!loaded" class="px-4 py-3 block" />
   <template v-else>
-    <div v-if="failed || users.length === 0" class="px-4 py-3 flex items-center gap-x-2">
+    <div v-if="failed || users.length === 0" class="px-4 py-3 flex items-center space-x-2">
       <IH-exclamation-circle class="inline-block" />
       <span v-if="failed">Failed to load the leaderboard.</span>
       <span v-else-if="users.length === 0"> This space does not have any activities yet. </span>
     </div>
     <UiContainerInfiniteScroll :loading-more="loadingMore" @end-reached="handleEndReached">
-      <div v-for="(user, i) in users" :key="i" class="border-b flex gap-x-1">
+      <div v-for="(user, i) in users" :key="i" class="border-b flex space-x-1">
         <div class="flex items-center pl-4 py-3 gap-x-3 leading-[22px] w-[40%] lg:w-[50%] truncate">
           <UiStamp :id="user.id" :size="32" />
           <router-link

--- a/apps/ui/src/views/Space/Leaderboard.vue
+++ b/apps/ui/src/views/Space/Leaderboard.vue
@@ -134,12 +134,10 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
   </div>
   <UiLoading v-if="!loaded" class="px-4 py-3 block" />
   <template v-else>
-    <div v-if="failed || users.length === 0">
-      <div class="px-4 py-3 flex items-center gap-x-2">
-        <IH-exclamation-circle class="inline-block" />
-        <span v-if="failed">Failed to load the leaderboard.</span>
-        <span v-else-if="users.length === 0"> This space does not have any activities yet. </span>
-      </div>
+    <div v-if="failed || users.length === 0" class="px-4 py-3 flex items-center gap-x-2">
+      <IH-exclamation-circle class="inline-block" />
+      <span v-if="failed">Failed to load the leaderboard.</span>
+      <span v-else-if="users.length === 0"> This space does not have any activities yet. </span>
     </div>
     <UiContainerInfiniteScroll :loading-more="loadingMore" @end-reached="handleEndReached">
       <div v-for="(user, i) in users" :key="i" class="border-b flex items-center">

--- a/apps/ui/src/views/Space/Leaderboard.vue
+++ b/apps/ui/src/views/Space/Leaderboard.vue
@@ -113,23 +113,25 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
 
 <template>
   <UiLabel label="Leaderboard" sticky />
-  <div class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b w-full flex font-medium">
-    <div class="pl-4 w-[40%] lg:w-[50%] flex items-center">User</div>
+  <div
+    class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b w-full flex font-medium gap-x-1"
+  >
+    <div class="pl-4 w-[40%] lg:w-[50%] flex items-center truncate">User</div>
     <button
-      class="flex w-[30%] lg:w-[25%] items-center justify-end hover:text-skin-link gap-x-1"
+      class="flex w-[30%] lg:w-[25%] items-center justify-end hover:text-skin-link gap-x-1 truncate"
       @click="handleSortChange('proposal_count')"
     >
       <span class="truncate">Proposals</span>
-      <IH-arrow-sm-down v-if="sortBy === 'proposal_count-desc'" />
-      <IH-arrow-sm-up v-else-if="sortBy === 'proposal_count-asc'" />
+      <IH-arrow-sm-down v-if="sortBy === 'proposal_count-desc'" class="shrink-0" />
+      <IH-arrow-sm-up v-else-if="sortBy === 'proposal_count-asc'" class="shrink-0" />
     </button>
     <button
-      class="flex justify-end items-center hover:text-skin-link pr-4 w-[30%] lg:w-[25%] gap-x-1"
+      class="flex justify-end items-center hover:text-skin-link pr-4 w-[30%] lg:w-[25%] gap-x-1 truncate"
       @click="handleSortChange('vote_count')"
     >
       <span class="truncate">Votes</span>
-      <IH-arrow-sm-down v-if="sortBy === 'vote_count-desc'" />
-      <IH-arrow-sm-up v-else-if="sortBy === 'vote_count-asc'" />
+      <IH-arrow-sm-down v-if="sortBy === 'vote_count-desc'" class="shrink-0" />
+      <IH-arrow-sm-up v-else-if="sortBy === 'vote_count-asc'" class="shrink-0" />
     </button>
   </div>
   <UiLoading v-if="!loaded" class="px-4 py-3 block" />
@@ -140,8 +142,8 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
       <span v-else-if="users.length === 0"> This space does not have any activities yet. </span>
     </div>
     <UiContainerInfiniteScroll :loading-more="loadingMore" @end-reached="handleEndReached">
-      <div v-for="(user, i) in users" :key="i" class="border-b flex items-center">
-        <div class="flex items-center pl-4 py-3 gap-x-3 leading-[22px] w-[40%] lg:w-[50%]">
+      <div v-for="(user, i) in users" :key="i" class="border-b flex gap-x-1">
+        <div class="flex items-center pl-4 py-3 gap-x-3 leading-[22px] w-[40%] lg:w-[50%] truncate">
           <UiStamp :id="user.id" :size="32" />
           <router-link
             :to="{
@@ -154,13 +156,17 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
             <div class="text-[17px] text-skin-text truncate" v-text="shorten(user.id)" />
           </router-link>
         </div>
-        <div class="flex flex-col items-end justify-center leading-[22px] w-[30%] lg:w-[25%]">
+        <div
+          class="flex flex-col items-end justify-center leading-[22px] w-[30%] lg:w-[25%] truncate"
+        >
           <h4 class="text-skin-link" v-text="_n(user.proposal_count)" />
           <div class="text-[17px]">
             {{ _p(user.proposal_count / space.proposal_count) }}
           </div>
         </div>
-        <div class="flex flex-col items-end justify-center pr-4 leading-[22px] w-[30%] lg:w-[25%]">
+        <div
+          class="flex flex-col items-end justify-center pr-4 leading-[22px] w-[30%] lg:w-[25%] truncate"
+        >
           <h4 class="text-skin-link" v-text="_n(user.vote_count)" />
           <div class="text-[17px]">
             {{ _p(user.vote_count / space.vote_count) }}

--- a/apps/ui/src/views/Space/Leaderboard.vue
+++ b/apps/ui/src/views/Space/Leaderboard.vue
@@ -112,107 +112,91 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
 </script>
 
 <template>
-  <div class="space-y-3">
+  <UiLabel label="Leaderboard" sticky />
+
+  <!-- <colgroup>
+      <col class="w-auto" />
+      <col class="w-auto md:w-[120px]" />
+      <col class="w-0 md:w-[240px]" /> -->
+  <!-- </colgroup> -->
+  <div class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b w-full flex">
+    <div class="pl-4 font-medium">
+      <span class="relative bottom-[1px]">User</span>
+    </div>
+    <div class="hidden md:table-cell w-0 md:w-[120px]">
+      <button
+        class="relative bottom-[1px] flex items-center justify-end min-w-0 w-full font-medium hover:text-skin-link"
+        @click="handleSortChange('proposal_count')"
+      >
+        <span>Proposals</span>
+        <IH-arrow-sm-down v-if="sortBy === 'proposal_count-desc'" class="ml-1" />
+        <IH-arrow-sm-up v-else-if="sortBy === 'proposal_count-asc'" class="ml-1" />
+      </button>
+    </div>
     <div>
-      <UiLabel label="Leaderboard" sticky />
-      <table class="text-left table-fixed w-full">
-        <colgroup>
-          <col class="w-auto" />
-          <col class="w-auto md:w-[120px]" />
-          <col class="w-0 md:w-[240px]" />
-        </colgroup>
-        <thead
-          class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 after:border-b after:absolute after:w-full"
-        >
-          <tr>
-            <th class="pl-4 font-medium">
-              <span class="relative bottom-[1px]">User</span>
-            </th>
-            <th class="hidden md:table-cell">
-              <button
-                class="relative bottom-[1px] flex items-center justify-end min-w-0 w-full font-medium hover:text-skin-link"
-                @click="handleSortChange('proposal_count')"
-              >
-                <span>Proposals</span>
-                <IH-arrow-sm-down v-if="sortBy === 'proposal_count-desc'" class="ml-1" />
-                <IH-arrow-sm-up v-else-if="sortBy === 'proposal_count-asc'" class="ml-1" />
-              </button>
-            </th>
-            <th>
-              <button
-                class="relative bottom-[1px] flex justify-end items-center min-w-0 w-full font-medium hover:text-skin-link pr-4"
-                @click="handleSortChange('vote_count')"
-              >
-                <span class="truncate">Votes</span>
-                <IH-arrow-sm-down v-if="sortBy === 'vote_count-desc'" class="ml-1" />
-                <IH-arrow-sm-up v-else-if="sortBy === 'vote_count-asc'" class="ml-1" />
-              </button>
-            </th>
-          </tr>
-        </thead>
-        <td v-if="!loaded" colspan="3">
-          <UiLoading class="px-4 py-3 block" />
-        </td>
-        <template v-else>
-          <tbody v-if="failed || users.length === 0">
-            <tr>
-              <td colspan="3">
-                <div class="px-4 py-3 flex items-center">
-                  <IH-exclamation-circle class="inline-block mr-2" />
-                  <template v-if="failed">Failed to load the leaderboard.</template>
-                  <template v-else-if="users.length === 0"
-                    >This space does not have any activities yet.</template
-                  >
-                </div>
-              </td>
-            </tr>
-            <UiContainerInfiniteScroll :loading-more="loadingMore" @end-reached="handleEndReached">
-              <tr v-for="(user, i) in users" :key="i" class="border-b relative">
-                <td class="text-left flex items-center pl-4 py-3">
-                  <UiStamp :id="user.id" :size="32" class="mr-3" />
-                  <div class="overflow-hidden">
-                    <router-link
-                      class="text-skin-text"
-                      :to="{
-                        name: 'user',
-                        params: { id: user.id }
-                      }"
-                    >
-                      <div class="leading-[22px]">
-                        <h4
-                          class="text-skin-link truncate"
-                          v-text="user.name || shorten(user.id)"
-                        />
-                        <div
-                          class="text-[17px] text-skin-text truncate"
-                          v-text="shorten(user.id)"
-                        />
-                      </div>
-                    </router-link>
-                  </div>
-                </td>
-                <td class="hidden md:table-cell align-middle text-right">
-                  <h4 class="text-skin-link" v-text="_n(user.proposal_count)" />
-                  <div class="text-[17px]">
-                    {{ _p(user.proposal_count / space.proposal_count) }}
-                  </div>
-                </td>
-                <td class="text-right pr-4 align-middle">
-                  <h4 class="text-skin-link" v-text="_n(user.vote_count)" />
-                  <div class="text-[17px]">
-                    {{ _p(user.vote_count / space.vote_count) }}
-                  </div>
-                </td>
-              </tr>
-              <template #loading>
-                <td colspan="3">
-                  <UiLoading class="p-4 block" />
-                </td>
-              </template>
-            </UiContainerInfiniteScroll>
-          </tbody>
-        </template>
-      </table>
+      <button
+        class="relative bottom-[1px] flex justify-end items-center min-w-0 w-full font-medium hover:text-skin-link pr-4 w-0 md:w-[240px]"
+        @click="handleSortChange('vote_count')"
+      >
+        <span class="truncate">Votes</span>
+        <IH-arrow-sm-down v-if="sortBy === 'vote_count-desc'" class="ml-1" />
+        <IH-arrow-sm-up v-else-if="sortBy === 'vote_count-asc'" class="ml-1" />
+      </button>
     </div>
   </div>
+
+  <div v-if="!loaded">
+    <UiLoading class="px-4 py-3 block" />
+  </div>
+
+  <template v-else>
+    <div v-if="failed || users.length === 0">
+      <td>
+        <div class="px-4 py-3 flex items-center">
+          <IH-exclamation-circle class="inline-block mr-2" />
+          <template v-if="failed">Failed to load the leaderboard.</template>
+          <template v-else-if="users.length === 0"
+            >This space does not have any activities yet.</template
+          >
+        </div>
+      </td>
+    </div>
+
+    <UiContainerInfiniteScroll :loading-more="loadingMore" @end-reached="handleEndReached">
+      <div v-for="(user, i) in users" :key="i" class="border-b relative flex items-center">
+        <div class="flex items-center pl-4 py-3">
+          <UiStamp :id="user.id" :size="32" class="mr-3" />
+          <div class="overflow-hidden">
+            <router-link
+              class="text-skin-text"
+              :to="{
+                name: 'user',
+                params: { id: user.id }
+              }"
+            >
+              <div class="leading-[22px]">
+                <h4 class="text-skin-link truncate" v-text="user.name || shorten(user.id)" />
+                <div class="text-[17px] text-skin-text truncate" v-text="shorten(user.id)" />
+              </div>
+            </router-link>
+          </div>
+        </div>
+        <div class="hidden md:table-cell text-right">
+          <h4 class="text-skin-link" v-text="_n(user.proposal_count)" />
+          <div class="text-[17px]">
+            {{ _p(user.proposal_count / space.proposal_count) }}
+          </div>
+        </div>
+        <div class="text-right pr-4">
+          <h4 class="text-skin-link" v-text="_n(user.vote_count)" />
+          <div class="text-[17px]">
+            {{ _p(user.vote_count / space.vote_count) }}
+          </div>
+        </div>
+      </div>
+      <template #loading>
+        <UiLoading class="p-4 block" />
+      </template>
+    </UiContainerInfiniteScroll>
+  </template>
 </template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #339 #330 #145

Migrate tables to div for pages:

- votes 
- delegates
- leaderboard

Migrating to div will fix a few issues with table

### How to test

1. Go to a proposal votes page
2. It should display data as before
3. The voting power background should display correctly on webkit engine (https://github.com/snapshot-labs/sx-monorepo/issues/145)
4. Go to the delegates and leaderboard page
5. It should display data as before
6. The 1px gap described in https://github.com/snapshot-labs/sx-monorepo/issues/330 should be fixed
