### PR TITLE
ci: deploy to staging mainnet API app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       - name: Deploy if files have changed
-        run: ./scripts/deploy-changed.sh apps/api ${{ vars.DIGITALOCEAN_APP_ID }}
+        run: ./scripts/deploy-api-prod.sh
 
   deploy_api_testnet:
     name: Deploy API to testnet

--- a/scripts/deploy-api-prod.sh
+++ b/scripts/deploy-api-prod.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NAME_SERVER="ns1.3dns.box"
+PRODUCTION_DOMAIN="api.snapshot.box"
+APP_DOMAIN_1="sx-api-starknet-mainnet-dfghg.ondigitalocean.app."
+APP_DOMAIN_2="sx-api-mainnet-2-fmlg8.ondigitalocean.app"
+APP_ID_1="c4eba570-abea-4ab3-8941-d968db6cad36"
+APP_ID_2="9282b162-7280-43b9-b429-9f53810003bc"
+
+CURRENT_DOMAIN=$(dig -t CNAME +short "$PRODUCTION_DOMAIN" @"$NAME_SERVER")
+
+CURRENT_STAGING_APP_ID=""
+if [ "$CURRENT_DOMAIN" = "$APP_DOMAIN_1" ]; then
+  CURRENT_STAGING_APP_ID=$APP_ID_2
+elif [ "$CURRENT_DOMAIN" = "$APP_DOMAIN_2" ]; then
+  CURRENT_STAGING_APP_ID=$APP_ID_1
+else
+  echo "Unknown domain: $CURRENT_DOMAIN"
+  exit -1
+fi
+
+echo "Starting deployment to staging app: $CURRENT_STAGING_APP_ID"
+
+./scripts/deploy-changed.sh apps/api "$CURRENT_STAGING_APP_ID"


### PR DESCRIPTION
### Summary

With new script deployment to DO app will be decided based on the URL that api.snapshot.box currently points to.

We use 3dns.box's authoritative nameserver to get latest records.

If it's currently pointing to APP_1 we will deploy to APP_2, if it's currently pointing to APP_2 we will deploy to APP_1.
