### PR TITLE
fix: fix fetching not triggered on internal page navigation

### DIFF
--- a/apps/ui/src/views/My/Home.vue
+++ b/apps/ui/src/views/My/Home.vue
@@ -93,7 +93,8 @@ watch(
 
     loadVotes(networkId.value, followedSpacesIds);
     fetch();
-  }
+  },
+  { immediate: true }
 );
 
 watch(filter, (toFilter, fromFilter) => {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #353 

Fix `watch` action not being triggered on internal page navigation

### How to test

1. Go to /explore
2. Navigate to /home via the Nav sidebar
3. It should load the home page content
