### PR TITLE
feat: use self-hosted subgraph for sepolia

### DIFF
--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -57,7 +57,7 @@ export const METADATA: Record<string, Metadata> = {
     chainId: 11155111,
     apiUrl:
       import.meta.env.VITE_EVM_SEPOLIA_API ??
-      'https://graph.spiky.pl/subgraphs/name/snapshot-labs/sx-subgraph',
+      'https://subgraph.snapshot.org/subgraphs/name/snapshot-labs/sx-subgraph',
     avatar: 'ipfs://bafkreid7ndxh6y2ljw2jhbisodiyrhcy2udvnwqgon5wgells3kh4si5z4',
     blockTime: 13.2816
   },

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -57,7 +57,7 @@ export const METADATA: Record<string, Metadata> = {
     chainId: 11155111,
     apiUrl:
       import.meta.env.VITE_EVM_SEPOLIA_API ??
-      'https://api.studio.thegraph.com/query/23545/sx-sepolia/version/latest',
+      'https://graph.spiky.pl/subgraphs/name/snapshot-labs/sx-subgraph',
     avatar: 'ipfs://bafkreid7ndxh6y2ljw2jhbisodiyrhcy2udvnwqgon5wgells3kh4si5z4',
     blockTime: 13.2816
   },


### PR DESCRIPTION
### Summary

For 3 weeks we couldn't deploy our subgraph on sepolia due to some issue on TheGraph. This means we are lacking some updated (reason is not indexed). This PR replaces official TheGraph's studio subgraph with our own `graph-node` deployed one. 

### Test plan

1. Can access Sepolia spaces (http://localhost:8080/#/sep:0x5559e6c038fD0494277ac85ab6576843A6d0187b)
2. API supports reason for votes: https://subgraph.snapshot.org/subgraphs/name/snapshot-labs/sx-subgraph/graphql?query=%7B%0A++votes%28where%3A+%7Bmetadata_%3A+%7B%7D%7D%29+%7B%0A++++id%0A++++metadata+%7B%0A++++++reason%0A++++%7D%0A++%7D%0A%7D