### PR TITLE
fix: Shorten strategy address

### DIFF
--- a/apps/ui/src/components/Modal/VotingPower.vue
+++ b/apps/ui/src/components/Modal/VotingPower.vue
@@ -48,7 +48,7 @@ const error = computed(() => props.votingPowerStatus === 'error');
           <a
             :href="network.helpers.getExplorerUrl(strategy.address, 'strategy')"
             target="_blank"
-            v-text="network.constants.STRATEGIES[strategy.address] || strategy.address"
+            v-text="network.constants.STRATEGIES[strategy.address] || shorten(strategy.address)"
           />
           <div class="text-skin-link">
             {{


### PR DESCRIPTION
### Summary

Issue: If the strategy address doesn't match configured type, we show entire address:
<img width="443" alt="Untitled 2" src="https://github.com/snapshot-labs/sx-monorepo/assets/15967809/5723e7fa-e28d-47f4-ba03-120857f7eb17">
Fix: shorten the address 
<img width="443" alt="Untitled 2" src="https://github.com/snapshot-labs/sx-monorepo/assets/15967809/cfcf8b81-0922-409c-b6bc-32364befc705">


### How to test

1. Go to http://localhost:8080/#/sn-sep:0x0141464688e48ae5b7c83045edb10ecc242ce0e1ad4ff44aca3402f7f47c1ab9/proposal/8
2. Click on voting power

### To-Do

- [ ]

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
