### PR TITLE
fix: format percentage values in delegates page

### DIFF
--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { _n, shorten } from '@/helpers/utils';
+import { _n, _p, shorten } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
 import { Space, SpaceMetadataDelegation } from '@/types';
 
@@ -131,13 +131,13 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
               class="hidden md:flex w-[20%] flex-col items-end justify-center leading-[22px] truncate"
             >
               <h4 class="text-skin-link" v-text="_n(delegate.tokenHoldersRepresentedAmount)" />
-              <div class="text-[17px]" v-text="`${delegate.delegatorsPercentage.toFixed(3)}%`" />
+              <div class="text-[17px]" v-text="_p(delegate.delegatorsPercentage)" />
             </div>
             <div
               class="w-[40%] md:w-[20%] flex flex-col items-end justify-center pr-4 leading-[22px] truncate"
             >
               <h4 class="text-skin-link" v-text="_n(delegate.delegatedVotes)" />
-              <div class="text-[17px]" v-text="`${delegate.votesPercentage.toFixed(3)}%`" />
+              <div class="text-[17px]" v-text="_p(delegate.votesPercentage)" />
             </div>
           </div>
           <template #loading>

--- a/apps/ui/src/composables/useDelegates.ts
+++ b/apps/ui/src/composables/useDelegates.ts
@@ -115,10 +115,9 @@ export function useDelegates(delegationApiUrl: string, governance: string) {
 
     const newDelegates = delegatesData.map((delegate: ApiDelegate) => {
       const delegatorsPercentage =
-        (Number(delegate.tokenHoldersRepresentedAmount) / Number(governanceData.totalDelegates)) *
-        100;
+        Number(delegate.tokenHoldersRepresentedAmount) / Number(governanceData.totalDelegates);
       const votesPercentage =
-        (Number(delegate.delegatedVotes) / Number(governanceData.delegatedVotes)) * 100 || 0;
+        Number(delegate.delegatedVotes) / Number(governanceData.delegatedVotes) || 0;
 
       return {
         name: names[delegate.user] || null,


### PR DESCRIPTION
### Summary

Closes: #455 
Use percentage format similar to the leaderboard and user profile

### How to test

1. Go to http://localhost:8080/#/sn:0x009fedaf0d7a480d21a27683b0965c0f8ded35b3f1cac39827a25a06a8a682a4/delegates
2. You should see the difference in the percentage format

| Before    | After |
| -------- | ------- |
| <img width="746" alt="Untitled 2" src="https://github.com/snapshot-labs/sx-monorepo/assets/15967809/b7b0aab0-22c0-40c0-a5c6-a181b907e65b">  | <img width="742" alt="Untitled 5" src="https://github.com/snapshot-labs/sx-monorepo/assets/15967809/a3301ff4-b441-4a4c-a528-3e31194de078">  |
| <img width="771" alt="Untitled 4" src="https://github.com/snapshot-labs/sx-monorepo/assets/15967809/35b6f125-655e-4e6e-8e2a-35611c2ab235">| <img width="769" alt="Untitled 5" src="https://github.com/snapshot-labs/sx-monorepo/assets/15967809/8fa3efaf-bc7c-431f-b16c-8336367553ca"> |