### PR TITLE
fix: cache spaceKey before calling createDraft

### DIFF
--- a/apps/ui/src/App.vue
+++ b/apps/ui/src/App.vue
@@ -25,11 +25,13 @@ const hasAppNav = computed(() =>
 async function handleTransactionAccept() {
   if (!spaceKey.value || !executionStrategy.value || !transaction.value) return;
 
-  const draftId = await createDraft(spaceKey.value, {
+  const space = spaceKey.value;
+  const draftId = await createDraft(space, {
     execution: [transaction.value],
     executionStrategy: executionStrategy.value
   });
-  router.push(`/${spaceKey.value}/create/${draftId}`);
+
+  router.push(`/${space}/create/${draftId}`);
 
   reset();
 }


### PR DESCRIPTION
### Summary

We reset WalletConnect transaction when modal is closed, right now handleTransactionAccept is async so it would be reset before createDraft returns. Because of this spaceKey.value was already reset when we tried to navigate to it.

Regression from https://github.com/snapshot-labs/sx-monorepo/pull/512

### How to test

1. Go to space with treasury configured (has to be on-chain currently: http://localhost:8080/#/sep:0xfa463A2Bdd8d27f1b0eA99270c3c4Bb3A7B2ADeF/treasury)
2. Connect via WalletConnect (in treasury section) and connect to UniSwap.
3. Initiate transaction on UniSwap (for example swap ETH to WETH).
4. Accept transaction on SX-UI.
5. Proposal opens and execution is visible.
