### PR TITLE
fix: fix wrong delegate address

### DIFF
--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -165,7 +165,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
                 />
                 <div
                   class="text-[17px] text-skin-text truncate"
-                  v-text="shorten(delegate.id)"
+                  v-text="shorten(delegate.user)"
                 />
               </router-link>
             </div>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an issue where the ID is show instead of the address, for a delegate address

![Screenshot 2024-08-18 at 16 29 58](https://github.com/user-attachments/assets/05f74032-b6fc-4ebe-b678-cae5229f1f18)


### How to test

1. Go to https://snapshot.box/#/matic:0x80D0Ffd8739eABF16436074fF64DC081c60C833A/delegates
2. All addresses should be correct now under the username

