### PR TITLE
fix: disable following on starknet spaces

### DIFF
--- a/apps/ui/src/components/ButtonFollow.vue
+++ b/apps/ui/src/components/ButtonFollow.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
 import { Space } from '@/types';
+import { METADATA } from '@/networks/starknet';
+
+// NOTE: Disabling on Starknet until we have support for starknet long addresses on sequencer
+const DISABLED_NETWORKS = Object.keys(METADATA);
 
 const props = defineProps<{
   space: Space;
@@ -12,7 +16,9 @@ const followedSpacesStore = useFollowedSpacesStore();
 const { web3 } = useWeb3();
 
 const spaceFollowed = computed(() => followedSpacesStore.isFollowed(spaceIdComposite));
-const hidden = computed(() => web3.value?.type === 'argentx');
+const hidden = computed(
+  () => web3.value?.type === 'argentx' || DISABLED_NETWORKS.includes(props.space.network)
+);
 
 const loading = computed(
   () =>

--- a/apps/ui/src/components/ButtonFollow.vue
+++ b/apps/ui/src/components/ButtonFollow.vue
@@ -17,7 +17,7 @@ const { web3 } = useWeb3();
 
 const spaceFollowed = computed(() => followedSpacesStore.isFollowed(spaceIdComposite));
 const hidden = computed(
-  () => web3.value?.type === 'argentx' || SUPPORTED_NETWORKS.includes(props.space.network)
+  () => web3.value?.type === 'argentx' || !SUPPORTED_NETWORKS.includes(props.space.network)
 );
 
 const loading = computed(

--- a/apps/ui/src/components/ButtonFollow.vue
+++ b/apps/ui/src/components/ButtonFollow.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { Space } from '@/types';
-import { METADATA } from '@/networks/starknet';
+import { evmNetworks, offchainNetworks } from '@/networks';
 
 // NOTE: Disabling on Starknet until we have support for starknet long addresses on sequencer
-const DISABLED_NETWORKS = Object.keys(METADATA);
+const SUPPORTED_NETWORKS = [...evmNetworks, ...offchainNetworks];
 
 const props = defineProps<{
   space: Space;
@@ -17,7 +17,7 @@ const { web3 } = useWeb3();
 
 const spaceFollowed = computed(() => followedSpacesStore.isFollowed(spaceIdComposite));
 const hidden = computed(
-  () => web3.value?.type === 'argentx' || DISABLED_NETWORKS.includes(props.space.network)
+  () => web3.value?.type === 'argentx' || SUPPORTED_NETWORKS.includes(props.space.network)
 );
 
 const loading = computed(


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR will hide the space FOLLOW/UNFOLLOW button on starknet spaces.

### How to test

1. Go to /explore?p=snapshotx
2. Hover some spaces to show the FOLLOW/UNFOLLOW button
3. It should be visible only on evm spaces
