### PR TITLE
feat: support editing statement from a starknet account

### DIFF
--- a/.changeset/ninety-dolphins-behave.md
+++ b/.changeset/ninety-dolphins-behave.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+add support for statement edition when aliased from a starknet account

--- a/packages/sx.js/src/clients/offchain/ethereum-sig/types.ts
+++ b/packages/sx.js/src/clients/offchain/ethereum-sig/types.ts
@@ -137,7 +137,7 @@ export const updateUserTypes = {
 
 export const updateStatementTypes = {
   Statement: [
-    { name: 'from', type: 'address' },
+    { name: 'from', type: 'string' },
     { name: 'timestamp', type: 'uint64' },
     { name: 'space', type: 'string' },
     { name: 'about', type: 'string' },


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #555 

This PR adds support for user space statement edition from a starknet account.

This change was missed from the previous PR as the user statement and starknet support PRs were opened in parallel.

### How to test

1. Connect with a starknet account
2. Go to a your profile on a space (e.g. http://localhost:8080/#/sn:0x05702362b68a350c1cae8f2a529d74fdbb502369ddcebfadac7e91da37636947/profile/YOUR-ADDRESS)
3. Edit and save the statement
4. It should ask to sign the create alias message if not already exist
5. It should save and show the edited statement
