### PR TITLE
fix: load sidebar spaces once all are available

### DIFF
--- a/apps/ui/src/stores/followedSpaces.ts
+++ b/apps/ui/src/stores/followedSpaces.ts
@@ -82,7 +82,7 @@ export const useFollowedSpacesStore = defineStore('followedSpaces', () => {
         )
       )
     );
-    fetchSpacesData(newIds);
+    await fetchSpacesData(newIds);
   }
 
   async function toggleSpaceFollow(id: string) {
@@ -123,6 +123,8 @@ export const useFollowedSpacesStore = defineStore('followedSpaces', () => {
     [() => web3.value.account, () => web3.value.authLoading, () => authInitiated.value],
     async ([web3, authLoading, authInitiated]) => {
       if (!authInitiated || authLoading) return;
+
+      followedSpacesLoaded.value = false;
 
       if (!web3) {
         followedSpacesIds.value = [];


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #375

Load sidebar followed spaces only once all are available

### How to test

1. Connect to your account, and go to space page you're following
2. Refresh the page
3. On page load, it should show the all the spaces at once (and not the space you are on first)
4. On account switch and login, it should do the same
