### PR TITLE
fix: add missing voted indicator in timeline proposals feed

### DIFF
--- a/apps/ui/src/composables/useAccount.ts
+++ b/apps/ui/src/composables/useAccount.ts
@@ -1,4 +1,4 @@
-import { getNetwork, offchainNetworks } from '@/networks';
+import { getNetwork } from '@/networks';
 import type { NetworkID, Proposal, Vote } from '@/types';
 
 const votes = ref<Record<Proposal['id'], Vote>>({});

--- a/apps/ui/src/composables/useAccount.ts
+++ b/apps/ui/src/composables/useAccount.ts
@@ -1,4 +1,4 @@
-import { getNetwork } from '@/networks';
+import { getNetwork, offchainNetworks } from '@/networks';
 import type { NetworkID, Proposal, Vote } from '@/types';
 
 const votes = ref<Record<Proposal['id'], Vote>>({});
@@ -11,7 +11,10 @@ export function useAccount() {
     if (!account) return;
 
     const network = getNetwork(networkId);
-    const userVotes = await network.api.loadUserVotes(spaceIds, account);
+    const userVotes = await network.api.loadUserVotes(
+      spaceIds.map(id => (offchainNetworks.includes(networkId) ? id.split(':')[1] : id)),
+      account
+    );
 
     votes.value = { ...votes.value, ...userVotes };
   }

--- a/apps/ui/src/composables/useAccount.ts
+++ b/apps/ui/src/composables/useAccount.ts
@@ -11,10 +11,7 @@ export function useAccount() {
     if (!account) return;
 
     const network = getNetwork(networkId);
-    const userVotes = await network.api.loadUserVotes(
-      spaceIds.map(id => (offchainNetworks.includes(networkId) ? id.split(':')[1] : id)),
-      account
-    );
+    const userVotes = await network.api.loadUserVotes(spaceIds, account);
 
     votes.value = { ...votes.value, ...userVotes };
   }

--- a/apps/ui/src/stores/followedSpaces.ts
+++ b/apps/ui/src/stores/followedSpaces.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import { enabledNetworks, getNetwork, offchainNetworks } from '@/networks';
 import pkg from '../../package.json';
-import { Space } from '@/types';
+import { NetworkID, Space } from '@/types';
 
 const offchainNetworkId = offchainNetworks.filter(network => enabledNetworks.includes(network))[0];
 const network = getNetwork(offchainNetworkId);
@@ -45,6 +45,21 @@ export const useFollowedSpacesStore = defineStore('followedSpaces', () => {
       followedSpacesIdsByAccount.value[web3.value.account] = spaces.map(getCompositeSpaceId);
     }
   });
+
+  const followedSpaceIdsByNetwork = computed(() =>
+    followedSpacesIds.value
+      .map(id => id.split(':') as [NetworkID, string])
+      .reduce(
+        (acc, [networkId, spaceId]) => {
+          acc[networkId] ||= [];
+          acc[networkId].push(
+            offchainNetworks.includes(networkId) ? spaceId : `${networkId}:${spaceId}`
+          );
+          return acc;
+        },
+        {} as Record<NetworkID, string[]>
+      )
+  );
 
   async function fetchSpacesData(ids: string[]) {
     if (!ids.length) return;
@@ -93,6 +108,7 @@ export const useFollowedSpacesStore = defineStore('followedSpaces', () => {
   return {
     followedSpaces,
     followedSpacesIds,
+    followedSpaceIdsByNetwork,
     followedSpacesLoaded,
     isFollowed
   };

--- a/apps/ui/src/views/My/Home.vue
+++ b/apps/ui/src/views/My/Home.vue
@@ -2,7 +2,7 @@
 import ProposalIconStatus from '@/components/ProposalIconStatus.vue';
 import { getNames } from '@/helpers/stamp';
 import { enabledNetworks, getNetwork, offchainNetworks } from '@/networks';
-import { Proposal } from '@/types';
+import { NetworkID, Proposal } from '@/types';
 
 const PROPOSALS_LIMIT = 20;
 
@@ -91,7 +91,9 @@ watch(
       return;
     }
 
-    loadVotes(networkId.value, followedSpacesIds);
+    for (const network in followedSpacesStore.followedSpaceIdsByNetwork) {
+      loadVotes(network as NetworkID, followedSpacesStore.followedSpaceIdsByNetwork[network]);
+    }
     fetch();
   }
 );


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR add support for loading voted indicator in timeline from all networks

### How to test

1. Go to http://localhost:8080/#/home
2. It should list a mix of onchain and offchain proposals
3. It should show the voted indicator next to proposal title, when voted, for onchain and offchain proposals

### To-Do

- [ ] Waiting for #293 to test the onchain part, offchain part already testable
