### PR TITLE
fix: disable features not supported on starknet wallet

### DIFF
--- a/apps/ui/src/components/ButtonFollow.vue
+++ b/apps/ui/src/components/ButtonFollow.vue
@@ -6,10 +6,13 @@ const props = defineProps<{
 }>();
 
 const spaceIdComposite = `${props.space.network}:${props.space.id}`;
+
 const { isSafeWallet } = useSafeWallet(props.space.network, props.space.snapshot_chain_id);
 const followedSpacesStore = useFollowedSpacesStore();
+const { web3 } = useWeb3();
 
 const spaceFollowed = computed(() => followedSpacesStore.isFollowed(spaceIdComposite));
+const hidden = computed(() => web3.value?.type === 'argentx');
 
 const loading = computed(
   () =>
@@ -20,6 +23,7 @@ const loading = computed(
 
 <template>
   <UiButton
+    v-if="!hidden"
     :disabled="loading || isSafeWallet"
     class="group"
     :class="{ 'hover:border-skin-danger': spaceFollowed }"

--- a/apps/ui/src/stores/followedSpaces.ts
+++ b/apps/ui/src/stores/followedSpaces.ts
@@ -120,13 +120,18 @@ export const useFollowedSpacesStore = defineStore('followedSpaces', () => {
   }
 
   watch(
-    [() => web3.value.account, () => web3.value.authLoading, () => authInitiated.value],
-    async ([web3, authLoading, authInitiated]) => {
+    [
+      () => web3.value.account,
+      () => web3.value.type,
+      () => web3.value.authLoading,
+      () => authInitiated.value
+    ],
+    async ([web3, walletType, authLoading, authInitiated]) => {
       if (!authInitiated || authLoading) return;
 
       followedSpacesLoaded.value = false;
 
-      if (!web3) {
+      if (!web3 || walletType === 'argentx') {
         followedSpacesIds.value = [];
         followedSpacesLoaded.value = true;
         return;

--- a/apps/ui/src/views/User.vue
+++ b/apps/ui/src/views/User.vue
@@ -120,7 +120,7 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
       <div class="relative bg-skin-bg h-[16px] top-[-16px] rounded-t-[16px] md:hidden" />
       <div class="absolute right-4 top-4 space-x-2 flex">
         <DropdownShare :message="shareMsg" class="!px-0 w-[46px]" />
-        <UiTooltip v-if="web3.account === user.id" title="Edit profile">
+        <UiTooltip v-if="web3.account === user.id && web3.type !== 'argentx'" title="Edit profile">
           <UiButton class="!px-0 w-[46px]" @click="modalOpenEditUser = true">
             <IH-cog class="inline-block" />
           </UiButton>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR disable features not supported by starknet wallet (due to sequencer not supporting starknet addresses yet):

- Hide all follow/unfollow space button
- Hide the edit user profile button for starknet user
- Skip loading follow list

### How to test

1. Log in with a starknet wallet
2. Go to your user profile page
3. The "EDIT" button should not appear
4. Go to any spaces or /explore page
5. The "FOLLOW" button should not appear
