### PR TITLE
fix: fix wrong network explorer url for strategies

### DIFF
--- a/apps/ui/src/components/Modal/VotingPower.vue
+++ b/apps/ui/src/components/Modal/VotingPower.vue
@@ -68,7 +68,12 @@ const error = computed(() => props.votingPowerStatus === 'error');
         <div class="flex justify-between">
           <div v-if="strategy.token" class="flex items-center gap-2">
             <a
-              :href="network.helpers.getExplorerUrl(strategy.token, 'contract', strategy.chainId)"
+              :href="
+                (network.constants.STORAGE_PROOF_STRATEGIES_TYPES?.includes(strategy.address)
+                  ? baseNetwork
+                  : network
+                ).helpers.getExplorerUrl(strategy.token, 'contract', strategy.chainId)
+              "
               target="_blank"
               class="flex items-center text-skin-text"
             >

--- a/apps/ui/src/components/Modal/VotingPower.vue
+++ b/apps/ui/src/components/Modal/VotingPower.vue
@@ -68,9 +68,7 @@ const error = computed(() => props.votingPowerStatus === 'error');
         <div class="flex justify-between">
           <div v-if="strategy.token" class="flex items-center gap-2">
             <a
-              :href="
-                baseNetwork.helpers.getExplorerUrl(strategy.token, 'contract', strategy.chainId)
-              "
+              :href="network.helpers.getExplorerUrl(strategy.token, 'contract', strategy.chainId)"
               target="_blank"
               class="flex items-center text-skin-text"
             >

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -41,6 +41,12 @@ export function createConstants(
     [config.Strategies.OZVotesTrace208StorageProof]: true
   };
 
+  const STORAGE_PROOF_STRATEGIES_TYPES = [
+    config.Strategies.EVMSlotValue,
+    config.Strategies.OZVotesStorageProof,
+    config.Strategies.OZVotesTrace208StorageProof
+  ];
+
   const SUPPORTED_EXECUTORS = {
     EthRelayer: true
   };
@@ -514,6 +520,7 @@ export function createConstants(
     EDITOR_VOTING_STRATEGIES,
     EDITOR_PROPOSAL_VALIDATION_VOTING_STRATEGIES,
     EDITOR_EXECUTION_STRATEGIES,
-    EDITOR_VOTING_TYPES
+    EDITOR_VOTING_TYPES,
+    STORAGE_PROOF_STRATEGIES_TYPES
   };
 }

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -233,6 +233,7 @@ export type NetworkConstants = {
   EDITOR_VOTING_STRATEGIES: StrategyTemplate[];
   EDITOR_PROPOSAL_VALIDATION_VOTING_STRATEGIES: StrategyTemplate[];
   EDITOR_EXECUTION_STRATEGIES: StrategyTemplate[];
+  STORAGE_PROOF_STRATEGIES_TYPES?: string[];
 };
 
 export type NetworkHelpers = {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #434

Fix an issue where the explorer url for a voting power strategy is on the wrong network

### How to test

1. Go to http://localhost:8080/#/sn-sep:0x0141464688e48ae5b7c83045edb10ecc242ce0e1ad4ff44aca3402f7f47c1ab9/proposals or http://localhost:8080/#/sn:0x071977084d73002fed430d99108da39d241b900099ccc2a4cdcb7d5041d851d2/proposals
2. Open the voting power modal
3. All links to the explorer should use the same network (etherscan/starkscan) as the space, but storage proof strategies (which will always use etherscan)
