### PR TITLE
fix: fix imprecise duration when greater than one month

### DIFF
--- a/apps/ui/src/helpers/utils.test.ts
+++ b/apps/ui/src/helpers/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { _vp, createErc1155Metadata } from './utils';
+import { _d, _vp, createErc1155Metadata } from './utils';
 
 describe('utils', () => {
   describe('_vp', () => {
@@ -83,6 +83,37 @@ describe('utils', () => {
           ]
         }
       });
+    });
+  });
+
+  describe('_d', () => {
+    it('formats full duration correctly', () => {
+      expect(_d(90061)).toBe('1d 1h 1m 1s');
+    });
+
+    it('omits zero values', () => {
+      expect(_d(86400)).toBe('1d');
+      expect(_d(3600)).toBe('1h');
+      expect(_d(60)).toBe('1m');
+      expect(_d(1)).toBe('1s');
+    });
+
+    it('handles large values', () => {
+      expect(_d(3666661)).toBe('42d 10h 31m 1s');
+    });
+
+    it('handles very large values', () => {
+      expect(_d(60 * 60 * 24 * 1001)).toBe('1001d');
+    });
+
+    it('returns empty string for zero', () => {
+      expect(_d(0)).toBe('');
+    });
+
+    it('handles edge cases', () => {
+      expect(_d(86399)).toBe('23h 59m 59s');
+      expect(_d(86400)).toBe('1d');
+      expect(_d(86401)).toBe('1d 1s');
     });
   });
 });

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -211,12 +211,23 @@ export function lsRemove(key: string) {
   return localStorage.removeItem(`${pkg.name}.${key}`);
 }
 
-export function _d(s: number) {
-  const duration = dayjs.duration(s, 'seconds');
-  const daysLeft = Math.floor(duration.asDays());
+export function _d(s: number): string {
+  const SECONDS_TO_DAYS = 60 * 60 * 24;
+  const SECONDS_TO_HOURS = 60 * 60;
+  const SECONDS_TO_MINUTES = 60;
 
-  return duration
-    .format(`[${daysLeft}d] H[h] m[m] s[s]`)
+  const days = Math.floor(s / SECONDS_TO_DAYS);
+  const hours = Math.floor((s - days * SECONDS_TO_DAYS) / SECONDS_TO_HOURS);
+  const minutes = Math.floor(
+    (s - days * SECONDS_TO_DAYS - hours * SECONDS_TO_HOURS) / SECONDS_TO_MINUTES
+  );
+  const seconds =
+    s -
+    days * SECONDS_TO_DAYS -
+    hours * SECONDS_TO_HOURS -
+    minutes * SECONDS_TO_MINUTES;
+
+  return `${days}d ${hours}h ${minutes}m ${seconds}s`
     .replace(/\b0+[a-z]+\s*/gi, '')
     .trim();
 }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #631 

This PR fix the extra hours added when using `_d()` to format a duration greater than one month.

The issue come from how the daysjs library compute the number of months (30.x days), which leads to some extra hours.

Since we're not showing the number of months/year at all, this PR will use simple math to show the number of days/hours/minutes/seconds instead of using daysjs. 

### How to test

1. Wait for #610 merge (as currently, there's no way to exit edit mode on the Editable component without submitting the tx)
2. Go to a space settings VOTING tab
3. Edit the voting delay (or any of the other 2 durations), and put something over one month (like 45 days)
4. Validate the change to exit edit mode
5. It should show the correct number of days, without extra hours
