### PR TITLE
feat: add user avatars on topic list item

### DIFF
--- a/apps/ui/src/components/TopicsListItem.vue
+++ b/apps/ui/src/components/TopicsListItem.vue
@@ -21,7 +21,7 @@ defineProps<{ topic: Topic }>();
               />
               <IS-lock-closed
                 v-if="topic.closed"
-                class="inline-block shrink-0 size-[16px] -mt-1"
+                class="inline-block shrink-0 size-[16px] -mt-1 md:mt-1"
               />
               <h3 class="text-[21px] inline md:truncate" v-text="topic.title" />
               <IH-arrow-sm-right

--- a/apps/ui/src/components/TopicsListItem.vue
+++ b/apps/ui/src/components/TopicsListItem.vue
@@ -9,11 +9,15 @@ defineProps<{ topic: Topic }>();
     <div class="border-b mx-4 py-[14px] flex">
       <div class="flex-auto mr-4 w-0">
         <div class="space-x-2 flex">
-          <div class="my-1 items-center leading-6">
-            <a :href="topic.url" target="_blank" class="space-x-1.5">
+          <div class="md:flex md:min-w-0 my-1 items-center leading-6">
+            <a
+              :href="topic.url"
+              target="_blank"
+              class="md:flex md:min-w-0 space-x-1.5"
+            >
               <IC-pin
                 v-if="topic.pinned"
-                class="inline-block shrink-0 size-[14px]"
+                class="inline-block shrink-0 md:mt-1.5 size-[14px]"
               />
               <IS-lock-closed
                 v-if="topic.closed"
@@ -27,7 +31,14 @@ defineProps<{ topic: Topic }>();
           </div>
         </div>
         <div class="inline">
-          #{{ topic.id }}
+          <span>
+            <img
+              v-for="(user, i) in topic.users"
+              :key="i"
+              :src="user.avatar_template"
+              class="rounded-full size-[22px] inline-block -ml-1.5 border-2 border-skin-bg"
+            />
+          </span>
           by
           <a :href="topic.user_url" target="_blank" class="text-skin-text">{{
             topic.username

--- a/apps/ui/src/components/TopicsListItem.vue
+++ b/apps/ui/src/components/TopicsListItem.vue
@@ -36,7 +36,7 @@ defineProps<{ topic: Topic }>();
               v-for="(user, i) in topic.users"
               :key="i"
               :src="user.avatar_template"
-              class="rounded-full size-[22px] inline-block -ml-1.5 border-2 border-skin-bg"
+              class="rounded-full size-[22px] inline-block -ml-1.5 border-2 border-skin-bg bg-skin-border"
             />
           </span>
           by

--- a/apps/ui/src/helpers/discourse.ts
+++ b/apps/ui/src/helpers/discourse.ts
@@ -26,6 +26,7 @@ export interface Topic {
   posts_count: number;
   url: string;
   user_url: string;
+  users: any[];
 }
 
 export const SPACES_DISCUSSIONS = {
@@ -65,7 +66,17 @@ export async function loadTopics(url: string): Promise<Topic[]> {
     topic.username = topic.last_poster_username;
     topic.user_url = `${baseUrl}/u/${topic.username}`;
     topic.created = Date.parse(topic.created_at) / 1000;
-
+    topic.users = topic.posters.map(poster =>
+      data.users.find(user => user.id === poster.user_id)
+    );
+    topic.users = topic.posters
+      .map(poster => data.users.find(user => user.id === poster.user_id))
+      .map(user => {
+        user.avatar_template = user.avatar_template.replace('{size}', '64');
+        if (user.avatar_template.startsWith('/'))
+          user.avatar_template = `${baseUrl}${user.avatar_template}`;
+        return user;
+      });
     return topic;
   });
 }

--- a/apps/ui/src/views/Space/Discussions.vue
+++ b/apps/ui/src/views/Space/Discussions.vue
@@ -40,11 +40,6 @@ watchEffect(() => setTitle(`Discussions - ${props.space.name}`));
         </a>
       </div>
     </div>
-    <TopicsList
-      title="Topics"
-      limit="off"
-      :loading="loading"
-      :topics="topics"
-    />
+    <TopicsList title="Topics" :loading="loading" :topics="topics" />
   </div>
 </template>


### PR DESCRIPTION
Add users avatar on the discussions page
<img width="1467" alt="image" src="https://github.com/user-attachments/assets/61468975-2ee1-4adf-97d9-b24f234403c1">

Also fix an issue with text overflow when topic title is long.