### PR TITLE
fix(ui): fix extra margin on textarea top inside editor

### DIFF
--- a/apps/ui/src/style.scss
+++ b/apps/ui/src/style.scss
@@ -296,19 +296,30 @@ input[type='number'] {
 }
 
 .s-box {
+  // Adding the gradient fade to the top of the input
+  .s-label:has(+ textarea),
+  .s-base:has(textarea:only-child) {
+     &::before {
+      @apply block bg-gradient-to-b from-skin-border to-transparent h-2 w-full absolute top-[20px] left-0;
+
+      content: '';
+    }
+  }
+
   .s-base {
     @apply relative;
+
+    textarea:only-child {
+      @apply border-t-0 border-transparent;
+    }
+
+    &:has(textarea:only-child)::before {
+      @apply top-0;
+    }
   }
 
   .s-label {
     @apply absolute px-3 mt-1 text-[17px];
-
-    &:has(+ textarea) ::before {
-      @apply block bg-gradient-to-b from-skin-border to-transparent h-2 w-full absolute top-[20px] left-0;
-
-      content: '';
-
-    }
   }
 
   .s-input {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #493 

This PR removes the extra margin on textarea, inside the composer editor

### How to test

1. Go to a proposal creation page
2. There should be not extra space between the textarea and the editor toolbar
3. There should be a gradient on top, when scrolling overflowing textarea
4. Go to any other textarea like the space creation
5. The textarea should remain the same
