### PR TITLE
style: add space breadcrumb on space pages

### DIFF
--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -28,10 +28,15 @@ const searchInput = ref();
 const searchValue = ref('');
 
 const hasAppNav = computed(() =>
-  ['space', 'my', 'settings'].includes(String(route.matched[0]?.name))
+  ['my', 'settings'].includes(String(route.matched[0]?.name))
 );
 const searchConfig = computed(
   () => SEARCH_CONFIG[route.matched[0]?.name || '']
+);
+const showBreadcrumb = computed(() =>
+  ['space', 'proposal', 'landing', 'settings'].includes(
+    String(route.matched[0]?.name)
+  )
 );
 
 async function handleLogin(connector) {
@@ -87,6 +92,15 @@ watch(
         >
           <IH-menu-alt-2 />
         </button>
+        <Breadcrumb v-if="showBreadcrumb">
+          <router-link
+            :to="{ path: '/' }"
+            class="flex items-center"
+            style="font-size: 24px"
+          >
+            snapshot
+          </router-link>
+        </Breadcrumb>
         <form
           v-if="searchConfig"
           id="search-form"
@@ -104,15 +118,6 @@ watch(
             />
           </label>
         </form>
-        <Breadcrumb v-else>
-          <router-link
-            :to="{ path: '/' }"
-            class="flex items-center"
-            style="font-size: 24px"
-          >
-            snapshot
-          </router-link>
-        </Breadcrumb>
       </div>
       <div :key="web3.account" class="flex">
         <UiButton

--- a/apps/ui/src/components/Breadcrumb.vue
+++ b/apps/ui/src/components/Breadcrumb.vue
@@ -9,10 +9,9 @@ const uiStore = useUiStore();
 const param = ref<string>('');
 
 watchEffect(() => {
-  param.value =
-    route.matched[0]?.name === 'space'
-      ? String(route.params.id)
-      : String(route.params.space);
+  param.value = String(
+    route.matched[0]?.name === 'space' ? route.params.id : route.params.space
+  );
 });
 
 const { resolved, address: spaceAddress, networkId } = useResolve(param);

--- a/apps/ui/src/components/Breadcrumb.vue
+++ b/apps/ui/src/components/Breadcrumb.vue
@@ -4,13 +4,34 @@ import { NetworkID } from '@/types';
 const route = useRoute();
 const spacesStore = useSpacesStore();
 const proposalsStore = useProposalsStore();
-const { param } = useRouteParser('space');
+const uiStore = useUiStore();
+
+const param = ref<string>('');
+
+watchEffect(() => {
+  param.value =
+    route.matched[0]?.name === 'space'
+      ? String(route.params.id)
+      : String(route.params.space);
+});
+
 const { resolved, address: spaceAddress, networkId } = useResolve(param);
 
-const show = computed(() => route.matched[0]?.name === 'proposal');
+const showSpaceLogo = computed(() =>
+  ['proposal', 'space'].includes(String(route.matched[0]?.name))
+);
+
+const isInsideAppNav = computed(() =>
+  ['space'].includes(String(route.matched[0]?.name))
+);
 
 const space = computed(() => {
-  if (!show || !resolved.value || !spaceAddress.value || !networkId.value) {
+  if (
+    !showSpaceLogo.value ||
+    !resolved.value ||
+    !spaceAddress.value ||
+    !networkId.value
+  ) {
     return null;
   }
   return (
@@ -25,7 +46,14 @@ const space = computed(() => {
 </script>
 
 <template>
-  <template v-if="show">
+  <div
+    v-if="showSpaceLogo"
+    :class="{
+      'mr-4 pr-2 h-full hidden lg:flex items-center border-r': isInsideAppNav,
+      'w-[216px]': isInsideAppNav && !uiStore.sidebarOpen,
+      '!flex w-[172px]': isInsideAppNav && uiStore.sidebarOpen
+    }"
+  >
     <router-link
       v-if="space"
       :to="{
@@ -41,6 +69,6 @@ const space = computed(() => {
       />
       <span class="truncate" v-text="space.name" />
     </router-link>
-  </template>
+  </div>
   <slot v-else />
 </template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/568

### How to test

1. Go to any space page http://localhost:8080/#/sn:0x05ea5ef0c54c84dc7382629684c6e536c0b06246b3b0981c426b42372e3ef263
2. you should see space logo
3. <img width="787" alt="Untitled 4" src="https://github.com/user-attachments/assets/50a6127c-0922-4f1a-a020-ad8919152ef9">
4. The proposal should still show logo without search bar
5. <img width="769" alt="Untitled 5" src="https://github.com/user-attachments/assets/eb8715fd-ce1f-4e69-b2a6-59f16a289547">
6. Landing page should still show snapshot logo
7.  <img width="656" alt="Untitled 6" src="https://github.com/user-attachments/assets/c60e2b2c-0699-415c-8a23-9691ab06161d">
8. settings page should still show logo like before
9. <img width="786" alt="Untitled 7" src="https://github.com/user-attachments/assets/f346a024-07a9-4036-bde9-6216c66c1ac3">




