### PR TITLE
feat: add transaction details to TransactionsListItem

### DIFF
--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -171,7 +171,7 @@ watch(
           </UiTooltip>
         </div>
       </div>
-      <template v-if="model.length > 0">
+      <template v-if="model.length > 0 && treasury">
         <UiLabel label="Transactions" class="border-t" />
         <div>
           <Draggable
@@ -180,7 +180,7 @@ watch(
             :item-key="() => undefined"
           >
             <template #item="{ element: tx, index: i }">
-              <TransactionsListItem :tx="tx">
+              <TransactionsListItem :tx="tx" :network-id="treasury.networkId">
                 <template #left>
                   <div
                     v-if="model.length > 1"

--- a/apps/ui/src/components/ProposalExecutionsList.vue
+++ b/apps/ui/src/components/ProposalExecutionsList.vue
@@ -99,8 +99,8 @@ function downloadExecution(execution: ProposalExecution) {
     <TransactionsListItem
       v-for="(tx, i) in execution.transactions"
       :key="i"
+      :network-id="execution.networkId"
       :tx="tx"
-      class="border-b last:border-b-0 px-4 py-3 space-x-2 flex items-center justify-between"
     />
     <ProposalExecutionActions
       v-if="

--- a/apps/ui/src/components/TransactionsListItem.vue
+++ b/apps/ui/src/components/TransactionsListItem.vue
@@ -2,9 +2,16 @@
 import { formatUnits } from '@ethersproject/units';
 import { getNames } from '@/helpers/stamp';
 import { _n, shorten } from '@/helpers/utils';
-import { Transaction } from '@/types';
+import { getNetwork } from '@/networks';
+import { NetworkID, Transaction } from '@/types';
 
-const props = defineProps<{ tx: Transaction }>();
+const props = defineProps<{ networkId: NetworkID; tx: Transaction }>();
+
+const expanded = ref(false);
+
+const network = computed(() => {
+  return getNetwork(props.networkId);
+});
 
 const title = computed(() => {
   if (props.tx._type === 'sendToken') {
@@ -32,6 +39,110 @@ const title = computed(() => {
   return '';
 });
 
+const interaction = computed(() => {
+  if (props.tx._type === 'sendToken' && props.tx.data === '0x') {
+    return { to: props.tx.to, type: 'send' };
+  }
+
+  if (props.tx._type === 'raw') {
+    return { to: props.tx.to, type: 'raw' };
+  }
+
+  return null;
+});
+
+const call = computed(() => {
+  if (props.tx._type === 'sendToken') {
+    if (props.tx.data === '0x') return null;
+
+    return { name: 'transfer', to: props.tx.to };
+  }
+
+  if (props.tx._type === 'sendNft') {
+    return { name: 'safeTransferFrom', to: props.tx.to };
+  }
+
+  if (props.tx._type === 'stakeToken') {
+    return { name: 'submit', to: props.tx.to };
+  }
+
+  if (props.tx._type === 'contractCall') {
+    const rawMethodName = props.tx._form.method.slice(
+      0,
+      props.tx._form.method.indexOf('(')
+    );
+    return { name: rawMethodName, to: props.tx.to };
+  }
+
+  return null;
+});
+
+const params = computed(() => {
+  if (props.tx._type === 'sendToken' && props.tx.data !== '0x') {
+    return [
+      { name: 'recipient', value: props.tx._form.recipient, type: 'address' },
+      { name: 'amount', value: props.tx._form.amount, type: 'raw' }
+    ];
+  }
+
+  if (props.tx._type === 'sendNft') {
+    const payload = [
+      { name: 'from', value: props.tx._form.sender, type: 'address' },
+      { name: 'to', value: props.tx._form.recipient, type: 'address' },
+      { name: 'tokenId', value: props.tx._form.nft.id, type: 'raw' }
+    ];
+
+    if (props.tx._form.nft.type === 'erc1155') {
+      payload.push({
+        name: 'amount',
+        value: props.tx._form.amount,
+        type: 'raw'
+      });
+      payload.push({
+        name: 'data',
+        value: '0',
+        type: 'raw'
+      });
+    }
+
+    return payload;
+  }
+
+  if (props.tx._type === 'stakeToken') {
+    return [
+      { name: 'referral', value: props.tx._form.args.referral, type: 'address' }
+    ];
+  }
+
+  if (props.tx._type === 'contractCall') {
+    return Object.entries(props.tx._form.args).map(([name, value]) => {
+      return {
+        name,
+        value,
+        type: 'raw'
+      };
+    });
+  }
+
+  return [];
+});
+
+const value = computed(() => {
+  if (props.tx.value !== '0') {
+    return props.tx.value;
+  }
+
+  return null;
+});
+
+const data = computed(() => {
+  if (props.tx._type === 'raw') {
+    return props.tx.data;
+  }
+
+  return null;
+});
+
 const parsedTitle = computedAsync(
   async () => {
     const { recipient } = props.tx._form;
@@ -45,17 +156,72 @@ const parsedTitle = computedAsync(
 </script>
 
 <template>
-  <div
-    class="border-b last:border-b-0 px-4 py-3 space-x-2 flex items-center justify-between"
-  >
-    <div class="flex items-center max-w-[70%]">
-      <slot name="left" />
-      <IH-cash v-if="tx._type === 'sendToken'" />
-      <IH-photograph v-else-if="tx._type === 'sendNft'" />
-      <IC-stake v-else-if="tx._type === 'stakeToken'" />
-      <IH-code v-else />
-      <div class="ml-2 truncate text-skin-link" v-html="parsedTitle" />
+  <div class="w-full border-b last:border-b-0">
+    <button
+      class="w-full px-4 py-3 space-x-2 flex items-center justify-between"
+      @click="expanded = !expanded"
+    >
+      <div class="flex items-center max-w-[70%]">
+        <slot name="left" />
+        <IH-cash v-if="tx._type === 'sendToken'" />
+        <IH-photograph v-else-if="tx._type === 'sendNft'" />
+        <IC-stake v-else-if="tx._type === 'stakeToken'" />
+        <IH-code v-else />
+        <div class="ml-2 truncate text-skin-link" v-html="parsedTitle" />
+      </div>
+      <slot name="right" />
+    </button>
+    <div v-if="expanded" class="border-y last:border-b-0 px-4 py-3">
+      <div v-if="call" class="text-skin-link">
+        Call
+        <code class="bg-skin-border px-2 py-1 mx-1 text-sm">{{
+          call.name
+        }}</code>
+        on
+        <a
+          class="inline-flex items-center"
+          target="_blank"
+          :href="network.helpers.getExplorerUrl(call.to, 'address')"
+        >
+          {{ shorten(call.to) }}
+          <IH-arrow-sm-right class="inline-block ml-1 -rotate-45" />
+        </a>
+      </div>
+      <div v-else-if="interaction" class="text-skin-link">
+        Interaction with
+        <a
+          class="inline-flex items-center"
+          target="_blank"
+          :href="network.helpers.getExplorerUrl(interaction.to, 'address')"
+        >
+          {{ shorten(interaction.to) }}
+          <IH-arrow-sm-right class="inline-block ml-1 -rotate-45" />
+        </a>
+      </div>
+      <template v-if="params.length > 0">
+        <h4 class="font-medium mt-3">Parameters</h4>
+        <div v-for="param in params" :key="param.name" class="flex space-x-2">
+          <span class="text-skin-link">{{ param.name }}</span>
+          <a
+            v-if="param.type === 'address'"
+            class="inline-flex items-center"
+            target="_blank"
+            :href="network.helpers.getExplorerUrl(param.value, 'address')"
+          >
+            {{ shorten(param.value) }}
+            <IH-arrow-sm-right class="inline-block ml-1 -rotate-45" />
+          </a>
+          <div v-else class="truncate inline-block">{{ param.value }}</div>
+        </div>
+      </template>
+      <div v-if="value" class="mt-3">
+        <h4 class="font-medium">Value</h4>
+        <div>{{ value }}</div>
+      </div>
+      <div v-if="data" class="mt-3">
+        <h4 class="font-medium">Data</h4>
+        <div>{{ data }}</div>
+      </div>
     </div>
-    <slot name="right" />
   </div>
 </template>


### PR DESCRIPTION
### Summary

This PR adds expandable section for Transactions with more details (Call info, parameters, value, data).
Data is shown or hidden depending on context (for example data is only shown for raw transactions as others have parsed information available).

Closes: https://github.com/snapshot-labs/workflow/issues/185

### How to test

1. Check out this proposal or create your own (you can also access details in editor): http://localhost:8080/#/s:0cf5e.eth/proposal/0x124cc146918a5c14e1c9fd40aaa293f5780304f6b26be1a9692160d8d4d4596e
2. You can expand transactions by clicking on them.

### Screenshots

<img width="676" alt="image" src="https://github.com/user-attachments/assets/9278ed0a-2b59-4d97-9496-c259cb5572cf">
<img width="639" alt="image" src="https://github.com/user-attachments/assets/be12b840-b3b2-4e82-ac28-b0cfd3849fb6">
<img width="639" alt="image" src="https://github.com/user-attachments/assets/5d033c01-9318-44f6-9022-6ea3393b330f">
