### PR TITLE
fix: fix followed space list not returning correct space network

### DIFF
--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -360,7 +360,7 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
     loadFollows: async (userId?: string, spaceId?: string): Promise<Follow[]> => {
       const {
         data: { follows }
-      }: { data: { follows: (Follow & { network: NetworkID })[] } } = await apollo.query({
+      }: { data: { follows: Follow[] } } = await apollo.query({
         query: USER_FOLLOWS_QUERY,
         variables: {
           first: 25,

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -360,7 +360,7 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
     loadFollows: async (userId?: string, spaceId?: string): Promise<Follow[]> => {
       const {
         data: { follows }
-      }: { data: { follows: Follow[] } } = await apollo.query({
+      }: { data: { follows: (Follow & { network: NetworkID })[] } } = await apollo.query({
         query: USER_FOLLOWS_QUERY,
         variables: {
           first: 25,
@@ -369,7 +369,10 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
         }
       });
 
-      return follows.map(follow => ({ ...follow, space: { ...follow.space, network: networkId } }));
+      return follows.map(follow => ({
+        ...follow,
+        space: { ...follow.space, network: follow.network }
+      }));
     }
   };
 }

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -146,6 +146,7 @@ export const USER_VOTES_QUERY = gql`
 export const USER_FOLLOWS_QUERY = gql`
   query ($follower: String!) {
     follows(where: { follower: $follower }) {
+      network
       space {
         id
       }

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -204,6 +204,7 @@ export type Follow = {
   follower: string;
   space: Space;
   created: number;
+  network: NetworkID;
 };
 
 export type Contact = {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an issue where the list of followed spaces loaded from the offchain network API was always returned with networkID `s` (or `sn`).

This was the correct behavior until we refactored sequencer to also support onchain spaces.

With this PR, list of spaces from `loadFollows` will have the correct networkID

### How to test

1. Follow an onchain space
2. Refresh the page
3. Before the fix: onchain space does not appear in the sidebar, after the fix, it should appear in the sidebar

### TODO

Having the offchain network returning a mix list of onchain and offchain spaces is not optimal, and confusing. This solution is temporary, until we implement https://github.com/snapshot-labs/sx-monorepo/issues/359