### PR TITLE
fix: do not flash "No spaces" message while loading spaces

### DIFF
--- a/apps/ui/src/views/Settings/Spaces.vue
+++ b/apps/ui/src/views/Settings/Spaces.vue
@@ -2,11 +2,19 @@
 useTitle('My spaces');
 
 const { web3 } = useWeb3();
-const { loaded, spaces, fetch } = useSpaces();
+const { loading: spacesLoading, spaces, fetch } = useSpaces();
+
+const loaded = ref(false);
 
 watch(
   () => web3.value.account,
-  controller => fetch({ controller }),
+  async controller => {
+    loaded.value = false;
+
+    controller && (await fetch({ controller }));
+
+    loaded.value = true;
+  },
   { immediate: true }
 );
 </script>
@@ -14,8 +22,11 @@ watch(
 <template>
   <UiContainer class="!max-w-screen-md pt-5">
     <h2 class="mb-4 mono !text-xl" v-text="'My spaces'" />
-    <UiLoading v-if="!loaded || web3.authLoading" />
-    <div v-else-if="!spaces.length" class="flex items-center text-skin-link space-x-2">
+    <UiLoading v-if="!loaded || spacesLoading || web3.authLoading" />
+    <div
+      v-else-if="!spaces.length || !web3.account"
+      class="flex items-center text-skin-link space-x-2"
+    >
       <IH-exclamation-circle class="inline-block shrink-0" />
       <span v-text="'There are no spaces here.'" />
     </div>

--- a/apps/ui/src/views/Settings/Spaces.vue
+++ b/apps/ui/src/views/Settings/Spaces.vue
@@ -1,30 +1,26 @@
 <script setup lang="ts">
-import { onMounted } from 'vue';
-
 useTitle('My spaces');
+
 const { web3 } = useWeb3();
 const { loaded, spaces, fetch } = useSpaces();
 
-onMounted(() => fetch({ controller: web3.value.account }));
+watch(
+  () => web3.value.account,
+  controller => fetch({ controller }),
+  { immediate: true }
+);
 </script>
 
 <template>
-  <div>
-    <UiContainer class="!max-w-screen-md pt-5">
-      <h2 class="mb-4 mono !text-xl" v-text="'My spaces'" />
-      <UiLoading v-if="!loaded" class="block mb-2" />
-      <div
-        v-if="loaded && !spaces.length && !web3.authLoading"
-        class="py-3 flex items-center text-skin-link"
-      >
-        <IH-exclamation-circle class="inline-block mr-2" />
-        <span v-text="'There are no spaces here.'" />
-      </div>
-      <div v-else-if="loaded" class="max-w-screen-md">
-        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 mb-3">
-          <SpacesListItem v-for="space in spaces" :key="space.id" :space="space" />
-        </div>
-      </div>
-    </UiContainer>
-  </div>
+  <UiContainer class="!max-w-screen-md pt-5">
+    <h2 class="mb-4 mono !text-xl" v-text="'My spaces'" />
+    <UiLoading v-if="!loaded || web3.authLoading" />
+    <div v-else-if="!spaces.length" class="flex items-center text-skin-link space-x-2">
+      <IH-exclamation-circle class="inline-block shrink-0" />
+      <span v-text="'There are no spaces here.'" />
+    </div>
+    <div v-else class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 mb-3">
+      <SpacesListItem v-for="space in spaces" :key="space.id" :space="space" />
+    </div>
+  </UiContainer>
 </template>

--- a/apps/ui/src/views/Settings/Spaces.vue
+++ b/apps/ui/src/views/Settings/Spaces.vue
@@ -2,10 +2,10 @@
 import { onMounted } from 'vue';
 
 useTitle('My spaces');
-const { web3Account } = useWeb3();
+const { web3 } = useWeb3();
 const { loaded, spaces, fetch } = useSpaces();
 
-onMounted(() => fetch({ controller: web3Account.value }));
+onMounted(() => fetch({ controller: web3.value.account }));
 </script>
 
 <template>
@@ -13,7 +13,10 @@ onMounted(() => fetch({ controller: web3Account.value }));
     <UiContainer class="!max-w-screen-md pt-5">
       <h2 class="mb-4 mono !text-xl" v-text="'My spaces'" />
       <UiLoading v-if="!loaded" class="block mb-2" />
-      <div v-if="loaded && !spaces.length" class="py-3 flex items-center text-skin-link">
+      <div
+        v-if="loaded && !spaces.length && !web3.authLoading"
+        class="py-3 flex items-center text-skin-link"
+      >
         <IH-exclamation-circle class="inline-block mr-2" />
         <span v-text="'There are no spaces here.'" />
       </div>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #390

This PR fix an issue where the "There are no spaces here." message is flashing briefly on http://localhost:8080/#/settings page load, due to the user being empty on page load.

Also adda fix to refresh the space list on account change

### How to test

1. Connect to your account
2. Go to http://localhost:8080/#/settings
3. You should not see the message "There are no spaces here." on page load
