### PR TITLE
fix: fix wrong topnav height

### DIFF
--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -80,7 +80,7 @@ watch(
 
 <template>
   <nav
-    class="border-b fixed top-0 inset-x-0 z-50 lg:left-[72px] flex items-center justify-between h-[71px] bg-skin-bg space-x-4 pr-4"
+    class="border-b fixed top-0 inset-x-0 z-50 lg:left-[72px] flex items-center justify-between h-[72px] bg-skin-bg space-x-4 pr-4"
     :class="{
       'translate-x-[72px] lg:translate-x-0': uiStore.sidebarOpen
     }"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fix gap above sticky navigation

<img width="1469" alt="image" src="https://github.com/user-attachments/assets/b1b52155-d00d-4487-b217-e9f59888e947">
