### PR TITLE
fix(ui): do not overlap the gradient with border

### DIFF
--- a/apps/ui/src/style.scss
+++ b/apps/ui/src/style.scss
@@ -313,7 +313,7 @@ input:placeholder-shown {
   .s-label:has(+ textarea),
   .s-base:has(textarea:only-child) {
      &::before {
-      @apply block bg-gradient-to-b from-skin-border to-transparent h-[8px] w-full absolute top-3.5 left-0;
+      @apply block bg-gradient-to-b from-skin-border to-transparent h-[8px] absolute top-3.5 left-[1px] right-[1px];
 
       content: '';
     }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

textarea gradient is currently overlapping with the border. 
It is not obvious due to border color, but it is when the textarea is errored

![Screenshot 2024-08-02 at 23 25 13](https://github.com/user-attachments/assets/3663913c-a8e2-4ea9-bd9a-0f81658f9bd0)

### How to test

1. Go to any textarea, like your profile
2. Fill the textarea to trigger an error
3. You should not see the gradient overlapping the border
