### PR TITLE
fix: fix abstain vote button color

### DIFF
--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -205,11 +205,10 @@ watch([sortBy, choiceFilter], () => {
             </UiTooltip>
             <UiButton
               v-else
-              class="!w-[40px] !h-[40px] !px-0 cursor-default bg-transparent"
+              class="!w-[40px] !h-[40px] !px-0 cursor-default bg-transparent !text-gray-500 !border-gray-500"
               :class="{
                 '!text-skin-success !border-skin-success': vote.choice === 1,
-                '!text-skin-danger !border-skin-danger': vote.choice === 2,
-                '!text-gray-500 !border-gray-500': vote.choice === 3
+                '!text-skin-danger !border-skin-danger': vote.choice === 2
               }"
             >
               <IH-check v-if="vote.choice === 1" class="inline-block" />


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #396

Fix ABSTAIN button text not having the correct color.

This was because abstain for highlight vote is index 0, whereas it is 3 for all the other types

### How to test

1. Go to  http://localhost:8080/#/sep:0x5559e6c038fD0494277ac85ab6576843A6d0187b/proposal/7/votes
2. The ABSTAIN button should now have grey text
