### PR TITLE
feat: add multiple treasuries support in editor

### DIFF
--- a/apps/ui/src/App.vue
+++ b/apps/ui/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { startIntercom } from './helpers/intercom';
+import { Transaction } from './types';
 
 const el = ref(null);
 
@@ -25,10 +26,12 @@ const hasAppNav = computed(() =>
 async function handleTransactionAccept() {
   if (!spaceKey.value || !executionStrategy.value || !transaction.value) return;
 
+  const executions = {} as Record<string, Transaction[]>;
+  executions[executionStrategy.value.address] = [transaction.value];
+
   const space = spaceKey.value;
   const draftId = await createDraft(space, {
-    execution: [transaction.value],
-    executionStrategy: executionStrategy.value
+    executions
   });
 
   router.push(`/${space}/create/${draftId}`);

--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -140,8 +140,8 @@ watch(
               }"
               v-text="
                 strategy.type === 'oSnap'
-                  ? 'oSnap'
-                  : `${network.constants.EXECUTORS[strategy.type]} execution strategy`
+                  ? 'oSnap execution'
+                  : `${network.constants.EXECUTORS[strategy.type]} execution`
               "
             />
           </div>

--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -12,6 +12,7 @@ const model = defineModel<TransactionType[]>({
 
 const props = defineProps<{
   space: Space;
+  disabled?: boolean;
   strategy: StrategyWithTreasury;
   extraContacts?: Contact[];
 }>();
@@ -110,7 +111,13 @@ watch(
         class="w-full flex justify-between px-4 py-3 text-start"
       >
         <div class="flex justify-between items-center">
-          <UiBadgeNetwork :id="treasury.networkId" class="mr-3">
+          <UiBadgeNetwork
+            :id="treasury.networkId"
+            class="mr-3"
+            :class="{
+              'opacity-40': disabled
+            }"
+          >
             <UiStamp
               :id="treasury.wallet"
               type="avatar"
@@ -121,10 +128,16 @@ watch(
           <div class="flex-1 leading-[22px]">
             <h4
               class="text-skin-link"
+              :class="{
+                'text-skin-border': disabled
+              }"
               v-text="treasury.name || shorten(treasury.wallet)"
             />
             <div
               class="text-skin-text text-[17px]"
+              :class="{
+                'text-skin-border': disabled
+              }"
               v-text="
                 strategy.type === 'oSnap'
                   ? 'oSnap'
@@ -136,7 +149,7 @@ watch(
         <div class="space-x-2">
           <UiTooltip title="Send token">
             <UiButton
-              :disabled="!treasury"
+              :disabled="!treasury || disabled"
               class="!px-0 w-[46px]"
               @click="openModal('sendToken')"
             >
@@ -145,7 +158,7 @@ watch(
           </UiTooltip>
           <UiTooltip title="Send NFT">
             <UiButton
-              :disabled="!treasury"
+              :disabled="!treasury || disabled"
               class="!px-0 w-[46px]"
               @click="openModal('sendNft')"
             >
@@ -154,7 +167,7 @@ watch(
           </UiTooltip>
           <UiTooltip title="Contract call">
             <UiButton
-              :disabled="!treasury"
+              :disabled="!treasury || disabled"
               class="!px-0 w-[46px]"
               @click="openModal('contractCall')"
             >

--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -132,7 +132,7 @@ watch(
           />
         </div>
       </button>
-      <div class="flex gap-2 p-3">
+      <div class="flex flex-col lg:flex-row gap-2 p-3">
         <UiButton
           class="w-full space-x-2"
           :disabled="!treasury"

--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import Draggable from 'vuedraggable';
 import { simulate } from '@/helpers/tenderly';
+import { shorten } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
 import {
   Contact,
@@ -108,80 +109,121 @@ watch(
 <template>
   <div class="space-y-3">
     <div class="overflow-hidden border rounded-lg">
-      <ExecutionButton :disabled="!treasury" @click="openModal('sendToken')">
-        <IH-cash class="inline-block" />
-        <span>Send token</span>
-      </ExecutionButton>
-      <ExecutionButton :disabled="!treasury" @click="openModal('sendNft')">
-        <IH-photograph class="inline-block" />
-        <span>Send NFT</span>
-      </ExecutionButton>
-      <ExecutionButton @click="openModal('contractCall')">
-        <IH-code class="inline-block" />
-        <span>Contract call</span>
-      </ExecutionButton>
-    </div>
-    <div v-if="model.length > 0" class="x-block !border-x rounded-lg">
-      <Draggable v-model="model" handle=".handle" :item-key="() => undefined">
-        <template #item="{ element: tx, index: i }">
-          <TransactionsListItem :tx="tx">
-            <template #left>
-              <div
-                v-if="model.length > 1"
-                class="handle mr-2 text-skin-link cursor-pointer opacity-50 hover:opacity-100"
-              >
-                <IH-switch-vertical />
-              </div>
-            </template>
-            <template #right>
-              <div class="flex gap-3">
-                <button type="button" @click="editTx(i)">
-                  <IH-pencil />
-                </button>
-                <button type="button" @click="removeTx(i)">
-                  <IH-trash />
-                </button>
-              </div>
-            </template>
-          </TransactionsListItem>
-        </template>
-      </Draggable>
-      <div
-        class="border-t px-4 py-2 space-x-2 flex items-center justify-between"
+      <button
+        v-if="treasury"
+        class="w-full flex justify-between items-center px-4 py-3 text-start border-b"
       >
-        <div class="flex items-center max-w-[70%]">
-          {{ model.length }}
-          {{ model.length === 1 ? 'transaction' : 'transactions' }}
+        <UiBadgeNetwork :id="treasury.networkId" class="mr-3">
+          <UiStamp
+            :id="treasury.wallet"
+            type="avatar"
+            :size="32"
+            class="rounded-md"
+          />
+        </UiBadgeNetwork>
+        <div class="flex-1 leading-[22px]">
+          <h4
+            class="text-skin-link"
+            v-text="treasury.name || shorten(treasury.wallet)"
+          />
+          <div
+            class="text-skin-text text-[17px]"
+            v-text="shorten(treasury.wallet)"
+          />
         </div>
-        <UiTooltip
-          v-if="!network?.supportsSimulation"
-          title="Simulation not supported on this network"
+      </button>
+      <div class="flex gap-2 p-3">
+        <UiButton
+          class="w-full space-x-2"
+          :disabled="!treasury"
+          @click="openModal('sendToken')"
         >
-          <IH-shield-exclamation />
-        </UiTooltip>
-        <UiTooltip
-          v-else-if="simulationState === null"
-          title="Simulate execution"
+          <IH-cash class="inline-block" />
+          <span>Send token</span>
+        </UiButton>
+        <UiButton
+          class="w-full space-x-2"
+          :disabled="!treasury"
+          @click="openModal('sendNft')"
         >
-          <button type="button" class="flex" @click="handleSimulateClick">
-            <IH-shield-check class="text-skin-link" />
-          </button>
-        </UiTooltip>
-        <UiLoading v-else-if="simulationState === 'SIMULATING'" />
-        <UiTooltip
-          v-if="simulationState === 'SIMULATION_SUCCEDED'"
-          title="Execution simulation succeeded"
-        >
-          <IH-shield-check class="text-skin-success" />
-        </UiTooltip>
-        <UiTooltip
-          v-if="simulationState === 'SIMULATION_FAILED'"
-          title="Execution simulation failed"
-        >
-          <IH-shield-check class="text-skin-danger" />
-        </UiTooltip>
+          <IH-photograph class="inline-block" />
+          <span>Send NFT</span>
+        </UiButton>
+        <UiButton class="w-full space-x-2" @click="openModal('contractCall')">
+          <IH-code class="inline-block" />
+          <span>Contract call</span>
+        </UiButton>
       </div>
+      <template v-if="model.length > 0">
+        <UiLabel label="Transactions" class="border-t" />
+        <div>
+          <Draggable
+            v-model="model"
+            handle=".handle"
+            :item-key="() => undefined"
+          >
+            <template #item="{ element: tx, index: i }">
+              <TransactionsListItem :tx="tx">
+                <template #left>
+                  <div
+                    v-if="model.length > 1"
+                    class="handle mr-2 text-skin-link cursor-pointer opacity-50 hover:opacity-100"
+                  >
+                    <IH-switch-vertical />
+                  </div>
+                </template>
+                <template #right>
+                  <div class="flex gap-3">
+                    <button type="button" @click="editTx(i)">
+                      <IH-pencil />
+                    </button>
+                    <button type="button" @click="removeTx(i)">
+                      <IH-trash />
+                    </button>
+                  </div>
+                </template>
+              </TransactionsListItem>
+            </template>
+          </Draggable>
+          <div
+            class="border-t px-4 py-2 space-x-2 flex items-center justify-between"
+          >
+            <div class="flex items-center max-w-[70%]">
+              {{ model.length }}
+              {{ model.length === 1 ? 'transaction' : 'transactions' }}
+            </div>
+            <UiTooltip
+              v-if="!network?.supportsSimulation"
+              title="Simulation not supported on this network"
+            >
+              <IH-shield-exclamation />
+            </UiTooltip>
+            <UiTooltip
+              v-else-if="simulationState === null"
+              title="Simulate execution"
+            >
+              <button type="button" class="flex" @click="handleSimulateClick">
+                <IH-shield-check class="text-skin-link" />
+              </button>
+            </UiTooltip>
+            <UiLoading v-else-if="simulationState === 'SIMULATING'" />
+            <UiTooltip
+              v-if="simulationState === 'SIMULATION_SUCCEDED'"
+              title="Execution simulation succeeded"
+            >
+              <IH-shield-check class="text-skin-success" />
+            </UiTooltip>
+            <UiTooltip
+              v-if="simulationState === 'SIMULATION_FAILED'"
+              title="Execution simulation failed"
+            >
+              <IH-shield-check class="text-skin-danger" />
+            </UiTooltip>
+          </div>
+        </div>
+      </template>
     </div>
+
     <teleport to="#modal">
       <ModalSendToken
         v-if="treasury && treasury.networkId"

--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -1,14 +1,10 @@
 <script setup lang="ts">
 import Draggable from 'vuedraggable';
+import { StrategyWithTreasury } from '@/composables/useTreasuries';
 import { simulate } from '@/helpers/tenderly';
 import { shorten } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
-import {
-  Contact,
-  Space,
-  SpaceMetadataTreasury,
-  Transaction as TransactionType
-} from '@/types';
+import { Contact, Space, Transaction as TransactionType } from '@/types';
 
 const model = defineModel<TransactionType[]>({
   required: true
@@ -16,12 +12,12 @@ const model = defineModel<TransactionType[]>({
 
 const props = defineProps<{
   space: Space;
-  treasuryData: SpaceMetadataTreasury;
+  strategy: StrategyWithTreasury;
   extraContacts?: Contact[];
 }>();
 
 const uiStore = useUiStore();
-const { treasury } = useTreasury(props.treasuryData);
+const { treasury } = useTreasury(props.strategy.treasury);
 
 const editedTx: Ref<number | null> = ref(null);
 const modalState: Ref<{
@@ -109,50 +105,63 @@ watch(
 <template>
   <div class="space-y-3">
     <div class="overflow-hidden border rounded-lg">
-      <button
-        v-if="treasury"
-        class="w-full flex justify-between items-center px-4 py-3 text-start border-b"
+      <div
+        v-if="treasury && network"
+        class="w-full flex justify-between px-4 py-3 text-start"
       >
-        <UiBadgeNetwork :id="treasury.networkId" class="mr-3">
-          <UiStamp
-            :id="treasury.wallet"
-            type="avatar"
-            :size="32"
-            class="rounded-md"
-          />
-        </UiBadgeNetwork>
-        <div class="flex-1 leading-[22px]">
-          <h4
-            class="text-skin-link"
-            v-text="treasury.name || shorten(treasury.wallet)"
-          />
-          <div
-            class="text-skin-text text-[17px]"
-            v-text="shorten(treasury.wallet)"
-          />
+        <div class="flex justify-between items-center">
+          <UiBadgeNetwork :id="treasury.networkId" class="mr-3">
+            <UiStamp
+              :id="treasury.wallet"
+              type="avatar"
+              :size="32"
+              class="rounded-md"
+            />
+          </UiBadgeNetwork>
+          <div class="flex-1 leading-[22px]">
+            <h4
+              class="text-skin-link"
+              v-text="treasury.name || shorten(treasury.wallet)"
+            />
+            <div
+              class="text-skin-text text-[17px]"
+              v-text="
+                strategy.type === 'oSnap'
+                  ? 'oSnap'
+                  : `${network.constants.EXECUTORS[strategy.type]} execution strategy`
+              "
+            />
+          </div>
         </div>
-      </button>
-      <div class="flex flex-col lg:flex-row gap-2 p-3">
-        <UiButton
-          class="w-full space-x-2"
-          :disabled="!treasury"
-          @click="openModal('sendToken')"
-        >
-          <IH-cash class="inline-block" />
-          <span>Send token</span>
-        </UiButton>
-        <UiButton
-          class="w-full space-x-2"
-          :disabled="!treasury"
-          @click="openModal('sendNft')"
-        >
-          <IH-photograph class="inline-block" />
-          <span>Send NFT</span>
-        </UiButton>
-        <UiButton class="w-full space-x-2" @click="openModal('contractCall')">
-          <IH-code class="inline-block" />
-          <span>Contract call</span>
-        </UiButton>
+        <div class="space-x-2">
+          <UiTooltip title="Send token">
+            <UiButton
+              :disabled="!treasury"
+              class="!px-0 w-[46px]"
+              @click="openModal('sendToken')"
+            >
+              <IH-cash class="inline-block" />
+            </UiButton>
+          </UiTooltip>
+          <UiTooltip title="Send NFT">
+            <UiButton
+              :disabled="!treasury"
+              class="!px-0 w-[46px]"
+              @click="openModal('sendNft')"
+            >
+              <IH-photograph class="inline-block" />
+            </UiButton>
+          </UiTooltip>
+          <UiTooltip title="Contract call">
+            <UiButton
+              :disabled="!treasury"
+              class="!px-0 w-[46px]"
+              @click="openModal('contractCall')"
+            >
+              <IH-code class="inline-block" />
+            </UiButton>
+          </UiTooltip>
+        </div>
       </div>
       <template v-if="model.length > 0">
         <UiLabel label="Transactions" class="border-t" />

--- a/apps/ui/src/components/ProposalExecutionsList.vue
+++ b/apps/ui/src/components/ProposalExecutionsList.vue
@@ -20,10 +20,10 @@ function getTreasuryExplorerUrl(networkId: NetworkID, safeAddress: string) {
 
 function getExecutionType(networkId: NetworkID, strategyType: string) {
   try {
-    if (strategyType === 'oSnap') return strategyType;
+    if (strategyType === 'oSnap') return 'oSnap execution';
 
     const network = getNetwork(networkId);
-    return network.constants.EXECUTORS[strategyType];
+    return `${network.constants.EXECUTORS[strategyType]} execution`;
   } catch (e) {
     return null;
   }

--- a/apps/ui/src/components/ProposalExecutionsList.vue
+++ b/apps/ui/src/components/ProposalExecutionsList.vue
@@ -17,6 +17,17 @@ function getTreasuryExplorerUrl(networkId: NetworkID, safeAddress: string) {
     return null;
   }
 }
+
+function getExecutionType(networkId: NetworkID, strategyType: string) {
+  try {
+    if (strategyType === 'oSnap') return strategyType;
+
+    const network = getNetwork(networkId);
+    return network.constants.EXECUTORS[strategyType];
+  } catch (e) {
+    return null;
+  }
+}
 </script>
 
 <template>
@@ -31,7 +42,7 @@ function getTreasuryExplorerUrl(networkId: NetworkID, safeAddress: string) {
         undefined
       "
       target="_blank"
-      class="flex justify-between items-center px-4 py-3 border-b"
+      class="flex justify-between items-center px-4 py-3"
       :class="{
         'pointer-events-none': !getTreasuryExplorerUrl(
           execution.networkId,
@@ -54,10 +65,14 @@ function getTreasuryExplorerUrl(networkId: NetworkID, safeAddress: string) {
         />
         <div
           class="text-skin-text text-[17px]"
-          v-text="shorten(execution.safeAddress)"
+          v-text="
+            getExecutionType(execution.networkId, execution.strategyType) ||
+            shorten(execution.safeAddress)
+          "
         />
       </div>
     </a>
+    <UiLabel label="Transactions" class="border-t" />
     <TransactionsListItem
       v-for="(tx, i) in execution.transactions"
       :key="i"

--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -11,7 +11,6 @@ import {
   SpaceMetadata,
   SpaceSettings,
   Statement,
-  Transaction,
   User,
   VoteType
 } from '@/types';
@@ -274,7 +273,7 @@ export function useActions() {
     discussion: string,
     type: VoteType,
     choices: string[],
-    executionInfo: ExecutionInfo | null
+    executions: ExecutionInfo[] | null
   ) {
     if (!web3.value.account) {
       forceLogin();
@@ -283,17 +282,6 @@ export function useActions() {
 
     const network = getNetwork(space.network);
 
-    const pinned = await network.helpers.pin({
-      title,
-      body,
-      discussion,
-      type,
-      choices: choices.filter(c => !!c),
-      execution: executionInfo?.transactions ?? []
-    });
-    if (!pinned || !pinned.cid) return false;
-    console.log('IPFS', pinned);
-
     await wrapPromise(
       space.network,
       network.actions.propose(
@@ -301,18 +289,12 @@ export function useActions() {
         web3.value.type as Connector,
         web3.value.account,
         space,
-        pinned.cid,
-        executionInfo === null
-          ? executionInfo
-          : {
-              ...executionInfo,
-              transactions: executionInfo.transactions.map(
-                (tx: Transaction) => ({
-                  ...tx,
-                  operation: 0
-                })
-              )
-            }
+        title,
+        body,
+        discussion,
+        type,
+        choices,
+        executions
       )
     );
 
@@ -332,7 +314,7 @@ export function useActions() {
     discussion: string,
     type: VoteType,
     choices: string[],
-    executionInfo: ExecutionInfo | null
+    executions: ExecutionInfo[] | null
   ) {
     if (!web3.value.account) {
       forceLogin();
@@ -340,17 +322,6 @@ export function useActions() {
     }
 
     const network = getNetwork(space.network);
-
-    const pinned = await network.helpers.pin({
-      title,
-      body,
-      discussion,
-      type,
-      choices: choices.filter(c => !!c),
-      execution: executionInfo?.transactions ?? []
-    });
-    if (!pinned || !pinned.cid) return false;
-    console.log('IPFS', pinned);
 
     await wrapPromise(
       space.network,
@@ -360,18 +331,12 @@ export function useActions() {
         web3.value.account,
         space,
         proposalId,
-        pinned.cid,
-        executionInfo === null
-          ? executionInfo
-          : {
-              ...executionInfo,
-              transactions: executionInfo.transactions.map(
-                (tx: Transaction) => ({
-                  ...tx,
-                  operation: 0
-                })
-              )
-            }
+        title,
+        body,
+        discussion,
+        type,
+        choices,
+        executions
       )
     );
 

--- a/apps/ui/src/composables/useTreasuries.ts
+++ b/apps/ui/src/composables/useTreasuries.ts
@@ -1,0 +1,88 @@
+import { CHAIN_IDS } from '@/helpers/constants';
+import { getIsOsnapEnabled } from '@/helpers/osnap';
+import { compareAddresses } from '@/helpers/utils';
+import { getNetwork, offchainNetworks } from '@/networks';
+import {
+  RequiredProperty,
+  SelectedStrategy,
+  Space,
+  SpaceMetadataTreasury
+} from '@/types';
+
+export type StrategyWithTreasury = SelectedStrategy & {
+  treasury: RequiredProperty<SpaceMetadataTreasury>;
+};
+
+type InputType = Space | null;
+export function useTreasuries(spaceRef: ComputedRef<InputType> | InputType) {
+  const strategiesWithTreasuries = computedAsync(async () => {
+    const space = isRef(spaceRef) ? spaceRef.value : spaceRef;
+
+    if (!space) return null;
+
+    let oSnapSupportPerTreasury: boolean[] | null = null;
+    if (offchainNetworks.includes(space.network)) {
+      oSnapSupportPerTreasury = await Promise.all(
+        space.treasuries.map(async treasury => {
+          if (
+            !treasury.network ||
+            !treasury.address ||
+            !CHAIN_IDS[treasury.network]
+          ) {
+            return false;
+          }
+
+          return getIsOsnapEnabled(
+            CHAIN_IDS[treasury.network].toString(),
+            treasury.address
+          );
+        })
+      );
+    }
+
+    return space.treasuries
+      .map((treasury, i) => {
+        if (offchainNetworks.includes(space.network)) {
+          if (!oSnapSupportPerTreasury || !oSnapSupportPerTreasury[i]) {
+            return null;
+          }
+
+          return {
+            address: treasury.address,
+            destinationAddress: null,
+            type: 'oSnap',
+            treasury: treasury as RequiredProperty<SpaceMetadataTreasury>
+          };
+        }
+
+        const strategy = space.executors_strategies.find(strategy => {
+          return (
+            strategy.treasury &&
+            strategy.treasury_chain &&
+            treasury.address &&
+            treasury.network &&
+            compareAddresses(strategy.treasury, treasury.address) &&
+            CHAIN_IDS[treasury.network] === strategy.treasury_chain
+          );
+        });
+
+        if (!strategy) return null;
+
+        return {
+          address: strategy.address,
+          destinationAddress: strategy.destination_address,
+          type: strategy.type,
+          treasury: treasury as RequiredProperty<SpaceMetadataTreasury>
+        };
+      })
+      .filter(
+        strategy =>
+          strategy &&
+          getNetwork(space.network).helpers.isExecutorSupported(strategy.type)
+      ) as StrategyWithTreasury[];
+  }, null);
+
+  return {
+    strategiesWithTreasuries
+  };
+}

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -154,6 +154,7 @@ function processExecutions(
 
   return [
     {
+      strategyType: match?.type || '',
       safeAddress: match?.treasury || '',
       safeName: matchingTreasury?.name || 'Unnamed treasury',
       networkId: matchingTreasury?.network || executionNetworkId,

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -40,7 +40,8 @@ import {
   Proposal,
   Space,
   SpaceMetadata,
-  StrategyParsedMetadata
+  StrategyParsedMetadata,
+  VoteType
 } from '@/types';
 
 const CONFIGS: Record<number, EvmNetworkConfig> = {
@@ -200,10 +201,26 @@ export function createActions(
       connectorType: Connector,
       account: string,
       space: Space,
-      cid: string,
-      executionInfo: ExecutionInfo | null
+      title: string,
+      body: string,
+      discussion: string,
+      type: VoteType,
+      choices: string[],
+      executions: ExecutionInfo[] | null
     ) => {
       await verifyNetwork(web3, chainId);
+
+      const executionInfo = executions?.[0];
+      const pinned = await helpers.pin({
+        title,
+        body,
+        discussion,
+        type,
+        choices: choices.filter(c => !!c),
+        execution: executionInfo?.transactions ?? []
+      });
+      if (!pinned || !pinned.cid) return false;
+      console.log('IPFS', pinned);
 
       const isContract = await getIsContract(account);
 
@@ -255,7 +272,7 @@ export function createActions(
         authenticator,
         strategies: strategiesWithMetadata,
         executionStrategy: selectedExecutionStrategy,
-        metadataUri: `ipfs://${cid}`
+        metadataUri: `ipfs://${pinned.cid}`
       };
 
       if (relayerType === 'evm') {
@@ -283,10 +300,26 @@ export function createActions(
       account: string,
       space: Space,
       proposalId: number | string,
-      cid: string,
-      executionInfo: ExecutionInfo | null
+      title: string,
+      body: string,
+      discussion: string,
+      type: VoteType,
+      choices: string[],
+      executions: ExecutionInfo[] | null
     ) {
       await verifyNetwork(web3, chainId);
+
+      const executionInfo = executions?.[0];
+      const pinned = await helpers.pin({
+        title,
+        body,
+        discussion,
+        type,
+        choices: choices.filter(c => !!c),
+        execution: executionInfo?.transactions ?? []
+      });
+      if (!pinned || !pinned.cid) return false;
+      console.log('IPFS', pinned);
 
       const isContract = await getIsContract(account);
 
@@ -322,7 +355,7 @@ export function createActions(
         proposal: proposalId as number,
         authenticator,
         executionStrategy: selectedExecutionStrategy,
-        metadataUri: `ipfs://${cid}`
+        metadataUri: `ipfs://${pinned.cid}`
       };
 
       if (relayerType === 'evm') {

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -166,6 +166,7 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     try {
       executions = proposal.plugins.oSnap.safes.map(safe => {
         return {
+          strategyType: 'oSnap',
           safeName: safe.safeName,
           safeAddress: safe.safeAddress,
           networkId: chainIdToNetworkId[Number(safe.network)],

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -36,7 +36,8 @@ import {
   Proposal,
   Space,
   SpaceMetadata,
-  StrategyParsedMetadata
+  StrategyParsedMetadata,
+  VoteType
 } from '@/types';
 
 const CONFIGS: Partial<Record<NetworkID, NetworkConfig>> = {
@@ -195,9 +196,25 @@ export function createActions(
       connectorType: Connector,
       account: string,
       space: Space,
-      cid: string,
-      executionInfo: ExecutionInfo | null
+      title: string,
+      body: string,
+      discussion: string,
+      type: VoteType,
+      choices: string[],
+      executions: ExecutionInfo[] | null
     ) => {
+      const executionInfo = executions?.[0];
+      const pinned = await helpers.pin({
+        title,
+        body,
+        discussion,
+        type,
+        choices: choices.filter(c => !!c),
+        execution: executionInfo?.transactions ?? []
+      });
+      if (!pinned || !pinned.cid) return false;
+      console.log('IPFS', pinned);
+
       const isContract = await getIsContract(connectorType, account);
 
       const { relayerType, authenticator, strategies } =
@@ -252,7 +269,7 @@ export function createActions(
         authenticator,
         strategies: strategiesWithMetadata,
         executionStrategy: selectedExecutionStrategy,
-        metadataUri: `ipfs://${cid}`
+        metadataUri: `ipfs://${pinned.cid}`
       };
 
       if (relayerType === 'starknet') {
@@ -281,9 +298,25 @@ export function createActions(
       account: string,
       space: Space,
       proposalId: number | string,
-      cid: string,
-      executionInfo: ExecutionInfo | null
+      title: string,
+      body: string,
+      discussion: string,
+      type: VoteType,
+      choices: string[],
+      executions: ExecutionInfo[] | null
     ) {
+      const executionInfo = executions?.[0];
+      const pinned = await helpers.pin({
+        title,
+        body,
+        discussion,
+        type,
+        choices: choices.filter(c => !!c),
+        execution: executionInfo?.transactions ?? []
+      });
+      if (!pinned || !pinned.cid) return false;
+      console.log('IPFS', pinned);
+
       const isContract = await getIsContract(connectorType, account);
 
       const { relayerType, authenticator } = pickAuthenticatorAndStrategies({
@@ -322,7 +355,7 @@ export function createActions(
         proposal: proposalId as number,
         authenticator,
         executionStrategy: selectedExecutionStrategy,
-        metadataUri: `ipfs://${cid}`
+        metadataUri: `ipfs://${pinned.cid}`
       };
 
       if (relayerType === 'starknet') {

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -122,8 +122,12 @@ export type ReadOnlyNetworkActions = {
     connectorType: Connector,
     account: string,
     space: Space,
-    cid: string,
-    executionInfo: ExecutionInfo | null
+    title: string,
+    body: string,
+    discussion: string,
+    type: VoteType,
+    choices: string[],
+    executions: ExecutionInfo[] | null
   ): Promise<any>;
   updateProposal(
     web3: Web3Provider,
@@ -131,8 +135,12 @@ export type ReadOnlyNetworkActions = {
     account: string,
     space: Space,
     proposalId: number | string,
-    cid: string,
-    executionInfo: ExecutionInfo | null
+    title: string,
+    body: string,
+    discussion: string,
+    type: VoteType,
+    choices: string[],
+    executions: ExecutionInfo[] | null
   ): Promise<any>;
   cancelProposal(web3: Web3Provider, proposal: Proposal);
   vote(

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -144,6 +144,7 @@ export type Space = {
 };
 
 export type ProposalExecution = {
+  strategyType: string;
   safeName: string;
   safeAddress: string;
   networkId: NetworkID;

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -289,8 +289,7 @@ export type Draft = {
   discussion: string;
   type: VoteType;
   choices: string[];
-  executionStrategy: SelectedStrategy | null;
-  execution: Transaction[];
+  executions: Record<string, Transaction[] | undefined>;
   updatedAt: number;
 };
 

--- a/apps/ui/src/views/Editor.vue
+++ b/apps/ui/src/views/Editor.vue
@@ -493,7 +493,7 @@ export default defineComponent({
             :key="execution.address"
             :model-value="execution.transactions"
             :space="space"
-            :treasury-data="execution.treasury"
+            :strategy="execution"
             :extra-contacts="extraContacts"
             class="mb-4"
             @update:model-value="

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -113,6 +113,16 @@ async function handleEditClick() {
 
   const spaceId = `${props.proposal.network}:${props.proposal.space.id}`;
 
+  const executions = Object.fromEntries(
+    props.proposal.executions.map(execution => {
+      const address = offchainNetworks.includes(props.proposal.network)
+        ? execution.safeAddress
+        : props.proposal.execution_strategy;
+
+      return [address, execution.transactions];
+    })
+  );
+
   const draftId = await createDraft(spaceId, {
     proposalId: props.proposal.proposal_id,
     title: props.proposal.title,
@@ -120,18 +130,7 @@ async function handleEditClick() {
     discussion: props.proposal.discussion,
     type: props.proposal.type,
     choices: props.proposal.choices,
-    executionStrategy:
-      props.proposal.execution_strategy_type === 'none'
-        ? null
-        : {
-            address: props.proposal.execution_strategy,
-            type: props.proposal.execution_strategy_type
-          },
-    execution:
-      !offchainNetworks.includes(props.proposal.network) &&
-      props.proposal.executions.length > 0
-        ? props.proposal.executions[0].transactions
-        : undefined
+    executions
   });
 
   router.push({


### PR DESCRIPTION
### Summary

This PR adds support for configuring execution with multiple treasuries 

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/138

### How to test

1. Get two spaces to test with (one on offchain with oSnap enabled and multiple treasuries configured and another onchain with execution and treasury configured).
2. Try creating proposals on both.
3. Everything works as expected: on offchain you can select multiple treasuries at once, onchain should be limited to one at the time.
4. You can open drafts with execution.
5. You can open editor with execution from treasury page by clicking Send token or Send NFT button.

### Screenshots

<img width="642" alt="image" src="https://github.com/user-attachments/assets/87f4ffde-d49a-428e-ab68-d6e8f94c1802">
<img width="628" alt="image" src="https://github.com/user-attachments/assets/981c075c-e6c1-4461-8975-561a5a18ed91">
