### PR TITLE
fix: use BigInt to compute proposal state

### DIFF
--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -57,10 +57,18 @@ function getProposalState(
   proposal: ApiProposal,
   current: number
 ): ProposalState {
+  // we have broken types, we should unify, this is quick fix for Nimbora PR
+  // those values are actually strings
+  // https://github.com/snapshot-labs/sx-monorepo/pull/529/files#r1691071502
+  const quorum = BigInt(proposal.quorum);
+  const scoresTotal = BigInt(proposal.scores_total);
+  const scoresFor = BigInt(proposal.scores_1);
+  const scoresAgainst = BigInt(proposal.scores_2);
+
   if (proposal.executed) return 'executed';
   if (proposal.max_end <= current) {
-    if (proposal.scores_total < proposal.quorum) return 'rejected';
-    return proposal.scores_1 > proposal.scores_2 ? 'passed' : 'rejected';
+    if (scoresTotal < quorum) return 'rejected';
+    return scoresFor > scoresAgainst ? 'passed' : 'rejected';
   }
   if (proposal.start > current) return 'pending';
 

--- a/apps/ui/src/networks/common/graphqlApi/types.ts
+++ b/apps/ui/src/networks/common/graphqlApi/types.ts
@@ -94,7 +94,7 @@ export type ApiProposal = {
   min_end: number;
   max_end: number;
   snapshot: number;
-  // TODO: those are actually numbers, we need to adjust it across the app at some point
+  // TODO: those are actually strings, we need to adjust it across the app at some point
   scores_1: number;
   scores_2: number;
   scores_3: number;


### PR DESCRIPTION
### Summary

Our types are broken and those are actually strings. We need to fix those, but it will require quite a bit of refactoring. https://github.com/snapshot-labs/sx-monorepo/pull/529/files#r1691071502

### How to test

1. This proposal is passed http://localhost:8080/#/sn:0x05ea5ef0c54c84dc7382629684c6e536c0b06246b3b0981c426b42372e3ef263/proposal/3

