### PR TITLE
fix: handle missing filters

### DIFF
--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -288,7 +288,7 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
         filters.end_lt = current;
       }
 
-      Object.keys(filters)
+      Object.keys(filters || {})
         .filter(key => /^(min|max)_end/.test(key))
         .forEach(key => {
           filters[key.replace(/^(min|max)_/, '')] = filters[key];


### PR DESCRIPTION
### Summary

filters can be undefined so we need to handle it, otherwise requests without
filters will fail (for example loading on space).

### How to test

1. Go to https://localhost:8080/#/s:0cf5e
2. Proposals load.

