### PR TITLE
fix: verify if legacy execution is non-null

### DIFF
--- a/apps/ui/src/composables/useEditor.ts
+++ b/apps/ui/src/composables/useEditor.ts
@@ -11,9 +11,15 @@ const processedProposals = Object.fromEntries(
 
     // convert single treasury to multiple treasuries format
     if ('execution' in processed && 'executionStrategy' in processed) {
-      processed.executions = {
-        [processed.executionStrategy.address]: processed.execution
-      };
+      processed.executions =
+        processed.executionStrategy && processed.execution
+          ? {
+              [processed.executionStrategy.address]: processed.execution
+            }
+          : {};
+
+      delete processed.execution;
+      delete processed.executionStrategy;
     }
 
     return [k, v];


### PR DESCRIPTION
### Summary

After #579 we convert old executions into new format, but it had two issues that caused crash or unexpected behaviour:
- drafts that didn't have execution at all (executionStrategy was null) would cause a crash
- drafts with execution in legacy format would keep reverting to that legacy execution even though if it was changed later

### How to test

1. Start by deleting your local storage `ui.proposals`.
2. Go back to commit before introduction of new format `git checkout 3792f72be6992a41f9fb46228c6326b23482f4ee`.
3. Enter editor and create draft without execution (insert just title/body) http://localhost:8080/#/s:0cf5e.eth/create
4. Switch back to this branch and reload app, no crashes.
5. In your old draft add some execution.
6. Refresh page again, new execution is visible.

