### PR TITLE
fix(ui): break long words in profile's about

### DIFF
--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -100,7 +100,7 @@ watchEffect(() => setTitle(props.space.name));
         </div>
         <div
           v-if="space.about"
-          class="max-w-[540px] text-skin-link text-md leading-[26px] mb-3"
+          class="max-w-[540px] text-skin-link text-md leading-[26px] mb-3 break-words"
           v-html="autoLinkText(space.about)"
         />
         <div v-if="socials.length > 0" class="space-x-2 flex">

--- a/apps/ui/src/views/SpaceUser.vue
+++ b/apps/ui/src/views/SpaceUser.vue
@@ -223,7 +223,7 @@ watchEffect(() =>
         </div>
         <div
           v-if="user.about"
-          class="max-w-[540px] text-skin-link text-md leading-[26px] mb-3"
+          class="max-w-[540px] text-skin-link text-md leading-[26px] mb-3 break-words"
           v-html="autoLinkText(user.about)"
         />
         <div v-if="socials.length" class="space-x-2 flex">

--- a/apps/ui/src/views/User.vue
+++ b/apps/ui/src/views/User.vue
@@ -161,7 +161,7 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
         </div>
         <div
           v-if="user.about"
-          class="max-w-[540px] text-skin-link text-md leading-[26px] mb-3"
+          class="max-w-[540px] text-skin-link text-md leading-[26px] mb-3 break-words"
           v-html="autoLinkText(user.about)"
         />
         <div v-if="socials.length" class="space-x-2 flex">


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fix words in profile's about not breaking, causing the following visual bug

![Screenshot 2024-08-12 at 15 06 13](https://github.com/user-attachments/assets/9f3a9c9b-a1ac-4e4a-9bde-1c090e28dbec)

This PR will force all words to break, when reaching the max width, on:

- Space overview
- User profile
- Space user profile

### How to test

1. Visit http://localhost:8080/#/s:test.wa0x6e.eth , http://localhost:8080/#/s:test.wa0x6e.eth/profile/0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3 , http://localhost:8080/#/profile/0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3
2. The about content should not overflow, and should look like this


![Screenshot 2024-08-12 at 15 09 35](https://github.com/user-attachments/assets/9a07b8e5-a7db-466a-b681-45ed31092807)
