### PR TITLE
fix: fix error style on textarea

### DIFF
--- a/apps/ui/src/style.scss
+++ b/apps/ui/src/style.scss
@@ -280,6 +280,12 @@ input[type='number'] {
     @apply mb-1 #{!important};
   }
 
+  textarea.s-input {
+    &, :focus {
+      @apply outline outline-1 outline-offset-0 outline-skin-danger border-transparent;
+    }
+  }
+
   .s-label {
     @apply text-skin-danger;
   }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #411

### How to test

1. Go to a form with textarea
2. Trigger an error on the textarea
3. It should have 1px red border, and red label text
