### PR TITLE
fix: Show argentx modal

### DIFF
--- a/apps/ui/src/helpers/argentx.ts
+++ b/apps/ui/src/helpers/argentx.ts
@@ -2,6 +2,13 @@ const get = () => import(/* webpackChunkName: "argentx" */ '@argent/get-starknet
 import LockConnector from '@snapshot-labs/lock/src/connector';
 
 export default class Connector extends LockConnector {
+  async logout() {
+    const argentx = await get();
+    await argentx.disconnect({
+      clearLastWallet: true
+    });
+  }
+
   async connect() {
     let provider;
     try {


### PR DESCRIPTION
## Issue:
On the interface when you try to log in with a Starknet wallet it will show a modal where you can select between few options, log in with email, connect with Argent X or connect with Braavos wallet. If an user select Argent X then log in then later log out, then if user try to log in again with a Starknet wallet, the modal with multiple choices wont show up anymore and it will auto log you with the Argent X account. We should instead show the modal with 3 choices again.

![image](https://github.com/snapshot-labs/sx-monorepo/assets/15967809/8f22461d-e139-47ae-bda6-bd1536971da5)




### How to test

1. Go to home page
2. Click on "Connect wallet" and then "Starknet"
3. connect with your argentx wallet
4. click logout
5. Try to connect again by clicking "Starknet"
6. After the fix, you should see the modal with sn wallets like above