### PR TITLE
fix: fix address comparison being case sensitive

### DIFF
--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -87,8 +87,8 @@ const treasuryExplorerUrl = computed(() => {
 });
 
 const executionStrategy = computed(() => {
-  let executorIndex = props.space.executors.findIndex(
-    executorAddress => executorAddress === treasury.value?.wallet
+  let executorIndex = props.space.executors.findIndex(executorAddress =>
+    compareAddresses(executorAddress, treasury.value?.wallet || '')
   );
 
   if (executorIndex === -1) {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #325

Fix an issue where execution strategy is not detected properly, due to different addresses casing

### How to test

1. Go to [#/sep:0xbFF55fd2A671288316956A0Cae8f1d24BA7E5C9B/treasury](http://localhost:8080/#/sep:0xbFF55fd2A671288316956A0Cae8f1d24BA7E5C9B/treasury)
2. Send a NFT from the treasury
3. On proposal editor, the strategy should be selected by default in the execution section
