### PR TITLE
fix: add gap between executions in settings

### DIFF
--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -642,13 +642,15 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
             Execution strategies determine if a proposal passes and how it is
             executed. This section is currently read-only.
           </span>
-          <FormStrategiesStrategyActive
-            v-for="strategy in executionStrategies"
-            :key="strategy.id"
-            read-only
-            :network-id="space.network"
-            :strategy="strategy"
-          />
+          <div class="space-y-3">
+            <FormStrategiesStrategyActive
+              v-for="strategy in executionStrategies"
+              :key="strategy.id"
+              read-only
+              :network-id="space.network"
+              :strategy="strategy"
+            />
+          </div>
         </div>
         <div v-else-if="activeTab === 'controller'" class="mb-4">
           <h3 class="text-md leading-6">Controller</h3>


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/178

### How to test

1. Go to http://localhost:8080/#/matic:0xcD4c00cAB0A86C182519e91a8b01b080B484C49B/settings
2. Click Executions
3. There is gap between executions.
=