### PR TITLE
fix: Walletconnect support for multichain wallets

### DIFF
--- a/apps/ui/src/helpers/connectors.ts
+++ b/apps/ui/src/helpers/connectors.ts
@@ -20,9 +20,10 @@ export default {
     icon: walletconnectIcon,
     options: {
       projectId: 'e6454bd61aba40b786e866a69bd4c5c6',
-      chains: [1],
-      optionalChains: [10, 56, 100, 42161, 137, 1088, 11155111],
-      methods: ['eth_sendTransaction', 'eth_signTypedData_v4'],
+      chains: [],
+      optionalChains: [1, 10, 56, 100, 42161, 137, 1088, 11155111],
+      methods: ['eth_sendTransaction'],
+      optionalMethods: ['eth_signTypedData_v4'],
       showQrModal: true
     }
   },


### PR DESCRIPTION
### Summary

Same changes as in https://github.com/snapshot-labs/snapshot/pull/4700

- chains = [] to support all networks while connecting using Wallet-connect
- move `eth_signTypedData_v4` method to optional
Closes: #

### How to test

1. Vote/Create proposals with Safe on other networks than mainnet (using wallet connect) 
  Before the fix: it should throw invalid network error
  After the fix: should be able to vote/create proposals
