### PR TITLE
fix: Change staking icon

### DIFF
--- a/apps/ui/src/assets/icons/stake.svg
+++ b/apps/ui/src/assets/icons/stake.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+<path d="M12 12V11C12 7.13401 8.86599 4 5 4H4V5C4 8.86599 7.13401 12 11 12H12ZM12 12V14M12 15H13C16.866 15 20 11.866 20 8V7H19C15.134 7 12 10.134 12 14M12 15V14M12 15V20" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/apps/ui/src/assets/icons/stake.svg
+++ b/apps/ui/src/assets/icons/stake.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none">
 <path d="M12 12V11C12 7.13401 8.86599 4 5 4H4V5C4 8.86599 7.13401 12 11 12H12ZM12 12V14M12 15H13C16.866 15 20 11.866 20 8V7H19C15.134 7 12 10.134 12 14M12 15V14M12 15V20" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
 </svg>

--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -323,7 +323,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
                   class="!px-0 w-[46px]"
                   @click.prevent="openModal('stake')"
                 >
-                  <IC-Stake class="inline-block" />
+                  <IC-stake class="inline-block" />
                 </UiButton>
               </UiTooltip>
             </div>

--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -10,7 +10,6 @@ import {
 } from '@/helpers/utils';
 import { evmNetworks, getNetwork } from '@/networks';
 import { Contact, Space, SpaceMetadataTreasury, Transaction } from '@/types';
-import ICStake from '~icons/c/stake';
 
 const ETHEREUM_NETWORKS = ['eth', 'sep'];
 
@@ -324,7 +323,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
                   class="!px-0 w-[46px]"
                   @click.prevent="openModal('stake')"
                 >
-                  <ICStake class="inline-block" />
+                  <IC-Stake class="inline-block" />
                 </UiButton>
               </UiTooltip>
             </div>

--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -10,6 +10,7 @@ import {
 } from '@/helpers/utils';
 import { evmNetworks, getNetwork } from '@/networks';
 import { Contact, Space, SpaceMetadataTreasury, Transaction } from '@/types';
+import ICStake from '~icons/c/stake';
 
 const ETHEREUM_NETWORKS = ['eth', 'sep'];
 
@@ -323,7 +324,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
                   class="!px-0 w-[46px]"
                   @click.prevent="openModal('stake')"
                 >
-                  <IH-fire class="inline-block" />
+                  <ICStake class="inline-block" />
                 </UiButton>
               </UiTooltip>
             </div>

--- a/apps/ui/src/components/TransactionsListItem.vue
+++ b/apps/ui/src/components/TransactionsListItem.vue
@@ -52,7 +52,7 @@ const parsedTitle = computedAsync(
       <slot name="left" />
       <IH-cash v-if="tx._type === 'sendToken'" />
       <IH-photograph v-else-if="tx._type === 'sendNft'" />
-      <IC-Stake v-else-if="tx._type === 'stakeToken'" />
+      <IC-stake v-else-if="tx._type === 'stakeToken'" />
       <IH-code v-else />
       <div class="ml-2 truncate text-skin-link" v-html="parsedTitle" />
     </div>

--- a/apps/ui/src/components/TransactionsListItem.vue
+++ b/apps/ui/src/components/TransactionsListItem.vue
@@ -3,7 +3,6 @@ import { formatUnits } from '@ethersproject/units';
 import { getNames } from '@/helpers/stamp';
 import { _n, shorten } from '@/helpers/utils';
 import { Transaction } from '@/types';
-import ICStake from '~icons/c/stake';
 
 const props = defineProps<{ tx: Transaction }>();
 
@@ -53,7 +52,7 @@ const parsedTitle = computedAsync(
       <slot name="left" />
       <IH-cash v-if="tx._type === 'sendToken'" />
       <IH-photograph v-else-if="tx._type === 'sendNft'" />
-      <ICStake v-else-if="tx._type === 'stakeToken'" />
+      <IC-Stake v-else-if="tx._type === 'stakeToken'" />
       <IH-code v-else />
       <div class="ml-2 truncate text-skin-link" v-html="parsedTitle" />
     </div>

--- a/apps/ui/src/components/TransactionsListItem.vue
+++ b/apps/ui/src/components/TransactionsListItem.vue
@@ -3,6 +3,7 @@ import { formatUnits } from '@ethersproject/units';
 import { getNames } from '@/helpers/stamp';
 import { _n, shorten } from '@/helpers/utils';
 import { Transaction } from '@/types';
+import ICStake from '~icons/c/stake';
 
 const props = defineProps<{ tx: Transaction }>();
 
@@ -52,7 +53,7 @@ const parsedTitle = computedAsync(
       <slot name="left" />
       <IH-cash v-if="tx._type === 'sendToken'" />
       <IH-photograph v-else-if="tx._type === 'sendNft'" />
-      <IH-fire v-else-if="tx._type === 'stakeToken'" />
+      <ICStake v-else-if="tx._type === 'stakeToken'" />
       <IH-code v-else />
       <div class="ml-2 truncate text-skin-link" v-html="parsedTitle" />
     </div>


### PR DESCRIPTION
### Summary

Closes: #576 
- Adjust the given image to be visible on both themes
- Change the icon on the treasury page and transactions page

| Before    | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/df369739-b83f-4c79-b050-bbcc0b724b36)  | ![image](https://github.com/user-attachments/assets/778fa0c9-f6a8-4440-96d4-b14333019151)   |
| ![image](https://github.com/user-attachments/assets/3b4470b4-d61d-48ef-a6b6-011d8c04dd2e) | ![image](https://github.com/user-attachments/assets/98a5187b-7db6-4ec2-8db5-1ec35bc86473) |

In light theme:
![image](https://github.com/user-attachments/assets/6ca3c1bc-4e34-4f2f-b7b2-cdd844c28056)
![image](https://github.com/user-attachments/assets/1b2f4868-e565-47a4-8e1d-917f07e6b981)


### How to test

1. Go to http://localhost:8080/#/eth:0x6E60b6dCc2923267104Bb4a68F4766f627430664/treasury
2. You should see new icon
3. Click stake button and enter a random value
4. It should redirect to new proposal page and in the bottom you should see new icon

