### PR TITLE
feat: always redirect editor to proposals page

### DIFF
--- a/apps/ui/src/views/Editor.vue
+++ b/apps/ui/src/views/Editor.vue
@@ -280,7 +280,10 @@ async function handleProposeClick() {
     }
     if (result) {
       proposalsStore.reset(address.value!, networkId.value!);
-      router.back();
+      router.push({
+        name: 'space-proposals',
+        params: { id: param.value }
+      });
     }
   } finally {
     sending.value = false;


### PR DESCRIPTION
### Summary

Currently our redirect is not stable (it just goes back), so you might end up at treasury page, overview, proposals page, previous draft etc.

This will make it always redirect to proposals page.

### How to test

1. Create proposal.
2. You get redirected to proposals page.

