### PR TITLE
chore: scope markdown-body CSS class

### DIFF
--- a/apps/ui/src/components/Ui/Markdown.vue
+++ b/apps/ui/src/components/Ui/Markdown.vue
@@ -123,14 +123,14 @@ onMounted(() => {
   <div class="markdown-body break-words" v-html="parsed" />
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import '@/assets/styles/highlightjs/github.scss';
 
 html.dark {
   @import '@/assets/styles/highlightjs/github-dark-dimmed.scss';
 }
 
-.markdown-body {
+.markdown-body:deep() {
   font-size: 22px;
   line-height: 1.3;
   word-wrap: break-word;

--- a/apps/ui/src/components/Ui/Markdown.vue
+++ b/apps/ui/src/components/Ui/Markdown.vue
@@ -136,17 +136,6 @@ html.dark {
   word-wrap: break-word;
   color: var(--content);
 
-  &::before {
-    display: table;
-    content: '';
-  }
-
-  &::after {
-    display: table;
-    clear: both;
-    content: '';
-  }
-
   > *:first-child {
     margin-top: 0 !important;
   }
@@ -326,5 +315,17 @@ html.dark {
       @apply p-3 m-0 bg-skin-border rounded-none border-none overflow-auto block;
     }
   }
+}
+
+// Those can't be nested because those don't work with :deep selector
+.markdown-body::before {
+  display: table;
+  content: '';
+}
+
+.markdown-body::after {
+  display: table;
+  clear: both;
+  content: '';
 }
 </style>


### PR DESCRIPTION
### Summary

It was unscoped because it would have not been applied on children. But this can be enforced by usage of :deep() selector.

### How to test

1. Go to some proposal: http://localhost:8080/#/s:uniswapgovernance.eth/proposal/0xc2eed288ba61241dd86928eff15b7c8c9622168fc4b435657f58dda8ce285d13
2. It looks like it used to.
3. Would be good to test it on some proposal that has super complex formatting, but I couldn't find anything.
