### PR TITLE
fix: show vote reason

### DIFF
--- a/apps/ui/src/components/Modal/VoteReason.vue
+++ b/apps/ui/src/components/Modal/VoteReason.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import type { Vote } from '@/types';
+
+defineProps<{
+  open: boolean;
+  vote: Vote | null;
+}>();
+
+defineEmits<{
+  (e: 'close'): void;
+}>();
+</script>
+
+<template>
+  <UiModal :open="open" @close="$emit('close')">
+    <template #header>
+      <h3 v-text="'Reason'" />
+    </template>
+    <div class="p-4 whitespace-pre-line text-skin-link" v-text="vote?.reason" />
+  </UiModal>
+</template>

--- a/apps/ui/src/components/Modal/Votes.vue
+++ b/apps/ui/src/components/Modal/Votes.vue
@@ -102,7 +102,6 @@ watch(
                   : 'bg-skin-border opacity-40'
               "
             />
-            <UiStamp :id="vote.voter.id" :size="24" />
             <router-link
               :to="{
                 name: 'user',
@@ -110,10 +109,11 @@ watch(
                   id: vote.voter.id
                 }
               }"
-              class="grow"
+              class="grow flex space-x-2 items-center"
               @click="$emit('close')"
             >
-              {{ vote.voter.name || shortenAddress(vote.voter.id) }}
+              <UiStamp :id="vote.voter.id" :size="24" />
+              <span>{{ vote.voter.name || shortenAddress(vote.voter.id) }}</span>
             </router-link>
 
             <template v-if="isEncrypted">

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -340,7 +340,7 @@ export function createApi(uri: string, networkId: NetworkID, opts: ApiOptions = 
 
       return data.votes.map(vote => {
         vote.voter.name = names[vote.voter.id] || null;
-        vote.reason = vote.metadata.reason;
+        vote.reason = vote.metadata?.reason;
         delete vote.metadata;
 
         return vote;

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -293,6 +293,9 @@ export function createApi(uri: string, networkId: NetworkID, opts: ApiOptions = 
 
       return data.votes.map(vote => {
         vote.voter.name = names[vote.voter.id] || null;
+        vote.reason = vote.metadata.reason;
+        delete vote.metadata;
+
         return vote;
       });
     },

--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -179,6 +179,9 @@ export const VOTES_QUERY = gql`
       space {
         id
       }
+      metadata {
+        reason
+      }
       proposal
       choice
       vp
@@ -197,6 +200,9 @@ export const USER_VOTES_QUERY = gql`
       }
       space {
         id
+      }
+      metadata {
+        reason
       }
       proposal
       choice

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -202,6 +202,7 @@ function formatVote(vote: ApiVote): Vote {
     proposal: vote.proposal.id,
     choice: vote.choice,
     vp: vote.vp,
+    reason: vote.reason,
     created: vote.created,
     tx: vote.ipfs
   };

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -147,6 +147,7 @@ export const USER_VOTES_QUERY = gql`
       }
       choice
       vp
+      reason
       created
     }
   }
@@ -189,6 +190,7 @@ export const VOTES_QUERY = gql`
       ipfs
       choice
       vp
+      reason
       created
     }
   }

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -89,5 +89,6 @@ export type ApiVote = {
   };
   choice: number | number[] | Record<string, number>;
   vp: number;
+  reason: string;
   created: number;
 };

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -248,6 +248,7 @@ export type Vote = {
   proposal: number | string;
   choice: number | number[] | Record<string, number>;
   vp: number;
+  reason: string;
   created: number;
   tx: string;
 };

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -255,7 +255,7 @@ export type Vote = {
   proposal: number | string;
   choice: number | number[] | Record<string, number>;
   vp: number;
-  reason: string;
+  reason?: string;
   created: number;
   tx: string;
 };

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -72,7 +72,7 @@ async function handleEndReached() {
   loadingMore.value = false;
 }
 
-function handleVoteClick(vote: Vote | null) {
+function handleChoiceClick(vote: Vote | null) {
   if (!vote?.reason) return;
 
   selectedVote.value = vote;
@@ -192,7 +192,7 @@ watch([sortBy, choiceFilter], () => {
           :class="{
             'cursor-pointer': vote.reason
           }"
-          @click="handleVoteClick(vote)"
+          @click="handleChoiceClick(vote)"
         >
           <template v-if="!!props.proposal.privacy && !props.proposal.completed">
             <div class="hidden md:block">

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -188,9 +188,9 @@ watch([sortBy, choiceFilter], () => {
           </div>
         </router-link>
         <a
-          class="grow w-[40%] flex flex-col items-start justify-center truncate leading-[22px] !cursor-default"
+          class="grow w-[40%] flex flex-col items-start justify-center truncate leading-[22px]"
           :class="{
-            'cursor-pointer': vote.reason
+            '!cursor-default': !vote.reason
           }"
           :tabindex="vote.reason ? 0 : -1"
           @click="handleChoiceClick(vote)"

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -93,16 +93,8 @@ watch([sortBy, choiceFilter], () => {
   <div
     class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b flex space-x-1 font-medium"
   >
-    <div class="pl-4 w-[50%] lg:w-[40%] truncate">Voter</div>
-    <button
-      class="hidden lg:flex w-[25%] lg:w-[20%] items-center hover:text-skin-link space-x-1 truncate"
-      @click="handleSortChange('created')"
-    >
-      <span>Date</span>
-      <IH-arrow-sm-down v-if="sortBy === 'created-desc'" class="shrink-0" />
-      <IH-arrow-sm-up v-else-if="sortBy === 'created-asc'" class="shrink-0" />
-    </button>
-    <div class="w-[25%] lg:w-[20%] truncate">
+    <div class="pl-4 max-w-[218px] w-[218px] truncate">Voter</div>
+    <div class="grow truncate">
       <template v-if="offchainNetworks.includes(proposal.network)">Choice</template>
       <UiSelectDropdown
         v-else
@@ -127,7 +119,15 @@ watch([sortBy, choiceFilter], () => {
       </UiSelectDropdown>
     </div>
     <button
-      class="w-[25%] lg:w-[20%] flex justify-end items-center hover:text-skin-link space-x-1 truncate"
+      class="hidden lg:flex max-w-[144px] w-[144px] items-center hover:text-skin-link space-x-1 truncate"
+      @click="handleSortChange('created')"
+    >
+      <span>Date</span>
+      <IH-arrow-sm-down v-if="sortBy === 'created-desc'" class="shrink-0" />
+      <IH-arrow-sm-up v-else-if="sortBy === 'created-asc'" class="shrink-0" />
+    </button>
+    <button
+      class="max-w-[144px] w-[144px] flex items-center hover:text-skin-link space-x-1 truncate"
       @click="handleSortChange('vp')"
     >
       <span class="truncate">Voting power</span>
@@ -159,7 +159,7 @@ watch([sortBy, choiceFilter], () => {
               : 'bg-skin-border opacity-40'
           "
         />
-        <div class="pl-4 py-3 w-[50%] lg:w-[40%] flex items-center gap-x-3 truncate">
+        <div class="!ml-auto pl-4 py-3 max-w-[218px] w-[218px] flex items-center gap-x-3 truncate">
           <UiStamp :id="vote.voter.id" :size="32" />
           <router-link
             :to="{
@@ -177,15 +177,8 @@ watch([sortBy, choiceFilter], () => {
             />
           </router-link>
         </div>
-        <div
-          class="hidden leading-[22px] w-[25%] lg:w-[20%] lg:flex flex-col justify-center truncate"
-        >
-          <h4>{{ _rt(vote.created) }}</h4>
-          <div class="text-[17px]">{{ _t(vote.created, 'MMM D, YYYY') }}</div>
-        </div>
-        <div
-          class="w-[25%] lg:w-[20%] flex flex-col items-start justify-center truncate leading-[22px]"
-        >
+
+        <div class="grow flex flex-col items-start justify-center truncate leading-[22px]">
           <template v-if="!!props.proposal.privacy && !props.proposal.completed">
             <div class="hidden md:block">
               <div class="flex gap-1 items-center">
@@ -236,8 +229,12 @@ watch([sortBy, choiceFilter], () => {
           </template>
         </div>
         <div
-          class="text-right leading-[22px] w-[25%] lg:w-[20%] flex flex-col items-end justify-center truncate"
+          class="hidden leading-[22px] max-w-[144px] w-[144px] lg:flex flex-col justify-center truncate"
         >
+          <h4>{{ _rt(vote.created) }}</h4>
+          <div class="text-[17px]">{{ _t(vote.created, 'MMM D, YYYY') }}</div>
+        </div>
+        <div class="leading-[22px] max-w-[144px] w-[144px] flex flex-col justify-center truncate">
           <h4 class="text-skin-link">
             {{ _vp(vote.vp / 10 ** votingPowerDecimals) }}
             {{ proposal.space.voting_power_symbol }}
@@ -247,7 +244,7 @@ watch([sortBy, choiceFilter], () => {
         <div class="w-[30px] lg:w-[60px] flex items-center justify-center">
           <UiDropdown>
             <template #button>
-              <IH-dots-vertical class="text-skin-link" />
+              <IH-dots-horizontal class="text-skin-link" />
             </template>
             <template #items>
               <UiDropdownItem v-slot="{ active }">

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -187,14 +187,11 @@ watch([sortBy, choiceFilter], () => {
             />
           </div>
         </router-link>
-        <a
+        <button
+          type="button"
           class="grow w-[40%] flex flex-col items-start justify-center truncate leading-[22px]"
-          :class="{
-            '!cursor-default': !vote.reason
-          }"
-          :tabindex="vote.reason ? 0 : -1"
+          :disabled="!vote.reason"
           @click="handleChoiceClick(vote)"
-          @keypress="handleChoiceClick(vote)"
         >
           <template v-if="!!props.proposal.privacy && !props.proposal.completed">
             <div class="hidden md:block">
@@ -237,7 +234,7 @@ watch([sortBy, choiceFilter], () => {
             </div>
             <div class="text-[17px] max-w-[100%] truncate">{{ vote.reason }}</div>
           </template>
-        </a>
+        </button>
         <div
           class="hidden leading-[22px] max-w-[144px] w-[144px] lg:flex flex-col justify-center truncate"
         >

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -289,6 +289,13 @@ watch([sortBy, choiceFilter], () => {
     </UiContainerInfiniteScroll>
   </template>
   <teleport to="#modal">
-    <ModalVoteReason :open="modalOpen" :vote="selectedVote" @close="modalOpen = false" />
+    <ModalVoteReason
+      :open="modalOpen"
+      :vote="selectedVote"
+      @close="
+        modalOpen = false;
+        selectedVote = null;
+      "
+    />
   </teleport>
 </template>

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -168,25 +168,25 @@ watch([sortBy, choiceFilter], () => {
               : 'bg-skin-border opacity-40'
           "
         />
-        <div class="!ml-auto pl-4 py-3 max-w-[218px] w-[218px] flex items-center gap-x-3 truncate">
+
+        <router-link
+          :to="{
+            name: 'user',
+            params: {
+              id: vote.voter.id
+            }
+          }"
+          class="leading-[22px] !ml-4 py-3 max-w-[218px] w-[218px] flex items-center space-x-3 truncate"
+        >
           <UiStamp :id="vote.voter.id" :size="32" />
-          <router-link
-            :to="{
-              name: 'user',
-              params: {
-                id: vote.voter.id
-              }
-            }"
-            class="overflow-hidden leading-[22px]"
-          >
+          <div class="flex flex-col truncate">
             <h4 class="truncate" v-text="vote.voter.name || shortenAddress(vote.voter.id)" />
             <div
               class="text-[17px] text-skin-text truncate"
               v-text="shortenAddress(vote.voter.id)"
             />
-          </router-link>
-        </div>
-
+          </div>
+        </router-link>
         <div
           class="grow w-[40%] flex flex-col items-start justify-center truncate leading-[22px]"
           :class="{

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -94,7 +94,7 @@ watch([sortBy, choiceFilter], () => {
     class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b flex space-x-1 font-medium"
   >
     <div class="pl-4 max-w-[218px] w-[218px] truncate">Voter</div>
-    <div class="grow truncate">
+    <div class="grow w-[40%] truncate">
       <template v-if="offchainNetworks.includes(proposal.network)">Choice</template>
       <UiSelectDropdown
         v-else
@@ -134,7 +134,7 @@ watch([sortBy, choiceFilter], () => {
       <IH-arrow-sm-down v-if="sortBy === 'vp-desc'" class="shrink-0" />
       <IH-arrow-sm-up v-else-if="sortBy === 'vp-asc'" class="shrink-0" />
     </button>
-    <div class="w-[30px] lg:w-[60px]" />
+    <div class="min-w-[44px] lg:w-[60px]" />
   </div>
 
   <UiLoading v-if="!loaded" class="px-4 py-3 block" />
@@ -178,7 +178,7 @@ watch([sortBy, choiceFilter], () => {
           </router-link>
         </div>
 
-        <div class="grow flex flex-col items-start justify-center truncate leading-[22px]">
+        <div class="grow w-[40%] flex flex-col items-start justify-center truncate leading-[22px]">
           <template v-if="!!props.proposal.privacy && !props.proposal.completed">
             <div class="hidden md:block">
               <div class="flex gap-1 items-center">
@@ -200,7 +200,7 @@ watch([sortBy, choiceFilter], () => {
               </UiTooltip>
               <div class="text-[17px] max-w-[100%] truncate">{{ vote.reason }}</div>
             </template>
-            <div v-else class="flex flex-col truncate leading-[22px]">
+            <template v-else>
               <div class="flex items-center space-x-2">
                 <div
                   class="rounded-full choice-bg inline-block w-[18px] h-[18px]"
@@ -225,7 +225,7 @@ watch([sortBy, choiceFilter], () => {
                 />
               </div>
               <div class="text-[17px] max-w-[100%] truncate">{{ vote.reason }}</div>
-            </div>
+            </template>
           </template>
         </div>
         <div
@@ -241,7 +241,7 @@ watch([sortBy, choiceFilter], () => {
           </h4>
           <div class="text-[17px]">{{ _n((vote.vp / proposal.scores_total) * 100) }}%</div>
         </div>
-        <div class="w-[30px] lg:w-[60px] flex items-center justify-center">
+        <div class="min-w-[44px] lg:w-[60px] flex items-center justify-center">
           <UiDropdown>
             <template #button>
               <IH-dots-horizontal class="text-skin-link" />

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -256,7 +256,7 @@ watch([sortBy, choiceFilter], () => {
         <div class="min-w-[44px] lg:w-[60px] flex items-center justify-center">
           <UiDropdown>
             <template #button>
-              <UiButton class="!p-0 border-0 !h-[auto]">
+              <UiButton class="!p-0 border-0 !h-[auto] bg-transparent">
                 <IH-dots-horizontal class="text-skin-link" />
               </UiButton>
             </template>

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -254,7 +254,9 @@ watch([sortBy, choiceFilter], () => {
         <div class="min-w-[44px] lg:w-[60px] flex items-center justify-center">
           <UiDropdown>
             <template #button>
-              <IH-dots-horizontal class="text-skin-link" />
+              <UiButton class="!p-0 border-0 !h-[auto]">
+                <IH-dots-horizontal class="text-skin-link" />
+              </UiButton>
             </template>
             <template #items>
               <UiDropdownItem v-slot="{ active }">

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -205,7 +205,7 @@ watch([sortBy, choiceFilter], () => {
               </UiTooltip>
               <div class="text-[17px] max-w-[100%] truncate">{{ vote.reason }}</div>
             </div>
-            <div v-else>
+            <div v-else class="flex flex-col truncate">
               <div class="flex items-center space-x-2">
                 <div
                   class="rounded-full choice-bg inline-block w-[18px] h-[18px]"
@@ -229,7 +229,6 @@ watch([sortBy, choiceFilter], () => {
                   v-text="proposal.choices[(vote.choice as number) - 1]"
                 />
               </div>
-
               <div class="text-[17px] max-w-[100%] truncate">{{ vote.reason }}</div>
             </div>
           </template>

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -102,7 +102,7 @@ watch([sortBy, choiceFilter], () => {
   <div
     class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 border-b flex space-x-1 font-medium"
   >
-    <div class="pl-4 max-w-[218px] w-[218px] truncate">Voter</div>
+    <div class="ml-4 max-w-[218px] w-[218px] truncate">Voter</div>
     <div class="grow w-[40%] truncate">
       <template v-if="offchainNetworks.includes(proposal.network)">Choice</template>
       <UiSelectDropdown

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -183,7 +183,9 @@ watch([sortBy, choiceFilter], () => {
           <h4>{{ _rt(vote.created) }}</h4>
           <div class="text-[17px]">{{ _t(vote.created, 'MMM D, YYYY') }}</div>
         </div>
-        <div class="w-[25%] lg:w-[20%] flex items-center truncate">
+        <div
+          class="w-[25%] lg:w-[20%] flex flex-col items-start justify-center truncate leading-[22px]"
+        >
           <template v-if="!!props.proposal.privacy && !props.proposal.completed">
             <div class="hidden md:block">
               <div class="flex gap-1 items-center">
@@ -196,16 +198,16 @@ watch([sortBy, choiceFilter], () => {
             </UiTooltip>
           </template>
           <template v-else>
-            <div v-if="proposal.type !== 'basic'" class="truncate">
+            <template v-if="proposal.type !== 'basic'">
               <UiTooltip
-                class="max-w-[100%] truncate !inline-block leading-[22px]"
                 :title="getChoiceText(proposal.choices, vote.choice)"
+                class="max-w-[100%] truncate"
               >
                 <h4>{{ getChoiceText(proposal.choices, vote.choice) }}</h4>
               </UiTooltip>
               <div class="text-[17px] max-w-[100%] truncate">{{ vote.reason }}</div>
-            </div>
-            <div v-else class="flex flex-col truncate">
+            </template>
+            <div v-else class="flex flex-col truncate leading-[22px]">
               <div class="flex items-center space-x-2">
                 <div
                   class="rounded-full choice-bg inline-block w-[18px] h-[18px]"

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -196,26 +196,30 @@ watch([sortBy, choiceFilter], () => {
             </UiTooltip>
           </template>
           <template v-else>
-            <UiTooltip
-              v-if="proposal.type !== 'basic'"
-              class="max-w-[100%] truncate !inline-block"
-              :title="getChoiceText(proposal.choices, vote.choice)"
-            >
-              {{ getChoiceText(proposal.choices, vote.choice) }}
-            </UiTooltip>
-            <UiButton
-              v-else
-              class="!w-[40px] !h-[40px] !px-0 cursor-default bg-transparent"
-              :class="{
-                '!text-skin-success !border-skin-success': vote.choice === 1,
-                '!text-skin-danger !border-skin-danger': vote.choice === 2,
-                '!text-gray-500 !border-gray-500': vote.choice === 3
-              }"
-            >
-              <IH-check v-if="vote.choice === 1" class="inline-block" />
-              <IH-x v-else-if="vote.choice === 2" class="inline-block" />
-              <IH-minus-sm v-else class="inline-block" />
-            </UiButton>
+            <div v-if="proposal.type !== 'basic'" class="truncate">
+              <UiTooltip
+                class="max-w-[100%] truncate !inline-block leading-[22px]"
+                :title="getChoiceText(proposal.choices, vote.choice)"
+              >
+                <h4>{{ getChoiceText(proposal.choices, vote.choice) }}</h4>
+              </UiTooltip>
+              <div class="text-[17px] max-w-[100%] truncate">{{ vote.reason }}</div>
+            </div>
+            <div v-else>
+              <UiButton
+                class="!w-[40px] !h-[40px] !px-0 cursor-default bg-transparent"
+                :class="{
+                  '!text-skin-success !border-skin-success': vote.choice === 1,
+                  '!text-skin-danger !border-skin-danger': vote.choice === 2,
+                  '!text-gray-500 !border-gray-500': vote.choice === 3
+                }"
+              >
+                <IH-check v-if="vote.choice === 1" class="inline-block" />
+                <IH-x v-else-if="vote.choice === 2" class="inline-block" />
+                <IH-minus-sm v-else class="inline-block" />
+              </UiButton>
+              <div class="text-[17px] max-w-[100%] truncate">{{ vote.reason }}</div>
+            </div>
           </template>
         </div>
         <div

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -136,7 +136,7 @@ watch([sortBy, choiceFilter], () => {
       <IH-arrow-sm-up v-else-if="sortBy === 'created-asc'" class="shrink-0" />
     </button>
     <button
-      class="max-w-[144px] w-[144px] flex items-center hover:text-skin-link space-x-1 truncate"
+      class="max-w-[144px] w-[144px] flex items-center justify-end hover:text-skin-link space-x-1 truncate"
       @click="handleSortChange('vp')"
     >
       <span class="truncate">Voting power</span>
@@ -242,7 +242,9 @@ watch([sortBy, choiceFilter], () => {
           <h4>{{ _rt(vote.created) }}</h4>
           <div class="text-[17px]">{{ _t(vote.created, 'MMM D, YYYY') }}</div>
         </div>
-        <div class="leading-[22px] max-w-[144px] w-[144px] flex flex-col justify-center truncate">
+        <div
+          class="leading-[22px] max-w-[144px] w-[144px] flex flex-col justify-center items-end truncate"
+        >
           <h4 class="text-skin-link">
             {{ _vp(vote.vp / 10 ** votingPowerDecimals) }}
             {{ proposal.space.voting_power_symbol }}

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -187,12 +187,14 @@ watch([sortBy, choiceFilter], () => {
             />
           </div>
         </router-link>
-        <div
-          class="grow w-[40%] flex flex-col items-start justify-center truncate leading-[22px]"
+        <a
+          class="grow w-[40%] flex flex-col items-start justify-center truncate leading-[22px] !cursor-default"
           :class="{
             'cursor-pointer': vote.reason
           }"
+          :tabindex="vote.reason ? 0 : -1"
           @click="handleChoiceClick(vote)"
+          @keypress="handleChoiceClick(vote)"
         >
           <template v-if="!!props.proposal.privacy && !props.proposal.completed">
             <div class="hidden md:block">
@@ -235,7 +237,7 @@ watch([sortBy, choiceFilter], () => {
             </div>
             <div class="text-[17px] max-w-[100%] truncate">{{ vote.reason }}</div>
           </template>
-        </div>
+        </a>
         <div
           class="hidden leading-[22px] max-w-[144px] w-[144px] lg:flex flex-col justify-center truncate"
         >

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -206,18 +206,30 @@ watch([sortBy, choiceFilter], () => {
               <div class="text-[17px] max-w-[100%] truncate">{{ vote.reason }}</div>
             </div>
             <div v-else>
-              <UiButton
-                class="!w-[40px] !h-[40px] !px-0 cursor-default bg-transparent"
-                :class="{
-                  '!text-skin-success !border-skin-success': vote.choice === 1,
-                  '!text-skin-danger !border-skin-danger': vote.choice === 2,
-                  '!text-gray-500 !border-gray-500': vote.choice === 3
-                }"
-              >
-                <IH-check v-if="vote.choice === 1" class="inline-block" />
-                <IH-x v-else-if="vote.choice === 2" class="inline-block" />
-                <IH-minus-sm v-else class="inline-block" />
-              </UiButton>
+              <div class="flex items-center space-x-2">
+                <div
+                  class="rounded-full choice-bg inline-block w-[18px] h-[18px]"
+                  :class="`_${vote.choice}`"
+                >
+                  <IH-check
+                    v-if="vote.choice === 1"
+                    class="text-white w-[14px] h-[14px] mt-0.5 ml-0.5"
+                  />
+                  <IH-x
+                    v-else-if="vote.choice === 2"
+                    class="text-white w-[14px] h-[14px] mt-0.5 ml-0.5"
+                  />
+                  <IH-minus-sm
+                    v-else-if="vote.choice === 3"
+                    class="text-white w-[14px] h-[14px] mt-0.5 ml-0.5"
+                  />
+                </div>
+                <div
+                  class="truncate grow text-skin-link"
+                  v-text="proposal.choices[(vote.choice as number) - 1]"
+                />
+              </div>
+
               <div class="text-[17px] max-w-[100%] truncate">{{ vote.reason }}</div>
             </div>
           </template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fetch the vote reason from the API, and show it on the proposals' vote page, following the figma here https://www.figma.com/design/hmHTau1Y1KYzrBBKLQr5QV/%23design?node-id=1243-10592&t=zNyM96TSGyLdmPjt-0

### Changes 

- Votes page column order change, to have the choice column just after the voter
- Choice column is the widest one now
- Reason is shown below the choice, if available
- Basic vote choice UI has changed for smaller icon+text
- Clicking on the choice will open the vote reason modal when reason exists
- Various UX/UI fixes on the votes pages and votes modal

### How to test

1. Go to a basic choice proposal: http://localhost:8080/#/s:apecoin.eth/proposal/0xf0ccdfb38ea5bee47e5f3f5ac83d5d9ecbeb605e328001c0ab4c6df7e91557e3/votes
2. It should show the basic choice with the new UI, as well as reason
3. Clicking on a choice with reason will open the reason modal
4. Go to a non-basic choice proposal: http://localhost:8080/#/s:apecoin.eth/proposal/0xd7a0d880fa558f3e7308113545a668d29dd4ed3fc10453ea7f1c2209d7b13f86/votes
5. It should show the reason below the choice when available, with a modal open on click
6. Go to an starknet proposal: http://localhost:8080/#/sn-sep:0x018df40f9cb5ac1b43a3c9291ebc02903f01e8241bd959520b36e7e293ace65f/proposal/3/votes
7. It should show the reason

### To-Do before/after merge

- [ ] Re-deploy mana to allow indexing of the new reason field
- [ ] Update checkpoint to support TEXT reason, instead of STRING, to support 1000 characters reason