### PR TITLE
chore: remove reset from API startup

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -65,7 +65,7 @@ async function run() {
     await sleep(PRODUCTION_INDEXER_DELAY);
   }
 
-  await checkpoint.reset();
+  // await checkpoint.reset();
   checkpoint.start();
 }
 


### PR DESCRIPTION
### Summary

This will allow us to merge PRs without long downtime on API.

Ideally we would call it, but because changing domains on DigitalOcean causes a redeploy we will call it on fully-synced instances.

This will work until we merge PR that needs to update past entities - that would require reset.