### PR TITLE
fix: reset the account button loading state on wallet change cancel

### DIFF
--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -31,19 +31,23 @@ export function useWeb3() {
 
     if (!connector) return;
 
-    auth = getInstance();
-    state.authLoading = true;
-    await auth.login(connector);
-    if (auth.provider.value) {
-      mixpanel.track('Connect', { connector });
+    try {
+      auth = getInstance();
+      state.authLoading = true;
+      await auth.login(connector);
+      if (auth.provider.value) {
+        mixpanel.track('Connect', { connector });
 
-      auth.web3 = new Web3Provider(auth.provider.value, 'any');
-      await loadProvider();
-    }
+        auth.web3 = new Web3Provider(auth.provider.value, 'any');
+        await loadProvider();
+      }
 
-    // NOTE: Handle case where metamask stays locked after user ignored
-    // the unlock request on subsequent page loads
-    if (state.type !== 'injected' || auth.provider?.value?._state?.isUnlocked) {
+      // NOTE: Handle case where metamask stays locked after user ignored
+      // the unlock request on subsequent page loads
+      if (state.type !== 'injected' || auth.provider?.value?._state?.isUnlocked) {
+        state.authLoading = false;
+      }
+    } finally {
       state.authLoading = false;
     }
   }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #450

This PR fix the issue where the Account button on the page top right is stuck on the `loading` state after cancelling a wallet change action.

### How to test

1. Connect to your wallet
2. Open the account modal, then click on the "Change wallet"
3. Choose WalletConnect or starknet
4. When the walletConnect modal open, close it
5. The Account button should not have loading state

This fix does not work on Coinbase wallet, as its modal is buggy, and can not be closed