### PR TITLE
fix: use contract to map timestamp to block number

### DIFF
--- a/packages/sx.js/src/starknetNetworks.ts
+++ b/packages/sx.js/src/starknetNetworks.ts
@@ -32,10 +32,7 @@ function createStarknetConfig(networkId: keyof typeof starknetNetworks): Network
     ...(network.Strategies.EVMSlotValue
       ? ({
           [validateAndParseAddress(network.Strategies.EVMSlotValue)]: {
-            type: 'evmSlotValue',
-            params: {
-              deployedOnChain: network.Meta.herodotusDeployedOnChain
-            }
+            type: 'evmSlotValue'
           }
         } as const)
       : {}),
@@ -44,7 +41,6 @@ function createStarknetConfig(networkId: keyof typeof starknetNetworks): Network
           [validateAndParseAddress(network.Strategies.OZVotesStorageProof)]: {
             type: 'ozVotesStorageProof',
             params: {
-              deployedOnChain: network.Meta.herodotusDeployedOnChain,
               trace: 224
             }
           }
@@ -55,7 +51,6 @@ function createStarknetConfig(networkId: keyof typeof starknetNetworks): Network
           [validateAndParseAddress(network.Strategies.OZVotesTrace208StorageProof)]: {
             type: 'ozVotesStorageProof',
             params: {
-              deployedOnChain: network.Meta.herodotusDeployedOnChain,
               trace: 208
             }
           }

--- a/packages/sx.js/src/strategies/starknet/index.ts
+++ b/packages/sx.js/src/strategies/starknet/index.ts
@@ -23,7 +23,7 @@ export function getStrategy(address: string, networkConfig: NetworkConfig): Stra
   }
 
   if (strategy.type === 'evmSlotValue') {
-    return createEvmSlotValueStrategy(strategy.params);
+    return createEvmSlotValueStrategy();
   }
 
   if (strategy.type === 'ozVotesStorageProof') {

--- a/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
+++ b/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
@@ -8,15 +8,13 @@ import OzVotesToken from './abis/OzVotesToken.json';
 import OZVotesStorageProof from './abis/OZVotesStorageProof.json';
 import SpaceAbi from '../../clients/starknet/starknet-tx/abis/Space.json';
 import { getUserAddressEnum } from '../../utils/starknet-enums';
-import { getSlotKey, getNestedSlotKey, getBinaryTree } from './utils';
+import { getSlotKey, getNestedSlotKey } from './utils';
 import { VotingPowerDetailsError } from '../../utils/errors';
 import type { ClientConfig, Envelope, Strategy, Propose, Vote } from '../../types';
 
 export default function createOzVotesStorageProofStrategy({
-  deployedOnChain,
   trace
 }: {
-  deployedOnChain: string;
   trace: 208 | 224;
 }): Strategy {
   const type = 'ozVotesStorageProof';
@@ -96,8 +94,8 @@ export default function createOzVotesStorageProofStrategy({
       ])) as any;
       const startTimestamp = proposalStruct.start_timestamp;
 
-      const tree = await getBinaryTree(deployedOnChain, startTimestamp, chainId);
-      const l1BlockNumber = tree.path[1].block_number;
+      const contract = new Contract(OZVotesStorageProof, address, starkProvider);
+      const l1BlockNumber = await contract.cached_timestamps(startTimestamp);
 
       const { proofs, checkpointIndex } = await getProofs(
         contractAddress,
@@ -154,19 +152,19 @@ export default function createOzVotesStorageProofStrategy({
 
       const contract = new Contract(OZVotesStorageProof, strategyAddress, starkProvider);
 
-      const tree = await getBinaryTree(deployedOnChain, timestamp, chainId);
-      if (tree.message === 'No blocks found for binsearch') {
-        throw new VotingPowerDetailsError('Failed to get binary tree', type, 'NOT_READY_YET');
+      let l1BlockNumber: bigint;
+      try {
+        l1BlockNumber = await contract.cached_timestamps(timestamp);
+      } catch (e) {
+        throw new VotingPowerDetailsError('Timestamp is not cached', type, 'NOT_READY_YET');
       }
-
-      const l1BlockNumber = tree.path[1].block_number;
 
       const { proofs, checkpointIndex } = await getProofs(
         contractAddress,
         voterAddress,
         numCheckpoints,
         slotIndex,
-        l1BlockNumber,
+        Number(l1BlockNumber),
         ethUrl,
         chainId
       );

--- a/packages/sx.js/src/strategies/starknet/utils.ts
+++ b/packages/sx.js/src/strategies/starknet/utils.ts
@@ -1,5 +1,4 @@
 import { keccak256 } from '@ethersproject/keccak256';
-import fetch from 'cross-fetch';
 
 export function getSlotKey(voterAddress: string, slotIndex: number) {
   return keccak256(
@@ -9,26 +8,4 @@ export function getSlotKey(voterAddress: string, slotIndex: number) {
 
 export function getNestedSlotKey(previous: string, index: number) {
   return `0x${(BigInt(keccak256(`${previous}`)) + BigInt(index)).toString(16)}`;
-}
-
-export async function getBinaryTree(
-  deployedOnChain: string,
-  snapshotTimestamp: number,
-  chainId: number
-) {
-  const apiUrl =
-    chainId === 1
-      ? 'https://rs-indexer.api.herodotus.cloud'
-      : 'https://staging.rs-indexer.api.herodotus.cloud';
-
-  const res = await fetch(
-    `${apiUrl}/remappers/binsearch-path?timestamp=${snapshotTimestamp}&deployed_on_chain=${deployedOnChain}&accumulates_chain=${chainId}`,
-    {
-      headers: {
-        accept: 'application/json'
-      }
-    }
-  );
-
-  return res.json();
 }

--- a/packages/sx.js/src/types/networkConfig.ts
+++ b/packages/sx.js/src/types/networkConfig.ts
@@ -48,15 +48,11 @@ export type WhitelistStrategyConfig = {
 
 export type EvmSlotValueStrategyConfig = {
   type: 'evmSlotValue';
-  params: {
-    deployedOnChain: string;
-  };
 };
 
 export type OzVotesStorageProofStrategyConfig = {
   type: 'ozVotesStorageProof';
   params: {
-    deployedOnChain: string;
     trace: 208 | 224;
   };
 };

--- a/packages/sx.js/test/unit/strategies/starknet/ozVotesStorageProof.test.ts
+++ b/packages/sx.js/test/unit/strategies/starknet/ozVotesStorageProof.test.ts
@@ -9,8 +9,7 @@ const ethUrl = process.env.SEPOLIA_NODE_URL as string;
 
 describe('ozVotesStorageProof', () => {
   const ozVotesStorageProofStrategy = createOzVotesStorageProofStrategy({
-    trace: 224,
-    deployedOnChain: 'SN_SEPOLIA'
+    trace: 224
   });
   const config = { starkProvider, ethUrl, networkConfig: starknetSepolia };
 


### PR DESCRIPTION
### Summary

This PR solves issue with `Timestamp not cached` being thrown when waiting for EVMSlotValue/OZVotesStorage strategies.

Previously we used Herodotus API to read block number for given timestamp. This is not ideal because it doesn't actually mean that this mapping is already available on the network (because mana needs time to process it and create transaction out of it).

This commit removes dependency on Herodotus API on UI. Now mapping timestamp to block number is done on strategy contract directly. If it resolves it means that it will also be available for contract when casting a vote or computing VP. If it's not available we are marking it as NOT_READY_YET so UI displays appropriate message.

### How to test

1. Create new proposal that uses EVMSlotValue/OZVotesStorage.
2. Message tells you that you have to wait for VP to be visible.
3. Wait for some time, refresh periodically, you can monitor mana logs (if you see `Cannot read properties of undefined (reading 'onchain_remapper_id')` then it's close) to see when status changes (or explorer if on mainnet). Generally once you see `cached proposal` with txId in mana logs it would be where it would break.
4. No error shows up at any point, you see "Wait" message which then turns into VP.

