### PR TITLE
fix: update space user statement page title

### DIFF
--- a/apps/ui/src/views/SpaceUser.vue
+++ b/apps/ui/src/views/SpaceUser.vue
@@ -18,7 +18,6 @@ const usersStore = useUsersStore();
 const spacesStore = useSpacesStore();
 const { param } = useRouteParser('id');
 const { resolved, address, networkId } = useResolve(param);
-const { setTitle } = useTitle();
 const { getCurrent } = useMetaStore();
 
 const userActivity = ref<UserActivity>({
@@ -169,10 +168,6 @@ watch(
 
     spacesStore.networksMap[networkId].spaces[address];
   }
-);
-
-watchEffect(() =>
-  setTitle(`${user.value?.name || userId.value} ${props.space.name}'s profile`)
 );
 </script>
 

--- a/apps/ui/src/views/SpaceUser/Statement.vue
+++ b/apps/ui/src/views/SpaceUser/Statement.vue
@@ -1,15 +1,16 @@
 <script setup lang="ts">
 import { enabledNetworks, getNetwork, offchainNetworks } from '@/networks';
-import { Space, Statement } from '@/types';
+import { Space, Statement, User } from '@/types';
 
 const offchainNetworkId = offchainNetworks.filter(network =>
   enabledNetworks.includes(network)
 )[0];
 const offchainNetwork = getNetwork(offchainNetworkId);
 
-const props = defineProps<{ space: Space }>();
+const props = defineProps<{ user: User; space: Space }>();
 
 const route = useRoute();
+const { setTitle } = useTitle();
 const { web3 } = useWeb3();
 
 const isEditMode = ref(false);
@@ -40,6 +41,10 @@ async function loadStatement() {
 }
 
 watch(userId, loadStatement, { immediate: true });
+
+watchEffect(() =>
+  setTitle(`${props.user.name || userId.value} ${props.space.name}'s profile`)
+);
 </script>
 
 <template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

When navigating from the space user /proposals page to /statement page, the page title is not updated

### How to test

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth/profile/0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3/proposals
2. Navigate to the STATEMENT tab
3. The page title should be updated (before, it was just showing `Snapshot`)
