### PR TITLE
feat: add metadata network constant for aliases/follows/profiles

### DIFF
--- a/apps/ui/.env
+++ b/apps/ui/.env
@@ -1,4 +1,5 @@
 VITE_ENABLED_NETWORKS=
+VITE_METADATA_NETWORK=
 VITE_MANA_URL=https://mana.pizza
 VITE_HIGHLIGHT_URL=https://testnet.highlight.red
 VITE_IPFS_GATEWAY=snapshot.4everland.link

--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -1,5 +1,5 @@
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
-import { enabledNetworks, getNetwork, getReadWriteNetwork, offchainNetworks } from '@/networks';
+import { getNetwork, getReadWriteNetwork, metadataNetwork } from '@/networks';
 import { registerTransaction } from '@/helpers/mana';
 import { convertToMetaTransactions } from '@/helpers/transactions';
 import type {
@@ -14,8 +14,6 @@ import type {
   User
 } from '@/types';
 import type { Connector, StrategyConfig } from '@/networks/types';
-
-const offchainNetworkId = offchainNetworks.filter(network => enabledNetworks.includes(network))[0];
 
 export function useActions() {
   const { mixpanel } = useMixpanel();
@@ -118,10 +116,10 @@ export function useActions() {
   }
 
   async function getAliasSigner() {
-    const network = getNetwork(offchainNetworkId);
+    const network = getNetwork(metadataNetwork);
 
     return alias.getAliasWallet(address =>
-      wrapPromise(offchainNetworkId, network.actions.setAlias(auth.web3, address))
+      wrapPromise(metadataNetwork, network.actions.setAlias(auth.web3, address))
     );
   }
 
@@ -519,11 +517,11 @@ export function useActions() {
       return false;
     }
 
-    const network = getNetwork(offchainNetworkId);
+    const network = getNetwork(metadataNetwork);
 
     try {
       await wrapPromise(
-        offchainNetworkId,
+        metadataNetwork,
         network.actions.followSpace(await getAliasSigner(), networkId, spaceId, web3.value.account)
       );
     } catch (e) {
@@ -540,11 +538,11 @@ export function useActions() {
       return false;
     }
 
-    const network = getNetwork(offchainNetworkId);
+    const network = getNetwork(metadataNetwork);
 
     try {
       await wrapPromise(
-        offchainNetworkId,
+        metadataNetwork,
         network.actions.unfollowSpace(
           await getAliasSigner(),
           networkId,
@@ -561,10 +559,10 @@ export function useActions() {
   }
 
   async function updateUser(user: User) {
-    const network = getNetwork(offchainNetworkId);
+    const network = getNetwork(metadataNetwork);
 
     await wrapPromise(
-      offchainNetworkId,
+      metadataNetwork,
       network.actions.updateUser(await getAliasSigner(), user, web3.value.account)
     );
 

--- a/apps/ui/src/composables/useAlias.ts
+++ b/apps/ui/src/composables/useAlias.ts
@@ -1,7 +1,7 @@
 import { Wallet } from '@ethersproject/wallet';
 import { getDefaultProvider } from '@ethersproject/providers';
 import { isHexString } from '@ethersproject/bytes';
-import { enabledNetworks, getNetwork, offchainNetworks } from '@/networks';
+import { metadataNetwork, getNetwork } from '@/networks';
 import pkg from '../../package.json';
 
 const ALIAS_AVAILABILITY_PERIOD = 60 * 60 * 24 * 30; // 30 days
@@ -9,8 +9,7 @@ const ALIAS_AVAILABILITY_BUFFER = 60 * 5; // 5 minutes
 
 const aliases = useStorage(`${pkg.name}.aliases`, {} as Record<string, string>);
 
-const networkId = offchainNetworks.filter(network => enabledNetworks.includes(network))[0];
-const network = getNetwork(networkId);
+const network = getNetwork(metadataNetwork);
 
 export function useAlias() {
   const provider = getDefaultProvider();

--- a/apps/ui/src/networks/index.ts
+++ b/apps/ui/src/networks/index.ts
@@ -17,10 +17,12 @@ const lineaTestnetNetwork = createEvmNetwork('linea-testnet');
 
 export const enabledNetworks: NetworkID[] = import.meta.env.VITE_ENABLED_NETWORKS
   ? (import.meta.env.VITE_ENABLED_NETWORKS.split(',') as NetworkID[])
-  : ['s', 'eth', 'matic', 'arb1', 'oeth', 'sep', 'sn', 'sn-sep'];
+  : ['s', 's-tn', 'eth', 'matic', 'arb1', 'oeth', 'sep', 'sn', 'sn-sep'];
 
 export const evmNetworks: NetworkID[] = ['eth', 'matic', 'arb1', 'oeth', 'sep', 'linea-testnet'];
 export const offchainNetworks: NetworkID[] = ['s', 's-tn'];
+// This network is used for aliases/follows/profiles/explore page.
+export const metadataNetwork: NetworkID = import.meta.env.VITE_METADATA_NETWORK || 's';
 
 export const getNetwork = (id: NetworkID) => {
   if (!enabledNetworks.includes(id)) throw new Error(`Network ${id} is not enabled`);
@@ -65,7 +67,7 @@ export const explorePageProtocols: Record<ExplorePageProtocol, ProtocolConfig> =
   snapshot: {
     key: 'snapshot',
     label: 'Snapshot',
-    networks: enabledNetworks.filter(network => offchainNetworks.includes(network)),
+    networks: [metadataNetwork],
     limit: 18
   },
   snapshotx: {

--- a/apps/ui/src/stores/followedSpaces.ts
+++ b/apps/ui/src/stores/followedSpaces.ts
@@ -1,10 +1,9 @@
 import { defineStore } from 'pinia';
-import { enabledNetworks, getNetwork, offchainNetworks } from '@/networks';
+import { metadataNetwork, offchainNetworks, getNetwork } from '@/networks';
 import pkg from '../../package.json';
 import { NetworkID, Space } from '@/types';
 
-const offchainNetworkId = offchainNetworks.filter(network => enabledNetworks.includes(network))[0];
-const network = getNetwork(offchainNetworkId);
+const network = getNetwork(metadataNetwork);
 
 function getCompositeSpaceId(space: Space) {
   return `${space.network}:${space.id}`;

--- a/apps/ui/src/stores/users.ts
+++ b/apps/ui/src/stores/users.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { enabledNetworks, getNetwork, offchainNetworks } from '@/networks';
+import { metadataNetwork, getNetwork } from '@/networks';
 import type { User } from '@/types';
 
 type UserRecord = {
@@ -8,8 +8,7 @@ type UserRecord = {
   user: User | null;
 };
 
-const networkId = offchainNetworks.filter(network => enabledNetworks.includes(network))[0];
-const network = getNetwork(networkId);
+const network = getNetwork(metadataNetwork);
 
 export const useUsersStore = defineStore('users', {
   state: () => ({

--- a/apps/ui/src/views/My/Home.vue
+++ b/apps/ui/src/views/My/Home.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import ProposalIconStatus from '@/components/ProposalIconStatus.vue';
 import { getNames } from '@/helpers/stamp';
-import { enabledNetworks, getNetwork, offchainNetworks } from '@/networks';
+import { metadataNetwork, getNetwork } from '@/networks';
 import { ProposalsFilter } from '@/networks/types';
 import { NetworkID, Proposal } from '@/types';
 
@@ -25,12 +25,8 @@ const selectIconBaseProps = {
   height: 16
 };
 
-const networkId = computed(
-  () => offchainNetworks.filter(network => enabledNetworks.includes(network))[0]
-);
-
 // TODO: Support multiple networks
-const network = computed(() => getNetwork(networkId.value));
+const network = computed(() => getNetwork(metadataNetwork));
 
 async function withAuthorNames(proposals: Proposal[]) {
   if (!proposals.length) return proposals;
@@ -49,7 +45,7 @@ async function loadProposalsPage(skip = 0) {
     await network.value.api.loadProposals(
       followedSpacesStore.followedSpacesIds.map(compositeSpaceId => compositeSpaceId.split(':')[1]),
       { limit: PROPOSALS_LIMIT, skip },
-      metaStore.getCurrent(networkId.value) || 0,
+      metaStore.getCurrent(metadataNetwork) || 0,
       { state: state.value }
     )
   );
@@ -77,7 +73,7 @@ async function handleEndReached() {
 }
 
 onMounted(() => {
-  metaStore.fetchBlock(networkId.value);
+  metaStore.fetchBlock(metadataNetwork);
 });
 
 watch(


### PR DESCRIPTION
### Summary

Currently aliases/follows/user profiles are fetched for first offchainNetwork that is enabled.

This is a bit annoying if you want to display both networks at the same time (in development or in sx-devnet deployment) because you need to switch env and metadata network is dependent on the order in your ENABLED_NETWORKS.

With this change we separate enabled networks from the network that is used for metadata and enable both s and s-tn networks at the same time.

### How to test

1. You can open testnet space: http://localhost:8080/#/s-tn:0cf5e.eth
2. You can open prod space: http://localhost:8080/#/s:0cf5e.eth
3. Explore page shows metadata network only (`s` by default): http://localhost:8080/#/explore
4. You can follow mainnet spaces.