### PR TITLE
fix: fix duplicates spaces while loading explore page on internal navigation

### DIFF
--- a/apps/ui/src/composables/useSpaces.ts
+++ b/apps/ui/src/composables/useSpaces.ts
@@ -108,7 +108,7 @@ export function useSpaces() {
           filter
         );
 
-        explorePageSpaces.value = [...(overwrite ? [] : explorePageSpaces.value), ...spaces];
+        explorePageSpaces.value = overwrite ? spaces : [explorePageSpaces.value, ...spaces];
 
         return {
           id,

--- a/apps/ui/src/composables/useSpaces.ts
+++ b/apps/ui/src/composables/useSpaces.ts
@@ -108,7 +108,7 @@ export function useSpaces() {
           filter
         );
 
-        explorePageSpaces.value.push(...spaces);
+        explorePageSpaces.value = [...(overwrite ? [] : explorePageSpaces.value), ...spaces];
 
         return {
           id,
@@ -163,7 +163,6 @@ export function useSpaces() {
   }
 
   watch(protocol, async () => {
-    explorePageSpaces.value = [];
     await fetch();
   });
 

--- a/apps/ui/src/composables/useSpaces.ts
+++ b/apps/ui/src/composables/useSpaces.ts
@@ -145,7 +145,6 @@ export function useSpaces() {
   async function fetch(filter?: SpacesFilter) {
     if (loading.value) return;
     loading.value = true;
-    explorePageSpaces.value = [];
 
     await _fetchSpaces(true, filter);
 
@@ -163,6 +162,7 @@ export function useSpaces() {
   }
 
   watch(protocol, async () => {
+    explorePageSpaces.value = [];
     await fetch();
   });
 

--- a/apps/ui/src/composables/useSpaces.ts
+++ b/apps/ui/src/composables/useSpaces.ts
@@ -108,7 +108,7 @@ export function useSpaces() {
           filter
         );
 
-        explorePageSpaces.value = overwrite ? spaces : [explorePageSpaces.value, ...spaces];
+        explorePageSpaces.value = overwrite ? spaces : [...explorePageSpaces.value, ...spaces];
 
         return {
           id,

--- a/apps/ui/src/composables/useSpaces.ts
+++ b/apps/ui/src/composables/useSpaces.ts
@@ -107,7 +107,9 @@ export function useSpaces() {
           },
           filter
         );
+
         explorePageSpaces.value.push(...spaces);
+
         return {
           id,
           spaces,
@@ -143,6 +145,7 @@ export function useSpaces() {
   async function fetch(filter?: SpacesFilter) {
     if (loading.value) return;
     loading.value = true;
+    explorePageSpaces.value = [];
 
     await _fetchSpaces(true, filter);
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #378

This PR fix the issue where the list of spaces in the Explore page is not reset on mount, leading to spaces repeated n times

### How to test

1. Go to http://localhost:8080/#/explore
2. Navigate away from this page
3. Navigate back to the explore page
4. The list of spaces should be back to only the first 20 spaces, and do not have duplicates
