### PR TITLE
fix: remove goerli from walletconnect chains list

### DIFF
--- a/apps/ui/src/helpers/connectors.ts
+++ b/apps/ui/src/helpers/connectors.ts
@@ -20,8 +20,8 @@ export default {
     icon: walletconnectIcon,
     options: {
       projectId: 'e6454bd61aba40b786e866a69bd4c5c6',
-      chains: [5],
-      optionalChains: [1, 42161, 137, 11155111],
+      chains: [1],
+      optionalChains: [42161, 137, 11155111],
       methods: ['eth_sendTransaction', 'eth_signTypedData_v4'],
       showQrModal: true
     }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #345 

Fix an issue where connecting with Uniswap via WalletConnect result in "unsupported chains" error

This is due to WalletConnect connector still including Goerli chainID in its chain list, removing it fix the issue

### How to test

1. Go to http://localhost:8080/#/
2. Connect via WalletConnect
3. Scan the QR code with your uniswap mobile application
4. It should prompt you to validate the signature, instead of showing the error message
