### PR TITLE
fix: add missing execution_destination field to subgraph

### DIFF
--- a/apps/subgraph-api/package.json
+++ b/apps/subgraph-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-subgraph",
   "private": true,
-  "version": "0.0.33",
+  "version": "0.0.34",
   "scripts": {
     "test": "graph test",
     "codegen": "graph codegen",

--- a/apps/subgraph-api/schema.graphql
+++ b/apps/subgraph-api/schema.graphql
@@ -106,6 +106,7 @@ type Proposal @entity {
   execution_time: Int!
   execution_strategy: String!
   execution_strategy_type: String!
+  execution_destination: String
   timelock_veto_guardian: String
   timelock_delay: BigInt!
   axiom_snapshot_address: String


### PR DESCRIPTION
# Summary

When adding L1 execution for Starknet I forgot to add this field to subgraph API so it's breaking when querying proposals.

Subgraphs are already deploying with this change.
