### PR TITLE
fix(ux): refactor all elements with only an onClick event to button

### DIFF
--- a/apps/ui/src/App.vue
+++ b/apps/ui/src/App.vue
@@ -93,6 +93,7 @@ watch(isSwiping, () => {
       <AppNav />
       <button
         v-if="uiStore.sidebarOpen"
+        type="button"
         class="backdrop lg:hidden"
         :style="{
           left: `${72 + (hasAppNav ? 240 : 0)}px`

--- a/apps/ui/src/App.vue
+++ b/apps/ui/src/App.vue
@@ -91,7 +91,7 @@ watch(isSwiping, () => {
       />
       <AppTopnav />
       <AppNav />
-      <div
+      <button
         v-if="uiStore.sidebarOpen"
         class="backdrop lg:hidden"
         :style="{

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -81,6 +81,7 @@ watch(
     >
       <div class="flex flex-grow items-center h-full">
         <button
+          type="button"
           class="inline-block text-skin-link mr-4 cursor-pointer lg:hidden"
           @click="uiStore.toggleSidebar"
         >

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -80,10 +80,12 @@ watch(
       }"
     >
       <div class="flex flex-grow items-center h-full">
-        <IH-menu-alt-2
+        <button
           class="inline-block text-skin-link mr-4 cursor-pointer lg:hidden"
           @click="uiStore.toggleSidebar"
-        />
+        >
+          <IH-menu-alt-2 />
+        </button>
         <form
           v-if="searchConfig"
           id="search-form"

--- a/apps/ui/src/components/ButtonStrategy.vue
+++ b/apps/ui/src/components/ButtonStrategy.vue
@@ -10,6 +10,7 @@ defineProps<{
 
 <template>
   <button
+    type="button"
     :disabled="disabled"
     class="flex flex-col md:flex-row rounded-lg border cursor-pointer w-full text-left items-stretch overflow-hidden"
     :class="{

--- a/apps/ui/src/components/CreateDeploymentProgress.vue
+++ b/apps/ui/src/components/CreateDeploymentProgress.vue
@@ -250,6 +250,7 @@ onMounted(() => deploy());
           <h4 v-text="step.title" />
           <button
             v-if="failed && i === currentStep"
+            type="button"
             class="text-skin-text"
             @click="deploy(currentStep)"
           >

--- a/apps/ui/src/components/CreateDeploymentProgress.vue
+++ b/apps/ui/src/components/CreateDeploymentProgress.vue
@@ -248,13 +248,13 @@ onMounted(() => deploy());
         </div>
         <div>
           <h4 v-text="step.title" />
-          <a
+          <button
             v-if="failed && i === currentStep"
             class="text-skin-text"
             @click="deploy(currentStep)"
           >
             Retry
-          </a>
+          </button>
           <a
             v-if="txIds[step.id]"
             class="inline-flex items-center"

--- a/apps/ui/src/components/DropdownShare.vue
+++ b/apps/ui/src/components/DropdownShare.vue
@@ -21,14 +21,14 @@ function handleCopyLinkClick() {
     </template>
     <template #items>
       <UiDropdownItem v-slot="{ active }">
-        <a
+        <button
           class="flex items-center gap-2"
           :class="{ 'opacity-80': active }"
           @click="handleCopyLinkClick"
         >
           <IH-link />
           Copy link
-        </a>
+        </button>
       </UiDropdownItem>
       <UiDropdownItem v-slot="{ active }">
         <a

--- a/apps/ui/src/components/DropdownShare.vue
+++ b/apps/ui/src/components/DropdownShare.vue
@@ -22,6 +22,7 @@ function handleCopyLinkClick() {
     <template #items>
       <UiDropdownItem v-slot="{ active }">
         <button
+          type="button"
           class="flex items-center gap-2"
           :class="{ 'opacity-80': active }"
           @click="handleCopyLinkClick"

--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -135,10 +135,10 @@ watch(
             </template>
             <template #right>
               <div class="flex gap-3">
-                <button @click="editTx(i)">
+                <button type="button" @click="editTx(i)">
                   <IH-pencil />
                 </button>
-                <button @click="removeTx(i)">
+                <button type="button" @click="removeTx(i)">
                   <IH-trash />
                 </button>
               </div>
@@ -163,7 +163,7 @@ watch(
           v-else-if="simulationState === null"
           title="Simulate execution"
         >
-          <button class="flex" @click="handleSimulateClick">
+          <button type="button" class="flex" @click="handleSimulateClick">
             <IH-shield-check class="text-skin-link" />
           </button>
         </UiTooltip>

--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -135,12 +135,12 @@ watch(
             </template>
             <template #right>
               <div class="flex gap-3">
-                <a @click="editTx(i)">
+                <button @click="editTx(i)">
                   <IH-pencil />
-                </a>
-                <a @click="removeTx(i)">
+                </button>
+                <button @click="removeTx(i)">
                   <IH-trash />
-                </a>
+                </button>
               </div>
             </template>
           </TransactionsListItem>

--- a/apps/ui/src/components/ExecutionButton.vue
+++ b/apps/ui/src/components/ExecutionButton.vue
@@ -15,6 +15,7 @@ const emit = defineEmits<{
 
 <template>
   <button
+    type="button"
     :disabled="disabled"
     class="button w-full text-left px-4 py-3 border-b last:border-b-0 text-skin-link space-x-2"
     :class="{}"

--- a/apps/ui/src/components/FormProfile.vue
+++ b/apps/ui/src/components/FormProfile.vue
@@ -206,10 +206,10 @@ onMounted(() => {
         <div class="whitespace-nowrap">{{ treasury.name }}</div>
       </div>
       <div class="flex gap-3">
-        <button @click="editTreasury(i)">
+        <button type="button" @click="editTreasury(i)">
           <IH-pencil />
         </button>
-        <button @click="deleteTreasury(i)">
+        <button type="button" @click="deleteTreasury(i)">
           <IH-trash />
         </button>
       </div>
@@ -225,10 +225,10 @@ onMounted(() => {
         <div class="whitespace-nowrap">{{ delegation.name }}</div>
       </div>
       <div class="flex gap-3">
-        <button @click="editDelegation(i)">
+        <button type="button" @click="editDelegation(i)">
           <IH-pencil />
         </button>
-        <button @click="deleteDelegation(i)">
+        <button type="button" @click="deleteDelegation(i)">
           <IH-trash />
         </button>
       </div>

--- a/apps/ui/src/components/FormProfile.vue
+++ b/apps/ui/src/components/FormProfile.vue
@@ -206,12 +206,12 @@ onMounted(() => {
         <div class="whitespace-nowrap">{{ treasury.name }}</div>
       </div>
       <div class="flex gap-3">
-        <a @click="editTreasury(i)">
+        <button @click="editTreasury(i)">
           <IH-pencil />
-        </a>
-        <a @click="deleteTreasury(i)">
+        </button>
+        <button @click="deleteTreasury(i)">
           <IH-trash />
-        </a>
+        </button>
       </div>
     </div>
     <UiButton class="w-full" @click="addTreasury">Add treasury</UiButton>
@@ -225,12 +225,12 @@ onMounted(() => {
         <div class="whitespace-nowrap">{{ delegation.name }}</div>
       </div>
       <div class="flex gap-3">
-        <a @click="editDelegation(i)">
+        <button @click="editDelegation(i)">
           <IH-pencil />
-        </a>
-        <a @click="deleteDelegation(i)">
+        </button>
+        <button @click="deleteDelegation(i)">
           <IH-trash />
-        </a>
+        </button>
       </div>
     </div>
     <UiButton class="w-full" @click="addDelegation">Add delegation</UiButton>

--- a/apps/ui/src/components/FormValidation.vue
+++ b/apps/ui/src/components/FormValidation.vue
@@ -91,10 +91,14 @@ watch(
             </div>
           </div>
           <div class="flex gap-3">
-            <button v-if="model.paramsDefinition" @click="editStrategy(model)">
+            <button
+              v-if="model.paramsDefinition"
+              type="button"
+              @click="editStrategy(model)"
+            >
               <IH-pencil />
             </button>
-            <button @click="removeStrategy()">
+            <button type="button" @click="removeStrategy()">
               <IH-trash />
             </button>
           </div>

--- a/apps/ui/src/components/FormValidation.vue
+++ b/apps/ui/src/components/FormValidation.vue
@@ -91,12 +91,12 @@ watch(
             </div>
           </div>
           <div class="flex gap-3">
-            <a v-if="model.paramsDefinition" @click="editStrategy(model)">
+            <button v-if="model.paramsDefinition" @click="editStrategy(model)">
               <IH-pencil />
-            </a>
-            <a @click="removeStrategy()">
+            </button>
+            <button @click="removeStrategy()">
               <IH-trash />
-            </a>
+            </button>
           </div>
         </div>
       </div>

--- a/apps/ui/src/components/Modal/Account.vue
+++ b/apps/ui/src/components/Modal/Account.vue
@@ -59,12 +59,10 @@ watch(open, () => (step.value = null));
       <h3 v-else v-text="'Account'" />
     </template>
     <div v-if="!web3.account || step === 'connect'">
-      <div class="m-4 space-y-2">
-        <a
+      <div class="m-4 flex flex-col space-y-2">
+        <button
           v-for="connector in availableConnectors"
           :key="connector.id"
-          target="_blank"
-          class="block"
           @click="$emit('login', connector.id)"
         >
           <UiButton
@@ -79,7 +77,7 @@ watch(open, () => (step.value = null));
             />
             {{ connector.name }}
           </UiButton>
-        </a>
+        </button>
       </div>
     </div>
     <div v-else>

--- a/apps/ui/src/components/Modal/Account.vue
+++ b/apps/ui/src/components/Modal/Account.vue
@@ -63,6 +63,7 @@ watch(open, () => (step.value = null));
         <button
           v-for="connector in availableConnectors"
           :key="connector.id"
+          type="button"
           @click="$emit('login', connector.id)"
         >
           <UiButton

--- a/apps/ui/src/components/Modal/Connector.vue
+++ b/apps/ui/src/components/Modal/Connector.vue
@@ -49,12 +49,10 @@ const availableConnectors = computed(() => {
       <h3 v-text="'Connect wallet'" />
     </template>
     <div>
-      <div class="m-4 space-y-2">
-        <a
+      <div class="m-4 space-y-2 flex flex-col">
+        <button
           v-for="connector in availableConnectors"
           :key="connector.id"
-          target="_blank"
-          class="block"
           @click="emit('pick', connector.id)"
         >
           <UiButton
@@ -69,7 +67,7 @@ const availableConnectors = computed(() => {
             />
             {{ connector.name }}
           </UiButton>
-        </a>
+        </button>
       </div>
     </div>
   </UiModal>

--- a/apps/ui/src/components/Modal/Connector.vue
+++ b/apps/ui/src/components/Modal/Connector.vue
@@ -53,6 +53,7 @@ const availableConnectors = computed(() => {
         <button
           v-for="connector in availableConnectors"
           :key="connector.id"
+          type="button"
           @click="emit('pick', connector.id)"
         >
           <UiButton

--- a/apps/ui/src/components/Modal/Delegate.vue
+++ b/apps/ui/src/components/Modal/Delegate.vue
@@ -89,12 +89,12 @@ watchEffect(async () => {
     <template #header>
       <h3>Delegate voting power</h3>
       <template v-if="showPicker">
-        <a
+        <button
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >
           <IH-arrow-narrow-left class="mr-2" />
-        </a>
+        </button>
         <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
           <IH-search class="mx-2" />
           <input

--- a/apps/ui/src/components/Modal/Delegate.vue
+++ b/apps/ui/src/components/Modal/Delegate.vue
@@ -90,6 +90,7 @@ watchEffect(async () => {
       <h3>Delegate voting power</h3>
       <template v-if="showPicker">
         <button
+          type="button"
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >

--- a/apps/ui/src/components/Modal/DelegationConfig.vue
+++ b/apps/ui/src/components/Modal/DelegationConfig.vue
@@ -132,6 +132,7 @@ watch(
       <h3 v-text="'Add delegation'" />
       <template v-if="showPicker">
         <button
+          type="button"
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >

--- a/apps/ui/src/components/Modal/DelegationConfig.vue
+++ b/apps/ui/src/components/Modal/DelegationConfig.vue
@@ -131,12 +131,12 @@ watch(
     <template #header>
       <h3 v-text="'Add delegation'" />
       <template v-if="showPicker">
-        <a
+        <button
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >
           <IH-arrow-narrow-left class="mr-2" />
-        </a>
+        </button>
         <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
           <IH-search class="mx-2" />
           <input

--- a/apps/ui/src/components/Modal/Drafts.vue
+++ b/apps/ui/src/components/Modal/Drafts.vue
@@ -53,7 +53,7 @@ function handleRemoveDraft(id: string) {
             {{ proposal.title || 'Untitled' }}
             <span class="text-skin-text">#{{ proposal.key }}</span>
           </router-link>
-          <button @click="handleRemoveDraft(proposal.id)">
+          <button type="button" @click="handleRemoveDraft(proposal.id)">
             <IH-trash />
           </button>
         </div>

--- a/apps/ui/src/components/Modal/Drafts.vue
+++ b/apps/ui/src/components/Modal/Drafts.vue
@@ -53,9 +53,9 @@ function handleRemoveDraft(id: string) {
             {{ proposal.title || 'Untitled' }}
             <span class="text-skin-text">#{{ proposal.key }}</span>
           </router-link>
-          <a @click="handleRemoveDraft(proposal.id)">
-            <IH-trash class="mr-2" />
-          </a>
+          <button @click="handleRemoveDraft(proposal.id)">
+            <IH-trash />
+          </button>
         </div>
       </div>
       <div v-else class="p-4 text-center">There isn't any drafts yet!</div>

--- a/apps/ui/src/components/Modal/EditSpace.vue
+++ b/apps/ui/src/components/Modal/EditSpace.vue
@@ -82,6 +82,7 @@ watch(
       <template v-else>
         <h3>Select contact</h3>
         <button
+          type="button"
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >

--- a/apps/ui/src/components/Modal/EditSpace.vue
+++ b/apps/ui/src/components/Modal/EditSpace.vue
@@ -81,12 +81,12 @@ watch(
       <h3 v-if="!showPicker">Edit profile</h3>
       <template v-else>
         <h3>Select contact</h3>
-        <a
+        <button
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >
           <IH-arrow-narrow-left class="mr-2" />
-        </a>
+        </button>
         <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
           <IH-search class="mx-2" />
           <input

--- a/apps/ui/src/components/Modal/EditStrategy.vue
+++ b/apps/ui/src/components/Modal/EditStrategy.vue
@@ -53,12 +53,12 @@ watch(
     <template #header>
       <h3>Edit strategy</h3>
       <template v-if="showPicker">
-        <a
+        <button
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >
           <IH-arrow-narrow-left class="mr-2" />
-        </a>
+        </button>
         <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
           <IH-search class="mx-2" />
           <input

--- a/apps/ui/src/components/Modal/EditStrategy.vue
+++ b/apps/ui/src/components/Modal/EditStrategy.vue
@@ -54,6 +54,7 @@ watch(
       <h3>Edit strategy</h3>
       <template v-if="showPicker">
         <button
+          type="button"
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >

--- a/apps/ui/src/components/Modal/SendNft.vue
+++ b/apps/ui/src/components/Modal/SendNft.vue
@@ -124,6 +124,7 @@ watchEffect(async () => {
       <h3 v-text="'Send NFT'" />
       <template v-if="showPicker">
         <button
+          type="button"
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >
@@ -173,6 +174,7 @@ watchEffect(async () => {
       <div class="s-base">
         <div class="s-label" v-text="'NFT'" />
         <button
+          type="button"
           class="s-input text-left h-[61px]"
           @click="handlePickerClick('nft')"
         >

--- a/apps/ui/src/components/Modal/SendNft.vue
+++ b/apps/ui/src/components/Modal/SendNft.vue
@@ -123,12 +123,12 @@ watchEffect(async () => {
     <template #header>
       <h3 v-text="'Send NFT'" />
       <template v-if="showPicker">
-        <a
+        <button
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >
           <IH-arrow-narrow-left class="mr-2" />
-        </a>
+        </button>
         <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
           <IH-search class="mx-2" />
           <input

--- a/apps/ui/src/components/Modal/SendToken.vue
+++ b/apps/ui/src/components/Modal/SendToken.vue
@@ -215,12 +215,12 @@ watchEffect(async () => {
     <template #header>
       <h3 v-text="'Send token'" />
       <template v-if="showPicker">
-        <a
+        <button
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >
           <IH-arrow-narrow-left class="mr-2" />
-        </a>
+        </button>
         <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
           <IH-search class="mx-2" />
           <input
@@ -299,7 +299,7 @@ watchEffect(async () => {
             }"
             @update:model-value="handleAmountUpdate"
           />
-          <a
+          <button
             class="absolute right-[16px] top-[4px]"
             @click="handleMaxClick"
             v-text="'max'"

--- a/apps/ui/src/components/Modal/SendToken.vue
+++ b/apps/ui/src/components/Modal/SendToken.vue
@@ -216,6 +216,7 @@ watchEffect(async () => {
       <h3 v-text="'Send token'" />
       <template v-if="showPicker">
         <button
+          type="button"
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >
@@ -271,6 +272,7 @@ watchEffect(async () => {
       <div class="s-base">
         <div class="s-label" v-text="'Token'" />
         <button
+          type="button"
           class="s-input text-left h-[61px]"
           @click="handlePickerClick('token')"
         >
@@ -300,6 +302,7 @@ watchEffect(async () => {
             @update:model-value="handleAmountUpdate"
           />
           <button
+            type="button"
             class="absolute right-[16px] top-[4px]"
             @click="handleMaxClick"
             v-text="'max'"

--- a/apps/ui/src/components/Modal/StakeToken.vue
+++ b/apps/ui/src/components/Modal/StakeToken.vue
@@ -131,13 +131,13 @@ watch(
             }"
             @update:model-value="handleAmountUpdate"
           />
-          <a
+          <button
             class="absolute right-[16px] top-[4px]"
             href="#"
             @click.prevent="handleMaxClick"
           >
             max
-          </a>
+          </button>
           <div
             class="absolute right-[16px] top-[26px] flex items-center gap-x-2"
           >

--- a/apps/ui/src/components/Modal/StakeToken.vue
+++ b/apps/ui/src/components/Modal/StakeToken.vue
@@ -132,6 +132,7 @@ watch(
             @update:model-value="handleAmountUpdate"
           />
           <button
+            type="button"
             class="absolute right-[16px] top-[4px]"
             href="#"
             @click.prevent="handleMaxClick"

--- a/apps/ui/src/components/Modal/Transaction.vue
+++ b/apps/ui/src/components/Modal/Transaction.vue
@@ -262,12 +262,12 @@ watchEffect(async () => {
     <template #header>
       <h3 v-text="'Add transaction'" />
       <template v-if="showPicker">
-        <a
+        <button
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >
           <IH-arrow-narrow-left class="mr-2" />
-        </a>
+        </button>
         <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
           <IH-search class="mx-2" />
           <input

--- a/apps/ui/src/components/Modal/Transaction.vue
+++ b/apps/ui/src/components/Modal/Transaction.vue
@@ -263,6 +263,7 @@ watchEffect(async () => {
       <h3 v-text="'Add transaction'" />
       <template v-if="showPicker">
         <button
+          type="button"
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >

--- a/apps/ui/src/components/Modal/TreasuryConfig.vue
+++ b/apps/ui/src/components/Modal/TreasuryConfig.vue
@@ -105,6 +105,7 @@ watch(
       <h3 v-text="'Add treasury'" />
       <template v-if="showPicker">
         <button
+          type="button"
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >

--- a/apps/ui/src/components/Modal/TreasuryConfig.vue
+++ b/apps/ui/src/components/Modal/TreasuryConfig.vue
@@ -104,12 +104,12 @@ watch(
     <template #header>
       <h3 v-text="'Add treasury'" />
       <template v-if="showPicker">
-        <a
+        <button
           class="absolute left-0 -top-1 p-4 text-color"
           @click="showPicker = false"
         >
           <IH-arrow-narrow-left class="mr-2" />
-        </a>
+        </button>
         <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
           <IH-search class="mx-2" />
           <input

--- a/apps/ui/src/components/PickerContact.vue
+++ b/apps/ui/src/components/PickerContact.vue
@@ -64,7 +64,7 @@ const filteredContacts = computed(() =>
       <button
         v-for="contact in filteredContacts"
         :key="contact.address"
-        role="button"
+        type="button"
         class="px-3 py-2.5 border-b last:border-0 flex justify-between"
         @click="emit('pick', contact.address)"
       >

--- a/apps/ui/src/components/PickerContact.vue
+++ b/apps/ui/src/components/PickerContact.vue
@@ -61,7 +61,7 @@ const filteredContacts = computed(() =>
         class="text-center py-3"
         v-text="'No results'"
       />
-      <div
+      <button
         v-for="contact in filteredContacts"
         :key="contact.address"
         role="button"
@@ -70,7 +70,7 @@ const filteredContacts = computed(() =>
       >
         <div class="flex items-center max-w-full">
           <UiStamp :id="contact.address" type="avatar" :size="32" />
-          <div class="flex flex-col ml-3 leading-5 overflow-hidden">
+          <div class="flex flex-col ml-3 leading-5 overflow-hidden text-left">
             <div class="text-skin-link" v-text="shorten(contact.name, 24)" />
             <div
               class="text-[17px] text-ellipsis overflow-hidden"
@@ -78,7 +78,7 @@ const filteredContacts = computed(() =>
             />
           </div>
         </div>
-      </div>
+      </button>
     </template>
   </div>
 </template>

--- a/apps/ui/src/components/PickerNft.vue
+++ b/apps/ui/src/components/PickerNft.vue
@@ -32,7 +32,7 @@ const filteredNfts = computed(() =>
       <button
         v-for="(nft, i) in filteredNfts"
         :key="i"
-        role="button"
+        type="button"
         class="block hover:opacity-80 transition-opacity"
         @click="emit('pick', nft.id)"
       >

--- a/apps/ui/src/components/PickerNft.vue
+++ b/apps/ui/src/components/PickerNft.vue
@@ -29,7 +29,7 @@ const filteredNfts = computed(() =>
       v-text="'No results'"
     />
     <div v-else class="grid gap-3 grid-cols-3 p-3">
-      <a
+      <button
         v-for="(nft, i) in filteredNfts"
         :key="i"
         role="button"
@@ -38,7 +38,7 @@ const filteredNfts = computed(() =>
       >
         <UiNftImage :item="nft" class="w-full" />
         <div class="mt-2 text-[17px] truncate">{{ nft.displayTitle }}</div>
-      </a>
+      </button>
     </div>
   </template>
 </template>

--- a/apps/ui/src/components/PickerToken.vue
+++ b/apps/ui/src/components/PickerToken.vue
@@ -132,7 +132,7 @@ watch(
     <button
       v-for="(asset, i) in filteredAssets"
       :key="i"
-      role="button"
+      type="button"
       class="px-3 py-2.5 border-b last:border-0 flex justify-between"
       @click="handlePick(asset)"
     >

--- a/apps/ui/src/components/PickerToken.vue
+++ b/apps/ui/src/components/PickerToken.vue
@@ -129,7 +129,7 @@ watch(
       class="text-center py-3"
       v-text="'No results'"
     />
-    <div
+    <button
       v-for="(asset, i) in filteredAssets"
       :key="i"
       role="button"
@@ -159,6 +159,6 @@ watch(
         />
         <div class="text-[17px]" v-text="`$${_n(asset.price)}`" />
       </div>
-    </div>
+    </button>
   </template>
 </template>

--- a/apps/ui/src/components/ProposalsListItem.vue
+++ b/apps/ui/src/components/ProposalsListItem.vue
@@ -106,6 +106,7 @@ async function handleVoteClick(choice: Choice) {
           </span>
           ·
           <button
+            type="button"
             class="text-skin-text"
             @click="modalOpenTimeline = true"
             v-text="_rt(getTsFromCurrent(proposal.network, proposal.max_end))"

--- a/apps/ui/src/components/ProposalsListItem.vue
+++ b/apps/ui/src/components/ProposalsListItem.vue
@@ -105,7 +105,7 @@ async function handleVoteClick(choice: Choice) {
             · {{ _p(totalProgress) }} {{ quorumLabel(proposal.quorum_type) }}
           </span>
           ·
-          <a
+          <button
             class="text-skin-text"
             @click="modalOpenTimeline = true"
             v-text="_rt(getTsFromCurrent(proposal.network, proposal.max_end))"

--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -98,6 +98,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
       >
         <div class="pl-4 w-[60%] flex items-center truncate">Delegatee</div>
         <button
+          type="button"
           class="hidden md:flex w-[20%] items-center justify-end hover:text-skin-link space-x-1 truncate"
           @click="handleSortChange('tokenHoldersRepresentedAmount')"
         >
@@ -112,6 +113,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
           />
         </button>
         <button
+          type="button"
           class="w-[40%] md:w-[20%] flex justify-end items-center hover:text-skin-link pr-4 space-x-1 truncate"
           @click="handleSortChange('delegatedVotes')"
         >

--- a/apps/ui/src/components/StrategiesConfigurator.vue
+++ b/apps/ui/src/components/StrategiesConfigurator.vue
@@ -97,11 +97,12 @@ function handleStrategySave(value: Record<string, any>) {
         <div class="flex gap-3">
           <button
             v-if="strategy.paramsDefinition"
+            type="button"
             @click="editStrategy(strategy)"
           >
             <IH-pencil />
           </button>
-          <button @click="removeStrategy(strategy)">
+          <button type="button" @click="removeStrategy(strategy)">
             <IH-trash />
           </button>
         </div>

--- a/apps/ui/src/components/StrategiesConfigurator.vue
+++ b/apps/ui/src/components/StrategiesConfigurator.vue
@@ -95,12 +95,15 @@ function handleStrategySave(value: Record<string, any>) {
           </div>
         </div>
         <div class="flex gap-3">
-          <a v-if="strategy.paramsDefinition" @click="editStrategy(strategy)">
+          <button
+            v-if="strategy.paramsDefinition"
+            @click="editStrategy(strategy)"
+          >
             <IH-pencil />
-          </a>
-          <a @click="removeStrategy(strategy)">
+          </button>
+          <button @click="removeStrategy(strategy)">
             <IH-trash />
-          </a>
+          </button>
         </div>
       </div>
     </div>

--- a/apps/ui/src/components/Ui/Alert.vue
+++ b/apps/ui/src/components/Ui/Alert.vue
@@ -26,6 +26,7 @@ const emit = defineEmits<{
     <slot />
     <button
       v-if="dismissible"
+      type="button"
       class="text-skin-link opacity-50 hover:opacity-100"
       @click="emit('close')"
     >

--- a/apps/ui/src/components/Ui/Alert.vue
+++ b/apps/ui/src/components/Ui/Alert.vue
@@ -24,12 +24,12 @@ const emit = defineEmits<{
     }"
   >
     <slot />
-    <a
+    <button
       v-if="dismissible"
       class="text-skin-link opacity-50 hover:opacity-100"
       @click="emit('close')"
     >
       <IH-x />
-    </a>
+    </button>
   </div>
 </template>

--- a/apps/ui/src/components/Ui/Composer.vue
+++ b/apps/ui/src/components/Ui/Composer.vue
@@ -23,6 +23,7 @@ const editor = useMarkdownEditor(
     <div class="flex justify-end gap-1 py-2 px-3">
       <UiTooltip title="Add heading text">
         <button
+          type="button"
           class="p-1 w-[26px] h-[26px] leading-[18px] hover:text-skin-link rounded focus-visible:ring-1"
           @click="editor.heading"
         >
@@ -31,6 +32,7 @@ const editor = useMarkdownEditor(
       </UiTooltip>
       <UiTooltip title="Add bold text">
         <button
+          type="button"
           class="p-1 w-[26px] h-[26px] leading-[18px] font-bold hover:text-skin-link rounded focus-visible:ring-1"
           @click="editor.bold"
         >
@@ -39,6 +41,7 @@ const editor = useMarkdownEditor(
       </UiTooltip>
       <UiTooltip title="Add italic text">
         <button
+          type="button"
           class="p-1 w-[26px] h-[26px] leading-[18px] italic hover:text-skin-link rounded focus-visible:ring-1"
           @click="editor.italic"
         >
@@ -47,6 +50,7 @@ const editor = useMarkdownEditor(
       </UiTooltip>
       <UiTooltip title="Add a link" class="w-[26px] h-[26px]">
         <button
+          type="button"
           class="p-1 w-[26px] h-[26px] leading-[18px] italic hover:text-skin-link rounded focus-visible:ring-1"
           @click="editor.link"
         >

--- a/apps/ui/src/components/Ui/Editable.vue
+++ b/apps/ui/src/components/Ui/Editable.vue
@@ -99,13 +99,18 @@ function handleSave() {
           }"
         >
           <button
+            type="button"
             :disabled="!!formErrors.value"
             class="hover:opacity-80"
             @click="handleSave"
           >
             <IH-check />
           </button>
-          <button class="hover:opacity-80" @click="editing = !editing">
+          <button
+            type="button"
+            class="hover:opacity-80"
+            @click="editing = !editing"
+          >
             <IH-x />
           </button>
         </div>
@@ -113,6 +118,7 @@ function handleSave() {
       <template v-else>
         <button
           v-if="editable"
+          type="button"
           class="hover:opacity-80"
           @click="editing = !editing"
         >

--- a/apps/ui/src/components/Ui/InputAddress.vue
+++ b/apps/ui/src/components/Ui/InputAddress.vue
@@ -23,7 +23,7 @@ const emit = defineEmits<{
 <template>
   <div class="relative">
     <div v-if="showPicker" class="absolute top-3.5 right-3 z-10">
-      <a @click="emit('pick', path || '')"><IH-identification /></a>
+      <button @click="emit('pick', path || '')"><IH-identification /></button>
     </div>
     <UiInputString v-bind="$attrs as any" class="!pr-7" />
   </div>

--- a/apps/ui/src/components/Ui/InputAddress.vue
+++ b/apps/ui/src/components/Ui/InputAddress.vue
@@ -23,7 +23,9 @@ const emit = defineEmits<{
 <template>
   <div class="relative">
     <div v-if="showPicker" class="absolute top-3.5 right-3 z-10">
-      <button @click="emit('pick', path || '')"><IH-identification /></button>
+      <button type="button" @click="emit('pick', path || '')">
+        <IH-identification />
+      </button>
     </div>
     <UiInputString v-bind="$attrs as any" class="!pr-7" />
   </div>

--- a/apps/ui/src/components/Ui/InputArray.vue
+++ b/apps/ui/src/components/Ui/InputArray.vue
@@ -19,6 +19,6 @@ function addItem() {
     <div v-for="(item, i) in input" :key="i">
       <SString v-model="input[i]" :definition="{ title: '' }" />
     </div>
-    <button @click="addItem">Add</button>
+    <button type="button" @click="addItem">Add</button>
   </UiWrapperInput>
 </template>

--- a/apps/ui/src/components/Ui/InputArray.vue
+++ b/apps/ui/src/components/Ui/InputArray.vue
@@ -19,6 +19,6 @@ function addItem() {
     <div v-for="(item, i) in input" :key="i">
       <SString v-model="input[i]" :definition="{ title: '' }" />
     </div>
-    <a @click="addItem">Add</a>
+    <button @click="addItem">Add</button>
   </UiWrapperInput>
 </template>

--- a/apps/ui/src/components/Ui/InputStamp.vue
+++ b/apps/ui/src/components/Ui/InputStamp.vue
@@ -46,6 +46,7 @@ async function handleFileChange(e: Event) {
 
 <template>
   <button
+    type="button"
     v-bind="$attrs"
     class="relative group max-w-max cursor-pointer mb-3 border-[4px] border-skin-bg rounded-lg overflow-hidden bg-skin-border"
     @click="openFilePicker()"

--- a/apps/ui/src/components/Ui/InputStamp.vue
+++ b/apps/ui/src/components/Ui/InputStamp.vue
@@ -45,7 +45,7 @@ async function handleFileChange(e: Event) {
 </script>
 
 <template>
-  <div
+  <button
     v-bind="$attrs"
     class="relative group max-w-max cursor-pointer mb-3 border-[4px] border-skin-bg rounded-lg overflow-hidden bg-skin-border"
     @click="openFilePicker()"
@@ -74,7 +74,7 @@ async function handleFileChange(e: Event) {
       <UiLoading v-if="isUploadingImage" class="block z-5" />
       <IH-pencil v-else class="invisible text-skin-link group-hover:visible" />
     </div>
-  </div>
+  </button>
   <input
     ref="fileInput"
     type="file"

--- a/apps/ui/src/components/Ui/InputStampCover.vue
+++ b/apps/ui/src/components/Ui/InputStampCover.vue
@@ -56,9 +56,9 @@ async function handleFileChange(e: Event) {
 </script>
 
 <template>
-  <div
+  <button
     v-bind="$attrs"
-    class="relative bg-skin-border h-[100px] -mb-[50px] overflow-hidden cursor-pointer group"
+    class="relative bg-skin-border h-[100px] -mb-[50px] w-full overflow-hidden cursor-pointer group"
     @click="openFilePicker()"
   >
     <img
@@ -87,7 +87,7 @@ async function handleFileChange(e: Event) {
       <UiLoading v-if="isUploadingImage" class="block z-5" />
       <IH-pencil v-else class="invisible text-skin-link group-hover:visible" />
     </div>
-  </div>
+  </button>
   <input
     ref="fileInput"
     type="file"

--- a/apps/ui/src/components/Ui/InputStampCover.vue
+++ b/apps/ui/src/components/Ui/InputStampCover.vue
@@ -57,6 +57,7 @@ async function handleFileChange(e: Event) {
 
 <template>
   <button
+    type="button"
     v-bind="$attrs"
     class="relative bg-skin-border h-[100px] -mb-[50px] w-full overflow-hidden cursor-pointer group"
     @click="openFilePicker()"

--- a/apps/ui/src/components/Ui/Modal.vue
+++ b/apps/ui/src/components/Ui/Modal.vue
@@ -42,12 +42,12 @@ watch(open, (val, prev) => {
         <div v-if="$slots.footer" class="border-t p-4 text-center">
           <slot name="footer" />
         </div>
-        <a
+        <button
           class="absolute right-0 -top-1 p-4 text-color"
           @click="$emit('close')"
         >
           <IH-x />
-        </a>
+        </button>
       </div>
     </div>
   </transition>

--- a/apps/ui/src/components/Ui/Modal.vue
+++ b/apps/ui/src/components/Ui/Modal.vue
@@ -43,6 +43,7 @@ watch(open, (val, prev) => {
           <slot name="footer" />
         </div>
         <button
+          type="button"
           class="absolute right-0 -top-1 p-4 text-color"
           @click="$emit('close')"
         >

--- a/apps/ui/src/components/Ui/SelectDropdown.vue
+++ b/apps/ui/src/components/Ui/SelectDropdown.vue
@@ -31,6 +31,7 @@ const items = computed(() => props.items);
     <template #button>
       <slot name="button">
         <button
+          type="button"
           class="flex items-center gap-2 relative rounded-full leading-[100%] border button px-[16px] min-w-[76px] h-[42px] top-1 outline-0 text-skin-link bg-skin-bg"
         >
           <div
@@ -61,6 +62,7 @@ const items = computed(() => props.items);
         v-slot="{ active, disabled }"
       >
         <button
+          type="button"
           class="flex items-center gap-2"
           :class="{ 'opacity-80': active, 'opacity-40': disabled }"
           @click="model = item.key"

--- a/apps/ui/src/views/Create.vue
+++ b/apps/ui/src/views/Create.vue
@@ -187,6 +187,7 @@ watchEffect(() => setTitle('Create space'));
           v-for="page in PAGES"
           ref="pagesRefs"
           :key="page.id"
+          type="button"
           :disabled="!accessiblePages[page.id]"
           class="px-3 py-1 block lg:w-full rounded text-left scroll-mr-3 first:ml-auto last:mr-auto whitespace-nowrap"
           :class="{

--- a/apps/ui/src/views/Network.vue
+++ b/apps/ui/src/views/Network.vue
@@ -192,7 +192,11 @@ watchEffect(() => setTitle('Network'));
       <div class="mb-2 eyebrow text-center">Frequently asked questions</div>
       <h1 class="mb-3 text-center">Questions?</h1>
       <div v-for="(question, i) in FAQ" :key="i" class="border-b">
-        <button class="flex items-center" @click="toggleQuestion(i)">
+        <button
+          type="button"
+          class="flex items-center"
+          @click="toggleQuestion(i)"
+        >
           <h3 class="py-3 flex-auto">
             {{ question.question }}
           </h3>

--- a/apps/ui/src/views/Network.vue
+++ b/apps/ui/src/views/Network.vue
@@ -91,16 +91,14 @@ watchEffect(() => setTitle('Network'));
         <h1 class="mb-4 mono max-w-[600px] mx-auto">
           Unlock governance for your ecosystem.
         </h1>
-        <div class="space-x-2">
-          <a target="_blank">
-            <a :href="LINK" target="_blank">
-              <UiButton class="primary">
-                Talk to sales
-                <IH-arrow-sm-right class="inline-block -rotate-45" />
-              </UiButton>
-            </a>
-          </a>
-        </div>
+        <a
+          :href="LINK"
+          target="_blank"
+          class="px-4 py-3 space-x-2 bg-skin-link text-skin-bg rounded-full"
+        >
+          Talk to sales
+          <IH-arrow-sm-right class="inline-block -rotate-45" />
+        </a>
       </UiContainer>
     </div>
 
@@ -166,11 +164,13 @@ watchEffect(() => setTitle('Network'));
     <UiContainer class="!max-w-[880px] text-center">
       <div class="eyebrow mb-2">Get started</div>
       <h1 class="mb-3">Start your integration</h1>
-      <a :href="LINK" target="_blank">
-        <UiButton class="primary">
-          Talk to sales
-          <IH-arrow-sm-right class="inline-block -rotate-45" />
-        </UiButton>
+      <a
+        :href="LINK"
+        target="_blank"
+        class="px-4 py-3 space-x-2 bg-skin-link text-skin-bg rounded-full"
+      >
+        Talk to sales
+        <IH-arrow-sm-right class="inline-block -rotate-45" />
       </a>
     </UiContainer>
 
@@ -192,13 +192,13 @@ watchEffect(() => setTitle('Network'));
       <div class="mb-2 eyebrow text-center">Frequently asked questions</div>
       <h1 class="mb-3 text-center">Questions?</h1>
       <div v-for="(question, i) in FAQ" :key="i" class="border-b">
-        <a class="flex items-center" @click="toggleQuestion(i)">
+        <button class="flex items-center" @click="toggleQuestion(i)">
           <h3 class="py-3 flex-auto">
             {{ question.question }}
           </h3>
           <IH-minus-sm v-if="currentQuestion === i" class="text-skin-text" />
           <IH-plus-sm v-else class="text-skin-text" />
-        </a>
+        </button>
         <div v-if="currentQuestion === i" class="text-[21px] pb-4 -mt-1">
           {{ question.answer }}
         </div>

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -226,7 +226,7 @@ watchEffect(() => {
             </div>
             <template v-else>
               <span class="mr-1.5">Voting power:</span>
-              <a @click="props.onClick">
+              <button @click="props.onClick">
                 <UiLoading v-if="votingPowerStatus === 'loading'" />
                 <IH-exclamation
                   v-else-if="votingPowerStatus === 'error'"
@@ -237,7 +237,7 @@ watchEffect(() => {
                   class="text-skin-link"
                   v-text="props.formattedVotingPower"
                 />
-              </a>
+              </button>
               <a
                 v-if="
                   votingPowerStatus === 'success' &&

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -226,7 +226,7 @@ watchEffect(() => {
             </div>
             <template v-else>
               <span class="mr-1.5">Voting power:</span>
-              <button @click="props.onClick">
+              <button type="button" @click="props.onClick">
                 <UiLoading v-if="votingPowerStatus === 'loading'" />
                 <IH-exclamation
                   v-else-if="votingPowerStatus === 'error'"

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -313,6 +313,7 @@ onBeforeUnmount(() => destroyAudio());
             <template #items>
               <UiDropdownItem v-if="editable" v-slot="{ active }">
                 <button
+                  type="button"
                   class="flex items-center gap-2"
                   :class="{ 'opacity-80': active }"
                   @click="handleEditClick"
@@ -327,6 +328,7 @@ onBeforeUnmount(() => destroyAudio());
                 :disabled="cancelling"
               >
                 <button
+                  type="button"
                   class="flex items-center gap-2"
                   :class="{ 'opacity-80': active, 'opacity-40': disabled }"
                   @click="handleCancelClick"
@@ -399,12 +401,17 @@ onBeforeUnmount(() => destroyAudio());
         </div>
       </div>
       <div>
-        <button class="text-skin-text" @click="modalOpenVotes = true">
+        <button
+          type="button"
+          class="text-skin-text"
+          @click="modalOpenVotes = true"
+        >
           {{ _n(proposal.vote_count) }}
           {{ proposal.vote_count !== 1 ? 'votes' : 'vote' }}
         </button>
         ·
         <button
+          type="button"
           class="text-skin-text"
           @click="modalOpenTimeline = true"
           v-text="votingTime"

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -399,12 +399,12 @@ onBeforeUnmount(() => destroyAudio());
         </div>
       </div>
       <div>
-        <a class="text-skin-text" @click="modalOpenVotes = true">
+        <button class="text-skin-text" @click="modalOpenVotes = true">
           {{ _n(proposal.vote_count) }}
           {{ proposal.vote_count !== 1 ? 'votes' : 'vote' }}
-        </a>
+        </button>
         ·
-        <a
+        <button
           class="text-skin-text"
           @click="modalOpenTimeline = true"
           v-text="votingTime"

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -143,6 +143,7 @@ watch([sortBy, choiceFilter], () => {
       </UiSelectDropdown>
     </div>
     <button
+      type="button"
       class="hidden lg:flex max-w-[144px] w-[144px] items-center hover:text-skin-link space-x-1 truncate"
       @click="handleSortChange('created')"
     >
@@ -151,6 +152,7 @@ watch([sortBy, choiceFilter], () => {
       <IH-arrow-sm-up v-else-if="sortBy === 'created-asc'" class="shrink-0" />
     </button>
     <button
+      type="button"
       class="max-w-[144px] w-[144px] flex items-center justify-end hover:text-skin-link space-x-1 truncate"
       @click="handleSortChange('vp')"
     >
@@ -313,6 +315,7 @@ watch([sortBy, choiceFilter], () => {
               </UiDropdownItem>
               <UiDropdownItem v-slot="{ active }">
                 <button
+                  type="button"
                   class="flex items-center gap-2"
                   :class="{ 'opacity-80': active }"
                   @click.prevent="copy(vote.voter.id)"

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -312,7 +312,7 @@ watch([sortBy, choiceFilter], () => {
                 </a>
               </UiDropdownItem>
               <UiDropdownItem v-slot="{ active }">
-                <a
+                <button
                   class="flex items-center gap-2"
                   :class="{ 'opacity-80': active }"
                   @click.prevent="copy(vote.voter.id)"
@@ -325,7 +325,7 @@ watch([sortBy, choiceFilter], () => {
                     <IH-check :width="16" />
                     Copied
                   </template>
-                </a>
+                </button>
               </UiDropdownItem>
             </template>
           </UiDropdown>

--- a/apps/ui/src/views/Settings/Contacts.vue
+++ b/apps/ui/src/views/Settings/Contacts.vue
@@ -50,12 +50,14 @@ function handleContactEdit(contact) {
       </div>
       <div class="flex flex-row items-center content-center gap-x-3">
         <button
+          type="button"
           class="invisible group-hover:visible"
           @click="handleContactEdit(contact)"
         >
           <IH-pencil />
         </button>
         <button
+          type="button"
           class="invisible group-hover:visible"
           @click="contactsStore.deleteContact(contact.address)"
         >

--- a/apps/ui/src/views/Settings/Contacts.vue
+++ b/apps/ui/src/views/Settings/Contacts.vue
@@ -27,11 +27,9 @@ function handleContactEdit(contact) {
     <div class="flex">
       <div class="flex-auto" />
       <div class="pt-4 px-4 space-x-2">
-        <a>
-          <UiButton class="!px-0 w-[46px]" @click="openModal('editContact')">
-            <IH-plus-sm class="inline-block" />
-          </UiButton>
-        </a>
+        <UiButton class="!px-0 w-[46px]" @click="openModal('editContact')">
+          <IH-plus-sm class="inline-block" />
+        </UiButton>
       </div>
     </div>
     <UiLabel label="Contacts" />
@@ -51,18 +49,18 @@ function handleContactEdit(contact) {
         </div>
       </div>
       <div class="flex flex-row items-center content-center gap-x-3">
-        <a
+        <button
           class="invisible group-hover:visible"
           @click="handleContactEdit(contact)"
         >
           <IH-pencil />
-        </a>
-        <a
+        </button>
+        <button
           class="invisible group-hover:visible"
           @click="contactsStore.deleteContact(contact.address)"
         >
           <IH-trash />
-        </a>
+        </button>
       </div>
     </div>
     <div v-if="!contactsStore.contacts.length" class="px-4 py-3 text-skin-link">

--- a/apps/ui/src/views/Space/Delegates.vue
+++ b/apps/ui/src/views/Space/Delegates.vue
@@ -19,7 +19,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
     class="overflow-y-scroll no-scrollbar z-40 sticky top-[71px] lg:top-[72px]"
   >
     <div class="flex px-4 space-x-3 bg-skin-bg border-b min-w-max">
-      <a
+      <button
         v-for="(delegation, i) in space.delegations"
         :key="i"
         @click="activeDelegationId = i"
@@ -28,7 +28,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
           :is-active="activeDelegationId === i"
           :text="delegation.name || `Delegates ${i + 1}`"
         />
-      </a>
+      </button>
     </div>
   </div>
   <SpaceDelegates

--- a/apps/ui/src/views/Space/Delegates.vue
+++ b/apps/ui/src/views/Space/Delegates.vue
@@ -22,6 +22,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
       <button
         v-for="(delegation, i) in space.delegations"
         :key="i"
+        type="button"
         @click="activeDelegationId = i"
       >
         <UiLink

--- a/apps/ui/src/views/Space/Leaderboard.vue
+++ b/apps/ui/src/views/Space/Leaderboard.vue
@@ -118,6 +118,7 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
   >
     <div class="pl-4 w-[40%] lg:w-[50%] flex items-center truncate">User</div>
     <button
+      type="button"
       class="flex w-[30%] lg:w-[25%] items-center justify-end hover:text-skin-link space-x-1 truncate"
       @click="handleSortChange('proposal_count')"
     >
@@ -132,6 +133,7 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
       />
     </button>
     <button
+      type="button"
       class="flex justify-end items-center hover:text-skin-link pr-4 w-[30%] lg:w-[25%] space-x-1 truncate"
       @click="handleSortChange('vote_count')"
     >

--- a/apps/ui/src/views/Space/Treasury.vue
+++ b/apps/ui/src/views/Space/Treasury.vue
@@ -26,7 +26,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
     class="overflow-y-scroll no-scrollbar z-40 sticky top-[71px] lg:top-[72px]"
   >
     <div class="flex px-4 space-x-3 bg-skin-bg border-b min-w-max">
-      <a
+      <button
         v-for="(treasury, i) in filteredTreasuries"
         :key="i"
         @click="activeTreasuryId = i"
@@ -35,7 +35,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
           :is-active="activeTreasuryId === i"
           :text="treasury.name || shorten(treasury.address)"
         />
-      </a>
+      </button>
     </div>
   </div>
   <SpaceTreasury

--- a/apps/ui/src/views/Space/Treasury.vue
+++ b/apps/ui/src/views/Space/Treasury.vue
@@ -29,6 +29,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
       <button
         v-for="(treasury, i) in filteredTreasuries"
         :key="i"
+        type="button"
         @click="activeTreasuryId = i"
       >
         <UiLink

--- a/apps/ui/src/views/User.vue
+++ b/apps/ui/src/views/User.vue
@@ -152,10 +152,10 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
         <div class="mb-3 flex items-center space-x-2">
           <span class="text-skin-text" v-text="shortenAddress(user.id)" />
           <UiTooltip title="Copy address">
-            <a href="#" class="text-skin-text" @click.prevent="copy(user.id)">
+            <button class="text-skin-text" @click.prevent="copy(user.id)">
               <IH-duplicate v-if="!copied" class="inline-block" />
               <IH-check v-else class="inline-block" />
-            </a>
+            </button>
           </UiTooltip>
         </div>
         <div

--- a/apps/ui/src/views/User.vue
+++ b/apps/ui/src/views/User.vue
@@ -152,7 +152,11 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
         <div class="mb-3 flex items-center space-x-2">
           <span class="text-skin-text" v-text="shortenAddress(user.id)" />
           <UiTooltip title="Copy address">
-            <button class="text-skin-text" @click.prevent="copy(user.id)">
+            <button
+              type="button"
+              class="text-skin-text"
+              @click.prevent="copy(user.id)"
+            >
               <IH-duplicate v-if="!copied" class="inline-block" />
               <IH-check v-else class="inline-block" />
             </button>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Following https://github.com/snapshot-labs/sx-monorepo/pull/476#discussion_r1687556280
Close #119 #120 

This PR is migrating all elements with just an `onClick` event to a `<button>` element, in order to make them keyboard navigation friendly.

All button element should also have a `type="button"`

### Notes

This PR only change `div` or `a` tag to `button` when necessary, with sometimes some css fixes in order to keep same UI.
This does not fix the nested button issue, making some element focusable twice, which will come in another PR