### PR TITLE
fix: vs-code run lint fix on file save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ dist.cjs
 .DS_Store
 *.pem
 .idea
-.vscode
 
 # debug
 npm-debug.log*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}


### PR DESCRIPTION
### Summary
- Using vs code, run lint fix on saving a file

### How to test
1. Make sure a file with lint errors
2. Saving a file should fix all lint errors
