### PR TITLE
fix(ux): reload votes after proposal changes

### DIFF
--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -102,6 +102,7 @@ watch(
     if (toId === fromId) return;
 
     reset();
+    loadVotes();
   }
 );
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR follows the trend with the last few PRs, and refresh the votes list in the proposal's votes page, on proposal change.

Until now, we already watch for proposal ID change, but just `reset()` the list without loading the new proposal votes.

This PR will reload the votes on proposal ID change.

### How to test

1. Go to a proposal's vote page: http://localhost:8080/#/s:safe.eth/proposal/0x8d97075eabfdf3fb9f43f3b490e8e5a7326d77bee919b78543621e36e5b2d233/votes
2. Change the proposal ID manually with `0xdcd7f8cb197c7132296d802e538df2a565fbe4f8af400f1afbed06b54a808060`
3. It should refresh the votes list
4. Going back and forward with the browser navigation back/forward should refresh the list on proposal change
