### PR TITLE
feat: prevent already voted message to show when changing accounts.

### DIFF
--- a/apps/ui/src/components/ProposalVote.vue
+++ b/apps/ui/src/components/ProposalVote.vue
@@ -6,8 +6,7 @@ import { Proposal as ProposalType } from '@/types';
 
 const props = defineProps<{ proposal: ProposalType }>();
 
-const uiStore = useUiStore();
-const { votes } = useAccount();
+const { votes, pendingVotes } = useAccount();
 const { getTsFromCurrent } = useMetaStore();
 const { isInvalidNetwork } = useSafeWallet(
   props.proposal.network,
@@ -43,7 +42,7 @@ const isSupported = computed(() => {
     You have already voted for this proposal
   </slot>
 
-  <slot v-else-if="uiStore.pendingVotes[proposal.id]" name="voted-pending">
+  <slot v-else-if="pendingVotes[proposal.id]" name="voted-pending">
     You have already voted for this proposal
   </slot>
   <slot v-else-if="proposal.state === 'pending'" name="waiting">

--- a/apps/ui/src/composables/useAccount.ts
+++ b/apps/ui/src/composables/useAccount.ts
@@ -2,6 +2,7 @@ import { getNetwork } from '@/networks';
 import type { NetworkID, Proposal, Vote } from '@/types';
 
 const votes = ref<Record<Proposal['id'], Vote>>({});
+const pendingVotes = ref<Record<string, boolean>>({});
 
 export function useAccount() {
   const { web3 } = useWeb3();
@@ -18,9 +19,15 @@ export function useAccount() {
     votes.value = { ...votes.value, ...userVotes };
   }
 
+  function addPendingVote(proposalId: string) {
+    pendingVotes.value[proposalId] = true;
+  }
+
   return {
     account: web3.value.account,
     votes,
-    loadVotes
+    pendingVotes,
+    loadVotes,
+    addPendingVote
   };
 }

--- a/apps/ui/src/composables/useAccount.ts
+++ b/apps/ui/src/composables/useAccount.ts
@@ -4,9 +4,11 @@ import type { NetworkID, Proposal, Vote } from '@/types';
 const votes = ref<Record<Proposal['id'], Vote>>({});
 
 export function useAccount() {
-  const { web3, web3Account } = useWeb3();
+  const { web3 } = useWeb3();
 
   async function loadVotes(networkId: NetworkID, spaceIds: string[]) {
+    votes.value = {};
+
     const account = web3.value.account;
     if (!account) return;
 
@@ -15,10 +17,6 @@ export function useAccount() {
 
     votes.value = { ...votes.value, ...userVotes };
   }
-
-  watchEffect(() => {
-    if (!web3Account.value) votes.value = {};
-  });
 
   return {
     account: web3.value.account,

--- a/apps/ui/src/composables/useAccount.ts
+++ b/apps/ui/src/composables/useAccount.ts
@@ -1,12 +1,20 @@
 import { getNetwork } from '@/networks';
 import type { NetworkID, Proposal, Vote } from '@/types';
 
+const { web3 } = useWeb3();
 const votes = ref<Record<Proposal['id'], Vote>>({});
 const pendingVotes = ref<Record<string, boolean>>({});
 
-export function useAccount() {
-  const { web3 } = useWeb3();
+watch(
+  () => web3.value.account,
+  (current, previous) => {
+    if (current !== previous) {
+      pendingVotes.value = {};
+    }
+  }
+);
 
+export function useAccount() {
   async function loadVotes(networkId: NetworkID, spaceIds: string[]) {
     votes.value = {};
 

--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -22,6 +22,7 @@ export function useActions() {
   const uiStore = useUiStore();
   const alias = useAlias();
   const { web3 } = useWeb3();
+  const { addPendingVote } = useAccount();
   const { getCurrentFromDuration } = useMetaStore();
   const { modalAccountOpen } = useModal();
   const auth = getInstance();
@@ -218,7 +219,7 @@ export function useActions() {
       )
     );
 
-    uiStore.addPendingVote(proposal.id);
+    addPendingVote(proposal.id);
 
     mixpanel.track('Vote', {
       network: proposal.network,

--- a/apps/ui/src/stores/ui.ts
+++ b/apps/ui/src/stores/ui.ts
@@ -26,8 +26,7 @@ export const useUiStore = defineStore('ui', {
   state: () => ({
     sidebarOpen: false,
     notifications: [] as Notification[],
-    pendingTransactions: [] as PendingTransaction[],
-    pendingVotes: {} as Record<string, boolean>
+    pendingTransactions: [] as PendingTransaction[]
   }),
   actions: {
     async toggleSidebar() {
@@ -81,9 +80,6 @@ export const useUiStore = defineStore('ui', {
           updateStorage(this.pendingTransactions);
         }
       });
-    },
-    async addPendingVote(proposalId: string) {
-      this.pendingVotes[proposalId] = true;
     }
   }
 });


### PR DESCRIPTION
### Summary

Now changing account will reset both votes and pending votes.

`pendingVotes` are now also part of `useAccount` composable to collocate them with regular votes and allow for easier reset when account changes.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/412

### How to test

1. Go to some proposal you already voted.
2. Change account by clicking Change account.
3. Message disappears.
4. Go to new proposal you haven't voted.
5. Vote.
6. Change account by clicking Change account.
7. Message disappears.
