### PR TITLE
feat: show total choice voting power in proposal results

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -4,7 +4,7 @@ import {
   quorumLabel,
   quorumProgress
 } from '@/helpers/quorum';
-import { _n, _p } from '@/helpers/utils';
+import { _n, _p, _vp } from '@/helpers/utils';
 import { Proposal as ProposalType } from '@/types';
 
 const DEFAULT_MAX_CHOICES = 6;
@@ -45,7 +45,8 @@ const results = computed(() => {
 
       return {
         choice: i + 1,
-        progress
+        progress,
+        score
       };
     })
     .sort((a, b) => b.progress - a.progress);
@@ -61,6 +62,15 @@ const visibleResults = computed(() => {
   }
 
   return results.value.slice(0, DEFAULT_MAX_CHOICES);
+});
+
+const votingPowerDecimals = computed(() => {
+  return Math.max(
+    ...props.proposal.space.strategies_parsed_metadata.map(
+      metadata => metadata.decimals
+    ),
+    0
+  );
 });
 
 const otherResultsSummary = computed(() => {
@@ -146,6 +156,10 @@ const otherResultsSummary = computed(() => {
           class="truncate grow"
           v-text="proposal.choices[result.choice - 1]"
         />
+        <div class="whitespace-nowrap">
+          {{ _vp(result.score / 10 ** votingPowerDecimals) }}
+          {{ proposal.space.voting_power_symbol }}
+        </div>
         <div v-text="_p(result.progress / 100)" />
       </div>
       <button

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -156,9 +156,8 @@ const otherResultsSummary = computed(() => {
           class="truncate grow"
           v-text="proposal.choices[result.choice - 1]"
         />
-        <div class="whitespace-nowrap">
+        <div>
           {{ _vp(result.score / 10 ** votingPowerDecimals) }}
-          {{ proposal.space.voting_power_symbol }}
         </div>
         <div v-text="_p(result.progress / 100)" />
       </div>

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -64,15 +64,6 @@ const visibleResults = computed(() => {
   return results.value.slice(0, DEFAULT_MAX_CHOICES);
 });
 
-const votingPowerDecimals = computed(() => {
-  return Math.max(
-    ...props.proposal.space.strategies_parsed_metadata.map(
-      metadata => metadata.decimals
-    ),
-    0
-  );
-});
-
 const otherResultsSummary = computed(() => {
   const oetherResultsStartIndex = hasOneExtra.value
     ? DEFAULT_MAX_CHOICES + 1
@@ -157,7 +148,7 @@ const otherResultsSummary = computed(() => {
           v-text="proposal.choices[result.choice - 1]"
         />
         <div>
-          {{ _vp(result.score / 10 ** votingPowerDecimals) }}
+          {{ _vp(result.score / 10 ** decimals) }}
         </div>
         <div v-text="_p(result.progress / 100)" />
       </div>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #515

- Add voting power beside each choice
 
  <img width="322" alt="Untitled 4" src="https://github.com/user-attachments/assets/332d5751-02d5-443a-97dc-807bda38eabd">



### How to test

1. Go to different proposals, and you should see total voting power on each choice of result
2. http://localhost:8080/#/s:safe.eth/proposal/0x8d97075eabfdf3fb9f43f3b490e8e5a7326d77bee919b78543621e36e5b2d233
3. http://localhost:8080/#/sn:0x07c251045154318a2376a3bb65be47d3c90df1740d8e35c9b9d943aa3f240e50/proposal/1/
4. http://localhost:8080/#/sn:0x07c251045154318a2376a3bb65be47d3c90df1740d8e35c9b9d943aa3f240e50/proposal/1/

