### PR TITLE
fix: App 2 domain should end with a dot

### DIFF
--- a/scripts/deploy-api-prod.sh
+++ b/scripts/deploy-api-prod.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 NAME_SERVER="ns1.3dns.box"
 PRODUCTION_DOMAIN="api.snapshot.box"
 APP_DOMAIN_1="sx-api-starknet-mainnet-dfghg.ondigitalocean.app."
-APP_DOMAIN_2="sx-api-mainnet-2-fmlg8.ondigitalocean.app"
+APP_DOMAIN_2="sx-api-mainnet-2-fmlg8.ondigitalocean.app."
 APP_ID_1="c4eba570-abea-4ab3-8941-d968db6cad36"
 APP_ID_2="9282b162-7280-43b9-b429-9f53810003bc"
 


### PR DESCRIPTION
https://discord.com/channels/955773041898573854/1031838169282392144/1278289389461442621

## Summary:
App deployment is failing because of the wrong domain
If we run this:
```bash
dig -t CNAME +short api.snapshot.box @ns1.3dns.box
```
It will return `sx-api-mainnet-2-fmlg8.ondigitalocean.app.` which has a `.` at the end