### PR TITLE
fix: Remove duplicate calls to stamp

### DIFF
--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -207,15 +207,6 @@ function formatVote(vote: ApiVote): Vote {
   };
 }
 
-function formatUser(user: User) {
-  return {
-    ...user,
-    proposal_count: user.proposal_count || 0,
-    vote_count: user.vote_count || 0,
-    name: user.name || ''
-  };
-}
-
 export function createApi(uri: string, networkId: NetworkID): NetworkApi {
   const httpLink = createHttpLink({ uri });
 
@@ -382,17 +373,23 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
 
       return formatSpace(data.space, networkId);
     },
-    loadUser: async (id: string): Promise<User | null> => {
-      const {
+    loadUser: async (id: string): Promise<User> => {
+      let {
         data: { user }
       } = await apollo.query({
         query: USER_QUERY,
         variables: { id }
       });
 
-      if (!user) return null;
+      if (!user) {
+        user = { id };
+      }
 
-      return formatUser(user);
+      user.name ||= (await getNames([id]))[id];
+      user.proposal_count ||= 0;
+      user.vote_count ||= 0;
+
+      return user;
     },
     loadUserActivities: async (): Promise<UserActivity[]> => {
       // NOTE: leaderboard implementation is pending on offchain

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -207,12 +207,12 @@ function formatVote(vote: ApiVote): Vote {
   };
 }
 
-async function formatUser(user: User) {
+function formatUser(user: User) {
   return {
     ...user,
     proposal_count: user.proposal_count || 0,
     vote_count: user.vote_count || 0,
-    name: user.name || (await getNames([user.id])[user.id])
+    name: user.name || ''
   };
 }
 

--- a/apps/ui/src/stores/users.ts
+++ b/apps/ui/src/stores/users.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia';
 import { enabledNetworks, getNetwork, offchainNetworks } from '@/networks';
-import { getNames } from '@/helpers/stamp';
 import type { User } from '@/types';
 
 type UserRecord = {

--- a/apps/ui/src/stores/users.ts
+++ b/apps/ui/src/stores/users.ts
@@ -36,14 +36,7 @@ export const useUsersStore = defineStore('users', {
       const record = toRef(this.users, userId) as Ref<UserRecord>;
       record.value.loading = false;
 
-      const user = (await network.api.loadUser(userId)) || {
-        id: userId,
-        proposal_count: 0,
-        vote_count: 0
-      };
-
-      user.name ||= (await getNames([userId]))[userId];
-      record.value.user = user;
+      record.value.user = await network.api.loadUser(userId);
 
       record.value.loaded = true;
       record.value.loading = false;


### PR DESCRIPTION
### Summary
- Fetching names is already handled at https://github.com/snapshot-labs/sx-monorepo/blob/2041534372a4393b0858bee74daae928851c2998/apps/ui/src/stores/users.ts#L45 so we can remove this duplicate call

Closes: #432 

### How to test

1. Go to https://snapshot.box/#/
2. Connect with `0xeF8305E140ac520225DAf050e2f71d5fBcC543e7` 
3. Open network tab in browser console. notice that we are calling stamp twice to get same address 
4. <img width="712" alt="Untitled 6" src="https://github.com/snapshot-labs/sx-monorepo/assets/15967809/ffbc47b7-a6ed-4359-a905-dc2c05f9d0da">
5. If the user is already having a profile on hub, use `VITE_ENABLED_NETWORKS=s-tn`

