### PR TITLE
fix(ui): remove extra loading icon

### DIFF
--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -277,7 +277,6 @@ onBeforeUnmount(() => destroyAudio());
               :loading="aiSpeechState.loading"
               @click="handleAiSpeechClick"
             >
-              <UiLoading class="inline-block !w-[22px] !h-[22px]" />
               <IH-pause
                 v-if="audioState === 'playing'"
                 class="inline-block w-[22px] h-[22px] text-skin-link"


### PR DESCRIPTION
### Summary
 
Remove extra `<Loading>` indicator inserted probably by an improper merge conflict resolution