### PR TITLE
feat: add special _vp formatter

### DIFF
--- a/apps/ui/src/components/IndicatorVotingPower.vue
+++ b/apps/ui/src/components/IndicatorVotingPower.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { _n } from '@/helpers/utils';
+import { _vp } from '@/helpers/utils';
 import { NetworkID } from '@/types';
 import { VotingPower, VotingPowerStatus } from '@/networks/types';
 import { evmNetworks } from '@/networks';
@@ -24,10 +24,7 @@ const decimals = computed(() =>
   Math.max(...props.votingPowers.map(votingPower => votingPower.decimals), 0)
 );
 const formattedVotingPower = computed(() => {
-  const value = _n(Number(votingPower.value) / 10 ** decimals.value, 'compact', {
-    maximumFractionDigits: 2,
-    formatDust: true
-  });
+  const value = _vp(Number(votingPower.value) / 10 ** decimals.value);
 
   if (props.votingPowerSymbol) {
     return `${value} ${props.votingPowerSymbol}`;

--- a/apps/ui/src/helpers/utils.test.ts
+++ b/apps/ui/src/helpers/utils.test.ts
@@ -1,8 +1,29 @@
 import { describe, it, expect } from 'vitest';
 
-import { createErc1155Metadata } from './utils';
+import { _vp, createErc1155Metadata } from './utils';
 
 describe('utils', () => {
+  describe('_vp', () => {
+    it('should format dust', () => {
+      expect(_vp(0.001)).toBe('~0');
+    });
+
+    it('should use 3 max decimals for small numbers', () => {
+      expect(_vp(0.1234)).toBe('0.123');
+      expect(_vp(55.5667)).toBe('55.567');
+      expect(_vp(444.6326)).toBe('444.633');
+      expect(_vp(999.90111)).toBe('999.901');
+    });
+
+    it('should use 1 max decimal for big numbers', () => {
+      expect(_vp(1000)).toBe('1k');
+      expect(_vp(1234)).toBe('1.2k');
+      expect(_vp(5556)).toBe('5.6k');
+      expect(_vp(44444)).toBe('44.4k');
+      expect(_vp(999900)).toBe('999.9k');
+    });
+  });
+
   describe('createErc1155Metadata', () => {
     it('should create metadata', () => {
       const metadata = createErc1155Metadata({

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -142,6 +142,10 @@ export function _n(
   return formatter.format(value).toLowerCase();
 }
 
+export function _vp(value: number) {
+  return _n(value, 'compact', { maximumFractionDigits: value >= 1000 ? 1 : 3, formatDust: true });
+}
+
 export function getCurrentName(currentUnit: 'block' | 'second') {
   if (currentUnit === 'block') return 'blocks';
   return 'seconds';

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { getNetwork, offchainNetworks } from '@/networks';
-import { shortenAddress, _t, _rt, _n, getChoiceText } from '@/helpers/utils';
+import { shortenAddress, _t, _rt, _n, getChoiceText, _vp } from '@/helpers/utils';
 import { Proposal as ProposalType, Vote } from '@/types';
 
 const LIMIT = 20;
@@ -222,12 +222,7 @@ watch([sortBy, choiceFilter], () => {
           class="text-right leading-[22px] w-[25%] lg:w-[20%] flex flex-col items-end justify-center truncate"
         >
           <h4 class="text-skin-link">
-            {{
-              _n(vote.vp / 10 ** votingPowerDecimals, 'compact', {
-                maximumFractionDigits: 3,
-                formatDust: true
-              })
-            }}
+            {{ _vp(vote.vp / 10 ** votingPowerDecimals) }}
             {{ proposal.space.voting_power_symbol }}
           </h4>
           <div class="text-[17px]">{{ _n((vote.vp / proposal.scores_total) * 100) }}%</div>


### PR DESCRIPTION
### Summary

This one is used for VP specifically using predefined rules of formatting. It will use maximium of 3 decimal digits (for numbers < 1000) or 1 otherwise.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/405

### How to test

1. Go to http://localhost:8080/#/s:aave.eth/proposal/0x364de11d3a298f2c76721a8926cb32823cc29d0a95eadecbc0a98c628a38194b/votes
2. Big VP values have maximum of 1 decimal digit.
