### PR TITLE
fix: only add oSnap plugin if there are safes defined

### DIFF
--- a/apps/ui/src/networks/offchain/actions.ts
+++ b/apps/ui/src/networks/offchain/actions.ts
@@ -78,7 +78,9 @@ export function createActions(
       });
     }
 
-    plugins.oSnap = { safes };
+    if (safes.length > 0) {
+      plugins.oSnap = { safes };
+    }
 
     return plugins;
   }


### PR DESCRIPTION
### Summary

Currently if you don't select any execution there will be empty oSnap section in plugins.
We should not add it if it's empty.

