### PR TITLE
fix(ui): fix missing gap between column

### DIFF
--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -171,7 +171,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
                   user: delegate.user
                 }
               }"
-              class="flex w-full"
+              class="flex w-full space-x-3"
             >
               <div
                 class="flex grow sm:grow-0 sm:shrink-0 items-center w-[190px] py-3 gap-x-3 leading-[22px] truncate"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an issue on the space delegate page, where the gap between column in the content is missing

![Screenshot 2024-08-30 at 02 01 29](https://github.com/user-attachments/assets/6c3d8b1a-dad8-4ce9-a8da-11e0f9570e93)


### How to test

1. Go to http://localhost:8080/#/matic:0x80D0Ffd8739eABF16436074fF64DC081c60C833A/delegates
2. There should be a 16px gap between all columns
