### PR TITLE
fix(ux): move post-vote actions to the vote modal

### DIFF
--- a/apps/ui/src/components/Modal/Vote.vue
+++ b/apps/ui/src/components/Modal/Vote.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { getChoiceText, getFormattedVotingPower } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
+import { offchainNetworks } from '@/networks';
 import { Choice, Proposal } from '@/types';
 
 const REASON_DEFINITION = {
@@ -29,6 +30,8 @@ const {
   fetch: fetchVotingPower,
   reset: resetVotingPower
 } = useVotingPower();
+const proposalsStore = useProposalsStore();
+const { loadVotes } = useAccount();
 
 const loading = ref(false);
 const form = ref<Record<string, string>>({ reason: '' });
@@ -65,8 +68,21 @@ async function handleSubmit() {
 
   try {
     await vote(props.proposal, props.choice, form.value.reason);
-    emit('voted');
-    emit('close');
+
+    try {
+      // TODO: Quick fix only for offchain proposals, need a more complete solution for onchain proposals
+      if (offchainNetworks.includes(props.proposal.network)) {
+        proposalsStore.fetchProposal(
+          props.proposal.space.id,
+          props.proposal.id,
+          props.proposal.network
+        );
+        await loadVotes(props.proposal.network, [props.proposal.space.id]);
+      }
+    } finally {
+      emit('voted');
+      emit('close');
+    }
   } finally {
     loading.value = false;
   }

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -73,23 +73,8 @@ async function handleVoteClick(choice: Choice) {
 }
 
 async function handleVoteSubmitted() {
-  if (!proposal.value) return;
-
   selectedChoice.value = null;
-
-  try {
-    // TODO: Quick fix only for offchain proposals, need a more complete solution for onchain proposals
-    if (offchainNetworks.includes(proposal.value.network)) {
-      proposalsStore.fetchProposal(
-        spaceAddress.value!,
-        id.value,
-        networkId.value!
-      );
-      await loadVotes(proposal.value.network, [proposal.value.space.id]);
-    }
-  } finally {
-    editMode.value = false;
-  }
+  editMode.value = false;
 }
 
 function handleFetchVotingPower() {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #604

We currently emit a `voted` event from the vote modal on vote submission, then let the calling component handle the necessary post-vote actions.

This lead to duplicated code since multiple component can listen to the `voted` event (Proposal view + ProposalListItem)

Moving these post-vote actions next to the API vote() action is more logical, and all calling components will benefit without code duplication.

### How to test

1. Vote on a basic offchain proposal from the proposal page
2. After vote submission, modal should close, and the vote form should reflect your current vote (with edit button), and the proposal results should be refreshed with your vote (should already be the current behavior, even before this PR, just confirming that it's not breaking)
3. Vote on a basic offchain proposal from the proposals list
4. After vote submission, modal should close, the vote form in the proposal list should be replaced by the results, with your new vote taken into account. (before this PR, basic vote form is still there)
