### PR TITLE
fix: prevent fetching proposal on wrong network

### DIFF
--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -113,11 +113,12 @@ watch(
 );
 
 watch(
-  [networkId, spaceAddress, id],
-  async ([networkId, spaceAddress, id]) => {
+  [networkId, spaceAddress],
+  async ([networkId, spaceAddress]) => {
+    // NOTE: do not watch id as it's not updated in-sync with networkId and spaceAddress (those are resolved async)
     if (!networkId || !spaceAddress) return;
 
-    proposalsStore.fetchProposal(spaceAddress, id, networkId);
+    proposalsStore.fetchProposal(spaceAddress, id.value, networkId);
   },
   { immediate: true }
 );


### PR DESCRIPTION
### Summary

Currently we watch both networkId + spaceAddress and id. But those values are not updated in-sync (id) is synchronous and networkId + spaceAddress are resolved async.

This means that if URL changes from one proposal to another we will call:
1. fetchProposal(oldNetwork, oldSpaceAddress, newProposalId)
2. fetchProposal(newNetwork, newSpaceAddress, newProposalId)

First call is invalid and it shouldn't happen.

This commit changes our watcher to only call fetchProposal when async properties change and id is read from current state.

### How to test

1. Go to http://localhost:8080/#/s:0cf5e.eth/proposal/0xb4f7cecf8cad2adbbe705730213dcbd4309585a66f14314dd1881901a8db2e81
2. Open console
3. Replace URL to http://localhost:8080/#/matic:0xcD4c00cAB0A86C182519e91a8b01b080B484C49B/proposal/1
4. No errors in the console

