### PR TITLE
fix(ui): improve space cover dimensions

### DIFF
--- a/apps/ui/src/components/SpaceCover.vue
+++ b/apps/ui/src/components/SpaceCover.vue
@@ -18,10 +18,10 @@ const cb = computed(() =>
     v-if="space.cover"
     :id="space.id"
     :width="1500"
-    :height="156"
+    :height="312"
     :cb="cb"
     type="space-cover-sx"
-    class="object-cover"
+    class="object-cover !rounded-none h-full w-full"
   />
   <div
     v-else
@@ -39,15 +39,13 @@ const cb = computed(() =>
 
 <style lang="scss" scoped>
 .space-fallback-cover {
-  object-fit: cover;
+  @apply object-cover w-full h-full;
 
   &::after {
+    @apply absolute h-full w-full pointer-events-none;
+
     content: '';
-    position: absolute;
-    width: 100%;
-    height: 100%;
     backdrop-filter: blur(50px) contrast(0.9) saturate(1.3);
-    pointer-events: none;
   }
 }
 </style>

--- a/apps/ui/src/components/SpaceCover.vue
+++ b/apps/ui/src/components/SpaceCover.vue
@@ -18,7 +18,7 @@ const cb = computed(() =>
     v-if="space.cover"
     :id="space.id"
     :width="1500"
-    :height="312"
+    :height="500"
     :cb="cb"
     type="space-cover-sx"
     class="object-cover !rounded-none h-full w-full"

--- a/apps/ui/src/components/SpaceCover.vue
+++ b/apps/ui/src/components/SpaceCover.vue
@@ -4,9 +4,16 @@ import { offchainNetworks } from '@/networks';
 import { getCacheHash, getStampUrl } from '@/helpers/utils';
 import { NetworkID } from '@/types';
 
-const props = defineProps<{
-  space: { id: string; cover: string; avatar: string; network: NetworkID };
-}>();
+const props = withDefaults(
+  defineProps<{
+    space: { id: string; cover: string; avatar: string; network: NetworkID };
+    size?: 'sm' | 'lg';
+  }>(),
+  { size: 'lg' }
+);
+
+const width = props.size === 'sm' ? 450 : 1500;
+const height = props.size === 'sm' ? 120 : 400;
 
 const cb = computed(() =>
   props.space.cover ? sha3.sha3_256(props.space.cover).slice(0, 16) : undefined
@@ -17,8 +24,8 @@ const cb = computed(() =>
   <UiStamp
     v-if="space.cover"
     :id="space.id"
-    :width="1500"
-    :height="500"
+    :width="width"
+    :height="height"
     :cb="cb"
     type="space-cover-sx"
     class="object-cover !rounded-none h-full w-full"

--- a/apps/ui/src/components/SpacesListItem.vue
+++ b/apps/ui/src/components/SpacesListItem.vue
@@ -13,7 +13,7 @@ const compositeSpaceId = `${props.space.network}:${props.space.id}`;
     class="text-skin-text border rounded-lg block h-[280px] relative group overflow-hidden"
   >
     <div class="h-[68px] w-full absolute">
-      <SpaceCover :space="props.space" />
+      <SpaceCover :space="props.space" size="sm" />
     </div>
     <div class="relative inline-block mx-4 mt-[34px]">
       <UiBadgeNetwork

--- a/apps/ui/src/components/SpacesListItem.vue
+++ b/apps/ui/src/components/SpacesListItem.vue
@@ -12,7 +12,9 @@ const compositeSpaceId = `${props.space.network}:${props.space.id}`;
     :to="{ name: 'space-overview', params: { id: compositeSpaceId } }"
     class="text-skin-text border rounded-lg block h-[280px] relative group overflow-hidden"
   >
-    <SpaceCover :space="props.space" class="!rounded-none w-full h-[68px] absolute" />
+    <div class="h-[68px] w-full absolute">
+      <SpaceCover :space="props.space" />
+    </div>
     <div class="relative inline-block mx-4 mt-[34px]">
       <UiBadgeNetwork
         :id="space.network"

--- a/apps/ui/src/components/Ui/InputStampCover.vue
+++ b/apps/ui/src/components/Ui/InputStampCover.vue
@@ -58,8 +58,9 @@ async function handleFileChange(e: Event) {
   >
     <img
       v-if="imgUrl"
+      alt=""
       :src="imgUrl"
-      class="h-[100px] w-full object-cover group-hover:opacity-80"
+      class="h-full w-full object-cover group-hover:opacity-80"
       :class="{
         'opacity-80': isUploadingImage
       }"
@@ -67,7 +68,7 @@ async function handleFileChange(e: Event) {
     <SpaceCover
       v-else-if="props.space?.cover"
       :space="props.space"
-      class="pointer-events-none !rounded-none min-h-full group-hover:opacity-80"
+      class="pointer-events-none group-hover:opacity-80"
     />
 
     <div

--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -62,8 +62,8 @@ watchEffect(() => setTitle(props.space.name));
 <template>
   <div>
     <div class="relative bg-skin-border h-[156px] md:h-[140px] -mb-[86px] md:-mb-[70px] top-[-1px]">
-      <div class="w-full h-full overflow-hidden">
-        <SpaceCover :space="props.space" class="!rounded-none w-full min-h-full" />
+      <div class="w-full h-full">
+        <SpaceCover :space="props.space" />
       </div>
       <div class="relative bg-skin-bg h-[16px] top-[-16px] rounded-t-[16px] md:hidden" />
       <div class="absolute right-4 top-4 space-x-2">


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/stamp/issues/172

### Changes 

Only 1 change: increasing the fetched image height.
The other changes are just CSS cleaning and DRY-ing 

### How to test

1. Go to the /explore page, and a onchain space with cover image (ens, nostra)
2. The space cover dimension should be better
