### PR TITLE
fix: hide leaderboard link from offchain space menu

### DIFF
--- a/apps/ui/src/components/App/Nav.vue
+++ b/apps/ui/src/components/App/Nav.vue
@@ -57,7 +57,7 @@ const navigationConfig = computed<Record<string, Record<string, NavigationItem>>
     leaderboard: {
       name: 'Leaderboard',
       icon: IHUserGroup,
-      hidden: space.value && offchainNetworks.includes(space.value.network)
+      hidden: (space.value && offchainNetworks.includes(space.value.network)) || false
     },
     ...(space.value?.delegations && space.value.delegations.length > 0
       ? {

--- a/apps/ui/src/components/App/Nav.vue
+++ b/apps/ui/src/components/App/Nav.vue
@@ -14,6 +14,7 @@ import IHGlobe from '~icons/heroicons-outline/globe-americas';
 import IHHome from '~icons/heroicons-outline/home';
 import IHBell from '~icons/heroicons-outline/bell';
 import { type FunctionalComponent } from 'vue';
+import { offchainNetworks } from '@/networks';
 
 type NavigationItem = {
   name: string;
@@ -55,7 +56,8 @@ const navigationConfig = computed<Record<string, Record<string, NavigationItem>>
     },
     leaderboard: {
       name: 'Leaderboard',
-      icon: IHUserGroup
+      icon: IHUserGroup,
+      hidden: (space.value && offchainNetworks.includes(space.value.network)) || false
     },
     ...(space.value?.delegations && space.value.delegations.length > 0
       ? {

--- a/apps/ui/src/components/App/Nav.vue
+++ b/apps/ui/src/components/App/Nav.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { compareAddresses } from '@/helpers/utils';
+import { offchainNetworks } from '@/networks';
 
 import IHGlobeAlt from '~icons/heroicons-outline/globe-alt';
 import IHNewspaper from '~icons/heroicons-outline/newspaper';
@@ -14,7 +15,6 @@ import IHGlobe from '~icons/heroicons-outline/globe-americas';
 import IHHome from '~icons/heroicons-outline/home';
 import IHBell from '~icons/heroicons-outline/bell';
 import { type FunctionalComponent } from 'vue';
-import { offchainNetworks } from '@/networks';
 
 type NavigationItem = {
   name: string;

--- a/apps/ui/src/components/App/Nav.vue
+++ b/apps/ui/src/components/App/Nav.vue
@@ -57,7 +57,7 @@ const navigationConfig = computed<Record<string, Record<string, NavigationItem>>
     leaderboard: {
       name: 'Leaderboard',
       icon: IHUserGroup,
-      hidden: (space.value && offchainNetworks.includes(space.value.network)) || false
+      hidden: space.value && offchainNetworks.includes(space.value.network)
     },
     ...(space.value?.delegations && space.value.delegations.length > 0
       ? {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR removes the leaderboard link from offchain spaces sidebar navigation; offchain leaderboard is not ready yet on the API side, and is always showing nothing

### How to test

1. Go to an offchain space
2. The leaderboard link should be gone from the sidebar menu
3. Go to an onchain space
4. The leaderboard link should still be there
