### PR TITLE
feat: display oSnap execution in proposal

### DIFF
--- a/apps/ui/src/components/TransactionsListItem.vue
+++ b/apps/ui/src/components/TransactionsListItem.vue
@@ -22,7 +22,11 @@ const title = computed(() => {
   }
 
   if (props.tx._type === 'contractCall') {
-    return `Contract call to <b>_NAME_</b>`;
+    return 'Contract call to <b>_NAME_</b>';
+  }
+
+  if (props.tx._type === 'raw') {
+    return 'Raw transaction to <b>_NAME_</b>';
   }
 
   return '';

--- a/apps/ui/src/helpers/__snapshots__/osnap.test.ts.snap
+++ b/apps/ui/src/helpers/__snapshots__/osnap.test.ts.snap
@@ -1,0 +1,117 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`parseOSnapTransaction > should parse oSnap contract interaction transaction 1`] = `
+{
+  "_form": {
+    "abi": [
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "address",
+            "name": "user",
+            "type": "address",
+          },
+          {
+            "indexed": false,
+            "internalType": "string",
+            "name": "content",
+            "type": "string",
+          },
+          {
+            "indexed": true,
+            "internalType": "string",
+            "name": "tag",
+            "type": "string",
+          },
+        ],
+        "name": "NewPost",
+        "type": "event",
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "string",
+            "name": "content",
+            "type": "string",
+          },
+          {
+            "internalType": "string",
+            "name": "tag",
+            "type": "string",
+          },
+        ],
+        "name": "post",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+      },
+    ],
+    "args": [
+      "test",
+      "test",
+    ],
+    "method": "post",
+    "recipient": "0x000000000000cd17345801aa8147b8D3950260FF",
+  },
+  "_type": "contractCall",
+  "data": "0x0ae1b13d000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000004746573740000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047465737400000000000000000000000000000000000000000000000000000000",
+  "salt": "",
+  "to": "0x000000000000cd17345801aa8147b8D3950260FF",
+  "value": "0",
+}
+`;
+
+exports[`parseOSnapTransaction > should parse oSnap raw transaction 1`] = `
+{
+  "_form": {
+    "recipient": "0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70",
+  },
+  "_type": "raw",
+  "data": "0x",
+  "salt": "",
+  "to": "0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70",
+  "value": "1",
+}
+`;
+
+exports[`parseOSnapTransaction > should parse oSnap transfer NFT transaction 1`] = `
+{
+  "_form": {
+    "amount": "1",
+    "nft": {
+      "address": "0x5A96CF3ace257Dfcc1fd3C037e548585124dc0C5",
+      "collection": "Weee Did It Palz",
+      "id": "810",
+      "name": "Weeedidit Palls #101",
+    },
+    "recipient": "0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70",
+  },
+  "_type": "sendNft",
+  "data": "0x42842e0e0000000000000000000000008edfcc5f141ffc2b6892530d1fb21bbcdc74b455000000000000000000000000556b14cbda79a36dc33fcd461a04a5bcb5dc2a70000000000000000000000000000000000000000000000000000000000000032a",
+  "salt": "",
+  "to": "0x5A96CF3ace257Dfcc1fd3C037e548585124dc0C5",
+  "value": "0",
+}
+`;
+
+exports[`parseOSnapTransaction > should parse oSnap transfer funds transaction 1`] = `
+{
+  "_form": {
+    "amount": "1000000000000000",
+    "recipient": "0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70",
+    "token": {
+      "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "decimals": 18,
+      "name": "Ether",
+      "symbol": "ETH",
+    },
+  },
+  "_type": "sendToken",
+  "data": "0x",
+  "salt": "",
+  "to": "0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70",
+  "value": "1000000000000000",
+}
+`;

--- a/apps/ui/src/helpers/osnap.test.ts
+++ b/apps/ui/src/helpers/osnap.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { parseOSnapTransaction } from './osnap';
+
+describe('parseOSnapTransaction', () => {
+  it('should parse oSnap transfer funds transaction', () => {
+    const transaction = {
+      to: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
+      data: '0x',
+      type: 'transferFunds' as const,
+      token: {
+        name: 'Ether',
+        symbol: 'ETH',
+        address: 'main',
+        balance: '0.379',
+        chainId: '11155111',
+        logoUri: 'https://safe-transaction-assets.safe.global/chains/1/currency_logo.png',
+        decimals: 18,
+        verified: false
+      },
+      value: '1000000000000000',
+      amount: '1000000000000000',
+      isValid: true,
+      formatted: ['0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70', 0, '1000000000000000', '0x'],
+      recipient: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70'
+    };
+
+    expect(parseOSnapTransaction(transaction)).toMatchSnapshot();
+  });
+
+  it('should parse oSnap transfer NFT transaction', () => {
+    const transaction = {
+      to: '0x5A96CF3ace257Dfcc1fd3C037e548585124dc0C5',
+      data: '0x42842e0e0000000000000000000000008edfcc5f141ffc2b6892530d1fb21bbcdc74b455000000000000000000000000556b14cbda79a36dc33fcd461a04a5bcb5dc2a70000000000000000000000000000000000000000000000000000000000000032a',
+      type: 'transferNFT' as const,
+      value: '0',
+      isValid: true,
+      formatted: [
+        '0x5A96CF3ace257Dfcc1fd3C037e548585124dc0C5',
+        0,
+        '0',
+        '0x42842e0e0000000000000000000000008edfcc5f141ffc2b6892530d1fb21bbcdc74b455000000000000000000000000556b14cbda79a36dc33fcd461a04a5bcb5dc2a70000000000000000000000000000000000000000000000000000000000000032a'
+      ],
+      recipient: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
+      collectable: {
+        id: '810',
+        uri: 'https://bafkreigtcra4mp2u5ppor2akc5mxjop6ag4o72ryugic63goqbxscpwygy.ipfs.nftstorage.link/',
+        name: 'Weeedidit Palls #101',
+        address: '0x5A96CF3ace257Dfcc1fd3C037e548585124dc0C5',
+        logoUri:
+          'https://safe-transaction-assets.safe.global/tokens/logos/0x5A96CF3ace257Dfcc1fd3C037e548585124dc0C5.png',
+        imageUri:
+          'https://nft-delivery.infura-ipfs.io/ipfs/QmQiJyvrV8sETi8HtV89yaJit5or7ZaMUo8pFsCJXMM8RL/101.png',
+        metadata: {
+          name: 'Weeedidit Palls #101',
+          image:
+            'https://nft-delivery.infura-ipfs.io/ipfs/QmQiJyvrV8sETi8HtV89yaJit5or7ZaMUo8pFsCJXMM8RL/101.png',
+          attributes: [],
+          description:
+            'Step into a surreal universe of vibrant colors and mind-bending shapes. Explore a world where imagination reigns and creativity knows no bounds.'
+        },
+        tokenName: 'Weee Did It Palz',
+        description:
+          'Step into a surreal universe of vibrant colors and mind-bending shapes. Explore a world where imagination reigns and creativity knows no bounds.',
+        tokenSymbol: 'WDIT'
+      }
+    };
+
+    expect(parseOSnapTransaction(transaction)).toMatchSnapshot();
+  });
+
+  it('should parse oSnap contract interaction transaction', () => {
+    const transaction = {
+      to: '0x000000000000cd17345801aa8147b8D3950260FF',
+      abi: '[{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"user","type":"address"},{"indexed":false,"internalType":"string","name":"content","type":"string"},{"indexed":true,"internalType":"string","name":"tag","type":"string"}],"name":"NewPost","type":"event"},{"inputs":[{"internalType":"string","name":"content","type":"string"},{"internalType":"string","name":"tag","type":"string"}],"name":"post","outputs":[],"stateMutability":"nonpayable","type":"function"}]',
+      data: '0x0ae1b13d000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000004746573740000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047465737400000000000000000000000000000000000000000000000000000000',
+      type: 'contractInteraction' as const,
+      value: '0',
+      method: {
+        gas: null,
+        name: 'post',
+        type: 'function',
+        inputs: [
+          {
+            name: 'content',
+            type: 'string',
+            indexed: null,
+            baseType: 'string',
+            components: null,
+            arrayLength: null,
+            _isParamType: true,
+            arrayChildren: null
+          },
+          {
+            name: 'tag',
+            type: 'string',
+            indexed: null,
+            baseType: 'string',
+            components: null,
+            arrayLength: null,
+            _isParamType: true,
+            arrayChildren: null
+          }
+        ],
+        outputs: [],
+        payable: false,
+        constant: false,
+        _isFragment: true,
+        stateMutability: 'nonpayable'
+      },
+      isValid: true,
+      formatted: [
+        '0x000000000000cd17345801aa8147b8D3950260FF',
+        0,
+        '0',
+        '0x0ae1b13d000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000004746573740000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000047465737400000000000000000000000000000000000000000000000000000000'
+      ],
+      parameters: ['test', 'test']
+    };
+
+    expect(parseOSnapTransaction(transaction)).toMatchSnapshot();
+  });
+
+  it('should parse oSnap raw transaction', () => {
+    const transaction = {
+      to: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
+      data: '0x',
+      type: 'raw' as const,
+      value: '1',
+      isValid: true,
+      formatted: ['0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70', 0, '1', '0x']
+    };
+
+    expect(parseOSnapTransaction(transaction)).toMatchSnapshot();
+  });
+
+  it('should throw on unknown transaction', () => {
+    const transaction = {
+      type: 'unknown'
+    };
+
+    expect(() => parseOSnapTransaction(transaction as any)).toThrowError(
+      'Invalid transaction type'
+    );
+  });
+});

--- a/apps/ui/src/helpers/osnap.ts
+++ b/apps/ui/src/helpers/osnap.ts
@@ -1,0 +1,149 @@
+import {
+  BaseTransaction,
+  ContractCallTransaction,
+  RawTransaction,
+  SendNftTransaction,
+  SendTokenTransaction,
+  Transaction
+} from '@/types';
+import { ETH_CONTRACT } from './constants';
+
+export const transactionTypes = [
+  'transferFunds',
+  'transferNFT',
+  'contractInteraction',
+  'raw',
+  'safeImport'
+] as const;
+
+type OSnapBaseTransaction = Omit<BaseTransaction, 'salt'>;
+
+type OSnapTransferFundsTransaction = OSnapBaseTransaction & {
+  type: 'transferFunds';
+  amount: string;
+  recipient: string;
+  token: {
+    name: string;
+    decimals: number;
+    symbol: string;
+    address: string;
+  };
+};
+
+type OSnapTransferNFTTransaction = OSnapBaseTransaction & {
+  type: 'transferNFT';
+  recipient: string;
+  collectable: {
+    address: string;
+    id: string;
+    name: string;
+    tokenName: string;
+  };
+};
+
+type OSnapContractInteractionTransaction = OSnapBaseTransaction & {
+  type: 'contractInteraction';
+  abi: string;
+  method: {
+    name: string;
+  };
+  parameters: any[];
+};
+
+type OSnapRawTransaction = OSnapBaseTransaction & {
+  type: 'raw';
+};
+
+type OSnapTransaction =
+  | OSnapTransferFundsTransaction
+  | OSnapTransferNFTTransaction
+  | OSnapContractInteractionTransaction
+  | OSnapRawTransaction;
+
+function parseTransferFundsTransaction(
+  transaction: OSnapTransferFundsTransaction
+): SendTokenTransaction {
+  return {
+    to: transaction.to,
+    data: transaction.data,
+    value: transaction.value,
+    salt: '',
+    _type: 'sendToken',
+    _form: {
+      recipient: transaction.recipient,
+      amount: transaction.amount,
+      token: {
+        name: transaction.token.name,
+        decimals: transaction.token.decimals,
+        symbol: transaction.token.symbol,
+        address: transaction.token.address === 'main' ? ETH_CONTRACT : transaction.token.address
+      }
+    }
+  };
+}
+
+function parseTransferNFTTransaction(transaction: OSnapTransferNFTTransaction): SendNftTransaction {
+  return {
+    to: transaction.to,
+    data: transaction.data,
+    value: transaction.value,
+    salt: '',
+    _type: 'sendNft',
+    _form: {
+      recipient: transaction.recipient,
+      amount: '1',
+      nft: {
+        address: transaction.collectable.address,
+        id: transaction.collectable.id,
+        name: transaction.collectable.name,
+        collection: transaction.collectable.tokenName
+      }
+    }
+  };
+}
+
+function parseContractInteractionTransaction(
+  transaction: OSnapContractInteractionTransaction
+): ContractCallTransaction {
+  return {
+    to: transaction.to,
+    data: transaction.data,
+    value: transaction.value,
+    salt: '',
+    _type: 'contractCall',
+    _form: {
+      recipient: transaction.to,
+      method: transaction.method.name,
+      args: transaction.parameters,
+      abi: JSON.parse(transaction.abi)
+    }
+  };
+}
+
+function parseRawTransaction(transaction: OSnapRawTransaction): RawTransaction {
+  return {
+    to: transaction.to,
+    data: transaction.data,
+    value: transaction.value,
+    salt: '',
+    _type: 'raw',
+    _form: {
+      recipient: transaction.to
+    }
+  };
+}
+
+export function parseOSnapTransaction(transaction: OSnapTransaction): Transaction {
+  switch (transaction.type) {
+    case 'transferFunds':
+      return parseTransferFundsTransaction(transaction);
+    case 'transferNFT':
+      return parseTransferNFTTransaction(transaction);
+    case 'contractInteraction':
+      return parseContractInteractionTransaction(transaction);
+    case 'raw':
+      return parseRawTransaction(transaction);
+    default:
+      throw new Error('Invalid transaction type');
+  }
+}

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -84,6 +84,7 @@ const PROPOSAL_FRAGMENT = gql`
     updated
     votes
     privacy
+    plugins
   }
 `;
 

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -75,6 +75,7 @@ export type ApiProposal = {
   updated: number | null;
   votes: number;
   privacy: Privacy;
+  plugins: Record<string, any>;
 };
 
 export type ApiVote = {

--- a/apps/ui/src/networks/offchain/index.ts
+++ b/apps/ui/src/networks/offchain/index.ts
@@ -16,7 +16,7 @@ const SNAPSHOT_URLS: Partial<Record<NetworkID, string | undefined>> = {
 };
 const CHAIN_IDS: Partial<Record<NetworkID, number>> = {
   s: 1,
-  's-tn': 5
+  's-tn': 11155111
 };
 
 export function createOffchainNetwork(networkId: NetworkID): Network {

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -328,11 +328,19 @@ export type ContractCallTransaction = BaseTransaction & {
   };
 };
 
+export type RawTransaction = BaseTransaction & {
+  _type: 'raw';
+  _form: {
+    recipient: string;
+  };
+};
+
 export type Transaction =
   | SendTokenTransaction
   | SendNftTransaction
   | StakeTokenTransaction
-  | ContractCallTransaction;
+  | ContractCallTransaction
+  | RawTransaction;
 
 // Utils
 export type RequiredProperty<T> = { [P in keyof T]: Required<NonNullable<T[P]>> };

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -351,6 +351,7 @@ onBeforeUnmount(() => destroyAudio());
         v-if="
           proposal.execution &&
           proposal.execution.length > 0 &&
+          proposal.scores.length > 0 &&
           BigInt(proposal.scores_total) >= BigInt(proposal.quorum) &&
           BigInt(proposal.scores[0]) > BigInt(proposal.scores[1]) &&
           proposal.has_execution_window_opened


### PR DESCRIPTION
### Summary

This PR adds display of oSnap execution in the proposal.

oSnap proposals can have multiple executions (each for different proposal), but for now this PR merges all of those together, just adding necessary conversion to UI-native format.

Those would be separated once https://github.com/snapshot-labs/sx-monorepo/issues/138 is being worked on.

### How to test

1. Run `VITE_ENABLED_NETWORKS=s-tn yarn dev`.
2. Check this proposal: http://localhost:8080/#/s-tn:0cf5e.eth/proposal/0x006df59eed550a3daa6078cb41c0f584a1fd6bcc517a2e608fb1ff57d34e0a12


### Screenshot

<img width="960" alt="image" src="https://github.com/snapshot-labs/sx-monorepo/assets/1968722/3c81f05a-5541-4410-8a54-78f98b4f26d7">
