### PR TITLE
fix: fix readOnly state not being read as reference

### DIFF
--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -123,8 +123,10 @@ const executionStrategy = computed(() => {
 
 const hasStakeableAssets = computed(() => {
   return (
-    !isReadOnly &&
-    assets.value.some(asset => asset.contractAddress === ETH_CONTRACT)
+    treasury.value &&
+    !isReadOnly.value &&
+    assets.value.some(asset => asset.contractAddress === ETH_CONTRACT) &&
+    ETHEREUM_NETWORKS.includes(treasury.value.networkId)
   );
 });
 
@@ -313,9 +315,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
               </div>
               <UiTooltip
                 v-if="
-                  asset.contractAddress === ETH_CONTRACT &&
-                  !isReadOnly &&
-                  ETHEREUM_NETWORKS.includes(treasury.networkId)
+                  asset.contractAddress === ETH_CONTRACT && hasStakeableAssets
                 "
                 title="Stake with Lido"
               >


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #564

Fix the missing `.value` when reading the computed `isReadOnly` variable.

Also applied some DRY, so we centralize the decision to enable the "Stake with lido" button or not with the `hasStakeableAssets` property.

### How to test

1. Go to http://localhost:8080/#/eth:0x6E60b6dCc2923267104Bb4a68F4766f627430664/treasury
2. The stake with lido button should appear
3. Clicking on the button should open the modal
4. Go to a space with a readonly ETH treasury
5. The button should not appear
6. Go to a space eth space with a trasury with an ETH token, not on the eth network (such as optimism)
7. The button should not appear
