### PR TITLE
fix: load treasury asset balance only when necessary

### DIFF
--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -106,7 +106,7 @@ const executionStrategy = computed(() => {
 });
 
 const hasStakeableAssets = computed(() => {
-  return assets.value.some(asset => asset.contractAddress === ETH_CONTRACT && !isReadOnly);
+  return !isReadOnly && assets.value.some(asset => asset.contractAddress === ETH_CONTRACT);
 });
 
 function openModal(type: 'tokens' | 'nfts' | 'stake') {

--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -105,6 +105,10 @@ const executionStrategy = computed(() => {
   };
 });
 
+const hasStakeableAssets = computed(() => {
+  return assets.value.some(asset => asset.contractAddress === ETH_CONTRACT && !isReadOnly);
+});
+
 function openModal(type: 'tokens' | 'nfts' | 'stake') {
   modalOpen.value[type] = true;
 }
@@ -324,6 +328,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
     </div>
     <teleport to="#modal">
       <ModalSendToken
+        v-if="!isReadOnly"
         :open="modalOpen.tokens"
         :address="treasury.wallet"
         :network="treasury.network"
@@ -341,6 +346,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
         @add="addTx"
       />
       <ModalStakeToken
+        v-if="hasStakeableAssets"
         :open="modalOpen.stake"
         :address="treasury.wallet"
         :network="treasury.network"


### PR DESCRIPTION
### Summary

On the all spaces' treasury page, the `loadBalance()` call is triggered 3 times, with exactly the same arguments, since in addition to the main treasury page, it's also called in the sendToken and stakeToken modal.

This quick fix removes the unnecessary duplicates calls, by avoiding mounting the stakeToken and SendToken modal when not relevant.

Note: This is just a quick fix, we will still have duplicated calls when all modals are mounted, a better long term solution would be to have a global variable on the `useBalance` composable.

This will hopefully solve the 429 issue we have on https://github.com/snapshot-labs/sx-monorepo/issues/258

### How to test

1. Go to any tresuries, like http://localhost:8080/#/s:balancer.eth/treasury
2. In the network tab of the dev console, you should only see one call to alchemy by method
