### PR TITLE
fix: shorten the strategy name only if it's an address

### DIFF
--- a/apps/ui/src/components/Modal/VotingPower.vue
+++ b/apps/ui/src/components/Modal/VotingPower.vue
@@ -49,12 +49,13 @@ const error = computed(() => props.votingPowerStatus === 'error');
           <a
             :href="network.helpers.getExplorerUrl(strategy.address, 'strategy')"
             target="_blank"
+            class="truncate"
             v-text="
               network.constants.STRATEGIES[strategy.address] ||
               (isValidAddress(strategy.address) ? shorten(strategy.address) : strategy.address)
             "
           />
-          <div class="text-skin-link">
+          <div class="text-skin-link shrink-0">
             {{
               _n(Number(strategy.value) / 10 ** finalDecimals, 'compact', {
                 maximumFractionDigits: 2,

--- a/apps/ui/src/components/Modal/VotingPower.vue
+++ b/apps/ui/src/components/Modal/VotingPower.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { getNetwork } from '@/networks';
 import { _n, shorten } from '@/helpers/utils';
+import { addressValidator as isValidAddress } from '@/helpers/validation';
 import { NetworkID } from '@/types';
 import { VotingPower, VotingPowerStatus } from '@/networks/types';
 
@@ -48,7 +49,10 @@ const error = computed(() => props.votingPowerStatus === 'error');
           <a
             :href="network.helpers.getExplorerUrl(strategy.address, 'strategy')"
             target="_blank"
-            v-text="network.constants.STRATEGIES[strategy.address] || shorten(strategy.address)"
+            v-text="
+              network.constants.STRATEGIES[strategy.address] ||
+              (isValidAddress(strategy.address) ? shorten(strategy.address) : strategy.address)
+            "
           />
           <div class="text-skin-link">
             {{


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->


This PR fix an issue where all the strategy name inside the voting power modal are shortened, when not a valid onchain startegy.
This leads to shortening of all offchain strategies name.

This PR will shorten the strategy name only if it's an address, and truncate it if not fitting on same line

### How to test

1. Go to http://localhost:8080/#/sn:0x071977084d73002fed430d99108da39d241b900099ccc2a4cdcb7d5041d851d2/proposals
2. Open the voting power modal
3. It should shorten the second strategy name
4. Go to http://localhost:8080/#/s:apecoin.eth/proposals
5. Open the voting power modal
6. It should not shorten the strategies name
