### PR TITLE
fix: add more network to WalletConnect support

### DIFF
--- a/apps/ui/src/components/Modal/LinkWalletConnect.vue
+++ b/apps/ui/src/components/Modal/LinkWalletConnect.vue
@@ -108,9 +108,9 @@ watch(loading, () => {
             class="w-[48px] mb-3"
           />
           <span class="text-center mb-2">
-            <strong class="text-skin-link">{{
+            <span class="font-medium text-skin-link">{{
               proposal.proposer.metadata.name
-            }}</strong>
+            }}</span>
             <span> is connected</span>
           </span>
           <span>You can start interacting with the app.</span>
@@ -128,12 +128,12 @@ watch(loading, () => {
       >
         <img :src="proposal.proposer.metadata.icons[0]" class="w-[48px] mb-3" />
         <span class="text-center mb-2">
-          <strong class="text-skin-link">{{
+          <span class="font-medium text-skin-link">{{
             proposal.proposer.metadata.name
-          }}</strong>
+          }}</span>
           <span> wants to connect</span>
         </span>
-        <div class="text-[17px] font-bold text-skin-link">
+        <div class="text-[17px] font-medium text-skin-link">
           {{ proposal.proposer.metadata.url }}
         </div>
       </div>

--- a/apps/ui/src/helpers/etherscan.ts
+++ b/apps/ui/src/helpers/etherscan.ts
@@ -1,6 +1,10 @@
 export async function getABI(chainId: number, address: string) {
-  let apiHost;
+  let apiHost: string;
   if (chainId === 1) apiHost = 'https://api.etherscan.io';
+  else if (chainId === 10) apiHost = 'https://api-optimistic.etherscan.io';
+  else if (chainId === 137) apiHost = 'https://api.polygonscan.com';
+  else if (chainId === 42161) apiHost = 'https://api.arbiscan.io';
+  else if (chainId === 59140) apiHost = 'https://api.lineascan.build';
   else if (chainId === 11155111) apiHost = 'https://api-sepolia.etherscan.io';
   else throw new Error('Unsupported chainId');
 

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -281,6 +281,10 @@ export function abiToDefinition(abi) {
       definition.properties[input.name].format = 'int256';
       definition.properties[input.name].examples = ['0'];
     }
+    if (input.type === 'bytes') {
+      definition.properties[input.name].format = 'bytes';
+      definition.properties[input.name].examples = ['0x0000…'];
+    }
     if (input.type === 'address') {
       definition.properties[input.name].format = 'ens-or-address';
       definition.properties[input.name].examples = ['0x0000…'];

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -98,7 +98,7 @@ ajv.addFormat('int256[]', {
 });
 
 ajv.addFormat('bytes[]', {
-  validate: getArrayValidator(bytesValidator)
+  validate: bytesValidator
 });
 
 ajv.addFormat('long', {

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -1,12 +1,5 @@
 import { Interface } from '@ethersproject/abi';
 import { isAddress } from '@ethersproject/address';
-import { BigNumber } from '@ethersproject/bignumber';
-import {
-  MaxInt256,
-  MaxUint256,
-  MinInt256,
-  Zero
-} from '@ethersproject/constants';
 import { parseUnits } from '@ethersproject/units';
 import Ajv, { ErrorObject } from 'ajv';
 import addFormats from 'ajv-formats';
@@ -30,40 +23,29 @@ export const addressValidator = (value: string) => {
   }
 };
 
-const bytesValidator = (value: string) =>
-  !!value.match(/^0x([0-9a-fA-F][0-9a-fA-F])+$/);
-
-const uint256Validator = (value: string) => {
-  if (!value.match(/^([0-9]|[1-9][0-9]+)$/)) return false;
+const validateType = (type: string, value: string) => {
+  if (!value) return false;
 
   try {
-    const number = BigNumber.from(value);
-    return number.gte(Zero) && number.lte(MaxUint256);
-  } catch {
+    const iface = new Interface([`function test(${type})`]);
+    iface.encodeFunctionData('test', [value]);
+    return true;
+  } catch (e) {
     return false;
   }
 };
 
-const int256Validator = (value: string) => {
-  if (!value.match(/^-?([0-9]|[1-9][0-9]+)$/)) return false;
-
-  try {
-    const number = BigNumber.from(value);
-    return number.gte(MinInt256) && number.lte(MaxInt256);
-  } catch {
-    return false;
-  }
-};
+const bytesValidator = (value: string) => validateType('bytes', value);
+const uint256Validator = (value: string) => validateType('uint256', value);
+const int256Validator = (value: string) => validateType('int256', value);
 
 const getArrayValidator =
   (valueValidator: (value: string) => boolean) => (value: string) => {
     if (!value) return false;
 
     try {
-      const parsed = JSON.parse(value);
-      if (!Array.isArray(parsed)) return false;
-
-      return parsed.every((value: string) => valueValidator(value));
+      const array = value.split(',').map(s => s.trim());
+      return array.every((value: string) => valueValidator(value));
     } catch {
       return false;
     }
@@ -98,7 +80,7 @@ ajv.addFormat('int256[]', {
 });
 
 ajv.addFormat('bytes[]', {
-  validate: bytesValidator
+  validate: getArrayValidator(bytesValidator)
 });
 
 ajv.addFormat('long', {


### PR DESCRIPTION
### Summary

We have predefined list of Etherscan APIs (they have special URLs, can't be generated automatically) and before we only had mainnet and sepolia there, this PR adds all EVM networks we support there.

Also changes bold weight to medium as requested.

Closes: https://github.com/snapshot-labs/workflow/issues/181

### How to test

1. Connect there: http://localhost:8080/#/s:fabien.eth/treasury on uniswap.
2. Create execution.
