### PR TITLE
fix: do not show empty choice text as invalid

### DIFF
--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -499,7 +499,7 @@ export function getChoiceText(availableChoices: string[], choice: Choice) {
   }
 
   if (typeof choice === 'number') {
-    return availableChoices[choice - 1] || 'Invalid choice';
+    return availableChoices[choice - 1] ?? 'Invalid choice';
   }
 
   if (Array.isArray(choice)) {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR addresses an issue where the `getChoiceText()` function will return a choice without text (empty string) as "Invalid choice", instead of just ... an empty string.

### How to test

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth/proposal/0xb06ef1cd8455e66a3bc064d3f1ec644c2dfed5aaaf33f2cd021b8612da7dd610
2. Select the choice without text and vote
3. In the vote modal, the "Choice" should be shown as an empty string, instead of showing "Invalid string"
