### PR TITLE
feat: store proposal_threshold as BigDecimal

### DIFF
--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -10,7 +10,7 @@ type Space {
   voting_delay: Int!
   min_voting_period: Int!
   max_voting_period: Int!
-  proposal_threshold: Int!
+  proposal_threshold: BigDecimalVP!
   next_strategy_index: Int!
   strategies_indicies: [Int]!
   strategies: [String]!

--- a/apps/api/src/utils.ts
+++ b/apps/api/src/utils.ts
@@ -185,7 +185,7 @@ export async function updateProposaValidationStrategy(
     ) as Record<string, any>;
 
     if (Object.keys(parsed).length !== 0) {
-      space.proposal_threshold = parsed.proposal_threshold;
+      space.proposal_threshold = parsed.proposal_threshold.toString(10);
       space.voting_power_validation_strategy_strategies = parsed.allowed_strategies.map(
         (strategy: StrategyConfig) => `0x${strategy.address.toString(16)}`
       );

--- a/apps/api/src/writer.ts
+++ b/apps/api/src/writer.ts
@@ -53,7 +53,7 @@ export const handleSpaceCreated: starknet.Writer = async ({ block, tx, event }) 
   space.voting_delay = Number(BigInt(event.voting_delay).toString());
   space.min_voting_period = Number(BigInt(event.min_voting_duration).toString());
   space.max_voting_period = Number(BigInt(event.max_voting_duration).toString());
-  space.proposal_threshold = 0;
+  space.proposal_threshold = '0';
   space.strategies_indicies = strategies.map((_, i) => i);
   space.strategies = strategies;
   space.next_strategy_index = strategies.length;


### PR DESCRIPTION
### Summary

Int is not big enough to store all our values.

### How to test

1. Run `yarn dev:full`.
2. Run following query at [sx-api](http://localhost:3000/).
3. Values are returned as strings.

```gql
{
  spaces {
    proposal_threshold
  }
}
```
