### PR TITLE
fix: watch proposal id, but ignore if space is unresolved

### DIFF
--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -98,12 +98,17 @@ watch(
 );
 
 watch(
-  [networkId, spaceAddress],
-  async ([networkId, spaceAddress]) => {
-    // NOTE: do not watch id as it's not updated in-sync with networkId and spaceAddress (those are resolved async)
+  [networkId, spaceAddress, id],
+  async ([networkId, spaceAddress, id]) => {
+    if (!resolved.value) {
+      // NOTE: id's not updated in-sync with networkId and spaceAddress (those are resolved async)
+      // we want to ignore updates if the values are not resolved yet
+      return;
+    }
+
     if (!networkId || !spaceAddress) return;
 
-    proposalsStore.fetchProposal(spaceAddress, id.value, networkId);
+    proposalsStore.fetchProposal(spaceAddress, id, networkId);
   },
   { immediate: true }
 );


### PR DESCRIPTION
### Summary



Because space data and proposal ID are resolved in different stages we have to avoid fetching new proposal if we have mismatched data (proposalId from new space, space data from new space).

Previously I changed it so we only watch space data and read proposalId on demand, but it introduced a bug that if only proposalId changes it wouldn't be triggered at all.

Now we watch both space data and proposalId, but only act when we know that space data was resolved.

### How to test

1. Go to http://localhost:8080/#/s:0cf5e.eth/proposal/0xb4f7cecf8cad2adbbe705730213dcbd4309585a66f14314dd1881901a8db2e81
2. Open console
3. Replace URL to http://localhost:8080/#/sn-sep:0x03ced313394107c43a2f36b63262c00a6422231ac229dc4cedd0d9928d8c3c5f/proposal/8
4. No errors in the console
5. Replace URL to http://localhost:8080/#/sn-sep:0x03ced313394107c43a2f36b63262c00a6422231ac229dc4cedd0d9928d8c3c5f/proposal/9
6. New proposal fetches
