### PR TITLE
fix: Don't show edit profile button if wallet is not connected

### DIFF
--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -5,7 +5,7 @@ import duration from 'dayjs/plugin/duration';
 import sha3 from 'js-sha3';
 import Autolinker from 'autolinker';
 import { sanitizeUrl as baseSanitizeUrl } from '@braintree/sanitize-url';
-import { getAddress } from '@ethersproject/address';
+import { getAddress, isAddress } from '@ethersproject/address';
 import { validateAndParseAddress } from 'starknet';
 import { upload as pin } from '@snapshot-labs/pineapple';
 import networks from '@/helpers/networks.json';
@@ -369,9 +369,7 @@ export function compareAddresses(a: string, b: string): boolean {
   if (a.length > 42 && b.length > 42) {
     return validateAndParseAddress(a) === validateAndParseAddress(b);
   }
-
-  // TODO: in future ignore padding as well
-  return a.toLowerCase() === b.toLowerCase();
+  return isAddress(a) && isAddress(b) && a.toLowerCase() === b.toLowerCase();
 }
 
 export function getSalt() {

--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -19,7 +19,9 @@ onMounted(() => {
 
 const isOffchainSpace = offchainNetworks.includes(props.space.network);
 
-const isController = computed(() => compareAddresses(props.space.controller, web3.value.account));
+const isController = computed(
+  () => web3.value.account && compareAddresses(props.space.controller, web3.value.account)
+);
 
 const socials = computed(() => getSocialNetworksLink(props.space));
 

--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -19,9 +19,7 @@ onMounted(() => {
 
 const isOffchainSpace = offchainNetworks.includes(props.space.network);
 
-const isController = computed(
-  () => web3.value.account && compareAddresses(props.space.controller, web3.value.account)
-);
+const isController = computed(() => compareAddresses(props.space.controller, web3.value.account));
 
 const socials = computed(() => getSocialNetworksLink(props.space));
 


### PR DESCRIPTION
### Summary
- Don't show the edit profile button if wallet is not connected
 
Closes: #428 

### How to test

1. Go to any space without connecting wallet, you should not see edit profile button after the fix
