### PR TITLE
fix(ui): use full screen for proposal overview on small screen

### DIFF
--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -197,7 +197,7 @@ onBeforeUnmount(() => destroyAudio());
 </script>
 
 <template>
-  <UiContainer class="pt-5 !max-w-[710px] mx-0 md:mx-auto">
+  <UiContainer class="pt-5 md:!max-w-[710px] !max-w-full mx-0 md:mx-auto">
     <div>
       <h1 class="mb-3 text-[40px] leading-[1.1em]">
         {{ proposal.title || `Proposal #${proposal.proposal_id}` }}


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

On screen width between 710 and 760px, the proposal content is not full width, making the content not aligned

![Screenshot 2024-09-02 at 02 45 43](https://github.com/user-attachments/assets/81a79b9d-ec4a-457f-9129-31715e11b584)


### How to test

1. Go to a proposal
2. Resize the screen
3. Below `md` size, the proposal should always take full width
