### PR TITLE
fix: truncate long user name

### DIFF
--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -136,7 +136,7 @@ watch(
           >
             <UiStamp :id="web3.account" :size="18" />
             <span
-              class="hidden sm:block"
+              class="hidden sm:block truncate"
               v-text="web3.name || shorten(web3.account)"
             />
           </span>

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -136,7 +136,7 @@ watch(
           >
             <UiStamp :id="web3.account" :size="18" />
             <span
-              class="hidden sm:block truncate"
+              class="hidden sm:block truncate max-w-[120px]"
               v-text="web3.name || shorten(web3.account)"
             />
           </span>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR truncates the user name in the topnav menu account, to avoid having 2 lines on small screen

Before fix: 

![Screenshot 2024-08-18 at 01 18 25](https://github.com/user-attachments/assets/8187d1af-0d24-45cc-8e6c-2c84153e995a)

After fix:

![Screenshot 2024-08-18 at 01 18 34](https://github.com/user-attachments/assets/abdc0e10-b254-4b32-847c-d1ea51844335)


### How to test

1. Set a 32 character profile name
2. It should be truncated when too long
