### PR TITLE
fix: return merkleWhitelist VP as bigint

### DIFF
--- a/packages/sx.js/src/strategies/evm/merkleWhitelist.ts
+++ b/packages/sx.js/src/strategies/evm/merkleWhitelist.ts
@@ -4,7 +4,7 @@ import { Strategy, StrategyConfig } from '../../clients/evm/types';
 
 type Entry = {
   address: string;
-  votingPower: bigint;
+  votingPower: string;
 };
 
 function getProofForVoter(
@@ -29,14 +29,13 @@ export default function createMerkleWhitelist(): Strategy {
       signerAddress: string,
       metadata: Record<string, any> | null
     ): Promise<string> {
-      const tree = metadata?.tree;
+      const tree: Entry[] = metadata?.tree;
 
       if (!tree) throw new Error('Invalid metadata. Missing tree');
 
-      const whitelist: [string, bigint][] = tree.map((entry: Entry) => [
-        entry.address,
-        entry.votingPower
-      ]);
+      const whitelist = tree.map(
+        entry => [entry.address, BigInt(entry.votingPower)] as [string, bigint]
+      );
       const merkleTree = StandardMerkleTree.of(whitelist, [
         'address',
         'uint96'
@@ -56,17 +55,16 @@ export default function createMerkleWhitelist(): Strategy {
       voterAddress: string,
       metadata: Record<string, any> | null
     ): Promise<bigint> {
-      const tree = metadata?.tree;
+      const tree: Entry[] = metadata?.tree;
 
       if (!tree) throw new Error('Invalid metadata. Missing tree');
 
       const match = tree.find(
-        (entry: Entry) =>
-          entry.address.toLowerCase() === voterAddress.toLowerCase()
+        entry => entry.address.toLowerCase() === voterAddress.toLowerCase()
       );
 
       if (match) {
-        return BigInt(match.votingPower.toString());
+        return BigInt(match.votingPower);
       }
 
       return 0n;

--- a/packages/sx.js/src/strategies/starknet/merkleWhitelist.ts
+++ b/packages/sx.js/src/strategies/starknet/merkleWhitelist.ts
@@ -7,7 +7,7 @@ import { AddressType, generateMerkleProof, Leaf } from '../../utils/merkletree';
 type Entry = {
   type: AddressType;
   address: string;
-  votingPower: bigint;
+  votingPower: string;
 };
 
 export default function createMerkleWhitelistStrategy(): Strategy {
@@ -22,12 +22,12 @@ export default function createMerkleWhitelistStrategy(): Strategy {
       envelope: Envelope<Propose | Vote>,
       clientConfig: ClientConfig
     ): Promise<string[]> {
-      const tree = metadata?.tree;
+      const tree: Entry[] = metadata?.tree;
 
       if (!tree) throw new Error('Invalid metadata. Missing tree');
 
       const leaves: Leaf[] = tree.map(
-        (entry: Entry) => new Leaf(entry.type, entry.address, entry.votingPower)
+        entry => new Leaf(entry.type, entry.address, BigInt(entry.votingPower))
       );
       const hashes = leaves.map(leaf => leaf.hash);
       const voterIndex = leaves.findIndex(
@@ -61,12 +61,12 @@ export default function createMerkleWhitelistStrategy(): Strategy {
       params: string[],
       clientConfig: ClientConfig
     ): Promise<bigint> {
-      const tree = metadata?.tree;
+      const tree: Entry[] = metadata?.tree;
 
       if (!tree) throw new Error('Invalid metadata. Missing tree');
 
       const leaves: Leaf[] = tree.map(
-        (entry: Entry) => new Leaf(entry.type, entry.address, entry.votingPower)
+        entry => new Leaf(entry.type, entry.address, BigInt(entry.votingPower))
       );
       const voter = leaves.find(
         leaf =>


### PR DESCRIPTION
### Summary

Because of incorrect types we were actually returning strings instead of bigints. This became an issue when adding those values together as instead of adding VPs we were concatenating them.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/492

### How to test

1. Apply following patch to mock address and show VP in the UI on closed proposal.
2. Go to http://localhost:8080/#/sn:0x071977084d73002fed430d99108da39d241b900099ccc2a4cdcb7d5041d851d2/proposal/15
3. You should see 110.4 VP (instead of 1.1k).
  
```diff
diff --git a/apps/ui/src/views/Proposal.vue b/apps/ui/src/views/Proposal.vue
index baac6cce..eea11109 100644
--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -78,7 +78,7 @@ async function getVotingPower() {
       proposal.value.strategies,
       proposal.value.strategies_params,
       proposal.value.space.strategies_parsed_metadata,
-      web3.value.account,
+      '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7',
       {
         at: proposal.value.state === 'pending' ? null : proposal.value.snapshot,
         chainId: proposal.value.space.snapshot_chain_id
@@ -199,12 +199,7 @@ watchEffect(() => {
       <div
         class="static md:fixed md:top-[72px] md:right-0 w-full md:h-[calc(100vh-72px)] md:max-w-[340px] p-4 md:pb-[88px] border-l-0 md:border-l space-y-4 no-scrollbar overflow-y-scroll"
       >
-        <div
-          v-if="
-            !proposal.cancelled &&
-            ['pending', 'active'].includes(proposal.state)
-          "
-        >
+        <div v-if="true">
           <h4 class="mb-2 eyebrow flex items-center space-x-2">
             <template v-if="editMode">
               <IH-cursor-click />

```