### PR TITLE
feat: add erc20votes related workarounds

### DIFF
--- a/apps/api/src/overrrides.ts
+++ b/apps/api/src/overrrides.ts
@@ -17,6 +17,7 @@ const createConfig = (
     manaRpcUrl: `${manaRpcUrl}/stark_rpc/${config.Meta.eip712ChainId}`,
     baseChainId: config.Meta.herodotusAccumulatesChainId,
     factoryAddress: config.Meta.spaceFactory,
+    erc20VotesStrategy: config.Strategies.ERC20Votes,
     propositionPowerValidationStrategyAddress: config.ProposalValidations.VotingPower,
     herodotusStrategies: [
       config.Strategies.OZVotesStorageProof,

--- a/apps/api/src/writer.ts
+++ b/apps/api/src/writer.ts
@@ -295,7 +295,7 @@ export const handleProposalValidationStrategyUpdated: starknet.Writer = async ({
   await space.save();
 };
 
-export const handlePropose: starknet.Writer = async ({ block, tx, rawEvent, event }) => {
+export const handlePropose: starknet.Writer = async ({ tx, rawEvent, event }) => {
   if (!rawEvent || !event || !tx.transaction_hash) return;
 
   console.log('Handle propose');
@@ -308,7 +308,7 @@ export const handlePropose: starknet.Writer = async ({ block, tx, rawEvent, even
   const proposalId = parseInt(BigInt(event.proposal_id).toString());
   const author = formatAddressVariant(findVariant(event.author));
 
-  const created = block?.timestamp ?? getCurrentTimestamp();
+  const created = BigInt(event.proposal.start_timestamp) - BigInt(space.voting_delay);
 
   const proposal = new Proposal(`${spaceId}/${proposalId}`);
   proposal.proposal_id = proposalId;
@@ -331,7 +331,7 @@ export const handlePropose: starknet.Writer = async ({ block, tx, rawEvent, even
   proposal.strategies_indicies = space.strategies_indicies;
   proposal.strategies = space.strategies;
   proposal.strategies_params = space.strategies_params;
-  proposal.created = created;
+  proposal.created = parseInt(created.toString());
   proposal.tx = tx.transaction_hash;
   proposal.execution_tx = null;
   proposal.veto_tx = null;
@@ -368,7 +368,7 @@ export const handlePropose: starknet.Writer = async ({ block, tx, rawEvent, even
   } else {
     const user = new User(author.address);
     user.address_type = author.type;
-    user.created = created;
+    user.created = parseInt(created.toString());
     await user.save();
   }
 

--- a/apps/ui/src/stores/proposals.ts
+++ b/apps/ui/src/stores/proposals.ts
@@ -42,7 +42,11 @@ export const useProposalsStore = defineStore('proposals', () => {
     return record.proposalsIdsList.map(proposalId => record.proposals[proposalId]);
   };
 
-  const getProposal = (spaceId: string, proposalId: number | string, networkId: NetworkID) => {
+  const getProposal = (
+    spaceId: string,
+    proposalId: number | string,
+    networkId: NetworkID
+  ): Proposal | undefined => {
     const record = proposals.value[getUniqueSpaceId(spaceId, networkId)];
     if (!record) return undefined;
 

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -31,6 +31,8 @@ const proposal = computed(() => {
 });
 
 const discussion = computed(() => {
+  if (!proposal.value) return null;
+
   return sanitizeUrl(proposal.value.discussion);
 });
 
@@ -61,7 +63,10 @@ async function getVotingPower() {
       proposal.value.strategies_params,
       proposal.value.space.strategies_parsed_metadata,
       web3.value.account,
-      { at: proposal.value.snapshot, chainId: proposal.value.space.snapshot_chain_id }
+      {
+        at: proposal.value.state === 'pending' ? null : proposal.value.snapshot,
+        chainId: proposal.value.space.snapshot_chain_id
+      }
     );
     votingPowerStatus.value = 'success';
   } catch (e: unknown) {

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -52,9 +52,11 @@ const shareMsg = encodeURIComponent(
 );
 
 const editable = computed(() => {
+  // HACK: here we need to use snapshot instead of start because start is artifically
+  // shifted for Starknet's proposals with ERC20Votes strategies.
   return (
     compareAddresses(props.proposal.author.id, web3.value.account) &&
-    props.proposal.start > (getCurrent(props.proposal.network) || Number.POSITIVE_INFINITY)
+    props.proposal.snapshot > (getCurrent(props.proposal.network) || Number.POSITIVE_INFINITY)
   );
 });
 


### PR DESCRIPTION
### Summary

This PR adds three changes related to handling ERC20Votes strategies
- When proposal is pending `snapshot` won't be passed to `getVotingValue` - instead live value will be computed (this would cause VP fail to load, due to timestamp in the future).
- Proposals now have `created` timestamp derived from proposal metadata meaning that it will have accurate timestamp (eliminating possibility of proposal starting before it's created) (https://github.com/snapshot-labs/sx-monorepo/issues/413)
- Proposals that use erc20votes strategies will have minimum of 10 minutes of voting delay applied to prevent voting on proposals in the same block it was created. This is only UI enforced limitation, if someone tries to vote at contract level it will fail.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/413

### How to test

1. Run `yarn dev:full`.
2. Create space with erc20votes strategy.
3. Create proposal, it will start in pending state, VP is shown properly.
4. Check timeline.
5. Once proposal becomes active VP is shown properly as well.
6. You can vote.
