### PR TITLE
fix: fetch avatar for offchain space

### DIFF
--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -105,7 +105,7 @@ function formatSpace(
     controller: '',
     snapshot_chain_id: parseInt(space.network),
     name: space.name,
-    avatar: '',
+    avatar: space.avatar,
     cover: '',
     about: space.about,
     external_url: space.website,

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -221,7 +221,7 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
       id: proposal.space.id,
       name: proposal.space.name,
       snapshot_chain_id: parseInt(proposal.space.network),
-      avatar: '',
+      avatar: proposal.space.avatar,
       controller: '',
       admins: proposal.space.admins,
       moderators: proposal.space.moderators,

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -8,6 +8,7 @@ const SPACE_FRAGMENT = gql`
     admins
     members
     name
+    avatar
     network
     about
     website
@@ -57,6 +58,7 @@ const PROPOSAL_FRAGMENT = gql`
     space {
       id
       name
+      avatar
       network
       admins
       moderators

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -7,6 +7,7 @@ export type ApiSpace = {
   admins: string[];
   members: string[];
   name: string;
+  avatar: string;
   network: string;
   about: string;
   website: string;
@@ -52,6 +53,7 @@ export type ApiProposal = {
   space: {
     id: string;
     name: string;
+    avatar: string;
     network: string;
     admins: string[];
     moderators: string[];


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

The `avatar` property for all offchain spaces is always an empty string;

This PR fetch and set the space's avatar property from offchain hub properly

### How to test

1. Go to the /explore page 
2. Open the web dev tools and inspect the space's avatar
3. Before this PR, none of the stamp's avatar have a `?cb=` query params
4. After this PR, all the avatar now have a `?cb=` query params