### PR TITLE
feat: collapse results into "Others" if more than 6 are there

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -45,8 +45,12 @@ const results = computed(() => {
     .sort((a, b) => b.progress - a.progress);
 });
 
+const hasOneExtra = computed(() => {
+  return results.value.length === DEFAULT_MAX_CHOICES + 1;
+});
+
 const visibleResults = computed(() => {
-  if (displayAllChoices.value) {
+  if (displayAllChoices.value || hasOneExtra.value) {
     return results.value;
   }
 
@@ -54,7 +58,9 @@ const visibleResults = computed(() => {
 });
 
 const otherResultsSummary = computed(() => {
-  return results.value.slice(DEFAULT_MAX_CHOICES).reduce(
+  const oetherResultsStartIndex = hasOneExtra.value ? DEFAULT_MAX_CHOICES + 1 : DEFAULT_MAX_CHOICES;
+
+  return results.value.slice(oetherResultsStartIndex).reduce(
     (acc, result) => ({
       progress: acc.progress + result.progress,
       count: acc.count + 1


### PR DESCRIPTION
### Summary

If more than 6 results are there "Others" button will be visible to summarise options that you can expand.

_There is special case if there are 7 results - last option won't be collapsed into "Others" because it would basically hide single choice and add extra friction to see it._

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/233

### How to test

1. Go to http://localhost:8080/#/s:cvx.eth/proposal/0xc8666fbf22c09c9eb0e21ab961814f43ee99aaff14a96b23351c633ce9fae8e7
2. You see "Others" summary.
3. You can expand votes on click.

### Screenshots

<img width="1029" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/91f45ccc-c0d6-462c-846a-58099b5fe489">
