### PR TITLE
fix: hide empty execution for SX proposals

### DIFF
--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -103,7 +103,8 @@ function processExecutions(
   // We should persist those values on proposal directly so it's stable.
   // Right now we can't really update subgraphs because of TheGraph issue.
 
-  if (!proposal.metadata.execution) return [];
+  const transactions = formatExecution(proposal.metadata.execution);
+  if (transactions.length === 0) return [];
 
   const match = proposal.space.metadata.executors_strategies.find(
     strategy => strategy.address === proposal.execution_strategy
@@ -134,7 +135,7 @@ function processExecutions(
       safeAddress: match?.treasury || '',
       safeName: matchingTreasury?.name || 'Unnamed treasury',
       networkId: matchingTreasury?.network || executionNetworkId,
-      transactions: formatExecution(proposal.metadata.execution)
+      transactions
     }
   ];
 }


### PR DESCRIPTION
### Summary

If execution has no transactions executions array should be empty. Right now every proposal has empty execution.

### How to test

1. Go to proposal without execution on SX: http://localhost:8080/#/sn-sep:0x012f384aacce933c2a346ade9a6c2918ece850b04db54efbf716c1a9fcb344da/proposal/5
2. It has no execution.
3. Proposals with executions still do (you need to enable `s-tn` network): http://localhost:8080/#/s-tn:0cf5e.eth/proposal/0x18b4c85fb3dba579b2714a3fcdba5ea96088f9f0a51f02002e81cc39a589d674

### Screenshots

Before:
<img width="726" alt="image" src="https://github.com/user-attachments/assets/0919ee85-77be-4770-a7e6-35e9f9ec9e5a">


After:
<img width="788" alt="image" src="https://github.com/user-attachments/assets/84ee6e46-25b3-40ac-beae-2c9f91b25a80">

