### PR TITLE
fix: add and remove events to provider properly

### DIFF
--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -164,11 +164,12 @@ export function useWeb3() {
       await login();
     });
 
-    if (STARKNET_CONNECTORS.includes(providerName)) return;
+    if (!STARKNET_CONNECTORS.includes(providerName)) {
+      provider.on('chainChanged', async chainId => {
+        handleChainChanged(parseInt(formatUnits(chainId, 0)));
+      });
+    }
 
-    provider.on('chainChanged', async chainId => {
-      handleChainChanged(parseInt(formatUnits(chainId, 0)));
-    });
     // auth.provider.on('disconnect', async () => {});
   }
 

--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -155,16 +155,19 @@ export function useWeb3() {
     if (loadedProviders.value.has(providerName)) return;
     loadedProviders.value.add(providerName);
 
-    if (!provider.on || STARKNET_CONNECTORS.includes(providerName)) return;
+    if (!provider.on) return;
 
-    provider.on('chainChanged', async chainId => {
-      handleChainChanged(parseInt(formatUnits(chainId, 0)));
-    });
     provider.on('accountsChanged', async accounts => {
       if (!accounts.length) return;
 
       state.account = formatAddress(accounts[0]);
       await login();
+    });
+
+    if (STARKNET_CONNECTORS.includes(providerName)) return;
+
+    provider.on('chainChanged', async chainId => {
+      handleChainChanged(parseInt(formatUnits(chainId, 0)));
     });
     // auth.provider.on('disconnect', async () => {});
   }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #541

This PR adds and removes events to auth provider properly:

- add events to same provider only once
- remove events on logout

### How to test

1. Add some `console.log()` to useWeb3 newly added functions
2. Log in, change account, log out
3. the events should be attached only once, and not again when changing account
4. the events should be cleared on logout
