### PR TITLE
feat: only fail waitForTransaction if it's missing or reverted

### DIFF
--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -1,8 +1,4 @@
-import {
-  constants as starknetConstants,
-  TransactionExecutionStatus,
-  TransactionFinalityStatus
-} from 'starknet';
+import { LibraryError, constants as starknetConstants, TransactionExecutionStatus } from 'starknet';
 import { createApi } from '../common/graphqlApi';
 import { STARKNET_CONNECTORS } from '../common/constants';
 import { createActions } from './actions';
@@ -80,30 +76,25 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
           try {
             tx = await provider.getTransactionReceipt(txId);
           } catch (e) {
-            if (retries > 20) {
-              clearInterval(timer);
-              reject();
-            }
+            if (e instanceof LibraryError && e.message.includes('Transaction hash not found')) {
+              if (retries > 60) {
+                clearInterval(timer);
+                reject();
+              }
 
-            retries++;
+              retries++;
+            }
 
             return;
           }
 
-          const successStates = [
-            TransactionFinalityStatus.ACCEPTED_ON_L1,
-            TransactionFinalityStatus.ACCEPTED_ON_L2
-          ];
-
-          if (successStates.includes(tx.finality_status as any)) {
-            clearInterval(timer);
+          if (tx.execution_status === TransactionExecutionStatus.SUCCEEDED) {
             resolve(tx);
-          }
-
-          if (tx.execution_status === TransactionExecutionStatus.REVERTED) {
-            clearInterval(timer);
+          } else {
             reject(tx);
           }
+
+          clearInterval(timer);
         }, 2000);
       });
     },


### PR DESCRIPTION
### Summary

Previously any failure in fetching receipt would result in waitForTransaction failing after 20 attempts. This means non-related errors (like rate limits) would cause it to fail, even though transaction has completed.

This PR changes this behavior, it will only fail if:
1. Transaction was missing for 60 attempts (2 minutes).
2. It was reverted.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/409

### How to test

1. Create Starknet space.
