### PR TITLE
fix: remove user in delegates query

### DIFF
--- a/apps/ui/src/composables/useDelegates.ts
+++ b/apps/ui/src/composables/useDelegates.ts
@@ -30,7 +30,6 @@ type DelegatesQueryFilter = {
   orderDirection: string;
   skip: number;
   first: number;
-  user?: string;
 };
 
 type SortOrder =
@@ -50,18 +49,13 @@ const DELEGATES_QUERY = gql`
     $orderBy: Delegate_orderBy!
     $orderDirection: OrderDirection!
     $governance: String!
-    $user: String
   ) {
     delegates(
       first: $first
       skip: $skip
       orderBy: $orderBy
       orderDirection: $orderDirection
-      where: {
-        tokenHoldersRepresentedAmount_gte: 0
-        governance: $governance
-        user: $user
-      }
+      where: { tokenHoldersRepresentedAmount_gte: 0, governance: $governance }
     ) {
       id
       user


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #563 

Fix an issue where the delegates grapqhl query is failing when requesting https://api.studio.thegraph.com/proxy/23545/delegates/version/latest , due to the schema expecting user as `Byte` type, instead of `String`.

`user` filter will be reinstated when the schema will be fixed, by accepting the String type for user.

### How to test

1. Go to http://localhost:8080/#/sn:0x05702362b68a350c1cae8f2a529d74fdbb502369ddcebfadac7e91da37636947/delegates
2. It should show delegates from both Starknet and Ethereum
