### PR TITLE
fix: fix no statement message always showing

### DIFF
--- a/apps/ui/src/views/SpaceUser/Statement.vue
+++ b/apps/ui/src/views/SpaceUser/Statement.vue
@@ -96,20 +96,21 @@ watchEffect(() =>
             </UiButton>
           </UiTooltip>
         </div>
-        <UiMarkdown
-          v-if="statement.statement"
-          class="text-skin-heading max-w-[592px]"
-          :body="stripHtmlTags(statement.statement)"
-        />
-        <div v-if="statement.source">
-          <h4 class="eyebrow text-skin-text mb-2">Source</h4>
-          <a :href="SOURCE_ICONS[statement.source].link" target="_blank">
-            <component
-              :is="SOURCE_ICONS[statement.source].icon"
-              class="max-h-[25px] max-w-[85px] w-auto text-skin-link"
-            />
-          </a>
-        </div>
+        <template v-if="statement.statement">
+          <UiMarkdown
+            class="text-skin-heading max-w-[592px]"
+            :body="stripHtmlTags(statement.statement)"
+          />
+          <div v-if="statement.source">
+            <h4 class="eyebrow text-skin-text mb-2">Source</h4>
+            <a :href="SOURCE_ICONS[statement.source].link" target="_blank">
+              <component
+                :is="SOURCE_ICONS[statement.source].icon"
+                class="max-h-[25px] max-w-[85px] w-auto text-skin-link"
+              />
+            </a>
+          </div>
+        </template>
         <div v-else class="flex items-center space-x-2">
           <IH-exclamation-circle class="inline-block shrink-0" />
           <span>This profile does not have statement.</span>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #680 

Fix an issue where the "no statement" message was always showing, even when a statement exist

### How to test

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth/profile/0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3
2. It should show the statement, and at the bottom, there shouldn't be a "no statement" message
