### PR TITLE
fix(ux): missing provider name when calling login()

### DIFF
--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -161,7 +161,7 @@ export function useWeb3() {
       if (!accounts.length) return;
 
       state.account = formatAddress(accounts[0]);
-      await login();
+      await login(providerName);
     });
 
     if (!STARKNET_CONNECTORS.includes(providerName)) {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #651

This PR fixes the issue where the `login()` function is called without an argument, even though we're targeting a specific provider, making this function always being called on the default injected wallet (which will trigger the unlock prompt on metamask if locked, even if you're not connected via metamask)

### How to test

1. Lock metamask wallet
2. Connect using your argent x wallet
3. Change the account in the argent X wallet
4. the connected account should change, and be reflected on the UI (before, metamask will also asked to be unlocked)
