### PR TITLE
fix: Get ENS names even if user doesn't exist on hub

### DIFF
--- a/apps/ui/src/stores/users.ts
+++ b/apps/ui/src/stores/users.ts
@@ -36,12 +36,14 @@ export const useUsersStore = defineStore('users', {
       const record = toRef(this.users, userId) as Ref<UserRecord>;
       record.value.loading = false;
 
-      const user = await network.api.loadUser(userId);
+      const user = (await network.api.loadUser(userId)) || {
+        id: userId,
+        proposal_count: 0,
+        vote_count: 0
+      };
 
-      if (user) {
-        user.name ||= (await getNames([userId]))[userId];
-        record.value.user = user;
-      }
+      user.name ||= (await getNames([userId]))[userId];
+      record.value.user = user;
 
       record.value.loaded = true;
       record.value.loading = false;

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -206,8 +206,9 @@ export type User = {
   id: string;
   proposal_count: number;
   vote_count: number;
-  created: number;
+  created?: number;
   follows?: string[];
+  name?: string;
 } & UserProfile;
 
 export type UserActivity = {


### PR DESCRIPTION
### Summary
- Get ENS names even if user doesn't exist on hub
- Load default object in such case

Closes: #429 

### How to test

1. Go to home page using env `VITE_ENABLED_NETWORKS=s-tn,sep,sn-sep` 
2. Login with a wallet that doesn't have a profile on snapshot testnet 
3. After the fix, you should see ENS name 
4. <img width="264" alt="Untitled 2" src="https://github.com/snapshot-labs/sx-monorepo/assets/15967809/f4648cdd-c689-4c67-a1c1-0fb309ca5b9d">

