### PR TITLE
fix(ui): use loading props from UiButton for the loading state

### DIFF
--- a/apps/ui/src/components/ButtonFollow.vue
+++ b/apps/ui/src/components/ButtonFollow.vue
@@ -32,10 +32,10 @@ const loading = computed(
     :disabled="loading || isSafeWallet"
     class="group"
     :class="{ 'hover:border-skin-danger': spaceFollowed }"
+    :loading="loading"
     @click.prevent="followedSpacesStore.toggleSpaceFollow(spaceIdComposite)"
   >
-    <UiLoading v-if="loading" />
-    <span v-else-if="spaceFollowed" class="inline-block">
+    <span v-if="spaceFollowed" class="inline-block">
       <span class="group-hover:inline hidden text-skin-danger">Unfollow</span>
       <span class="group-hover:hidden">Following</span>
     </span>

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -253,14 +253,10 @@ onBeforeUnmount(() => destroyAudio());
             <UiButton
               class="!p-0 border-0 !h-[auto]"
               :disabled="aiSummaryState.loading"
+              :loading="aiSummaryState.loading"
               @click="handleAiSummaryClick"
             >
-              <UiLoading
-                v-if="aiSummaryState.loading"
-                class="inline-block !w-[22px] !h-[22px]"
-              />
               <IH-sparkles
-                v-else
                 class="inline-block w-[22px] h-[22px]"
                 :class="aiSummaryOpen ? 'text-skin-link' : 'text-skin-text'"
               />
@@ -277,14 +273,12 @@ onBeforeUnmount(() => destroyAudio());
             <UiButton
               class="!p-0 border-0 !h-[auto]"
               :disabled="aiSpeechState.loading"
+              :loading="aiSpeechState.loading"
               @click="handleAiSpeechClick"
             >
-              <UiLoading
-                v-if="aiSpeechState.loading"
-                class="inline-block !w-[22px] !h-[22px]"
-              />
+              <UiLoading class="inline-block !w-[22px] !h-[22px]" />
               <IH-pause
-                v-else-if="audioState === 'playing'"
+                v-if="audioState === 'playing'"
                 class="inline-block w-[22px] h-[22px] text-skin-link"
               />
               <IH-play


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Use the `loading` prop from the `UiButton` for the button's loading state

### How to test

1. Go to a space
2. follow a space
3. the button should show a loading indicator while switching state
4. Go to a proposal
5. Click on the AI summary icon
6. Button should switch to the loading state while loading the summary
