### PR TITLE
fix: read execution_strategy from event directly

### DIFF
--- a/apps/api/src/writer.ts
+++ b/apps/api/src/writer.ts
@@ -565,16 +565,14 @@ export const handleUpdate: starknet.Writer = async ({
     console.log('failed to update proposal metadata', e);
   }
 
-  /*
   const executionStrategy = await handleExecutionStrategy(
-    event.proposal.execution_strategy,
+    event.execution_strategy,
     event.payload
   );
   if (executionStrategy) {
     proposal.execution_strategy_type = executionStrategy.executionStrategyType;
     proposal.quorum = executionStrategy.quorum;
   }
-  */
 
   await proposal.save();
 };


### PR DESCRIPTION
### Summary

It's stored directly in the event, not under proposal.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/503

### How to test

1. Ideally test with https://github.com/checkpoint-labs/checkpoint/pull/312 (so easily notice if it breaks or not).
2. If you want modify `SN_MAIN` startBlock to `652679` to speed up testing.
3. Run `NETWORK_NODE_URL=https://starknet-mainnet.infura.io/v3/XXX NETWORK=SN_MAIN yarn dev`.
4. No more error, indexing doesn't get stuck (if testing using that Checkpoint's PR).
