### PR TITLE
fix: remove empty strategies from overrides

### DIFF
--- a/apps/api/src/overrrides.ts
+++ b/apps/api/src/overrrides.ts
@@ -25,7 +25,9 @@ const createConfig = (
       config.Strategies.OZVotesStorageProof,
       config.Strategies.OZVotesTrace208StorageProof,
       config.Strategies.EVMSlotValue
-    ].map(strategy => validateAndParseAddress(strategy)),
+    ]
+      .filter(address => !!address)
+      .map(strategy => validateAndParseAddress(strategy)),
     startBlock
   };
 };


### PR DESCRIPTION
### Summary

Mainnet doesn't have `OZVotesTrace208StorageProof` so we need to remove it before calling `validateAndParseAddress`