### PR TITLE
fix(ux): disable tooltips on touch devices

### DIFF
--- a/apps/ui/src/components/App/Sidebar.vue
+++ b/apps/ui/src/components/App/Sidebar.vue
@@ -35,7 +35,7 @@ const followedSpacesStore = useFollowedSpacesStore();
           class="block"
           @click="uiStore.sidebarOpen = false"
         >
-          <UiTooltip :title="element.name" placement="right" :touch="false">
+          <UiTooltip :title="element.name" placement="right">
             <SpaceAvatar :space="element" :size="32" class="!rounded-[4px]" />
           </UiTooltip>
         </router-link>

--- a/apps/ui/src/components/IndicatorVotingPower.vue
+++ b/apps/ui/src/components/IndicatorVotingPower.vue
@@ -48,7 +48,7 @@ function handleModalOpen() {
       :formatted-voting-power="formattedVotingPower"
       :on-click="handleModalOpen"
     >
-      <UiTooltip title="Your voting power" :touch="false">
+      <UiTooltip title="Your voting power">
         <UiButton
           v-if="
             web3.account &&

--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -318,7 +318,6 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
                   ETHEREUM_NETWORKS.includes(treasury.networkId)
                 "
                 title="Stake with Lido"
-                :touch="false"
               >
                 <UiButton
                   class="!px-0 w-[46px]"

--- a/apps/ui/src/components/Ui/Tooltip.vue
+++ b/apps/ui/src/components/Ui/Tooltip.vue
@@ -9,7 +9,7 @@ withDefaults(
   }>(),
   {
     placement: 'top',
-    touch: true
+    touch: false
   }
 );
 </script>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #487 

Disable tooltip on mobile globally, instead of case by case

### How to test

1. Navigate the site with a mobile devices
2. Click on button such as follow space, create new proposal, etc ... will not open the tooltip anymore
