### PR TITLE
feat: add support for spaces search

### DIFF
--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -43,10 +43,9 @@ function handleSearchSubmit(e: Event) {
 }
 
 watch(
-  () => route.matched[0]?.name,
-  () => {
-    if (['space', 'my'].includes(route.matched[0]?.name as string)) searchValue.value = '';
-  }
+  () => (route.query.q as string) || '',
+  searchQuery => (searchValue.value = searchQuery),
+  { immediate: true }
 );
 </script>
 
@@ -74,7 +73,7 @@ watch(
           <form class="flex flex-grow" @submit="handleSearchSubmit">
             <input
               ref="searchInput"
-              v-model="searchValue"
+              v-model.trim="searchValue"
               type="text"
               placeholder="Search"
               class="bg-transparent text-skin-link text-[19px] w-full"

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -10,6 +10,19 @@ const { modalAccountOpen } = useModal();
 const { login, web3 } = useWeb3();
 const { toggleSkin, currentMode } = useUserSkin();
 
+const SEARCH_CONFIG = {
+  space: {
+    defaultRoute: 'space-proposals',
+    searchRoute: 'space-search',
+    placeholder: 'Search for a proposal'
+  },
+  my: {
+    defaultRoute: 'my-explore',
+    searchRoute: 'my-explore',
+    placeholder: 'Search for a space'
+  }
+};
+
 const loading = ref(false);
 const searchInput = ref();
 const searchValue = ref('');
@@ -19,7 +32,7 @@ const { focused } = useFocus(searchInput);
 const hasAppNav = computed(() =>
   ['space', 'my', 'settings'].includes(String(route.matched[0]?.name))
 );
-const hasSearch = computed(() => ['space', 'my'].includes(String(route.matched[0]?.name)));
+const searchConfig = computed(() => SEARCH_CONFIG[route.matched[0]?.name || '']);
 
 async function handleLogin(connector) {
   modalAccountOpen.value = false;
@@ -31,15 +44,16 @@ async function handleLogin(connector) {
 function handleSearchSubmit(e: Event) {
   e.preventDefault();
 
-  if (route.matched[0]?.name === 'space') {
-    if (!searchValue.value) {
-      router.push({ name: 'space-proposals' });
-    } else {
-      router.push({ name: 'space-search', query: { q: searchValue.value } });
-    }
-  } else if (route.matched[0]?.name === 'my') {
-    router.push({ name: 'my-explore', query: { q: searchValue.value } });
-  }
+  if (!searchConfig.value) return;
+
+  router.push(
+    !searchValue.value
+      ? { name: searchConfig.value.defaultRoute }
+      : {
+          name: searchConfig.value.searchRoute,
+          query: { q: searchValue.value }
+        }
+  );
 }
 
 watch(
@@ -68,14 +82,14 @@ watch(
           class="inline-block text-skin-link mr-4 cursor-pointer lg:hidden"
           @click="uiStore.toggleSidebar"
         />
-        <div v-if="hasSearch" class="flex items-center flex-1 px-2 py-3 h-full">
+        <div v-if="searchConfig" class="flex items-center flex-1 px-2 py-3 h-full">
           <IH-search class="mr-2.5 flex-shrink-0" :class="{ 'text-skin-link': focused }" />
           <form class="flex flex-grow" @submit="handleSearchSubmit">
             <input
               ref="searchInput"
               v-model.trim="searchValue"
               type="text"
-              placeholder="Search"
+              :placeholder="searchConfig.placeholder"
               class="bg-transparent text-skin-link text-[19px] w-full"
             />
           </form>

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -37,6 +37,8 @@ function handleSearchSubmit(e: Event) {
     } else {
       router.push({ name: 'space-search', query: { q: searchValue.value } });
     }
+  } else if (route.matched[0]?.name === 'my') {
+    router.push({ name: 'my-explore', query: { q: searchValue.value } });
   }
 }
 

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -42,10 +42,12 @@ function handleSearchSubmit(e: Event) {
   }
 }
 
-watch(route, to => {
-  if (to.name === 'space-search') return;
-  searchValue.value = '';
-});
+watch(
+  () => route.matched[0]?.name,
+  () => {
+    if (['space', 'my'].includes(route.matched[0]?.name as string)) searchValue.value = '';
+  }
+);
 </script>
 
 <template>

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -46,14 +46,15 @@ function handleSearchSubmit(e: Event) {
 
   if (!searchConfig.value) return;
 
-  router.push(
-    !searchValue.value
-      ? { name: searchConfig.value.defaultRoute }
-      : {
-          name: searchConfig.value.searchRoute,
-          query: { q: searchValue.value }
-        }
-  );
+  if (!searchValue.value) return router.push({ name: searchConfig.value.defaultRoute });
+
+  router.push({
+    name: searchConfig.value.searchRoute,
+    query: {
+      ...(searchConfig.value.searchRoute === route.matched[0]?.name ? route.query : {}),
+      q: searchValue.value
+    }
+  });
 }
 
 watch(

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -31,10 +31,12 @@ async function handleLogin(connector) {
 function handleSearchSubmit(e: Event) {
   e.preventDefault();
 
-  if (!searchValue.value) {
-    router.push({ name: 'space-proposals' });
-  } else {
-    router.push({ name: 'space-search', query: { q: searchValue.value } });
+  if (route.matched[0]?.name === 'space') {
+    if (!searchValue.value) {
+      router.push({ name: 'space-proposals' });
+    } else {
+      router.push({ name: 'space-search', query: { q: searchValue.value } });
+    }
   }
 }
 

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -51,7 +51,7 @@ function handleSearchSubmit(e: Event) {
   router.push({
     name: searchConfig.value.searchRoute,
     query: {
-      ...(searchConfig.value.searchRoute === route.matched[0]?.name ? route.query : {}),
+      ...(searchConfig.value.searchRoute === route.name ? route.query : {}),
       q: searchValue.value
     }
   });

--- a/apps/ui/src/composables/useSpaces.ts
+++ b/apps/ui/src/composables/useSpaces.ts
@@ -161,11 +161,6 @@ export function useSpaces() {
     loadingMore.value = false;
   }
 
-  watch(protocol, async () => {
-    explorePageSpaces.value = [];
-    await fetch();
-  });
-
   return {
     loading,
     loadingMore,

--- a/apps/ui/src/composables/useSpaces.ts
+++ b/apps/ui/src/composables/useSpaces.ts
@@ -87,6 +87,8 @@ export function useSpaces() {
 
   async function _fetchSpaces(overwrite: boolean, filter?: SpacesFilter) {
     const { networks, limit } = explorePageProtocols[protocol.value];
+    if (overwrite) explorePageSpaces.value = [];
+
     const results = await Promise.all(
       networks.map(async id => {
         const network = getNetwork(id as NetworkID);
@@ -108,7 +110,7 @@ export function useSpaces() {
           filter
         );
 
-        explorePageSpaces.value = overwrite ? spaces : [...explorePageSpaces.value, ...spaces];
+        explorePageSpaces.value = [...explorePageSpaces.value, ...spaces];
 
         return {
           id,
@@ -147,6 +149,8 @@ export function useSpaces() {
     loading.value = true;
 
     await _fetchSpaces(true, filter);
+
+    console.log(protocol.value, explorePageSpaces.value);
 
     loaded.value = true;
     loading.value = false;

--- a/apps/ui/src/composables/useSpaces.ts
+++ b/apps/ui/src/composables/useSpaces.ts
@@ -150,8 +150,6 @@ export function useSpaces() {
 
     await _fetchSpaces(true, filter);
 
-    console.log(protocol.value, explorePageSpaces.value);
-
     loaded.value = true;
     loading.value = false;
   }

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -376,14 +376,21 @@ export function createApi(uri: string, networkId: NetworkID, opts: ApiOptions = 
       { limit, skip = 0 }: PaginationOpts,
       filter?: SpacesFilter
     ): Promise<Space[]> => {
+      const _filter: Record<string, any> = clone(filter || {});
+
+      if (_filter.searchQuery) {
+        _filter.metadata_ = { name_contains_nocase: _filter.searchQuery };
+      }
+      delete _filter.searchQuery;
+
       const { data } = await apollo.query({
         query: SPACES_QUERY,
         variables: {
           first: limit,
           skip,
           where: {
-            ...filter,
-            metadata_: {}
+            metadata_: {},
+            ..._filter
           }
         }
       });

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -332,30 +332,30 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
       { limit, skip = 0 }: PaginationOpts,
       filter?: SpacesFilter
     ): Promise<Space[]> => {
-      if (filter) {
+      if (!filter || filter.hasOwnProperty('searchQuery')) {
         const { data } = await apollo.query({
-          query: SPACES_QUERY,
+          query: RANKING_QUERY,
           variables: {
-            first: limit,
+            first: Math.min(limit, 20),
             skip,
-            where: {
-              ...filter
-            }
+            where: filter?.searchQuery ? { search: filter.searchQuery } : {}
           }
         });
-
-        return data.spaces.map(space => formatSpace(space, networkId));
+        return data.ranking.items.map(space => formatSpace(space, networkId));
       }
 
       const { data } = await apollo.query({
-        query: RANKING_QUERY,
+        query: SPACES_QUERY,
         variables: {
-          first: Math.min(limit, 20),
-          skip
+          first: limit,
+          skip,
+          where: {
+            ...filter
+          }
         }
       });
 
-      return data.ranking.items.map(space => formatSpace(space, networkId));
+      return data.spaces.map(space => formatSpace(space, networkId));
     },
     loadSpace: async (id: string): Promise<Space | null> => {
       const { data } = await apollo.query({

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -19,6 +19,7 @@ export type PaginationOpts = { limit: number; skip?: number };
 export type SpacesFilter = {
   controller?: string;
   id_in?: string[];
+  searchQuery?: string;
 };
 export type ProposalsFilter = {
   state?: 'any' | 'active' | 'pending' | 'closed';

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -6,18 +6,29 @@ const protocols = Object.values(explorePageProtocols).map(({ key, label }: Proto
   key,
   label
 }));
+const DEFAULT_PROTOCOL = 'snapshot';
 
 const { setTitle } = useTitle();
 const spacesStore = useSpacesStore();
 const route = useRoute();
+const router = useRouter();
 
-const protocol = ref<ExplorePageProtocol>('snapshot');
+const protocol = ref<ExplorePageProtocol>(DEFAULT_PROTOCOL);
+
+watch(protocol, value => {
+  router.push({ query: { q: route.query.q, p: value } });
+});
 
 watch(
-  [() => route.query.q as string, () => protocol.value],
-  ([query, protocol]) => {
-    spacesStore.protocol = protocol;
-    spacesStore.fetch({ searchQuery: query });
+  [() => route.query.q as string, () => route.query.p as string],
+  ([searchQuery, protocolQuery]) => {
+    const _protocol = (
+      explorePageProtocols[protocolQuery] ? protocolQuery : DEFAULT_PROTOCOL
+    ) as ExplorePageProtocol;
+
+    protocol.value = _protocol;
+    spacesStore.protocol = _protocol;
+    spacesStore.fetch({ searchQuery });
   },
   {
     immediate: true

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -16,7 +16,7 @@ const router = useRouter();
 const protocol = ref<ExplorePageProtocol>(DEFAULT_PROTOCOL);
 
 watch(protocol, value => {
-  router.push({ query: { q: route.query.q, p: value } });
+  router.push({ query: { ...route.query, p: value } });
 });
 
 watch(
@@ -70,7 +70,7 @@ watchEffect(() => setTitle('Explore'));
         </UiContainerInfiniteScroll>
       </div>
       <div v-else class="px-4 py-3 flex items-center space-x-2">
-        <IH-exclamation-circle class="inline-block" />
+        <IH-exclamation-circle class="inline-block shrink-0" />
         <span>No results found for your search</span>
       </div>
     </div>

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -42,8 +42,11 @@ watchEffect(() => setTitle('Explore'));
   <div>
     <UiLabel label="Spaces" sticky />
     <UiLoading v-if="spacesStore.loading" class="block m-4" />
-    <div v-else-if="spacesStore.loaded" class="max-w-screen-md mx-auto p-4">
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 mb-3">
+    <div v-else-if="spacesStore.loaded">
+      <div
+        v-if="spacesStore.explorePageSpaces.length"
+        class="max-w-screen-md mx-auto p-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 mb-3"
+      >
         <UiContainerInfiniteScroll
           :loading-more="spacesStore.loadingMore"
           @end-reached="spacesStore.fetchMore({ searchQuery: route.query.q as string })"
@@ -54,6 +57,10 @@ watchEffect(() => setTitle('Explore'));
             :space="space"
           />
         </UiContainerInfiniteScroll>
+      </div>
+      <div v-else class="px-4 py-3 flex items-center space-x-2">
+        <IH-exclamation-circle class="inline-block" />
+        <span>No results found for your search</span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #389 

This PR add the ability to search for a space

### UI/UX changes

- The search input should be pre-populated on page load with the query string from the url (`q=xxx`) if available
- Use different placeholder for space and proposal search
- Explore page now have a message when no spaces results
- Move explore page protocol to query string in the url (`?p=snapshot|snapshotx`)

### New features

- Using the topnav searchbar from the "My" pages should redirect to the explore page, and show a list of spaces matching the search results

### How to test

1. Go to http://localhost:8080/#/home
2. Search for a space using the top searchbar
3. It should show your results in the /explore page
4. You can switch protocol, without to search for the keyword again
5. The URL should reflect your search filters, reloading the page will keep the same results

### TODO

- [x] Code improvement