### PR TITLE
feat: Render HTML based content

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -78,6 +78,7 @@
     "starknetkit": "^1.1.9",
     "stream-browserify": "^3.0.0",
     "tippy.js": "^6.3.7",
+    "turndown": "^7.2.0",
     "unplugin-auto-import": "^0.16.6",
     "util": "^0.12.5",
     "vue": "^3.4.15",

--- a/apps/ui/src/components/Ui/Markdown.vue
+++ b/apps/ui/src/components/Ui/Markdown.vue
@@ -141,6 +141,7 @@ html.dark {
   }
 
   > *:last-child {
+    padding-bottom: 0 !important;
     margin-bottom: 0 !important;
   }
 

--- a/apps/ui/src/components/Ui/Markdown.vue
+++ b/apps/ui/src/components/Ui/Markdown.vue
@@ -152,7 +152,17 @@ html.dark {
     color: inherit;
     text-decoration: none;
   }
+  img[alt^='discourse-emoji'] {
+    display: inline;
+    width: 20px;
+    height: 20px;
+  }
 
+  img[alt^='discourse-thumbnail'] {
+    display: inline;
+    width: 35px;
+    height: 35px;
+  }
   p,
   blockquote,
   ul,

--- a/apps/ui/src/components/Ui/Markdown.vue
+++ b/apps/ui/src/components/Ui/Markdown.vue
@@ -227,6 +227,7 @@ html.dark {
   ul,
   ol {
     padding-left: 2em;
+    padding-bottom: 8px;
   }
 
   ul.no-list,

--- a/apps/ui/src/helpers/turndownService.ts
+++ b/apps/ui/src/helpers/turndownService.ts
@@ -6,6 +6,23 @@ const turndownService = new TurndownService({
 });
 
 export default function (options: { discussion?: string } = {}) {
+  turndownService.addRule('table', {
+    filter: ['table'],
+    replacement: function (content, node) {
+      const headers = Array.from(node.querySelectorAll('thead th')).map(
+        (th: any) => th.textContent
+      );
+      const rows = Array.from(node.querySelectorAll('tbody tr')).map(
+        (tr: any) =>
+          Array.from(tr.querySelectorAll('td')).map((td: any) => td.textContent)
+      );
+      return `
+        | ${headers.join(' | ')} |
+        | ${headers.map(() => '---').join(' | ')} |
+        | ${rows.map(row => row.join(' | ')).join('| \n |')} |
+      `;
+    }
+  });
   turndownService.addRule('handleQuote', {
     filter: ['aside'],
     replacement: function (content, node) {
@@ -56,5 +73,7 @@ export default function (options: { discussion?: string } = {}) {
       }
     });
   }
+
+  turndownService.escape = string => string;
   return turndownService.turndown.bind(turndownService);
 }

--- a/apps/ui/src/helpers/turndownService.ts
+++ b/apps/ui/src/helpers/turndownService.ts
@@ -28,7 +28,8 @@ export default function (options: { discussion?: string } = {}) {
     replacement: function (content, node) {
       if (node.classList.contains('quote')) {
         const image = node.querySelector('.title img');
-        return `> ### ![discourse-emoji](${image?.src}) ${node.querySelector('.title')?.textContent}
+        node.querySelector('.title img')?.remove();
+        return `> ### ![discourse-emoji](${image?.src}) ${turndownService.turndown(node.querySelector('.title')?.innerHTML)}
         > ${node.querySelector('blockquote')?.textContent}
          `;
       } else if (node.classList.contains('twitterstatus')) {
@@ -76,6 +77,10 @@ export default function (options: { discussion?: string } = {}) {
           const groupIdentifier = node.href.match(/\/(groups|g)\/(.*)/)?.[2];
           return `[${node.textContent}](${baseUrl}g/${groupIdentifier})`;
         }
+        if (node.classList.contains('badge-category__wrapper')) {
+          return `- [${node.textContent}](${node.href})`;
+        }
+
         if (node.querySelector('img')) {
           return `[![${node.querySelector('img').alt}](${node.querySelector('img').src}) ${node.textContent}](${node.href})`;
         }

--- a/apps/ui/src/helpers/turndownService.ts
+++ b/apps/ui/src/helpers/turndownService.ts
@@ -63,7 +63,18 @@ export default function (options: { discussion?: string } = {}) {
       filter: ['a'],
       replacement: function (content, node) {
         if (node.classList.contains('mention')) {
-          return `[${node.textContent}](${options.discussion?.match(/^(https?:\/\/[^\/]+\/)/)?.[1]}u/${node.textContent.replace('@', '')})`;
+          const baseUrl = options.discussion?.match(
+            /^(https?:\/\/[^\/]+\/)/
+          )?.[1];
+          const username = node.href.match(/\/u\/(.*)/)?.[1];
+          return `[${node.textContent}](${baseUrl}u/${username})`;
+        }
+        if (node.classList.contains('mention-group')) {
+          const baseUrl = options.discussion?.match(
+            /^(https?:\/\/[^\/]+\/)/
+          )?.[1];
+          const groupIdentifier = node.href.match(/\/(groups|g)\/(.*)/)?.[2];
+          return `[${node.textContent}](${baseUrl}g/${groupIdentifier})`;
         }
         if (node.querySelector('img')) {
           return `[![${node.querySelector('img').alt}](${node.querySelector('img').src}) ${node.textContent}](${node.href})`;

--- a/apps/ui/src/helpers/turndownService.ts
+++ b/apps/ui/src/helpers/turndownService.ts
@@ -1,0 +1,60 @@
+import TurndownService from 'turndown';
+
+const turndownService = new TurndownService({
+  linkStyle: 'referenced',
+  headingStyle: 'atx'
+});
+
+export default function (options: { discussion?: string } = {}) {
+  turndownService.addRule('handleQuote', {
+    filter: ['aside'],
+    replacement: function (content, node) {
+      if (node.classList.contains('quote')) {
+        const image = node.querySelector('.title img');
+        return `> ### ![discourse-emoji](${image?.src}) ${node.querySelector('.title')?.textContent}
+        > ${node.querySelector('blockquote')?.textContent}
+         `;
+      } else if (node.classList.contains('twitterstatus')) {
+        const image = node.querySelector('.thumbnail')?.src;
+        const displayName = node.querySelector('article h4 a')?.textContent;
+        const screenName = node.querySelector('.twitter-screen-name a');
+        const date = node.querySelector('.date')?.textContent;
+        const tweet = node.querySelector('.tweet')?.innerHTML;
+        return `
+        > ### [${date}](${screenName?.href})
+        > ![discourse-thumbnail](${image}) ${displayName} ([${screenName?.textContent}](${screenName?.href}))
+        >
+        > ${turndownService.turndown(tweet)}
+        `;
+      }
+      return content;
+    }
+  });
+
+  turndownService.addRule('emoji', {
+    filter: ['img'],
+    replacement: function (content, node) {
+      if (node.classList.contains('emoji')) {
+        return `![discourse-emoji-${node.alt}](${node.src})`;
+      }
+      return `![${node.alt}](${node.src})`;
+    }
+  });
+
+  if (options.discussion) {
+    turndownService.addRule('mention', {
+      filter: ['a'],
+      replacement: function (content, node) {
+        if (node.classList.contains('mention')) {
+          return `[${node.textContent}](${options.discussion?.match(/^(https?:\/\/[^\/]+\/)/)?.[1]}u/${node.textContent.replace('@', '')})`;
+        }
+        if (node.querySelector('img')) {
+          return `[![${node.querySelector('img').alt}](${node.querySelector('img').src}) ${node.textContent}](${node.href})`;
+        }
+
+        return `[${node.textContent}](${node.href})`;
+      }
+    });
+  }
+  return turndownService.turndown.bind(turndownService);
+}

--- a/apps/ui/src/views/Proposal/Discussion.vue
+++ b/apps/ui/src/views/Proposal/Discussion.vue
@@ -70,10 +70,7 @@ onMounted(async () => {
             </div>
           </div>
           <div>
-            <UiMarkdown
-              class="text-md pt-3 pb-2"
-              :body="toMarkdown(reply.cooked)"
-            />
+            <UiMarkdown class="text-md py-3" :body="toMarkdown(reply.cooked)" />
             <div class="text-sm space-x-2.5 flex">
               <div class="items-center flex gap-1">
                 <IH-thumb-up class="inline-block" /> {{ reply.like_count }}

--- a/apps/ui/src/views/Proposal/Discussion.vue
+++ b/apps/ui/src/views/Proposal/Discussion.vue
@@ -45,7 +45,7 @@ const toMarkdown = computed(() =>
     </div>
     <div v-if="loaded" class="px-4">
       <div
-        v-for="(reply, i) in replies.slice(1)"
+        v-for="(reply, i) in replies"
         :key="i"
         class="py-4 border-b last:border-b-0"
       >

--- a/apps/ui/src/views/Proposal/Discussion.vue
+++ b/apps/ui/src/views/Proposal/Discussion.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { loadReplies, Reply } from '@/helpers/discourse';
-import { _rt, sanitizeUrl, stripHtmlTags } from '@/helpers/utils';
+import turndownService from '@/helpers/turndownService';
+import { _rt, sanitizeUrl } from '@/helpers/utils';
 import { Proposal } from '@/types';
 
 const props = defineProps<{ proposal: Proposal }>();
@@ -21,6 +22,9 @@ onMounted(async () => {
     console.error(e);
   }
 });
+const toMarkdown = computed(() =>
+  turndownService({ discussion: discussion.value || '' })
+);
 </script>
 
 <template>
@@ -68,7 +72,7 @@ onMounted(async () => {
           <div>
             <UiMarkdown
               class="text-md pt-3 pb-2"
-              :body="stripHtmlTags(reply.cooked)"
+              :body="toMarkdown(reply.cooked)"
             />
             <div class="text-sm space-x-2.5 flex">
               <div class="items-center flex gap-1">

--- a/apps/ui/src/views/Proposal/Discussion.vue
+++ b/apps/ui/src/views/Proposal/Discussion.vue
@@ -11,6 +11,9 @@ const loading = ref(false);
 const loaded = ref(false);
 
 const discussion = computed(() => sanitizeUrl(props.proposal.discussion));
+const toMarkdown = computed(() =>
+  turndownService({ discussion: discussion.value || '' })
+);
 
 onMounted(async () => {
   try {
@@ -22,9 +25,6 @@ onMounted(async () => {
     console.error(e);
   }
 });
-const toMarkdown = computed(() =>
-  turndownService({ discussion: discussion.value || '' })
-);
 </script>
 
 <template>

--- a/apps/ui/src/views/SpaceUser/Statement.vue
+++ b/apps/ui/src/views/SpaceUser/Statement.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { compareAddresses, stripHtmlTags } from '@/helpers/utils';
+import turndownService from '@/helpers/turndownService';
+import { compareAddresses } from '@/helpers/utils';
 import { enabledNetworks, getNetwork, offchainNetworks } from '@/networks';
 import { Space, Statement, User } from '@/types';
 import ICAgora from '~icons/c/agora';
@@ -57,6 +58,8 @@ watch(userId, loadStatement, { immediate: true });
 watchEffect(() =>
   setTitle(`${props.user.name || userId.value} ${props.space.name}'s profile`)
 );
+
+const toMarkdown = computed(() => turndownService());
 </script>
 
 <template>
@@ -99,7 +102,7 @@ watchEffect(() =>
         <template v-if="statement.statement">
           <UiMarkdown
             class="text-skin-heading max-w-[592px]"
-            :body="stripHtmlTags(statement.statement)"
+            :body="toMarkdown(statement.statement)"
           />
           <div v-if="statement.source">
             <h4 class="eyebrow text-skin-text mb-2">Source</h4>

--- a/apps/ui/src/views/SpaceUser/Statement.vue
+++ b/apps/ui/src/views/SpaceUser/Statement.vue
@@ -29,6 +29,7 @@ const loading = ref(false);
 const statement = ref<Statement | null>(null);
 
 const userId = computed(() => route.params.user as string);
+const toMarkdown = computed(() => turndownService());
 
 async function loadStatement() {
   loading.value = true;
@@ -58,8 +59,6 @@ watch(userId, loadStatement, { immediate: true });
 watchEffect(() =>
   setTitle(`${props.user.name || userId.value} ${props.space.name}'s profile`)
 );
-
-const toMarkdown = computed(() => turndownService());
 </script>
 
 <template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1687,6 +1687,11 @@
     semver "^7.3.8"
     superstruct "^1.0.3"
 
+"@mixmark-io/domino@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@mixmark-io/domino/-/domino-2.2.0.tgz#4e8ec69bf1afeb7a14f0628b7e2c0f35bdb336c3"
+  integrity sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==
+
 "@motionone/animation@^10.15.1", "@motionone/animation@^10.17.0":
   version "10.17.0"
   resolved "https://registry.yarnpkg.com/@motionone/animation/-/animation-10.17.0.tgz#7633c6f684b5fee2b61c405881b8c24662c68fca"
@@ -11369,6 +11374,11 @@ rehackt@0.0.5:
   resolved "https://registry.yarnpkg.com/rehackt/-/rehackt-0.0.5.tgz#184c82ea369d5b0b989ede0593ebea8b2bcfb1d6"
   integrity sha512-BI1rV+miEkaHj8zd2n+gaMgzu/fKz7BGlb4zZ6HAiY9adDmJMkaDcmuXlJFv0eyKUob+oszs3/2gdnXUrzx2Tg==
 
+remarkable-emoji@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/remarkable-emoji/-/remarkable-emoji-0.1.3.tgz#38c7dba14f725dbd2672686805ae7abb04432eb3"
+  integrity sha512-2Ls1rTm6SvBZoSNA3Op2rLTllgoL3oaT2mSQojuWPN3e+VldWXgBZ6AbMnF7HCDePWjoibcMoutVP21aj3iF0w==
+
 remarkable@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/remarkable/-/remarkable-2.0.1.tgz#280ae6627384dfb13d98ee3995627ca550a12f31"
@@ -12896,6 +12906,13 @@ turbo@^1.12.3:
     turbo-linux-arm64 "1.12.3"
     turbo-windows-64 "1.12.3"
     turbo-windows-arm64 "1.12.3"
+
+turndown@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.2.0.tgz#67d614fe8371fb511079a93345abfd156c0ffcf4"
+  integrity sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==
+  dependencies:
+    "@mixmark-io/domino" "^2.2.0"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
### Summary
- Render HTML content on User statement and discussion
- Display first post in a topic (previously hidden)
- Imporve twitter card
- ![image](https://github.com/user-attachments/assets/b508890c-9fe1-4086-b5cf-5d86850463cd)


Closes: https://github.com/snapshot-labs/workflow/issues/189

### How to test

1. Go to a discussion page. http://localhost:8080/#/s:lido-snapshot.eth/proposal/0xa478fa5518769096eda2b7403a1d4104ca47de3102e8a9abab8640ef1b50650c/discussion
2. Should be formated similar to https://research.lido.fi/t/organize-the-lido-alliance-program-as-a-lido-dao-adjacent-borg/8173/3

### To-Do

- [x] Find if some case is missing

