### PR TITLE
fix: do not show empty div

### DIFF
--- a/apps/ui/src/components/Modal/SendToken.vue
+++ b/apps/ui/src/components/Modal/SendToken.vue
@@ -320,9 +320,8 @@ watchEffect(async () => {
             v-text="'max'"
           />
         </div>
-        <div class="w-full">
+        <div v-if="currentToken.price !== 0" class="w-full">
           <UiInputAmount
-            v-if="currentToken.price !== 0"
             :model-value="form.value"
             :definition="{ type: 'number', title: 'USD', examples: ['0'] }"
             @update:model-value="handleValueUpdate"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #173

When DIV is empty, do not show so adjacent div can take full width


### How to test

1. Visit http://localhost:8080/#/sn-sep:0x060018768b13a610cd7393d844d8c53960b28f48126a97850f82f933961b894b/treasury
2. Open the "Send token" modal
3. the "Amount" input should take full width
