### PR TITLE
fix(ux): logout user on wallet lock

### DIFF
--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -158,7 +158,10 @@ export function useWeb3() {
     if (!provider.on) return;
 
     provider.on('accountsChanged', async accounts => {
-      if (!accounts.length) return;
+      if (!accounts.length) {
+        logout();
+        return;
+      }
 
       state.account = formatAddress(accounts[0]);
       await login();


### PR DESCRIPTION
### Summary

This PR will logout the when the user lock the wallet while connected on the site (=> connected account change to empty value)

This adds more logic in the UX:

- if user locks the wallet => he don't want to connect => log him out
- will avoid the wallet unlock prompt on page refresh

This behavior is used more widely:

- from MM test app: https://metamask.github.io/test-dapp/
- from uniswap: https://app.uniswap.org/

### How to test

1. Log in with your metamask/argent X wallet
2. Lock the wallet
3. It should log you out
4. Refresh the page
5. You should stay logged out, and there's no wallet unlock prompt anymore

### Note

We're detecting and reacting to the wallet locking event in this PR, and will not handle the case where the wallet was already locked before user landed on the page, which will be fixed in another PR