### PR TITLE
fix(ux): enable link in the reason modal

### DIFF
--- a/apps/ui/src/components/Modal/VoteReason.vue
+++ b/apps/ui/src/components/Modal/VoteReason.vue
@@ -18,8 +18,14 @@ defineEmits<{
       <h3 v-text="'Reason'" />
     </template>
     <div
-      class="p-4 whitespace-pre-line text-skin-link"
+      class="vote-reason p-4 whitespace-pre-line text-skin-link"
       v-html="autoLinkText(vote?.reason || '')"
     />
   </UiModal>
 </template>
+
+<style class="scss" scoped>
+.vote-reason:deep() a {
+  text-decoration: underline;
+}
+</style>

--- a/apps/ui/src/components/Modal/VoteReason.vue
+++ b/apps/ui/src/components/Modal/VoteReason.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { autoLinkText } from '@/helpers/utils';
 import { Vote } from '@/types';
 
 defineProps<{
@@ -16,6 +17,9 @@ defineEmits<{
     <template #header>
       <h3 v-text="'Reason'" />
     </template>
-    <div class="p-4 whitespace-pre-line text-skin-link" v-text="vote?.reason" />
+    <div
+      class="p-4 whitespace-pre-line text-skin-link"
+      v-html="autoLinkText(vote?.reason || '')"
+    />
   </UiModal>
 </template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #533 

Enable links in the modal reason

### How to test

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth/proposal/0xa07fcb08c8f7623819cf432d8f6b13e6427147e6a36657fbf7e79ee2442a5eb8/votes
2. Open the reason modal 
3. the url should be clickable
