### PR TITLE
fix: fix invalid proposal end filter name

### DIFF
--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -288,12 +288,12 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
         filters.end_lt = current;
       }
 
-      for (const key of Object.keys(filters)) {
-        if (/^(min|max)_end/.test(key)) {
+      Object.keys(filters)
+        .filter(key => /^(min|max)_end/.test(key))
+        .forEach(key => {
           filters[key.replace(/^(min|max)_/, '')] = filters[key];
           delete filters[key];
-        }
-      }
+        });
 
       delete filters?.state;
 

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -367,7 +367,7 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
     loadFollows: async (userId?: string, spaceId?: string): Promise<Follow[]> => {
       const {
         data: { follows }
-      }: { data: { follows: (Follow & { network: NetworkID })[] } } = await apollo.query({
+      }: { data: { follows: Follow[] } } = await apollo.query({
         query: USER_FOLLOWS_QUERY,
         variables: {
           first: 25,
@@ -376,10 +376,7 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
         }
       });
 
-      return follows.map(follow => ({
-        ...follow,
-        space: { ...follow.space, network: follow.network }
-      }));
+      return follows.map(follow => ({ ...follow, space: { ...follow.space, network: networkId } }));
     }
   };
 }

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -288,6 +288,13 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
         filters.end_lt = current;
       }
 
+      for (const key of Object.keys(filters)) {
+        if (/^(min|max)_end/.test(key)) {
+          filters[key.replace(/^(min|max)_/, '')] = filters[key];
+          delete filters[key];
+        }
+      }
+
       delete filters?.state;
 
       const { data } = await apollo.query({
@@ -360,7 +367,7 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
     loadFollows: async (userId?: string, spaceId?: string): Promise<Follow[]> => {
       const {
         data: { follows }
-      }: { data: { follows: Follow[] } } = await apollo.query({
+      }: { data: { follows: (Follow & { network: NetworkID })[] } } = await apollo.query({
         query: USER_FOLLOWS_QUERY,
         variables: {
           first: 25,
@@ -369,7 +376,10 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
         }
       });
 
-      return follows.map(follow => ({ ...follow, space: { ...follow.space, network: networkId } }));
+      return follows.map(follow => ({
+        ...follow,
+        space: { ...follow.space, network: follow.network }
+      }));
     }
   };
 }

--- a/apps/ui/src/stores/notifications.ts
+++ b/apps/ui/src/stores/notifications.ts
@@ -38,7 +38,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
   ) {
     return network.api.loadProposals(spaceIds, { limit: 100 }, current, {
       state,
-      ...{ [state === 'closed' ? 'end_gte' : 'start_gte']: pivotTs }
+      ...{ [state === 'closed' ? 'max_end_gte' : 'start_gte']: pivotTs }
     });
   }
 
@@ -102,9 +102,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
     shownLastUnreadTs.value = notifications.value[0]?.timestamp ?? 0;
   }
 
-  const unreadNotificationsCount = computed(
-    () => notifications.value.filter(n => n.unread).length
-  );
+  const unreadNotificationsCount = computed(() => notifications.value.filter(n => n.unread).length);
 
   watch(
     [() => followedSpacesStore.followedSpacesLoaded, () => followedSpacesStore.followedSpacesIds],


### PR DESCRIPTION
### Summary

This PR fix an issue where the `end_gte` filter passed to `loadProposals` is not universal for all chains, and only valid for offchain spaces, as onchain spaces uses `max_end` and `min_end` variant

This PR will use `max|min_end` everywhere variant inside the UI, and will do the "translation" only inside the networks not supporting it.
