### PR TITLE
fix: fix "no data" message flashing on /home page load

### DIFF
--- a/apps/ui/src/views/My/Home.vue
+++ b/apps/ui/src/views/My/Home.vue
@@ -81,8 +81,10 @@ onMounted(() => {
 });
 
 watch(
-  () => followedSpacesStore.followedSpacesIds,
-  followedSpacesIds => {
+  [() => followedSpacesStore.followedSpacesLoaded, () => followedSpacesStore.followedSpacesIds],
+  ([followedSpacesloaded, followedSpacesIds]) => {
+    if (!followedSpacesloaded) return;
+
     loaded.value = false;
     proposals.value = [];
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fix issue pointed out here https://github.com/snapshot-labs/sx-monorepo/pull/317#pullrequestreview-2068818017

where the "No proposals" message was being showed briefly on page load

### Test

1. Go to http://localhost:8080/#/home
2. You should see the LOADING icon until the proposals list are loaded and shown, without seeing the "No proposals" message
