### PR TITLE
fix: make StampCover button block

### DIFF
--- a/apps/ui/src/components/Ui/InputStampCover.vue
+++ b/apps/ui/src/components/Ui/InputStampCover.vue
@@ -59,7 +59,7 @@ async function handleFileChange(e: Event) {
   <button
     type="button"
     v-bind="$attrs"
-    class="relative bg-skin-border h-[100px] -mb-[50px] w-full overflow-hidden cursor-pointer group"
+    class="relative block bg-skin-border h-[100px] -mb-[50px] w-full overflow-hidden cursor-pointer group"
     @click="openFilePicker()"
   >
     <img


### PR DESCRIPTION
### Summary

Regression from: https://github.com/snapshot-labs/sx-monorepo/pull/531

### How to test

1. Go to http://localhost:8080/#/create
2. Avatar is shown at the bottom edge of cover (previously it was in the center).

### Screenshots

<img width="922" alt="image" src="https://github.com/user-attachments/assets/b35134c1-288a-4147-8934-5941122344c3">
