### PR TITLE
fix: fix cloning of `undefined`

### DIFF
--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -301,11 +301,11 @@ export function createApi(uri: string, networkId: NetworkID, opts: ApiOptions = 
       spaceIds: string[],
       { limit, skip = 0 }: PaginationOpts,
       current: number,
-      filters: ProposalsFilter,
+      filters?: ProposalsFilter,
       searchQuery = ''
     ): Promise<Proposal[]> => {
-      const _filters: Record<string, any> = clone(filters);
-      const state = _filters?.state;
+      const _filters: Record<string, any> = clone(filters || {});
+      const state = _filters.state;
 
       if (state === 'active') {
         _filters.start_lte = current;
@@ -316,7 +316,7 @@ export function createApi(uri: string, networkId: NetworkID, opts: ApiOptions = 
         _filters.max_end_lt = current;
       }
 
-      delete _filters?.state;
+      delete _filters.state;
 
       const { data } = await apollo.query({
         query: PROPOSALS_QUERY,

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -277,11 +277,11 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
       spaceIds: string[],
       { limit, skip = 0 }: PaginationOpts,
       current: number,
-      filters: ProposalsFilter,
+      filters?: ProposalsFilter,
       searchQuery = ''
     ): Promise<Proposal[]> => {
-      const _filters: Record<string, any> = clone(filters);
-      const state = _filters?.state;
+      const _filters: Record<string, any> = clone(filters || {});
+      const state = _filters.state;
 
       if (state === 'active') {
         _filters.start_lte = current;
@@ -299,7 +299,7 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
           delete _filters[key];
         });
 
-      delete _filters?.state;
+      delete _filters.state;
 
       const { data } = await apollo.query({
         query: PROPOSALS_QUERY,


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fixes calling `clone` on `undefined`, resulting on an uncaught error

This PR edit the `loadProposals` signature, to explicitly state that `filter` can be `undefined`, and add fallback when cloning it

### How to test

1. Go to http://localhost:8080/#/s:ens.eth
2. Proposals should load
