### PR TITLE
fix: disable lido staking on non-eth network

### DIFF
--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -5,6 +5,8 @@ import { ETH_CONTRACT } from '@/helpers/constants';
 import { Contact, Space, SpaceMetadataTreasury, Transaction } from '@/types';
 import type { Token } from '@/helpers/alchemy';
 
+const ETHEREUM_NETWORKS = ['eth', 'sep'];
+
 const props = defineProps<{
   space: Space;
   treasuryData: SpaceMetadataTreasury;
@@ -250,7 +252,11 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
                 <div class="text-[17px] truncate text-skin-text" v-text="asset.name" />
               </div>
               <UiTooltip
-                v-if="asset.contractAddress === ETH_CONTRACT && !isReadOnly"
+                v-if="
+                  asset.contractAddress === ETH_CONTRACT &&
+                  !isReadOnly &&
+                  ETHEREUM_NETWORKS.includes(treasury.networkId)
+                "
                 title="Stake with Lido"
                 :touch="false"
               >


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #468 

This PR will show the "Stake with Lido" button only on Ethereum and Sepolia treasuries.

### How to test

1. Go to http://localhost:8080/#/oeth:0x2EF7E7CF469f5296011664682D58b57D38a3c83f/treasury
2. It should not show the "Stake with Lido" button next to the ETH asset
3. Go to an space with Ethereum treasury
4. It should show the "Stake with Lido" button next to the ETH asset
