### PR TITLE
fix(ux): prefill vote reason on edition

### DIFF
--- a/apps/ui/src/components/Modal/Vote.vue
+++ b/apps/ui/src/components/Modal/Vote.vue
@@ -29,7 +29,7 @@ const {
   fetch: fetchVotingPower,
   reset: resetVotingPower
 } = useVotingPower();
-const { votes } = useAccount();
+const { loadVotes, votes } = useAccount();
 
 const loading = ref(false);
 const form = ref<Record<string, string>>({ reason: '' });
@@ -79,13 +79,14 @@ function handleFetchVotingPower() {
 
 watch(
   [() => props.open, () => web3.value.account],
-  ([open, toAccount], [, fromAccount]) => {
+  async ([open, toAccount], [, fromAccount]) => {
     if (fromAccount && toAccount && fromAccount !== toAccount) {
       resetVotingPower();
     }
 
     if (open) {
       handleFetchVotingPower();
+      await loadVotes(props.proposal.network, [props.proposal.space.id]);
       form.value.reason =
         votes.value[`${props.proposal.network}:${props.proposal.id}`]?.reason ||
         '';

--- a/apps/ui/src/components/Modal/Vote.vue
+++ b/apps/ui/src/components/Modal/Vote.vue
@@ -32,10 +32,7 @@ const {
 const { votes } = useAccount();
 
 const loading = ref(false);
-const form = ref<Record<string, string>>({
-  reason:
-    votes.value[`${props.proposal.network}:${props.proposal.id}`]?.reason || ''
-});
+const form = ref<Record<string, string>>({ reason: '' });
 const formErrors = ref({} as Record<string, any>);
 const formValidated = ref(false);
 
@@ -87,7 +84,12 @@ watch(
       resetVotingPower();
     }
 
-    if (open) handleFetchVotingPower();
+    if (open) {
+      handleFetchVotingPower();
+      form.value.reason =
+        votes.value[`${props.proposal.network}:${props.proposal.id}`]?.reason ||
+        '';
+    }
   },
   { immediate: true }
 );

--- a/apps/ui/src/components/Modal/Vote.vue
+++ b/apps/ui/src/components/Modal/Vote.vue
@@ -80,17 +80,22 @@ function handleFetchVotingPower() {
 watch(
   [() => props.open, () => web3.value.account],
   async ([open, toAccount], [, fromAccount]) => {
+    if (!open) return;
+
     if (fromAccount && toAccount && fromAccount !== toAccount) {
+      loading.value = true;
       resetVotingPower();
+      form.value.reason = '';
+      await loadVotes(props.proposal.network, [props.proposal.space.id]);
     }
 
-    if (open) {
-      handleFetchVotingPower();
-      await loadVotes(props.proposal.network, [props.proposal.space.id]);
-      form.value.reason =
-        votes.value[`${props.proposal.network}:${props.proposal.id}`]?.reason ||
-        '';
-    }
+    handleFetchVotingPower();
+
+    form.value.reason =
+      votes.value[`${props.proposal.network}:${props.proposal.id}`]?.reason ||
+      '';
+
+    loading.value = false;
   },
   { immediate: true }
 );

--- a/apps/ui/src/components/Modal/Vote.vue
+++ b/apps/ui/src/components/Modal/Vote.vue
@@ -29,9 +29,13 @@ const {
   fetch: fetchVotingPower,
   reset: resetVotingPower
 } = useVotingPower();
+const { votes } = useAccount();
 
 const loading = ref(false);
-const form = ref<Record<string, string>>({ reason: '' });
+const form = ref<Record<string, string>>({
+  reason:
+    votes.value[`${props.proposal.network}:${props.proposal.id}`]?.reason || ''
+});
 const formErrors = ref({} as Record<string, any>);
 const formValidated = ref(false);
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #607

In the vote modal, the reason textarea should be prefilled with the existing vote reason if available, when editing a vote

### How to test

1. Vote on an offchain proposal with a reason
2. Go back to edit your vote
3. The reason textarea should be prefilled with your previous reason
4. Change the connected account (via your injected wallet)
5. The reason should be refreshed to reflect the vote associated to your account
