### PR TITLE
fix(ux): convert link with just onClick event to Button

### DIFF
--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -122,8 +122,8 @@ watch(
         </UiButton>
         <IndicatorPendingTransactions class="ml-2" />
         <UiButton class="!px-0 w-[46px] ml-2" @click="toggleSkin">
-          <IH-light-bulb v-if="currentMode === 'dark'" class="inline-block" />
-          <IH-moon v-else class="inline-block" />
+          <IH-light-bulb v-if="currentMode === 'dark'" />
+          <IH-moon v-else />
         </UiButton>
       </div>
     </div>

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -104,13 +104,9 @@ watch(
           </router-link>
         </Breadcrumb>
       </div>
-      <div :key="web3.account" class="flex">
+      <div :key="web3.account" class="flex space-x-2">
         <UiButton v-if="loading || web3.authLoading" loading class="!px-0 w-[46px]" />
-        <UiButton
-          v-else
-          class="float-left !px-0 w-[46px] sm:w-auto sm:!px-3 text-center"
-          @click="modalAccountOpen = true"
-        >
+        <UiButton v-else class="!px-0 w-[46px] sm:w-auto sm:!px-3" @click="modalAccountOpen = true">
           <span v-if="auth.isAuthenticated.value" class="sm:flex items-center space-x-2">
             <UiStamp :id="web3.account" :size="18" />
             <span class="hidden sm:block" v-text="web3.name || shorten(web3.account)" />
@@ -120,8 +116,8 @@ watch(
             <IH-login class="sm:hidden inline-block" />
           </template>
         </UiButton>
-        <IndicatorPendingTransactions class="ml-2" />
-        <UiButton class="!px-0 w-[46px] ml-2" @click="toggleSkin">
+        <IndicatorPendingTransactions />
+        <UiButton class="!px-0 w-[46px]" @click="toggleSkin">
           <IH-light-bulb v-if="currentMode === 'dark'" />
           <IH-moon v-else />
         </UiButton>

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -105,8 +105,8 @@ watch(
         </Breadcrumb>
       </div>
       <div :key="web3.account" class="flex space-x-2">
-        <UiButton v-if="loading || web3.authLoading" loading class="!px-0 w-[46px]" />
-        <UiButton v-else class="!px-0 w-[46px] sm:w-auto sm:!px-3" @click="modalAccountOpen = true">
+        <UiButtonRound v-if="loading || web3.authLoading" loading />
+        <UiButtonRound v-else class="sm:w-auto sm:!px-3" @click="modalAccountOpen = true">
           <span v-if="auth.isAuthenticated.value" class="sm:flex items-center space-x-2">
             <UiStamp :id="web3.account" :size="18" />
             <span class="hidden sm:block" v-text="web3.name || shorten(web3.account)" />
@@ -115,12 +115,12 @@ watch(
             <span class="hidden sm:block" v-text="'Connect wallet'" />
             <IH-login class="sm:hidden inline-block" />
           </template>
-        </UiButton>
+        </UiButtonRound>
         <IndicatorPendingTransactions />
-        <UiButton class="!px-0 w-[46px]" @click="toggleSkin">
+        <UiButtonRound @click="toggleSkin">
           <IH-light-bulb v-if="currentMode === 'dark'" />
           <IH-moon v-else />
-        </UiButton>
+        </UiButtonRound>
       </div>
     </div>
   </nav>

--- a/apps/ui/src/components/ButtonFollow.vue
+++ b/apps/ui/src/components/ButtonFollow.vue
@@ -24,16 +24,16 @@ const loading = computed(
 <template>
   <UiButton
     v-if="!hidden"
+    :loading="loading"
     :disabled="loading || isSafeWallet"
-    class="group"
+    class="group !px-0"
     :class="{ 'hover:border-skin-danger': spaceFollowed }"
     @click.prevent="followedSpacesStore.toggleSpaceFollow(spaceIdComposite)"
   >
-    <UiLoading v-if="loading" />
-    <span v-else-if="spaceFollowed" class="inline-block">
+    <span v-if="spaceFollowed" class="px-3.5">
       <span class="group-hover:inline hidden text-skin-danger">Unfollow</span>
       <span class="group-hover:hidden">Following</span>
     </span>
-    <span v-else class="inline-block">Follow</span>
+    <span v-else class="px-3.5">Follow</span>
   </UiButton>
 </template>

--- a/apps/ui/src/components/DropdownShare.vue
+++ b/apps/ui/src/components/DropdownShare.vue
@@ -15,7 +15,7 @@ function handleCopyLinkClick() {
     <template #button>
       <slot name="button">
         <UiButton v-bind="$attrs">
-          <IH-share class="inline-block" />
+          <IH-share />
         </UiButton>
       </slot>
     </template>

--- a/apps/ui/src/components/EditorChoices.vue
+++ b/apps/ui/src/components/EditorChoices.vue
@@ -63,7 +63,7 @@ function handlePressEnter(index) {
           </div>
         </template>
       </Draggable>
-      <UiButton v-if="proposal.type !== 'basic'" class="w-full space-x-1" @click="handleAddChoice">
+      <UiButton v-if="proposal.type !== 'basic'" class="w-full" @click="handleAddChoice">
         <IH-plus-sm />
         <span>Add choice</span>
       </UiButton>

--- a/apps/ui/src/components/EditorChoices.vue
+++ b/apps/ui/src/components/EditorChoices.vue
@@ -54,10 +54,10 @@ function handlePressEnter(index) {
               </div>
               <UiButton
                 v-if="proposal.choices.length > 1 && proposal.type !== 'basic'"
-                class="border-0 rounded-l-none rounded-r-lg bg-transparent !h-[40px] w-[40px] !px-0 text-center text-skin-text shrink-0"
+                class="!border-0 !rounded-l-none !rounded-r-lg !bg-transparent !h-[40px] !w-[40px] !px-0 !text-skin-text shrink-0"
                 @click="proposal.choices.splice(index, 1)"
               >
-                <IH-trash class="inline-block" />
+                <IH-trash />
               </UiButton>
             </div>
           </div>

--- a/apps/ui/src/components/EditorChoices.vue
+++ b/apps/ui/src/components/EditorChoices.vue
@@ -63,11 +63,7 @@ function handlePressEnter(index) {
           </div>
         </template>
       </Draggable>
-      <UiButton
-        v-if="proposal.type !== 'basic'"
-        class="w-full flex items-center justify-center space-x-1"
-        @click="handleAddChoice"
-      >
+      <UiButton v-if="proposal.type !== 'basic'" class="w-full space-x-1" @click="handleAddChoice">
         <IH-plus-sm />
         <span>Add choice</span>
       </UiButton>

--- a/apps/ui/src/components/IndicatorPendingTransactions.vue
+++ b/apps/ui/src/components/IndicatorPendingTransactions.vue
@@ -15,9 +15,9 @@ const pendingTransactionsModalOpen = ref(false);
     v-bind="$attrs"
     title="Pending transactions"
   >
-    <UiButton primary class="!px-0 w-[46px]" @click="pendingTransactionsModalOpen = true">
+    <UiButtonRound primary @click="pendingTransactionsModalOpen = true">
       {{ uiStore.pendingTransactions.length }}
-    </UiButton>
+    </UiButtonRound>
   </UiTooltip>
   <teleport to="#modal">
     <ModalPendingTransactions

--- a/apps/ui/src/components/IndicatorVotingPower.vue
+++ b/apps/ui/src/components/IndicatorVotingPower.vue
@@ -50,7 +50,6 @@ function handleModalOpen() {
         <UiButton
           v-if="web3.account && !(evmNetworks.includes(networkId) && web3.type === 'argentx')"
           :loading="loading"
-          class="flex flex-row items-center justify-center"
           :class="{
             '!px-0 w-[46px]': loading
           }"

--- a/apps/ui/src/components/Modal/Account.vue
+++ b/apps/ui/src/components/Modal/Account.vue
@@ -61,7 +61,7 @@ watch(open, () => (step.value = null));
           class="block"
           @click="$emit('login', connector.id)"
         >
-          <UiButton class="button-outline w-full flex justify-center items-center">
+          <UiButton class="button w-full">
             <img
               :src="getConnectorIconUrl(connector.icon)"
               height="28"
@@ -85,12 +85,10 @@ watch(open, () => (step.value = null));
           <span>My profile</span>
         </router-link>
         <router-link to="/settings" class="s-button" @click="emit('close')"> Settings </router-link>
-        <UiButton class="button-outline w-full" @click="step = 'connect'">
+        <UiButton class="w-full" @click="step = 'connect'">
           {{ web3.account ? 'Change wallet' : 'Connect wallet' }}
         </UiButton>
-        <UiButton class="button-outline w-full !text-skin-danger" @click="handleLogout">
-          Log out
-        </UiButton>
+        <UiButton class="w-full !text-skin-danger" @click="handleLogout"> Log out </UiButton>
       </div>
     </div>
   </UiModal>

--- a/apps/ui/src/components/Modal/Account.vue
+++ b/apps/ui/src/components/Modal/Account.vue
@@ -78,25 +78,13 @@ watch(open, () => (step.value = null));
       <div class="m-4 space-y-2">
         <router-link
           :to="{ name: 'user', params: { id: web3.account } }"
-          class="block"
-          tabindex="-1"
+          class="s-button space-x-2"
+          @click="emit('close')"
         >
-          <UiButton
-            class="button-outline w-full flex justify-center items-center space-x-2"
-            @click="emit('close')"
-          >
-            <UiStamp :id="web3.account" :size="18" />
-            <span>My profile</span>
-          </UiButton>
+          <UiStamp :id="web3.account" :size="18" />
+          <span>My profile</span>
         </router-link>
-        <router-link to="/settings" class="block" tabindex="-1">
-          <UiButton
-            class="button-outline w-full flex justify-center items-center"
-            @click="emit('close')"
-          >
-            <span>Settings</span>
-          </UiButton>
-        </router-link>
+        <router-link to="/settings" class="s-button" @click="emit('close')"> Settings </router-link>
         <UiButton class="button-outline w-full" @click="step = 'connect'">
           {{ web3.account ? 'Change wallet' : 'Connect wallet' }}
         </UiButton>

--- a/apps/ui/src/components/Modal/Account.vue
+++ b/apps/ui/src/components/Modal/Account.vue
@@ -61,15 +61,15 @@ watch(open, () => (step.value = null));
           class="block"
           @click="$emit('login', connector.id)"
         >
-          <UiButton class="button w-full">
+          <UiButton class="w-full space-x-2">
             <img
               :src="getConnectorIconUrl(connector.icon)"
               height="28"
               width="28"
-              class="mr-2 -mt-1"
+              class="-mt-1"
               :alt="connector.name"
             />
-            {{ connector.name }}
+            <span v-text="connector.name" />
           </UiButton>
         </a>
       </div>

--- a/apps/ui/src/components/Modal/Account.vue
+++ b/apps/ui/src/components/Modal/Account.vue
@@ -61,7 +61,7 @@ watch(open, () => (step.value = null));
           class="block"
           @click="$emit('login', connector.id)"
         >
-          <UiButton class="w-full space-x-2">
+          <UiButton class="w-full">
             <img
               :src="getConnectorIconUrl(connector.icon)"
               height="28"

--- a/apps/ui/src/components/Modal/Connector.vue
+++ b/apps/ui/src/components/Modal/Connector.vue
@@ -54,15 +54,15 @@ const availableConnectors = computed(() => {
           class="block"
           @click="emit('pick', connector.id)"
         >
-          <UiButton class="w-full">
+          <UiButton class="w-full space-x-2">
             <img
               :src="getConnectorIconUrl(connector.icon)"
               height="28"
               width="28"
-              class="mr-2 -mt-1"
+              class="-mt-1"
               :alt="connector.name"
             />
-            {{ connector.name }}
+            <span v-text="connector.name" />
           </UiButton>
         </a>
       </div>

--- a/apps/ui/src/components/Modal/Connector.vue
+++ b/apps/ui/src/components/Modal/Connector.vue
@@ -54,7 +54,7 @@ const availableConnectors = computed(() => {
           class="block"
           @click="emit('pick', connector.id)"
         >
-          <UiButton class="button-outline w-full flex justify-center items-center">
+          <UiButton class="w-full">
             <img
               :src="getConnectorIconUrl(connector.icon)"
               height="28"

--- a/apps/ui/src/components/Modal/Connector.vue
+++ b/apps/ui/src/components/Modal/Connector.vue
@@ -54,7 +54,7 @@ const availableConnectors = computed(() => {
           class="block"
           @click="emit('pick', connector.id)"
         >
-          <UiButton class="w-full space-x-2">
+          <UiButton class="w-full">
             <img
               :src="getConnectorIconUrl(connector.icon)"
               height="28"

--- a/apps/ui/src/components/Modal/Drafts.vue
+++ b/apps/ui/src/components/Modal/Drafts.vue
@@ -51,9 +51,9 @@ function handleRemoveDraft(id: string) {
             {{ proposal.title || 'Untitled' }}
             <span class="text-skin-text">#{{ proposal.key }}</span>
           </router-link>
-          <a @click="handleRemoveDraft(proposal.id)">
-            <IH-trash class="mr-2" />
-          </a>
+          <UiButton class="!border-0 !px-0 !h-auto" @click="handleRemoveDraft(proposal.id)">
+            <IH-trash />
+          </UiButton>
         </div>
       </div>
       <div v-else class="p-4 text-center">There isn't any drafts yet!</div>

--- a/apps/ui/src/components/Modal/Drafts.vue
+++ b/apps/ui/src/components/Modal/Drafts.vue
@@ -51,7 +51,7 @@ function handleRemoveDraft(id: string) {
             {{ proposal.title || 'Untitled' }}
             <span class="text-skin-text">#{{ proposal.key }}</span>
           </router-link>
-          <UiButton class="!border-0 !px-0 !h-auto" @click="handleRemoveDraft(proposal.id)">
+          <UiButton simple @click="handleRemoveDraft(proposal.id)">
             <IH-trash />
           </UiButton>
         </div>

--- a/apps/ui/src/components/Modal/VotingPower.vue
+++ b/apps/ui/src/components/Modal/VotingPower.vue
@@ -37,7 +37,8 @@ const error = computed(() => props.votingPowerStatus === 'error');
       <div v-if="error" class="p-4 flex flex-col gap-3 items-start">
         <UiAlert type="error">There was an error fetching your voting power.</UiAlert>
         <UiButton class="space-x-2" @click="$emit('getVotingPower')">
-          <IH-refresh />Retry
+          <IH-refresh />
+          <span>Retry</span>
         </UiButton>
       </div>
       <div

--- a/apps/ui/src/components/Modal/VotingPower.vue
+++ b/apps/ui/src/components/Modal/VotingPower.vue
@@ -36,7 +36,7 @@ const error = computed(() => props.votingPowerStatus === 'error');
     <div v-else>
       <div v-if="error" class="p-4 flex flex-col gap-3 items-start">
         <UiAlert type="error">There was an error fetching your voting power.</UiAlert>
-        <UiButton type="button" class="flex items-center gap-2" @click="$emit('getVotingPower')">
+        <UiButton class="space-x-2" @click="$emit('getVotingPower')">
           <IH-refresh />Retry
         </UiButton>
       </div>

--- a/apps/ui/src/components/Modal/VotingPower.vue
+++ b/apps/ui/src/components/Modal/VotingPower.vue
@@ -36,7 +36,7 @@ const error = computed(() => props.votingPowerStatus === 'error');
     <div v-else>
       <div v-if="error" class="p-4 flex flex-col gap-3 items-start">
         <UiAlert type="error">There was an error fetching your voting power.</UiAlert>
-        <UiButton class="space-x-2" @click="$emit('getVotingPower')">
+        <UiButton @click="$emit('getVotingPower')">
           <IH-refresh />
           <span>Retry</span>
         </UiButton>

--- a/apps/ui/src/components/ProposalExecutionActions.vue
+++ b/apps/ui/src/components/ProposalExecutionActions.vue
@@ -61,7 +61,7 @@ const network = computed(() => getNetwork(props.proposal.network));
     <template v-else>
       <UiButton
         v-if="hasFinalize"
-        class="mb-2 w-full flex justify-center items-center"
+        class="mb-2 w-full"
         :loading="finalizeProposalSending"
         @click="finalizeProposal"
       >
@@ -70,7 +70,7 @@ const network = computed(() => getNetwork(props.proposal.network));
       </UiButton>
       <UiButton
         v-else-if="proposal.state !== 'executed'"
-        class="mb-2 w-full flex justify-center items-center"
+        class="mb-2 w-full"
         :loading="executeProposalSending"
         @click="executeProposal"
       >
@@ -81,7 +81,7 @@ const network = computed(() => getNetwork(props.proposal.network));
         v-if="hasExecuteQueued"
         :disabled="executionCountdown > 0"
         :title="executionCountdown === 0 ? '' : 'Veto period has not ended yet'"
-        class="mb-2 w-full flex justify-center items-center"
+        class="mb-2 w-full"
         :loading="executeQueuedProposalSending"
         @click="executeQueuedProposal"
       >
@@ -100,7 +100,7 @@ const network = computed(() => getNetwork(props.proposal.network));
           compareAddresses(proposal.timelock_veto_guardian, web3.account)
         "
         :disabled="executionCountdown === 0"
-        class="mb-2 w-full flex justify-center items-center"
+        class="mb-2 w-full"
         :loading="vetoProposalSending"
         @click="vetoProposal"
       >

--- a/apps/ui/src/components/ProposalExecutionActions.vue
+++ b/apps/ui/src/components/ProposalExecutionActions.vue
@@ -61,31 +61,31 @@ const network = computed(() => getNetwork(props.proposal.network));
     <template v-else>
       <UiButton
         v-if="hasFinalize"
-        class="mb-2 w-full"
+        class="mb-2 w-full space-x-2"
         :loading="finalizeProposalSending"
         @click="finalizeProposal"
       >
-        <IH-check-circle class="inline-block mr-2" />
+        <IH-check-circle class="shrink-0" />
         Finalize proposal
       </UiButton>
       <UiButton
         v-else-if="proposal.state !== 'executed'"
-        class="mb-2 w-full"
+        class="mb-2 w-full space-x-2"
         :loading="executeProposalSending"
         @click="executeProposal"
       >
-        <IH-play class="inline-block mr-2" />
+        <IH-play class="shrink-0" />
         Execute proposal
       </UiButton>
       <UiButton
         v-if="hasExecuteQueued"
         :disabled="executionCountdown > 0"
         :title="executionCountdown === 0 ? '' : 'Veto period has not ended yet'"
-        class="mb-2 w-full"
+        class="mb-2 w-full space-x-2"
         :loading="executeQueuedProposalSending"
         @click="executeQueuedProposal"
       >
-        <IH-play class="inline-block mr-2 flex-shrink-0" />
+        <IH-play class="shrink-0" />
         <template v-if="executionCountdown === 0">Execute queued transactions</template>
         <template v-else>
           Execution available in {{ dayjs.duration(executionCountdown).format('HH:mm:ss') }}
@@ -100,11 +100,11 @@ const network = computed(() => getNetwork(props.proposal.network));
           compareAddresses(proposal.timelock_veto_guardian, web3.account)
         "
         :disabled="executionCountdown === 0"
-        class="mb-2 w-full"
+        class="mb-2 w-full space-x-2"
         :loading="vetoProposalSending"
         @click="vetoProposal"
       >
-        <IH-play class="inline-block mr-2 flex-shrink-0" />
+        <IH-play class="shrink-0" />
         Veto execution
       </UiButton>
     </template>

--- a/apps/ui/src/components/ProposalVoteApproval.vue
+++ b/apps/ui/src/components/ProposalVoteApproval.vue
@@ -27,7 +27,7 @@ function toggleSelectedChoice(choice: number) {
       <UiButton
         v-for="(choice, index) in proposal.choices"
         :key="index"
-        class="!h-[48px] text-left w-full flex items-center"
+        class="!h-[48px] text-left w-full"
         :class="{ 'border-skin-text': selectedChoices.includes(index + 1) }"
         @click="toggleSelectedChoice(index + 1)"
       >

--- a/apps/ui/src/components/ProposalVoteBasic.vue
+++ b/apps/ui/src/components/ProposalVoteBasic.vue
@@ -17,34 +17,34 @@ const emit = defineEmits<{
 <template>
   <div class="flex space-x-2">
     <UiTooltip title="For">
-      <UiButton
-        class="!text-skin-success !border-skin-success !px-0"
-        :class="{ '!w-[48px] !h-[48px]': size === 48, '!w-[40px] !h-[40px]': size === 40 }"
+      <UiButtonRound
+        class="!text-skin-success !border-skin-success"
+        :size="size"
         :loading="sendingType === 'for'"
         @click="emit('vote', 'for')"
       >
         <IH-check />
-      </UiButton>
+      </UiButtonRound>
     </UiTooltip>
     <UiTooltip title="Against">
-      <UiButton
-        class="!text-skin-danger !border-skin-danger !px-0"
-        :class="{ '!w-[48px] !h-[48px]': size === 48, '!w-[40px] !h-[40px]': size === 40 }"
+      <UiButtonRound
+        class="!text-skin-danger !border-skin-danger"
+        :size="size"
         :loading="sendingType === 'against'"
         @click="emit('vote', 'against')"
       >
         <IH-x />
-      </UiButton>
+      </UiButtonRound>
     </UiTooltip>
     <UiTooltip title="Abstain">
-      <UiButton
-        class="!text-gray-500 !border-gray-500 !px-0"
-        :class="{ '!w-[48px] !h-[48px]': size === 48, '!w-[40px] !h-[40px]': size === 40 }"
+      <UiButtonRound
+        class="!text-gray-500 !border-gray-500"
+        :size="size"
         :loading="sendingType === 'abstain'"
         @click="emit('vote', 'abstain')"
       >
         <IH-minus-sm />
-      </UiButton>
+      </UiButtonRound>
     </UiTooltip>
   </div>
 </template>

--- a/apps/ui/src/components/ProposalVoteBasic.vue
+++ b/apps/ui/src/components/ProposalVoteBasic.vue
@@ -23,7 +23,7 @@ const emit = defineEmits<{
         :loading="sendingType === 'for'"
         @click="emit('vote', 'for')"
       >
-        <IH-check class="inline-block" />
+        <IH-check />
       </UiButton>
     </UiTooltip>
     <UiTooltip title="Against">
@@ -33,7 +33,7 @@ const emit = defineEmits<{
         :loading="sendingType === 'against'"
         @click="emit('vote', 'against')"
       >
-        <IH-x class="inline-block" />
+        <IH-x />
       </UiButton>
     </UiTooltip>
     <UiTooltip title="Abstain">
@@ -43,7 +43,7 @@ const emit = defineEmits<{
         :loading="sendingType === 'abstain'"
         @click="emit('vote', 'abstain')"
       >
-        <IH-minus-sm class="inline-block" />
+        <IH-minus-sm />
       </UiButton>
     </UiTooltip>
   </div>

--- a/apps/ui/src/components/ProposalVoteRankedChoice.vue
+++ b/apps/ui/src/components/ProposalVoteRankedChoice.vue
@@ -24,7 +24,7 @@ const selectedChoices = ref<number[]>(props.proposal.choices.map((_, i) => i + 1
       item-key="id"
     >
       <template #item="{ element, index }">
-        <UiButton class="!h-[48px] text-left w-full flex items-center handle cursor-grab gap-2">
+        <UiButton class="!h-[48px] text-left w-full handle cursor-grab gap-2">
           <IC-drag class="text-skin-text" />
 
           <div class="grow truncate">

--- a/apps/ui/src/components/ProposalVoteRankedChoice.vue
+++ b/apps/ui/src/components/ProposalVoteRankedChoice.vue
@@ -24,14 +24,13 @@ const selectedChoices = ref<number[]>(props.proposal.choices.map((_, i) => i + 1
       item-key="id"
     >
       <template #item="{ element, index }">
-        <UiButton class="!h-[48px] text-left w-full handle cursor-grab gap-2">
+        <UiButton class="!h-[48px] text-left w-full handle cursor-grab">
           <IC-drag class="text-skin-text" />
-
           <div class="grow truncate">
             {{ proposal.choices[element - 1] }}
           </div>
           <div
-            class="h-[18px] min-w-[18px] rounded-full leading-[18px] text-[13px] text-skin-link bg-skin-border px-2 text-center inline-block"
+            class="h-[18px] min-w-[18px] rounded-full leading-[18px] text-[13px] text-skin-link bg-skin-border px-2 text-center"
           >
             #{{ index + 1 }}
           </div>

--- a/apps/ui/src/components/ProposalVoteSingleChoice.vue
+++ b/apps/ui/src/components/ProposalVoteSingleChoice.vue
@@ -19,7 +19,7 @@ const selectedChoice = ref<number | null>(null);
       <UiButton
         v-for="(choice, index) in proposal.choices"
         :key="index"
-        class="!h-[48px] text-left w-full flex items-center"
+        class="!h-[48px] text-left w-full"
         :class="{ 'border-skin-text': selectedChoice === index + 1 }"
         @click="selectedChoice = index + 1"
       >

--- a/apps/ui/src/components/ProposalVoteWeighted.vue
+++ b/apps/ui/src/components/ProposalVoteWeighted.vue
@@ -56,25 +56,23 @@ watch(
         </div>
 
         <div class="flex gap-1 items-center">
-          <UiButton
+          <UiButtonRound
             :disabled="!selectedChoices[i + 1]"
-            class="rounded-full !p-0 !h-[28px] !w-[28px] text-sm shrink-0"
+            :size="28"
+            class="text-sm"
             @click.stop="decreaseChoice(i + 1)"
           >
             -
-          </UiButton>
+          </UiButtonRound>
           <UiInputNumber
             v-model.number="selectedChoices[i + 1]"
             :definition="{ examples: [0] }"
             min="0"
             class="!w-[18px] !px-0 !m-0 text-center !rounded-none !border-0 shrink-0"
           />
-          <UiButton
-            class="rounded-full !p-0 !h-[28px] !w-[28px] text-sm shrink-0"
-            @click.stop="increaseChoice(i + 1)"
-          >
+          <UiButtonRound :size="28" class="text-sm" @click.stop="increaseChoice(i + 1)">
             +
-          </UiButton>
+          </UiButtonRound>
         </div>
         <div
           class="top-0 left-0 bottom-0 absolute bg-skin-border opacity-40 -z-10"

--- a/apps/ui/src/components/ProposalsList.vue
+++ b/apps/ui/src/components/ProposalsList.vue
@@ -43,8 +43,8 @@ const currentLimit = computed(() => {
           :show-space="showSpace"
         />
       </UiContainerInfiniteScroll>
-      <div v-if="!proposals.length" class="px-4 py-3 flex items-center text-skin-link">
-        <IH-exclamation-circle class="inline-block mr-2" />
+      <div v-if="!proposals.length" class="px-4 py-3 space-x-2 flex items-center text-skin-link">
+        <IH-exclamation-circle />
         <span v-text="'There are no proposals here.'" />
       </div>
       <router-link

--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -68,7 +68,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
       <div class="flex-auto" />
       <UiTooltip title="Delegate">
         <UiButton class="!px-0 w-[46px]" @click="delegateModalOpen = true">
-          <IH-user-add class="inline-block" />
+          <IH-user-add />
         </UiButton>
       </UiTooltip>
     </div>

--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -67,9 +67,9 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
     <div v-if="delegation.contractAddress" class="p-4 space-x-2 flex">
       <div class="flex-auto" />
       <UiTooltip title="Delegate">
-        <UiButton class="!px-0 w-[46px]" @click="delegateModalOpen = true">
+        <UiButtonRound @click="delegateModalOpen = true">
           <IH-user-add />
-        </UiButton>
+        </UiButtonRound>
       </UiTooltip>
     </div>
     <UiLabel label="Delegates" sticky />

--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -152,7 +152,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
             width="480"
             height="332"
             viewBox="0 0 480 332"
-            class="inline-block w-[26px] h-[26px]"
+            class="w-[26px] h-[26px]"
           >
             <path
               fill="rgba(var(--link))"
@@ -169,7 +169,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
       </UiTooltip>
       <UiTooltip v-if="!isReadOnly" :title="page === 'tokens' ? 'Send token' : 'Send NFT'">
         <UiButton class="!px-0 w-[46px]" @click="openModal(page)">
-          <IH-arrow-sm-right class="inline-block -rotate-45" />
+          <IH-arrow-sm-right class="-rotate-45" />
         </UiButton>
       </UiTooltip>
     </div>

--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -163,8 +163,8 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
       </UiTooltip>
       <UiTooltip title="Copy address">
         <UiButton class="!px-0 w-[46px]" @click="copy(treasury.wallet)">
-          <IH-duplicate v-if="!copied" class="inline-block" />
-          <IH-check v-else class="inline-block" />
+          <IH-duplicate v-if="!copied" />
+          <IH-check v-else />
         </UiButton>
       </UiTooltip>
       <UiTooltip v-if="!isReadOnly" :title="page === 'tokens' ? 'Send token' : 'Send NFT'">
@@ -265,7 +265,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
                 :touch="false"
               >
                 <UiButton class="!px-0 w-[46px]" @click.prevent="openModal('stake')">
-                  <IH-fire class="inline-block" />
+                  <IH-fire />
                 </UiButton>
               </UiTooltip>
             </div>

--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -146,7 +146,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
         v-if="currentNetworkId && evmNetworks.includes(currentNetworkId) && !isReadOnly"
         title="Connect to apps"
       >
-        <UiButton class="!px-0 w-[46px]" @click="modalOpen.walletConnectLink = true">
+        <UiButtonRound @click="modalOpen.walletConnectLink = true">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="480"
@@ -159,18 +159,18 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
               d="m126.613 93.9842c62.622-61.3123 164.152-61.3123 226.775 0l7.536 7.3788c3.131 3.066 3.131 8.036 0 11.102l-25.781 25.242c-1.566 1.533-4.104 1.533-5.67 0l-10.371-10.154c-43.687-42.7734-114.517-42.7734-158.204 0l-11.107 10.874c-1.565 1.533-4.103 1.533-5.669 0l-25.781-25.242c-3.132-3.066-3.132-8.036 0-11.102zm280.093 52.2038 22.946 22.465c3.131 3.066 3.131 8.036 0 11.102l-103.463 101.301c-3.131 3.065-8.208 3.065-11.339 0l-73.432-71.896c-.783-.767-2.052-.767-2.835 0l-73.43 71.896c-3.131 3.065-8.208 3.065-11.339 0l-103.4657-101.302c-3.1311-3.066-3.1311-8.036 0-11.102l22.9456-22.466c3.1311-3.065 8.2077-3.065 11.3388 0l73.4333 71.897c.782.767 2.051.767 2.834 0l73.429-71.897c3.131-3.065 8.208-3.065 11.339 0l73.433 71.897c.783.767 2.052.767 2.835 0l73.431-71.895c3.132-3.066 8.208-3.066 11.339 0z"
             />
           </svg>
-        </UiButton>
+        </UiButtonRound>
       </UiTooltip>
       <UiTooltip title="Copy address">
-        <UiButton class="!px-0 w-[46px]" @click="copy(treasury.wallet)">
+        <UiButtonRound @click="copy(treasury.wallet)">
           <IH-duplicate v-if="!copied" />
           <IH-check v-else />
-        </UiButton>
+        </UiButtonRound>
       </UiTooltip>
       <UiTooltip v-if="!isReadOnly" :title="page === 'tokens' ? 'Send token' : 'Send NFT'">
-        <UiButton class="!px-0 w-[46px]" @click="openModal(page)">
+        <UiButtonRound @click="openModal(page)">
           <IH-arrow-sm-right class="-rotate-45" />
-        </UiButton>
+        </UiButtonRound>
       </UiTooltip>
     </div>
     <div class="space-y-3">
@@ -264,9 +264,9 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
                 title="Stake with Lido"
                 :touch="false"
               >
-                <UiButton class="!px-0 w-[46px]" @click.prevent="openModal('stake')">
+                <UiButtonRound @click.prevent="openModal('stake')">
                   <IH-fire />
-                </UiButton>
+                </UiButtonRound>
               </UiTooltip>
             </div>
             <div

--- a/apps/ui/src/components/StrategiesConfigurator.vue
+++ b/apps/ui/src/components/StrategiesConfigurator.vue
@@ -89,12 +89,16 @@ function handleStrategySave(value: Record<string, any>) {
           </div>
         </div>
         <div class="flex gap-3">
-          <a v-if="strategy.paramsDefinition" @click="editStrategy(strategy)">
+          <UiButton
+            v-if="strategy.paramsDefinition"
+            class="!border-0 !px-0 !h-auto"
+            @click="editStrategy(strategy)"
+          >
             <IH-pencil />
-          </a>
-          <a @click="removeStrategy(strategy)">
+          </UiButton>
+          <UiButton class="!border-0 !px-0 !h-auto" @click="removeStrategy(strategy)">
             <IH-trash />
-          </a>
+          </UiButton>
         </div>
       </div>
     </div>

--- a/apps/ui/src/components/StrategiesConfigurator.vue
+++ b/apps/ui/src/components/StrategiesConfigurator.vue
@@ -89,14 +89,10 @@ function handleStrategySave(value: Record<string, any>) {
           </div>
         </div>
         <div class="flex gap-3">
-          <UiButton
-            v-if="strategy.paramsDefinition"
-            class="!border-0 !px-0 !h-auto"
-            @click="editStrategy(strategy)"
-          >
+          <UiButton v-if="strategy.paramsDefinition" simple @click="editStrategy(strategy)">
             <IH-pencil />
           </UiButton>
-          <UiButton class="!border-0 !px-0 !h-auto" @click="removeStrategy(strategy)">
+          <UiButton simple @click="removeStrategy(strategy)">
             <IH-trash />
           </UiButton>
         </div>

--- a/apps/ui/src/components/Ui/Button.vue
+++ b/apps/ui/src/components/Ui/Button.vue
@@ -5,12 +5,14 @@ withDefaults(
     primary?: boolean;
     loading?: boolean;
     disabled?: boolean;
+    simple?: boolean;
   }>(),
   {
     type: 'button',
     primary: false,
     loading: false,
-    disabled: false
+    disabled: false,
+    simple: false
   }
 );
 </script>
@@ -19,8 +21,11 @@ withDefaults(
   <button
     :type="type"
     :disabled="disabled || loading"
-    :class="primary && 'primary'"
     class="s-button"
+    :class="{
+      '!border-0 !px-0 !h-auto': simple,
+      primary: primary
+    }"
   >
     <UiLoading v-if="loading" :inverse="primary" />
     <slot v-else />

--- a/apps/ui/src/components/Ui/Button.vue
+++ b/apps/ui/src/components/Ui/Button.vue
@@ -20,22 +20,9 @@ withDefaults(
     :type="type"
     :disabled="disabled || loading"
     :class="primary && 'primary'"
-    class="rounded-full leading-[100%] border button px-3.5 h-[46px] text-skin-link bg-skin-bg"
+    class="s-button"
   >
     <UiLoading v-if="loading" :inverse="primary" />
     <slot v-else />
   </button>
 </template>
-
-<style scoped lang="scss">
-.button {
-  &:disabled {
-    color: rgba(var(--border)) !important;
-    cursor: not-allowed;
-  }
-
-  &.primary {
-    @apply bg-skin-link text-skin-bg border-skin-link;
-  }
-}
-</style>

--- a/apps/ui/src/components/Ui/Button.vue
+++ b/apps/ui/src/components/Ui/Button.vue
@@ -24,6 +24,7 @@ withDefaults(
     class="s-button"
     :class="{
       '!border-0 !px-0 !h-auto': simple,
+      'min-w-[46px]': !simple,
       primary: primary
     }"
   >

--- a/apps/ui/src/components/Ui/ButtonRound.vue
+++ b/apps/ui/src/components/Ui/ButtonRound.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    primary?: boolean;
+    loading?: boolean;
+    disabled?: boolean;
+    size?: number;
+  }>(),
+  {
+    primary: false,
+    loading: false,
+    disabled: false,
+    size: 46
+  }
+);
+</script>
+
+<template>
+  <UiButton
+    :disabled="disabled || loading"
+    :loading="loading"
+    :class="`!px-0 shrink-0 w-[${size}px] !h-[${size}px]`"
+  >
+    <slot />
+  </UiButton>
+</template>

--- a/apps/ui/src/style.scss
+++ b/apps/ui/src/style.scss
@@ -268,6 +268,19 @@ input:placeholder-shown {
 
 // Shot UI kit
 
+.s-button {
+  @apply rounded-full leading-[100%] border px-3.5 h-[46px] text-skin-link bg-skin-bg flex items-center justify-center;
+
+  &:disabled {
+    color: rgba(var(--border)) !important;
+    cursor: not-allowed;
+  }
+
+  &.primary {
+    @apply bg-skin-link text-skin-bg border-skin-link;
+  }
+}
+
 .s-input {
   @apply text-skin-heading border border-skin-border block rounded-[24px] py-2 px-3 w-full bg-transparent mb-3 focus:outline-none;
 }

--- a/apps/ui/src/style.scss
+++ b/apps/ui/src/style.scss
@@ -269,7 +269,7 @@ input:placeholder-shown {
 // Shot UI kit
 
 .s-button {
-  @apply rounded-full leading-[100%] border px-3.5 h-[46px] text-skin-link bg-skin-bg flex items-center justify-center;
+  @apply rounded-full leading-[100%] border px-3.5 h-[46px] text-skin-link bg-skin-bg flex items-center justify-center space-x-2;
 
   &:disabled {
     color: rgba(var(--border)) !important;

--- a/apps/ui/src/views/App.vue
+++ b/apps/ui/src/views/App.vue
@@ -31,8 +31,8 @@ onMounted(() => load());
               <div v-text="app.category" />
             </div>
           </div>
-          <a v-if="app.link" :href="app.link" target="_blank">
-            <UiButton class="primary w-full">Use integration</UiButton>
+          <a v-if="app.link" :href="app.link" target="_blank" class="s-button primary w-full">
+            Use integration
           </a>
         </div>
         <div class="md:flex md:space-x-4">

--- a/apps/ui/src/views/Editor.vue
+++ b/apps/ui/src/views/Editor.vue
@@ -325,26 +325,24 @@ export default defineComponent({
 <template>
   <div v-if="proposal">
     <nav class="border-b bg-skin-bg fixed top-0 z-50 right-0 left-0 lg:left-[72px]">
-      <div class="flex items-center h-[71px] mx-4">
-        <div class="flex-auto space-x-2">
-          <router-link :to="{ name: 'space-overview', params: { id: param } }" class="mr-2">
-            <UiButton class="leading-3 w-[46px] !px-0">
-              <IH-arrow-narrow-left class="inline-block" />
-            </UiButton>
+      <div class="flex items-center h-[71px] mx-4 leading-[46px]">
+        <div class="flex space-x-3 grow truncate">
+          <router-link
+            :to="{ name: 'space-overview', params: { id: param } }"
+            class="s-button w-[46px] !p-0 shrink-0"
+          >
+            <IH-arrow-narrow-left />
           </router-link>
-          <h4 class="py-2 inline-block">New proposal</h4>
+          <h4 class="truncate">New proposal</h4>
         </div>
         <IndicatorPendingTransactions class="mr-2" />
         <UiLoading v-if="!space" class="block p-4" />
-        <div v-else class="space-x-2">
-          <UiButton
-            class="float-left leading-3 !pl-3 !pr-2.5 rounded-r-none"
-            @click="modalOpen = true"
-          >
-            <IH-collection class="inline-block" />
+        <div v-else class="flex">
+          <UiButton class="!pl-3 !pr-2.5 !rounded-r-none" @click="modalOpen = true">
+            <IH-collection />
           </UiButton>
           <UiButton
-            class="rounded-l-none border-l-0 float-left !m-0 !px-3"
+            class="!rounded-l-none !border-l-0 !m-0 !px-3"
             :loading="sending || (web3.account !== '' && fetchingVotingPower)"
             :disabled="!canSubmit"
             @click="handleProposeClick"

--- a/apps/ui/src/views/Editor.vue
+++ b/apps/ui/src/views/Editor.vue
@@ -351,7 +351,7 @@ export default defineComponent({
               class="hidden mr-2 md:inline-block"
               v-text="proposal?.proposalId ? 'Update' : 'Publish'"
             />
-            <IH-paper-airplane class="inline-block rotate-90" />
+            <IH-paper-airplane class="rotate-90" />
           </UiButton>
         </div>
       </div>

--- a/apps/ui/src/views/Landing.vue
+++ b/apps/ui/src/views/Landing.vue
@@ -27,12 +27,12 @@ const SOCIALS = [
     <div class="py-8 mb-6 border-b hero">
       <UiContainer class="!max-w-screen-md my-1">
         <h1 class="mb-4 mono max-w-[580px]">The governance stack for your organization.</h1>
-        <a href="https://tally.so/r/wA2D2o" target="_blank">
-          <UiButton class="primary">
-            Sign up for beta
-            <IH-arrow-sm-right class="inline-block -rotate-45" />
-          </UiButton>
-        </a>
+        <div class="inline-block">
+          <a href="https://tally.so/r/wA2D2o" target="_blank" class="s-button primary space-x-1">
+            <span>Sign up for beta</span>
+            <IH-arrow-sm-right class="-rotate-45" />
+          </a>
+        </div>
       </UiContainer>
     </div>
     <UiContainer class="!max-w-screen-md space-y-4">

--- a/apps/ui/src/views/Network.vue
+++ b/apps/ui/src/views/Network.vue
@@ -81,14 +81,10 @@ watchEffect(() => setTitle('Network'));
     <div class="py-8 text-center">
       <UiContainer class="!max-w-[880px] my-1">
         <h1 class="mb-4 mono max-w-[600px] mx-auto">Unlock governance for your ecosystem.</h1>
-        <div class="space-x-2">
-          <a target="_blank">
-            <a :href="LINK" target="_blank">
-              <UiButton class="primary">
-                Talk to sales
-                <IH-arrow-sm-right class="inline-block -rotate-45" />
-              </UiButton>
-            </a>
+        <div class="inline-block">
+          <a :href="LINK" target="_blank" class="s-button primary space-x-1">
+            <span>Talk to sales</span>
+            <IH-arrow-sm-right class="-rotate-45" />
           </a>
         </div>
       </UiContainer>
@@ -151,12 +147,12 @@ watchEffect(() => setTitle('Network'));
     <UiContainer class="!max-w-[880px] text-center">
       <div class="eyebrow mb-2">Get started</div>
       <h1 class="mb-3">Start your integration</h1>
-      <a :href="LINK" target="_blank">
-        <UiButton class="primary">
-          Talk to sales
-          <IH-arrow-sm-right class="inline-block -rotate-45" />
-        </UiButton>
-      </a>
+      <div class="inline-block">
+        <a :href="LINK" target="_blank" class="s-button primary space-x-1">
+          <span>Talk to sales</span>
+          <IH-arrow-sm-right class="-rotate-45" />
+        </a>
+      </div>
     </UiContainer>
 
     <UiContainer class="!max-w-[880px]">

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -238,10 +238,10 @@ onBeforeUnmount(() => destroyAudio());
               :disabled="aiSummaryState.loading"
               @click="handleAiSummaryClick"
             >
-              <UiLoading v-if="aiSummaryState.loading" class="inline-block !w-[22px] !h-[22px]" />
+              <UiLoading v-if="aiSummaryState.loading" class="!w-[22px] !h-[22px]" />
               <IH-sparkles
                 v-else
-                class="inline-block w-[22px] h-[22px]"
+                class="w-[22px] h-[22px]"
                 :class="aiSummaryOpen ? 'text-skin-link' : 'text-skin-text'"
               />
             </UiButton>
@@ -259,25 +259,25 @@ onBeforeUnmount(() => destroyAudio());
               :disabled="aiSpeechState.loading"
               @click="handleAiSpeechClick"
             >
-              <UiLoading v-if="aiSpeechState.loading" class="inline-block !w-[22px] !h-[22px]" />
+              <UiLoading v-if="aiSpeechState.loading" class="!w-[22px] !h-[22px]" />
               <IH-pause
                 v-else-if="audioState === 'playing'"
-                class="inline-block w-[22px] h-[22px] text-skin-link"
+                class="w-[22px] h-[22px] text-skin-link"
               />
-              <IH-play v-else class="inline-block text-skin-text w-[22px] h-[22px]" />
+              <IH-play v-else class="text-skin-text w-[22px] h-[22px]" />
             </UiButton>
           </UiTooltip>
           <DropdownShare :message="shareMsg">
             <template #button>
               <UiButton class="!p-0 !border-0 !h-auto">
-                <IH-share class="text-skin-text inline-block w-[22px] h-[22px]" />
+                <IH-share class="text-skin-text w-[22px] h-[22px]" />
               </UiButton>
             </template>
           </DropdownShare>
           <UiDropdown>
             <template #button>
               <UiButton class="!p-0 !border-0 !h-auto">
-                <IH-dots-vertical class="text-skin-text inline-block w-[22px] h-[22px]" />
+                <IH-dots-vertical class="text-skin-text w-[22px] h-[22px]" />
               </UiButton>
             </template>
             <template #items>

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -226,7 +226,7 @@ onBeforeUnmount(() => destroyAudio());
             >
           </div>
         </router-link>
-        <div class="flex gap-2 items-center">
+        <div class="flex space-x-2 items-center">
           <UiTooltip
             v-if="
               offchainNetworks.includes(props.proposal.network) && props.proposal.body.length > 500
@@ -234,13 +234,12 @@ onBeforeUnmount(() => destroyAudio());
             :title="'AI summary'"
           >
             <UiButton
-              class="!p-0 !border-0 !h-[auto]"
+              simple
+              :loading="aiSummaryState.loading"
               :disabled="aiSummaryState.loading"
               @click="handleAiSummaryClick"
             >
-              <UiLoading v-if="aiSummaryState.loading" class="!w-[22px] !h-[22px]" />
               <IH-sparkles
-                v-else
                 class="w-[22px] h-[22px]"
                 :class="aiSummaryOpen ? 'text-skin-link' : 'text-skin-text'"
               />
@@ -255,28 +254,25 @@ onBeforeUnmount(() => destroyAudio());
             :title="audioState === 'playing' ? 'Pause' : 'Listen'"
           >
             <UiButton
-              class="!p-0 !border-0 !h-[auto]"
+              simple
+              :loading="aiSpeechState.loading"
               :disabled="aiSpeechState.loading"
               @click="handleAiSpeechClick"
             >
-              <UiLoading v-if="aiSpeechState.loading" class="!w-[22px] !h-[22px]" />
-              <IH-pause
-                v-else-if="audioState === 'playing'"
-                class="w-[22px] h-[22px] text-skin-link"
-              />
+              <IH-pause v-if="audioState === 'playing'" class="w-[22px] h-[22px] text-skin-link" />
               <IH-play v-else class="text-skin-text w-[22px] h-[22px]" />
             </UiButton>
           </UiTooltip>
           <DropdownShare :message="shareMsg">
             <template #button>
-              <UiButton class="!p-0 !border-0 !h-auto">
+              <UiButton simple>
                 <IH-share class="text-skin-text w-[22px] h-[22px]" />
               </UiButton>
             </template>
           </DropdownShare>
           <UiDropdown>
             <template #button>
-              <UiButton class="!p-0 !border-0 !h-auto">
+              <UiButton simple>
                 <IH-dots-vertical class="text-skin-text w-[22px] h-[22px]" />
               </UiButton>
             </template>

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -234,7 +234,7 @@ onBeforeUnmount(() => destroyAudio());
             :title="'AI summary'"
           >
             <UiButton
-              class="!p-0 border-0 !h-[auto]"
+              class="!p-0 !border-0 !h-[auto]"
               :disabled="aiSummaryState.loading"
               @click="handleAiSummaryClick"
             >
@@ -255,7 +255,7 @@ onBeforeUnmount(() => destroyAudio());
             :title="audioState === 'playing' ? 'Pause' : 'Listen'"
           >
             <UiButton
-              class="!p-0 border-0 !h-[auto]"
+              class="!p-0 !border-0 !h-[auto]"
               :disabled="aiSpeechState.loading"
               @click="handleAiSpeechClick"
             >
@@ -269,14 +269,14 @@ onBeforeUnmount(() => destroyAudio());
           </UiTooltip>
           <DropdownShare :message="shareMsg">
             <template #button>
-              <UiButton class="!p-0 border-0 !h-[auto]">
+              <UiButton class="!p-0 !border-0 !h-auto">
                 <IH-share class="text-skin-text inline-block w-[22px] h-[22px]" />
               </UiButton>
             </template>
           </DropdownShare>
           <UiDropdown>
             <template #button>
-              <UiButton class="!p-0 border-0 !h-[auto]">
+              <UiButton class="!p-0 !border-0 !h-auto">
                 <IH-dots-vertical class="text-skin-text inline-block w-[22px] h-[22px]" />
               </UiButton>
             </template>

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -212,9 +212,9 @@ watch([sortBy, choiceFilter], () => {
                 '!text-gray-500 !border-gray-500': vote.choice === 3
               }"
             >
-              <IH-check v-if="vote.choice === 1" class="inline-block" />
-              <IH-x v-else-if="vote.choice === 2" class="inline-block" />
-              <IH-minus-sm v-else class="inline-block" />
+              <IH-check v-if="vote.choice === 1" />
+              <IH-x v-else-if="vote.choice === 2" />
+              <IH-minus-sm v-else />
             </UiButton>
           </template>
         </div>

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -203,9 +203,10 @@ watch([sortBy, choiceFilter], () => {
             >
               {{ getChoiceText(proposal.choices, vote.choice) }}
             </UiTooltip>
-            <UiButton
+            <UiButtonRound
               v-else
-              class="!w-[40px] !h-[40px] !px-0 cursor-default bg-transparent"
+              :size="40"
+              class="cursor-default bg-transparent"
               :class="{
                 '!text-skin-success !border-skin-success': vote.choice === 1,
                 '!text-skin-danger !border-skin-danger': vote.choice === 2,
@@ -215,7 +216,7 @@ watch([sortBy, choiceFilter], () => {
               <IH-check v-if="vote.choice === 1" />
               <IH-x v-else-if="vote.choice === 2" />
               <IH-minus-sm v-else />
-            </UiButton>
+            </UiButtonRound>
           </template>
         </div>
         <div

--- a/apps/ui/src/views/Settings/Contacts.vue
+++ b/apps/ui/src/views/Settings/Contacts.vue
@@ -27,11 +27,9 @@ function handleContactEdit(contact) {
     <div class="flex">
       <div class="flex-auto" />
       <div class="pt-4 px-4 space-x-2">
-        <a>
-          <UiButton class="!px-0 w-[46px]" @click="openModal('editContact')">
-            <IH-plus-sm />
-          </UiButton>
-        </a>
+        <UiButton class="!px-0 w-[46px]" @click="openModal('editContact')">
+          <IH-plus-sm />
+        </UiButton>
       </div>
     </div>
     <UiLabel label="Contacts" />

--- a/apps/ui/src/views/Settings/Contacts.vue
+++ b/apps/ui/src/views/Settings/Contacts.vue
@@ -29,7 +29,7 @@ function handleContactEdit(contact) {
       <div class="pt-4 px-4 space-x-2">
         <a>
           <UiButton class="!px-0 w-[46px]" @click="openModal('editContact')">
-            <IH-plus-sm class="inline-block" />
+            <IH-plus-sm />
           </UiButton>
         </a>
       </div>

--- a/apps/ui/src/views/Settings/Contacts.vue
+++ b/apps/ui/src/views/Settings/Contacts.vue
@@ -27,9 +27,9 @@ function handleContactEdit(contact) {
     <div class="flex">
       <div class="flex-auto" />
       <div class="pt-4 px-4 space-x-2">
-        <UiButton class="!px-0 w-[46px]" @click="openModal('editContact')">
+        <UiButtonRound @click="openModal('editContact')">
           <IH-plus-sm />
-        </UiButton>
+        </UiButtonRound>
       </div>
     </div>
     <UiLabel label="Contacts" />

--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -37,17 +37,15 @@ watchEffect(() => setTitle(props.space.name));
         <SpaceCover :space="props.space" />
       </div>
       <div class="relative bg-skin-bg h-[16px] top-[-16px] rounded-t-[16px] md:hidden" />
-      <div class="absolute right-4 top-4 space-x-2">
-        <router-link :to="{ name: 'editor' }" tabindex="-1">
-          <UiTooltip title="New proposal">
-            <UiButton class="!px-0 w-[46px]">
-              <IH-pencil-alt class="inline-block" />
-            </UiButton>
-          </UiTooltip>
-        </router-link>
+      <div class="absolute right-4 top-4 space-x-2 flex">
+        <UiTooltip title="New proposal">
+          <router-link :to="{ name: 'editor' }" class="s-button !px-0 w-[46px]">
+            <IH-pencil-alt />
+          </router-link>
+        </UiTooltip>
         <UiTooltip v-if="isController" title="Edit profile">
           <UiButton class="!px-0 w-[46px]" @click="editSpaceModalOpen = true">
-            <IH-cog class="inline-block" />
+            <IH-cog />
           </UiButton>
         </UiTooltip>
         <ButtonFollow :space="space" />

--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -44,9 +44,9 @@ watchEffect(() => setTitle(props.space.name));
           </router-link>
         </UiTooltip>
         <UiTooltip v-if="isController" title="Edit profile">
-          <UiButton class="!px-0 w-[46px]" @click="editSpaceModalOpen = true">
+          <UiButtonRound @click="editSpaceModalOpen = true">
             <IH-cog />
-          </UiButton>
+          </UiButtonRound>
         </UiTooltip>
         <ButtonFollow :space="space" />
       </div>

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -125,13 +125,11 @@ watchEffect(() => setTitle(`Proposals - ${props.space.name}`));
           :voting-powers="votingPowers"
           @get-voting-power="getVotingPower"
         />
-        <router-link :to="{ name: 'editor' }" tabindex="-1">
-          <UiTooltip title="New proposal">
-            <UiButton class="!px-0 w-[46px]">
-              <IH-pencil-alt class="inline-block" />
-            </UiButton>
-          </UiTooltip>
-        </router-link>
+        <UiTooltip title="New proposal">
+          <router-link :to="{ name: 'editor' }" class="s-button !px-0 w-[46px]">
+            <IH-pencil-alt />
+          </router-link>
+        </UiTooltip>
       </div>
     </div>
     <ProposalsList

--- a/apps/ui/src/views/User.vue
+++ b/apps/ui/src/views/User.vue
@@ -112,7 +112,7 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
         <DropdownShare :message="shareMsg" class="!px-0 w-[46px]" />
         <UiTooltip v-if="web3.account === user.id && web3.type !== 'argentx'" title="Edit profile">
           <UiButton class="!px-0 w-[46px]" @click="modalOpenEditUser = true">
-            <IH-cog class="inline-block" />
+            <IH-cog />
           </UiButton>
         </UiTooltip>
       </div>
@@ -129,12 +129,9 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
         <div class="mb-3 flex items-center space-x-2">
           <span class="text-skin-text" v-text="shortenAddress(user.id)" />
           <UiTooltip title="Copy address">
-            <UiButton
-              class="!border-0 !px-0 !h-auto !text-skin-text"
-              @click.prevent="copy(user.id)"
-            >
-              <IH-duplicate v-if="!copied" class="inline-block" />
-              <IH-check v-else class="inline-block" />
+            <UiButton simple class="!text-skin-text" @click.prevent="copy(user.id)">
+              <IH-duplicate v-if="!copied" />
+              <IH-check v-else />
             </UiButton>
           </UiTooltip>
         </div>

--- a/apps/ui/src/views/User.vue
+++ b/apps/ui/src/views/User.vue
@@ -129,10 +129,13 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
         <div class="mb-3 flex items-center space-x-2">
           <span class="text-skin-text" v-text="shortenAddress(user.id)" />
           <UiTooltip title="Copy address">
-            <a href="#" class="text-skin-text" @click.prevent="copy(user.id)">
+            <UiButton
+              class="!border-0 !px-0 !h-auto !text-skin-text"
+              @click.prevent="copy(user.id)"
+            >
               <IH-duplicate v-if="!copied" class="inline-block" />
               <IH-check v-else class="inline-block" />
-            </a>
+            </UiButton>
           </UiTooltip>
         </div>
         <div
@@ -193,7 +196,7 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
         <h4 class="text-skin-link truncate" v-text="_n(activity.vote_count)" />
         <div class="text-[17px] truncate" v-text="_p(activity.vote_percentage)" />
       </div>
-      <div class="hidden lg:block lg:w-[88px] text-right">
+      <div class="hidden lg:flex lg:w-[88px] justify-end">
         <router-link
           :to="{
             name: 'space-overview',
@@ -201,12 +204,9 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
               id: activity.spaceId
             }
           }"
-          tabindex="-1"
-          class="text-skin-link"
+          class="s-button !px-0 w-[40px] !h-[40px]"
         >
-          <UiButton class="!px-0 w-[40px] !h-[40px]">
-            <IH-arrow-sm-right class="inline-block" />
-          </UiButton>
+          <IH-arrow-sm-right />
         </router-link>
       </div>
     </div>

--- a/apps/ui/src/views/User.vue
+++ b/apps/ui/src/views/User.vue
@@ -111,9 +111,9 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
       <div class="absolute right-4 top-4 space-x-2 flex">
         <DropdownShare :message="shareMsg" class="!px-0 w-[46px]" />
         <UiTooltip v-if="web3.account === user.id && web3.type !== 'argentx'" title="Edit profile">
-          <UiButton class="!px-0 w-[46px]" @click="modalOpenEditUser = true">
+          <UiButtonRound @click="modalOpenEditUser = true">
             <IH-cog />
-          </UiButton>
+          </UiButtonRound>
         </UiTooltip>
       </div>
     </div>
@@ -201,7 +201,7 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
               id: activity.spaceId
             }
           }"
-          class="s-button !px-0 w-[40px] !h-[40px]"
+          class="s-button !px-0 w-[40px] !min-w-[40px] !h-[40px]"
         >
           <IH-arrow-sm-right />
         </router-link>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Following this discussion https://github.com/snapshot-labs/sx-monorepo/pull/476#discussion_r1687556280

This PR will convert all `<a>` with just an `onClick` handler to `UiButton`, to allow those elements to be keyboard navigation friendly, without the need to add/remove tabindex and `keypress.enter` handler

- Move the UiButton style to `s-button`
- Make all button-like element use this new `.s-button` class to looks like a link, instead of nesting a button inside a link
- Convert all link with just an onclick handler to button
- Button are now `flex` by default, remove the redundant flex classes on UiButton and `inline-block` on their content
- Add a `simple` prop to UiButton, for button without any styling
- Add a new `UiButtonRound` component for all round buttons
- Move all button with child `UiLoading` to use the `:loading` property