### PR TITLE
fix: make picker items full-width and start-aligned

### DIFF
--- a/apps/ui/src/components/PickerContact.vue
+++ b/apps/ui/src/components/PickerContact.vue
@@ -65,7 +65,7 @@ const filteredContacts = computed(() =>
         v-for="contact in filteredContacts"
         :key="contact.address"
         type="button"
-        class="px-3 py-2.5 border-b last:border-0 flex justify-between"
+        class="w-full px-3 py-2.5 border-b last:border-0 flex justify-between"
         @click="emit('pick', contact.address)"
       >
         <div class="flex items-center max-w-full">

--- a/apps/ui/src/components/PickerToken.vue
+++ b/apps/ui/src/components/PickerToken.vue
@@ -133,7 +133,7 @@ watch(
       v-for="(asset, i) in filteredAssets"
       :key="i"
       type="button"
-      class="px-3 py-2.5 border-b last:border-0 flex justify-between"
+      class="w-full px-3 py-2.5 border-b last:border-0 flex justify-between text-start"
       @click="handlePick(asset)"
     >
       <div class="flex items-center min-w-0 pr-2">


### PR DESCRIPTION
### Summary

After converting elements to button tokens lost full-width property and alignment.


### How to test

1. Go there: http://localhost:8080/#/sn-sep:0x04d43d2fcc5dc1e0172c8fab38a2142d55336edac22a97f5503a72d37e18e252/treasury
2. Click on Send Token button -> open token list.
3. It looks good.
4. Try contact picker as well.

### Screenshots
After:
<img width="498" alt="image" src="https://github.com/user-attachments/assets/ab306ef6-1faa-404a-b1f3-1e8be2d86f05">

Before:
![image](https://github.com/user-attachments/assets/0098f94a-ca65-4968-a59e-a8e5eb29c80f)
