### PR TITLE
chore: only bump sx.js as patch

### DIFF
--- a/.changeset/large-snails-exercise.md
+++ b/.changeset/large-snails-exercise.md
@@ -1,5 +1,5 @@
 ---
-"@snapshot-labs/sx": minor
+"@snapshot-labs/sx": patch
 ---
 
 support on-chain voting with Safe using relayer


### PR DESCRIPTION
We are currently only bumping patch version to stay at 0.1.x
