### PR TITLE
fix: fix offchain spaces loading using wrong graphql queries

### DIFF
--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -332,7 +332,7 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
       const { data } = await apollo.query({
         query: SPACES_RANKING_QUERY,
         variables: {
-          first: Math.min(limit, 20),
+          first: limit,
           skip,
           where: {
             ...filter
@@ -340,7 +340,7 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
         }
       });
 
-      return data.ranking.items.map(space => formatSpace(space, networkId));
+      return data.spaces.map(space => formatSpace(space, networkId));
     },
     loadSpace: async (id: string): Promise<Space | null> => {
       const { data } = await apollo.query({

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -26,7 +26,6 @@ import {
 } from '@/types';
 import { ApiSpace, ApiProposal, ApiVote } from './types';
 import { DEFAULT_VOTING_DELAY } from '../constants';
-import { clone } from '@/helpers/utils';
 
 const DEFAULT_AUTHENTICATOR = 'OffchainAuthenticator';
 
@@ -331,22 +330,19 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
       { limit, skip = 0 }: PaginationOpts,
       filter?: SpacesFilter
     ): Promise<Space[]> => {
-      let _filters = clone(filter || {});
-
-      if (!_filters?.id_in) {
+      if (!filter?.id_in) {
         const { data } = await apollo.query({
           query: RANKING_QUERY,
           variables: {
-            first: limit,
+            first: Math.min(limit, 20),
             skip,
             where: {
-              ..._filters
+              ...filter
             }
           }
         });
 
-        _filters = { id_in: data.ranking.items.map(space => space.id) };
-        skip = 0;
+        return data.ranking.items.map(space => formatSpace(space, networkId));
       }
 
       const { data } = await apollo.query({
@@ -355,18 +351,12 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
           first: limit,
           skip,
           where: {
-            ..._filters
+            ...filter
           }
         }
       });
 
-      const spaces: Space[] = data.spaces.map(space => formatSpace(space, networkId));
-
-      if (_filters.id_in) {
-        spaces.sort((a, b) => _filters.id_in!.indexOf(a.id) - _filters.id_in!.indexOf(b.id));
-      }
-
-      return spaces;
+      return data.spaces.map(space => formatSpace(space, networkId));
     },
     loadSpace: async (id: string): Promise<Space | null> => {
       const { data } = await apollo.query({

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -1,6 +1,6 @@
 import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client/core';
 import {
-  SPACES_RANKING_QUERY,
+  SPACES_QUERY,
   RANKING_QUERY,
   SPACE_QUERY,
   PROPOSALS_QUERY,
@@ -350,7 +350,7 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
       }
 
       const { data } = await apollo.query({
-        query: SPACES_RANKING_QUERY,
+        query: SPACES_QUERY,
         variables: {
           first: limit,
           skip,

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -330,11 +330,11 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
       { limit, skip = 0 }: PaginationOpts,
       filter?: SpacesFilter
     ): Promise<Space[]> => {
-      if (!filter?.id_in) {
+      if (filter) {
         const { data } = await apollo.query({
-          query: RANKING_QUERY,
+          query: SPACES_QUERY,
           variables: {
-            first: Math.min(limit, 20),
+            first: limit,
             skip,
             where: {
               ...filter
@@ -342,21 +342,18 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
           }
         });
 
-        return data.ranking.items.map(space => formatSpace(space, networkId));
+        return data.spaces.map(space => formatSpace(space, networkId));
       }
 
       const { data } = await apollo.query({
-        query: SPACES_QUERY,
+        query: RANKING_QUERY,
         variables: {
-          first: limit,
-          skip,
-          where: {
-            ...filter
-          }
+          first: Math.min(limit, 20),
+          skip
         }
       });
 
-      return data.spaces.map(space => formatSpace(space, networkId));
+      return data.ranking.items.map(space => formatSpace(space, networkId));
     },
     loadSpace: async (id: string): Promise<Space | null> => {
       const { data } = await apollo.query({

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -105,7 +105,7 @@ export const PROPOSALS_QUERY = gql`
   ${PROPOSAL_FRAGMENT}
 `;
 
-export const SPACES_RANKING_QUERY = gql`
+export const SPACES_QUERY = gql`
   query ($first: Int, $skip: Int, $where: SpaceWhere) {
     spaces(first: $first, skip: $skip, where: $where) {
       ...offchainSpaceFragment

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -106,11 +106,9 @@ export const PROPOSALS_QUERY = gql`
 `;
 
 export const SPACES_RANKING_QUERY = gql`
-  query ($first: Int, $skip: Int, $where: RankingWhere) {
-    ranking(first: $first, skip: $skip, where: $where) {
-      items {
-        ...offchainSpaceFragment
-      }
+  query ($first: Int, $skip: Int, $where: SpaceWhere) {
+    spaces(first: $first, skip: $skip, where: $where) {
+      ...offchainSpaceFragment
     }
   }
   ${SPACE_FRAGMENT}

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -114,6 +114,17 @@ export const SPACES_RANKING_QUERY = gql`
   ${SPACE_FRAGMENT}
 `;
 
+export const RANKING_QUERY = gql`
+  query ($first: Int, $skip: Int, $where: RankingWhere) {
+    ranking(first: $first, skip: $skip, where: $where) {
+      items {
+        ...offchainSpaceFragment
+      }
+    }
+  }
+  ${SPACE_FRAGMENT}
+`;
+
 export const SPACE_QUERY = gql`
   query ($id: String!) {
     space(id: $id) {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #366 #373

This PR revert back the offchain spaces loading to use the `Space` endpoint, instead of  `Ranking`, due to them not being swappable, causing all `loadSpaces` from offchain to always load the top X spaces, and not honoring the `id_in` filter.

This was causing:

- the follow list to load only spaces if they're in the top 20
- the "My Spaces" (http://localhost:8080/#/settings) to always list the top 20 spaces, and not the user's own space

This PR will use the `ranking` graphql endpoint only when no `id_in` filter is passed to `loadSpaces`, and used as extra, and not replacement

### How to test

1. Your follow list should list all 25 spaces
2. The explore page should load space sorted by popularity
