### PR TITLE
fix: catch fetchUser failures in loadProvider call

### DIFF
--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -99,7 +99,11 @@ export function useWeb3() {
 
       if (acc) {
         const usersStore = useUsersStore();
-        await usersStore.fetchUser(acc);
+        try {
+          await usersStore.fetchUser(acc);
+        } catch (e) {
+          console.warn('failed to fetch user', e);
+        }
         state.account = formatAddress(acc);
         state.name = usersStore.getUser(acc)?.name || '';
       }


### PR DESCRIPTION
### Summary

loadProvider call is important for app functionality. It shouldn't be interrupted by fetching user (due to bugs or just network issues).

