### PR TITLE
feat: add UiInputAmount and decimals validation

### DIFF
--- a/apps/ui/src/components/Modal/SendToken.vue
+++ b/apps/ui/src/components/Modal/SendToken.vue
@@ -22,17 +22,6 @@ const RECIPIENT_DEFINITION = {
   examples: ['Address or ENS']
 };
 
-const formValidator = getValidator({
-  $async: true,
-  type: 'object',
-  title: 'TokenTransfer',
-  additionalProperties: false,
-  required: ['to'],
-  properties: {
-    to: RECIPIENT_DEFINITION
-  }
-});
-
 const props = defineProps<{
   open: boolean;
   address: string;
@@ -51,8 +40,8 @@ const searchInput: Ref<HTMLElement | null> = ref(null);
 const form: {
   to: string;
   token: string;
-  amount: string | number;
-  value: string | number;
+  amount: string;
+  value: string;
 } = reactive(clone(DEFAULT_FORM_STATE));
 
 const showPicker = ref(false);
@@ -91,6 +80,27 @@ const currentToken = computed(() => {
   return token;
 });
 
+const amountDefinition = computed(() => ({
+  type: 'string',
+  decimals: currentToken.value?.decimals ?? 0,
+  title: 'Amount',
+  examples: ['0']
+}));
+
+const formValidator = computed(() =>
+  getValidator({
+    $async: true,
+    type: 'object',
+    title: 'TokenTransfer',
+    additionalProperties: false,
+    required: ['to', 'amount'],
+    properties: {
+      to: RECIPIENT_DEFINITION,
+      amount: amountDefinition.value
+    }
+  })
+);
+
 const formValid = computed(
   () =>
     currentToken.value &&
@@ -124,23 +134,28 @@ function handlePickerClick(type: 'token' | 'contact') {
   });
 }
 
-function handleAmountUpdate(value) {
+function handleAmountUpdate(value: string) {
   form.amount = value;
 
   if (value === '') {
     form.value = '';
   } else if (currentToken.value) {
-    form.value = parseFloat((value * currentToken.value.price).toFixed(2));
+    const float = parseFloat(value.replace(',', '.'));
+    form.value = (float * currentToken.value.price).toFixed(2);
   }
 }
 
-function handleValueUpdate(value) {
+function handleValueUpdate(value: string) {
   form.value = value;
 
   if (value === '') {
     form.amount = '';
   } else if (currentToken.value) {
-    form.amount = parseFloat((value / currentToken.value.price).toFixed(6));
+    const decimals = Math.min(currentToken.value.decimals, 6);
+
+    const float = parseFloat(value.replace(',', '.'));
+    const parsed = (float / currentToken.value.price).toFixed(decimals);
+    form.amount = parseFloat(parsed) === 0 ? '0' : parsed;
   }
 }
 
@@ -195,16 +210,16 @@ watch([() => props.address, () => props.network], ([address, network]) => {
 watch(currentToken, token => {
   if (!token || form.amount === '') return;
 
-  const amount =
-    typeof form.amount === 'string' ? parseFloat(form.amount) : form.amount;
-  form.value = parseFloat((amount * token.price).toFixed(2));
+  const amount = parseFloat(form.amount.replace(',', '.'));
+  form.value = (amount * token.price).toFixed(2);
 });
 
 watchEffect(async () => {
   formValidated.value = false;
 
-  formErrors.value = await formValidator.validateAsync({
-    to: form.to
+  formErrors.value = await formValidator.value.validateAsync({
+    to: form.to,
+    amount: form.amount
   });
   formValidated.value = true;
 });
@@ -292,13 +307,10 @@ watchEffect(async () => {
       </div>
       <div class="flex gap-2.5">
         <div class="relative w-full">
-          <UiInputNumber
+          <UiInputAmount
             :model-value="form.amount"
-            :definition="{
-              type: 'number',
-              title: 'Amount',
-              examples: ['0']
-            }"
+            :definition="amountDefinition"
+            :error="formErrors.amount"
             @update:model-value="handleAmountUpdate"
           />
           <button
@@ -308,13 +320,14 @@ watchEffect(async () => {
             v-text="'max'"
           />
         </div>
-        <UiInputNumber
-          v-if="currentToken.price !== 0"
-          class="w-full"
-          :model-value="form.value"
-          :definition="{ type: 'number', title: 'USD', examples: ['0'] }"
-          @update:model-value="handleValueUpdate"
-        />
+        <div class="w-full">
+          <UiInputAmount
+            v-if="currentToken.price !== 0"
+            :model-value="form.value"
+            :definition="{ type: 'number', title: 'USD', examples: ['0'] }"
+            @update:model-value="handleValueUpdate"
+          />
+        </div>
       </div>
     </div>
     <template v-if="!showPicker" #footer>

--- a/apps/ui/src/components/Ui/InputAmount.vue
+++ b/apps/ui/src/components/Ui/InputAmount.vue
@@ -1,0 +1,72 @@
+<script lang="ts">
+export default {
+  inheritAttrs: false
+};
+</script>
+
+<script setup lang="ts">
+const model = defineModel<string>({
+  required: true
+});
+
+const props = defineProps<{
+  error?: string;
+  definition: any;
+}>();
+
+const dirty = ref(false);
+
+const inputValue = computed(() => {
+  if (!model.value && !dirty.value && props.definition.default) {
+    return props.definition.default;
+  }
+
+  return model.value;
+});
+
+function handleInput(event: Event) {
+  const inputEvent = event as InputEvent;
+  const target = inputEvent.target as HTMLInputElement;
+  const value = target.value;
+
+  dirty.value = true;
+
+  if (value === '') {
+    model.value = '';
+    return;
+  }
+
+  if (!/^[0-9]*[.,]?[0-9]*$/.test(value)) {
+    target.value = model.value;
+    return;
+  }
+
+  model.value = value;
+}
+
+watch(model, () => {
+  dirty.value = true;
+});
+</script>
+
+<template>
+  <UiWrapperInput
+    v-slot="{ id }"
+    :definition="definition"
+    :error="error"
+    :dirty="dirty"
+    :input-value-length="inputValue?.length"
+  >
+    <input
+      :id="id"
+      :value="inputValue"
+      type="text"
+      class="s-input"
+      pattern="^[0-9]*[.,]?[0-9]*$"
+      inputmode="decimal"
+      v-bind="$attrs"
+      :placeholder="definition.examples && definition.examples[0]"
+      @input="handleInput"
+    />
+  </UiWrapperInput>
+</template>

--- a/apps/ui/src/helpers/validation.test.ts
+++ b/apps/ui/src/helpers/validation.test.ts
@@ -1,39 +1,38 @@
 import { describe, expect, it } from 'vitest';
 import { getValidator } from './validation';
 
-describe('validation', () => {
-  describe('addresses-with-voting-power', () => {
-    const schema = {
-      type: 'object',
-      properties: {
-        whitelist: {
-          type: 'string',
-          format: 'addresses-with-voting-power'
-        }
+describe('addresses-with-voting-power', () => {
+  const schema = {
+    type: 'object',
+    properties: {
+      whitelist: {
+        type: 'string',
+        format: 'addresses-with-voting-power'
       }
-    };
-    const validator = getValidator(schema);
+    }
+  };
+  const validator = getValidator(schema);
 
-    it('should not return errors for a single valid EVM address with voting power', () => {
-      const result = validator.validate({
-        whitelist: '0x395ed61716b48dc904140b515e9f682e33330154:1'
-      });
-
-      expect(result).toEqual({});
+  it('should not return errors for a single valid EVM address with voting power', () => {
+    const result = validator.validate({
+      whitelist: '0x395ed61716b48dc904140b515e9f682e33330154:1'
     });
 
-    it('should not return errors for a single valid starknet address with voting power', () => {
-      const result = validator.validate({
-        whitelist:
-          '0x7d2f37b75a5e779f7da01c22acee1b66c39e8ba470ee5448f05e1462afcedb4:1'
-      });
+    expect(result).toEqual({});
+  });
 
-      expect(result).toEqual({});
+  it('should not return errors for a single valid starknet address with voting power', () => {
+    const result = validator.validate({
+      whitelist:
+        '0x7d2f37b75a5e779f7da01c22acee1b66c39e8ba470ee5448f05e1462afcedb4:1'
     });
 
-    it('should not return errors for a list of addresses with voting power', () => {
-      const result = validator.validate({
-        whitelist: `
+    expect(result).toEqual({});
+  });
+
+  it('should not return errors for a list of addresses with voting power', () => {
+    const result = validator.validate({
+      whitelist: `
           0x7d2f37b75a5e779f7da01c22acee1b66c39e8ba470ee5448f05e1462afcedb4 :  1
 
 0x7d2f37b75a5e779f7da01c22acee1b66c39e8ba470ee5448f05e1462afcedb4:2
@@ -41,57 +40,104 @@ describe('validation', () => {
 
 
         `
-      });
-
-      expect(result).toEqual({});
     });
 
-    it('should return an error when voting power is missing', () => {
-      const result = validator.validate({
-        whitelist: '0x395ed61716b48dc904140b515e9f682e33330154'
-      });
+    expect(result).toEqual({});
+  });
 
-      expect(result).toHaveProperty('whitelist');
+  it('should return an error when voting power is missing', () => {
+    const result = validator.validate({
+      whitelist: '0x395ed61716b48dc904140b515e9f682e33330154'
     });
 
-    it('should return an error when voting power is empty', () => {
-      const result = validator.validate({
-        whitelist: '0x395ed61716b48dc904140b515e9f682e33330154:'
-      });
+    expect(result).toHaveProperty('whitelist');
+  });
 
-      expect(result).toHaveProperty('whitelist');
+  it('should return an error when voting power is empty', () => {
+    const result = validator.validate({
+      whitelist: '0x395ed61716b48dc904140b515e9f682e33330154:'
     });
 
-    it('should return an error when voting power is invalid', () => {
-      const result = validator.validate({
-        whitelist: '0x395ed61716b48dc904140b515e9f682e33330154:4xx!'
-      });
+    expect(result).toHaveProperty('whitelist');
+  });
 
-      expect(result).toHaveProperty('whitelist');
+  it('should return an error when voting power is invalid', () => {
+    const result = validator.validate({
+      whitelist: '0x395ed61716b48dc904140b515e9f682e33330154:4xx!'
     });
 
-    it('should return an error when address is not valid', () => {
-      const result = validator.validate({
-        whitelist: '-0x395ed61716b48dc904140b515e9f682e33330154:0'
-      });
+    expect(result).toHaveProperty('whitelist');
+  });
 
-      expect(result).toHaveProperty('whitelist');
+  it('should return an error when address is not valid', () => {
+    const result = validator.validate({
+      whitelist: '-0x395ed61716b48dc904140b515e9f682e33330154:0'
     });
 
-    it('should return an error when address is empty', () => {
-      const result = validator.validate({
-        whitelist: ':0'
-      });
+    expect(result).toHaveProperty('whitelist');
+  });
 
-      expect(result).toHaveProperty('whitelist');
+  it('should return an error when address is empty', () => {
+    const result = validator.validate({
+      whitelist: ':0'
     });
 
-    it('should return an error when not following the address:vp format', () => {
-      const result = validator.validate({
-        whitelist: 'hello world'
-      });
+    expect(result).toHaveProperty('whitelist');
+  });
 
-      expect(result).toHaveProperty('whitelist');
+  it('should return an error when not following the address:vp format', () => {
+    const result = validator.validate({
+      whitelist: 'hello world'
+    });
+
+    expect(result).toHaveProperty('whitelist');
+  });
+});
+
+describe('decimals', () => {
+  it('should verify that number has no decimals if 0 decimals is specified', () => {
+    const schema = {
+      type: 'object',
+      required: ['value'],
+      properties: {
+        value: {
+          type: 'string',
+          decimals: 0
+        }
+      }
+    };
+
+    const validator = getValidator(schema);
+
+    expect(validator.validate({ value: '10' })).toEqual({});
+    expect(validator.validate({ value: '10.1' })).toEqual({
+      value: 'Can have at most 0 decimals.'
+    });
+    expect(validator.validate({ value: '10.00000000000001' })).toEqual({
+      value: 'Can have at most 0 decimals.'
+    });
+  });
+
+  it('should verify that number has at most 8 decimals', () => {
+    const schema = {
+      type: 'object',
+      required: ['value'],
+      properties: {
+        value: {
+          type: 'string',
+          decimals: 8
+        }
+      }
+    };
+
+    const validator = getValidator(schema);
+
+    expect(validator.validate({ value: '10' })).toEqual({});
+    expect(validator.validate({ value: '10.0' })).toEqual({});
+    expect(validator.validate({ value: '10.1' })).toEqual({});
+    expect(validator.validate({ value: '10.00000001' })).toEqual({});
+    expect(validator.validate({ value: '10.000000001' })).toEqual({
+      value: 'Can have at most 8 decimals.'
     });
   });
 });

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -213,6 +213,22 @@ ajv.addFormat('ethValue', {
   }
 });
 
+ajv.addKeyword({
+  keyword: 'decimals',
+  type: 'string',
+  schemaType: 'number',
+  validate: (schema: number, data: string) => {
+    if (!data) return true;
+
+    const regex = new RegExp(`^\\d+[.,]?\\d{0,${schema}}$`);
+    return regex.test(data);
+  },
+  error: {
+    message: ctx => {
+      return `Can have at most ${ctx.schemaValue} decimals`;
+    }
+  }
+});
 ajv.addKeyword('options');
 
 function getErrorMessage(errorObject: Partial<ErrorObject>): string {


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/583

This PR adds new `UiInputAmount` that can be used to input numeric amounts, but without drawbacks of using number input for it:
- Because it's no longer number it doesn't get converted to exponential form (for example in StakeToken modal output value would be displayed as `1e-7`).
- Similarly when entering small value like `0.000000000000001` and triggering re-render, for example by going to contact picker and back it would be turned to exponential form.
- `UiInputAmount` value has consistent type (always string), where `UiInputNumber` could have either `string` (when input is empty) or `number`.

This PR also adds decimals validation so we can validate the form (SendToken and StakeToken).

### How to test

1. Go there: http://localhost:8080/#/eth:0x6E60b6dCc2923267104Bb4a68F4766f627430664/treasury
2. Try creating SendToken execution, enter big values or small ones, trigger decimals error.
3. Try creating StakeToken execution, enter big values or small ones, trigger decimals error.
4. Nothing breaks.

**Note:** Currently if you enter error state (for example too many decimals) and open picker and back dirty flag gets cleared so it won't display the error on UI, but it's true for all inputs at the moment, we have issue for that: https://github.com/snapshot-labs/sx-monorepo/issues/573

### Screenshots

Before

https://github.com/user-attachments/assets/49dc80bb-c292-4657-837d-6a19a73eb1e4



After


https://github.com/user-attachments/assets/bc708716-f111-45f0-8daf-95c92f51b416


