### PR TITLE
fix: fix scroll to top on modal open

### DIFF
--- a/apps/ui/src/App.vue
+++ b/apps/ui/src/App.vue
@@ -67,7 +67,7 @@ watch(isSwiping, () => {
 </script>
 
 <template>
-  <div ref="el" class="h-screen" :class="{ 'overflow-hidden': scrollDisabled }">
+  <div ref="el" class="min-h-screen" :class="{ 'overflow-clip': scrollDisabled }">
     <UiLoading v-if="app.loading || !app.init" class="overlay big" />
     <div v-else class="pb-6 flex">
       <AppSidebar class="lg:visible" :class="{ invisible: !uiStore.sidebarOpen }" />


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #361 

This PR fix the UI issue where the page scroll back to the top when opening a modal

### How to test

1. Go to any page with a scroll and modal
2. Open the modal
3. Page should not scroll to the top
4. Any sticky element should stay visible
