### PR TITLE
fix: Results percentage for offchain proposals

### DIFF
--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -220,6 +220,15 @@ export function _d(s: number) {
     .trim();
 }
 
+export function toBigIntOrNumber(value) {
+  const parsedValue = parseFloat(value);
+  if (Number.isInteger(parsedValue)) {
+    return BigInt(value);
+  } else {
+    return parsedValue;
+  }
+}
+
 export function _t(number, format = 'MMM D, YYYY · h:mm A') {
   try {
     return dayjs(number * 1e3).format(format);

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -167,7 +167,6 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
       console.warn('failed to parse oSnap execution', e);
     }
   }
-
   return {
     id: proposal.id,
     network: networkId,
@@ -191,8 +190,8 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     quorum: proposal.quorum,
     quorum_type: proposal.quorumType,
     choices: proposal.choices,
-    scores: proposal.scores.map(v => Math.floor(v)),
-    scores_total: Math.floor(proposal.scores_total),
+    scores: proposal.scores,
+    scores_total: proposal.scores_total,
     vote_count: proposal.votes,
     state: getProposalState(proposal),
     cancelled: false,

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -10,6 +10,7 @@ import {
 } from '@/helpers/utils';
 import { offchainNetworks } from '@/networks';
 import { Proposal } from '@/types';
+import { toBigIntOrNumber } from '../../helpers/utils';
 
 const props = defineProps<{
   proposal: Proposal;
@@ -385,8 +386,10 @@ onBeforeUnmount(() => destroyAudio());
           proposal.executions &&
           proposal.executions.length > 0 &&
           proposal.scores.length > 0 &&
-          BigInt(proposal.scores_total) >= BigInt(proposal.quorum) &&
-          BigInt(proposal.scores[0]) > BigInt(proposal.scores[1]) &&
+          toBigIntOrNumber(proposal.scores_total) >=
+            toBigIntOrNumber(proposal.quorum) &&
+          toBigIntOrNumber(proposal.scores[0]) >
+            toBigIntOrNumber(proposal.scores[1]) &&
           proposal.has_execution_window_opened
         "
       >


### PR DESCRIPTION
closes #527 

### Summary
- Remove `math.floor` on https://github.com/snapshot-labs/sx-monorepo/blob/master/apps/ui/src/networks/offchain/api/index.ts#L194-L195  which is ignoring decimal values coming from off-chain proposals (for example values like `0.23` or `10.23`
- On proposal page we should still handle `BigInt` https://github.com/snapshot-labs/sx-monorepo/blob/master/apps/ui/src/views/Proposal/Overview.vue#L388-L389 so I have a create a new function `toBigIntOrNumber` which can both bigInt and decimals

### How to test

1. You should be able to see results on http://localhost:8080/#/s:fabien.eth/proposal/0x476a51fa0bdd939649ce8208bf976b7057836836d9a4aeefa4ed2e466c0055a2
2. You should be able to see executable actions on proposals with executions same as before
