### PR TITLE
fix: avoid user votes flashing on load

### DIFF
--- a/apps/ui/src/composables/useAccount.ts
+++ b/apps/ui/src/composables/useAccount.ts
@@ -9,6 +9,7 @@ watch(
   () => web3.value.account,
   (current, previous) => {
     if (current !== previous) {
+      votes.value = {};
       pendingVotes.value = {};
     }
   }
@@ -17,10 +18,7 @@ watch(
 export function useAccount() {
   async function loadVotes(networkId: NetworkID, spaceIds: string[]) {
     const account = web3.value.account;
-    if (!account) {
-      votes.value = {};
-      return;
-    }
+    if (!account) return;
 
     const network = getNetwork(networkId);
     votes.value = await network.api.loadUserVotes(spaceIds, account);

--- a/apps/ui/src/composables/useAccount.ts
+++ b/apps/ui/src/composables/useAccount.ts
@@ -16,15 +16,14 @@ watch(
 
 export function useAccount() {
   async function loadVotes(networkId: NetworkID, spaceIds: string[]) {
-    votes.value = {};
-
     const account = web3.value.account;
-    if (!account) return;
+    if (!account) {
+      votes.value = {};
+      return;
+    }
 
     const network = getNetwork(networkId);
-    const userVotes = await network.api.loadUserVotes(spaceIds, account);
-
-    votes.value = { ...votes.value, ...userVotes };
+    votes.value = await network.api.loadUserVotes(spaceIds, account);
   }
 
   function addPendingVote(proposalId: string) {

--- a/apps/ui/src/composables/useAccount.ts
+++ b/apps/ui/src/composables/useAccount.ts
@@ -21,7 +21,9 @@ export function useAccount() {
     if (!account) return;
 
     const network = getNetwork(networkId);
-    votes.value = await network.api.loadUserVotes(spaceIds, account);
+    const userVotes = await network.api.loadUserVotes(spaceIds, account);
+
+    votes.value = { ...votes.value, ...userVotes };
   }
 
   function addPendingVote(proposalId: string) {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

When re-loading the connected users' votes again for the same space, the `votes` object will be cleared before the API requeste, then re-populated again with the results.

This creates some flashing on the UI, where the state of an item where the user has already voted will flash briefly to "Not voted" state while the API request is fetching.

This PR will clear the local votes object only for guest user, connected user votes will just overwrite the existing one (removed the object concatenation, as we're just loading and saving in the memory votes from a single space)
