### PR TITLE
fix: strip HTML tags from delegate statement

### DIFF
--- a/apps/ui/src/components/EditorStatement.vue
+++ b/apps/ui/src/components/EditorStatement.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { stripHtmlTags } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
 import { Statement } from '@/types';
 
@@ -96,7 +97,7 @@ watchEffect(async () => {
       <UiMarkdown
         v-if="previewEnabled"
         class="px-3 py-2 mb-3 border rounded-lg min-h-[200px]"
-        :body="form.statement"
+        :body="stripHtmlTags(form.statement)"
       />
       <UiComposer
         v-else

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -547,3 +547,8 @@ export function getFormattedVotingPower(votingPower?: VotingPowerItem) {
 
   return symbol ? `${value} ${symbol}` : value;
 }
+
+export function stripHtmlTags(text: string) {
+  const doc = new DOMParser().parseFromString(text, 'text/html');
+  return doc.body.textContent || '';
+}

--- a/apps/ui/src/views/SpaceUser/Statement.vue
+++ b/apps/ui/src/views/SpaceUser/Statement.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { compareAddresses } from '@/helpers/utils';
+import { compareAddresses, stripHtmlTags } from '@/helpers/utils';
 import { enabledNetworks, getNetwork, offchainNetworks } from '@/networks';
 import { Space, Statement, User } from '@/types';
 
@@ -88,7 +88,7 @@ watchEffect(() =>
         <UiMarkdown
           v-if="statement.statement"
           class="text-skin-heading max-w-[592px]"
-          :body="statement.statement"
+          :body="stripHtmlTags(statement.statement)"
         />
         <div v-else class="flex items-center space-x-2">
           <IH-exclamation-circle class="inline-block shrink-0" />


### PR DESCRIPTION
### Summary

Some delegates statement may contain HTML tags, specially when imported from third party services.

This PR will strip all html tags, before showing the statement

Before fix:

![Screenshot 2024-08-21 at 13 36 45](https://github.com/user-attachments/assets/b53c245f-d4af-4dd3-a422-240e375eb609)


After fix 

![Screenshot 2024-08-21 at 13 36 52](https://github.com/user-attachments/assets/2f42d872-2bf1-421a-95dc-11ec1b9cb709)


### How to test

1. Edit your delegate statement to include some html tags
2. It should show the statement without html tags in the profile
3. It should show the original statement with html tags in the edit textarea
