### PR TITLE
feat: add horizontal scroller component to handle x scroll logic

### DIFF
--- a/apps/ui/src/App.vue
+++ b/apps/ui/src/App.vue
@@ -3,6 +3,7 @@ import { startIntercom } from './helpers/intercom';
 import { Transaction } from './types';
 
 const el = ref(null);
+const sidebarSwipeEnabled = ref(true);
 
 const route = useRoute();
 const router = useRouter();
@@ -10,7 +11,16 @@ const uiStore = useUiStore();
 const { modalOpen } = useModal();
 const { init, app } = useApp();
 const { web3 } = useWeb3();
-const { isSwiping, direction } = useSwipe(el);
+const { isSwiping, direction } = useSwipe(el, {
+  onSwipe(e: TouchEvent) {
+    const noSideBarSwipe = (e.target as Element)?.closest(
+      '[data-no-sidebar-swipe]'
+    );
+    sidebarSwipeEnabled.value =
+      !noSideBarSwipe ||
+      (noSideBarSwipe && noSideBarSwipe.getBoundingClientRect().x === 0);
+  }
+});
 const { createDraft } = useEditor();
 const { spaceKey, network, executionStrategy, transaction, reset } =
   useWalletConnectTransaction();
@@ -60,6 +70,7 @@ watch(route, () => {
 
 watch(isSwiping, () => {
   if (
+    sidebarSwipeEnabled.value &&
     isSwiping.value &&
     !modalOpen.value &&
     ((direction.value === 'right' && !uiStore.sidebarOpen) ||

--- a/apps/ui/src/components/Ui/ScrollerHorizontal.vue
+++ b/apps/ui/src/components/Ui/ScrollerHorizontal.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    gradient: false | 'sm' | 'md';
+  }>(),
+  { gradient: false }
+);
+</script>
+
+<template>
+  <div class="relative">
+    <div
+      v-if="gradient"
+      class="bg-gradient-to-r from-skin-bg left-0 top-[1px] bottom-[1px] absolute z-10 pointer-events-none"
+      :class="{
+        'w-2': gradient === 'sm',
+        'w-3': gradient === 'md'
+      }"
+    />
+    <div class="overflow-x-auto no-scrollbar">
+      <div data-no-sidebar-swipe>
+        <slot />
+      </div>
+    </div>
+    <div
+      v-if="gradient"
+      class="bg-gradient-to-l from-skin-bg right-0 top-[1px] bottom-[1px] absolute z-10 pointer-events-none"
+      :class="{
+        'w-2': gradient === 'sm',
+        'w-3': gradient === 'md'
+      }"
+    />
+  </div>
+</template>

--- a/apps/ui/src/views/Network.vue
+++ b/apps/ui/src/views/Network.vue
@@ -151,8 +151,8 @@ watchEffect(() => setTitle('Network'));
 
     <div class="text-center">
       <div class="eyebrow mb-4">Trusted by</div>
-      <div class="overflow-y-scroll no-scrollbar px-4">
-        <div class="w-fit mx-auto">
+      <UiScrollerHorizontal>
+        <div class="w-fit mx-auto px-4">
           <div class="grid grid-flow-col auto-cols-max justify-center gap-4">
             <a
               v-for="(customer, i) in CUSTOMERS"
@@ -168,7 +168,7 @@ watchEffect(() => setTitle('Network'));
             </a>
           </div>
         </div>
-      </div>
+      </UiScrollerHorizontal>
     </div>
 
     <UiContainer class="!max-w-[880px] text-center">

--- a/apps/ui/src/views/Space/Delegates.vue
+++ b/apps/ui/src/views/Space/Delegates.vue
@@ -14,9 +14,10 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
 </script>
 
 <template>
-  <div
+  <UiScrollerHorizontal
     v-if="space.delegations.length !== 1"
-    class="overflow-y-scroll no-scrollbar z-40 sticky top-[71px] lg:top-[72px]"
+    class="z-40 sticky top-[71px] lg:top-[72px]"
+    gradient="md"
   >
     <div class="flex px-4 space-x-3 bg-skin-bg border-b min-w-max">
       <button
@@ -31,7 +32,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
         />
       </button>
     </div>
-  </div>
+  </UiScrollerHorizontal>
   <SpaceDelegates
     v-if="delegateData"
     :key="activeDelegationId"

--- a/apps/ui/src/views/Space/Treasury.vue
+++ b/apps/ui/src/views/Space/Treasury.vue
@@ -21,9 +21,10 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
 </script>
 
 <template>
-  <div
+  <UiScrollerHorizontal
     v-if="filteredTreasuries.length !== 1"
-    class="overflow-y-scroll no-scrollbar z-40 sticky top-[71px] lg:top-[72px]"
+    gradient="md"
+    class="z-40 sticky top-[71px] lg:top-[72px]"
   >
     <div class="flex px-4 space-x-3 bg-skin-bg border-b min-w-max">
       <button
@@ -38,7 +39,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
         />
       </button>
     </div>
-  </div>
+  </UiScrollerHorizontal>
   <SpaceTreasury
     :key="activeTreasuryId"
     :space="space"

--- a/apps/ui/src/views/SpaceUser.vue
+++ b/apps/ui/src/views/SpaceUser.vue
@@ -238,8 +238,9 @@ watch(
         </div>
       </div>
     </div>
-    <div
-      class="overflow-y-scroll no-scrollbar z-40 sticky top-[71px] lg:top-[72px]"
+    <UiScrollerHorizontal
+      class="z-40 sticky top-[71px] lg:top-[72px]"
+      gradient="md"
     >
       <div class="flex px-4 space-x-3 bg-skin-bg border-b min-w-max">
         <router-link
@@ -254,7 +255,7 @@ watch(
           />
         </router-link>
       </div>
-    </div>
+    </UiScrollerHorizontal>
     <router-view :user="user" :space="space" />
   </div>
 </template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #630 

Extracted the duplicate logic inside #617 and #618 

This PR extract the extra special handling of horizontally scrollable content in a component, to avoid duplication and adds more option like:

- add left and right gradient on demand via props
- disable the uiSidebar menu opening on small screen, when swiping right

Also convert more horizontall scrollable content to use this new component

### How to test

1. Go to http://localhost:8080/#/matic:0x80D0Ffd8739eABF16436074fF64DC081c60C833A/treasury
2. The TIMELOCK|DAOWALLET menu in the top should be horizontally scrollable on small screen, without triggering the uisidebar opening when swipping, and have a left and right gradient
3. Same for the STATEMENT|PROPOSALS menu in http://localhost:8080/#/s:test.wa0x6e.eth/profile/0xab54624A67E8c018a06B176bAAE76a40a385A46
4. Same for the menu in http://localhost:8080/#/matic:0x80D0Ffd8739eABF16436074fF64DC081c60C833A/delegates
5. Same for the TRUSTED BY section in http://localhost:8080/#/network (but without gradient)
