### PR TITLE
feat: check for custom min voting power when voting

### DIFF
--- a/apps/ui/src/components/MessageVotingPower.vue
+++ b/apps/ui/src/components/MessageVotingPower.vue
@@ -33,7 +33,15 @@ defineEmits<{
     type="error"
     v-bind="$attrs"
   >
-    You do not have enough voting power to vote.
+    <span v-if="votingPower.threshold.vote">
+      You need at least a voting power of
+      <i>
+        {{ Number(votingPower.threshold.vote) / 10 ** votingPower.decimals }}
+        {{ votingPower.symbol }}
+      </i>
+      to vote.
+    </span>
+    <span v-else> You do not have enough voting power to vote. </span>
   </UiAlert>
   <UiAlert
     v-else-if="action === 'propose' && !votingPower.canPropose"

--- a/apps/ui/src/components/MessageVotingPower.vue
+++ b/apps/ui/src/components/MessageVotingPower.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { VotingPowerItem } from '@/stores/votingPowers';
 
-defineProps<{
+const props = defineProps<{
   votingPower: VotingPowerItem;
   action?: 'vote' | 'propose';
 }>();
@@ -9,6 +9,18 @@ defineProps<{
 defineEmits<{
   (e: 'fetchVotingPower');
 }>();
+
+const insufficientVp: ComputedRef<boolean> = computed(() => {
+  return !!(
+    props.votingPower.threshold.vote && props.votingPower.totalVotingPower > 0n
+  );
+});
+
+const formattedVotingThreshold = computed(() => {
+  return (
+    Number(props.votingPower.threshold.vote) / 10 ** props.votingPower.decimals
+  );
+});
 </script>
 
 <template>
@@ -33,12 +45,9 @@ defineEmits<{
     type="error"
     v-bind="$attrs"
   >
-    <span v-if="votingPower.threshold.vote">
+    <span v-if="insufficientVp">
       You need at least a voting power of
-      <i>
-        {{ Number(votingPower.threshold.vote) / 10 ** votingPower.decimals }}
-        {{ votingPower.symbol }}
-      </i>
+      <i> {{ formattedVotingThreshold }} {{ votingPower.symbol }} </i>
       to vote.
     </span>
     <span v-else> You do not have enough voting power to vote. </span>

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -265,7 +265,9 @@ function formatProposal(
     state: getProposalState(proposal, current),
     network: networkId,
     privacy: null,
-    quorum: +proposal.quorum
+    quorum: +proposal.quorum,
+    validation: 'any',
+    validation_params: {}
   };
 }
 

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -244,6 +244,8 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     strategies: proposal.strategies.map(strategy => strategy.name),
     strategies_indicies: [],
     strategies_params: proposal.strategies.map(strategy => strategy),
+    validation: proposal.validation.name,
+    validation_params: proposal.validation.params,
     tx: '',
     execution_tx: null,
     veto_tx: null,

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -81,6 +81,10 @@ const PROPOSAL_FRAGMENT = gql`
       params
       network
     }
+    validation {
+      name
+      params
+    }
     created
     updated
     votes

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -72,6 +72,7 @@ export type ApiProposal = {
   scores_total: number;
   state: 'active' | 'pending' | 'closed';
   strategies: { network: string; params: Record<string, any>; name: string }[];
+  validation: { name: string; params: Record<string, any> };
   created: number;
   updated: number | null;
   votes: number;

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -200,6 +200,11 @@ export type Proposal = {
   strategies_indicies: number[];
   strategies: string[];
   strategies_params: any[];
+  validation: string;
+  validation_params: {
+    minScore?: number;
+    strategies?: Record<string, any>[];
+  };
   created: number;
   edited: number | null;
   tx: string;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #597

This PR add support for custom minimum required voting power for offchain voting.

Until now, we allowed anyone with voting power > 0 to cast the vote, and it'll just fail on the backend with an error.

With this PR, we will validate the voting power before allowing user to cast the vote, preventing user frustration and unnecessary actions.

### How to test

Go to snapshot.org, and create some proposals with the following conditions (need to edit space settings before creating each proposals):

A. A regular proposal, with basic voting validation (anyone with non-null vp can vote)
B. A proposal with custom minimum voting power (need at least X vp to vote)

Now, try to vote on each of these proposals, by opening the vote modal.

In case of A: 

1. you should be able to vote if your account has vp > 0
2. if your vp === 0, it should show the warning message that you don't have enough vp, and disable the voting form 

In case of B:

1. When your vp === 0, it should show the warning message that you don't have enough vp, and disable the voting form 
2. When your vp > 0, but < X, it should show that you need at least X vp to vote, and disable the voting form 
3. When your vp >= X, you should be able to vote