### PR TITLE
fix: hide result progress bar on ongoing shutter proposal

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -167,7 +167,10 @@ const otherResultsSummary = computed(() => {
         </div>
       </div>
     </div>
-    <div v-else class="h-full flex items-center">
+    <div
+      v-else-if="!props.proposal.privacy || props.proposal.completed"
+      class="h-full flex items-center"
+    >
       <div
         class="rounded-full h-1.5 overflow-hidden"
         :style="{


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #398

This PR hides the results progress bar on active proposals which you have voted, and with shutter and quorum enabled

### How to test

1. Create a proposal on a space with shutter and quorum
2. Vote on the proposal
3. In the space proposals page, the proposal should appear without the progress bar
