### PR TITLE
feat: index Vote reason

### DIFF
--- a/apps/api/src/ipfs.ts
+++ b/apps/api/src/ipfs.ts
@@ -5,7 +5,8 @@ import {
   SpaceMetadataItem,
   ProposalMetadataItem,
   StrategiesParsedMetadataDataItem,
-  ExecutionStrategy
+  ExecutionStrategy,
+  VoteMetadataItem
 } from '../.checkpoint/models';
 import L1AvatarExectionStrategyAbi from './abis/l1/L1AvatarExectionStrategy.json';
 import { ethProvider, dropIpfs, getJSON, getSpaceName } from './utils';
@@ -130,6 +131,18 @@ export async function handleProposalMetadata(metadataUri: string) {
   if (metadata.execution) proposalMetadataItem.execution = JSON.stringify(metadata.execution);
 
   await proposalMetadataItem.save();
+}
+
+export async function handleVoteMetadata(metadataUri: string) {
+  const exists = await VoteMetadataItem.loadEntity(dropIpfs(metadataUri));
+  if (exists) return;
+
+  const voteMetadataItem = new VoteMetadataItem(dropIpfs(metadataUri));
+
+  const metadata: any = await getJSON(metadataUri);
+  voteMetadataItem.reason = metadata.reason ?? '';
+
+  await voteMetadataItem.save();
 }
 
 export async function handleStrategiesParsedMetadata(metadataUri: string) {

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -147,8 +147,14 @@ type Vote {
   proposal: Int!
   choice: Int!
   vp: BigDecimalVP!
+  metadata: VoteMetadataItem
   created: Int!
   tx: String!
+}
+
+type VoteMetadataItem {
+  id: String!
+  reason: String!
 }
 
 type User {

--- a/apps/subgraph-api/package.json
+++ b/apps/subgraph-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-subgraph",
   "private": true,
-  "version": "0.0.36",
+  "version": "0.0.37",
   "scripts": {
     "test": "graph test",
     "codegen": "graph codegen",

--- a/apps/subgraph-api/schema.graphql
+++ b/apps/subgraph-api/schema.graphql
@@ -147,8 +147,14 @@ type Vote @entity {
   proposal: Int!
   choice: Int!
   vp: BigDecimal!
+  metadata: VoteMetadata
   created: Int!
   tx: Bytes!
+}
+
+type VoteMetadata @entity {
+  id: ID!
+  reason: String!
 }
 
 type User @entity {

--- a/apps/subgraph-api/src/ipfs.ts
+++ b/apps/subgraph-api/src/ipfs.ts
@@ -1,6 +1,11 @@
 import { Bytes, dataSource, json } from '@graphprotocol/graph-ts'
 import { JSON } from 'assemblyscript-json'
-import { SpaceMetadata, ProposalMetadata, StrategiesParsedMetadataData } from '../generated/schema'
+import {
+  SpaceMetadata,
+  ProposalMetadata,
+  VoteMetadata,
+  StrategiesParsedMetadataData,
+} from '../generated/schema'
 import { toChecksumAddress, updateStrategiesParsedMetadata } from './helpers'
 
 export function handleSpaceMetadata(content: Bytes): void {
@@ -99,6 +104,17 @@ export function handleSpaceMetadata(content: Bytes): void {
   }
 
   spaceMetadata.save()
+}
+
+export function handleVoteMetadata(content: Bytes): void {
+  let proposalMetadata = new VoteMetadata(dataSource.stringParam())
+
+  let value = json.fromBytes(content)
+  let obj = value.toObject()
+  let reason = obj.get('reason')
+
+  proposalMetadata.reason = reason ? reason.toString() : ''
+  proposalMetadata.save()
 }
 
 export function handleProposalMetadata(content: Bytes): void {

--- a/apps/subgraph-api/subgraph.yaml
+++ b/apps/subgraph-api/subgraph.yaml
@@ -78,6 +78,8 @@ templates:
           handler: handleProposalCancelled
         - event: VoteCast(uint256,address,uint8,uint256)
           handler: handleVoteCreated
+        - event: VoteCastWithMetadata(uint256,address,uint8,uint256,string)
+          handler: handleVoteCreatedWithMetadata
         - event: MetadataURIUpdated(string)
           handler: handleMetadataUriUpdated
         - event: VotingDelayUpdated(uint32)
@@ -159,6 +161,19 @@ templates:
       handler: handleProposalMetadata
       entities:
         - ProposalMetadata
+      abis:
+        - name: Space
+          file: ./abis/Space.json
+    network: sepolia
+  - name: VoteMetadata
+    kind: file/ipfs
+    mapping:
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/ipfs.ts
+      handler: handleVoteMetadata
+      entities:
+        - VoteMetadata
       abis:
         - name: Space
           file: ./abis/Space.json


### PR DESCRIPTION
### Summary

This PR adds indexing for vote reason on both EVM and Starknet APIs.

### How to test

1. Run `yarn dev:full`.
2. Wait for everything to get indexed (you can check _meta block on APIs to see progress or logs for Checkpoint).
3. Run query below on both [Checkpoint](http://localhost:3000/) and [Subgraph](http://localhost:8000/subgraphs/name/snapshot-labs/sx-subgraph/graphql).
4. Some votes should have reason.

```gql
{
  votes {
    metadata {
      reason
    }
  }
}
```