### PR TITLE
refactor: remove extra div and class

### DIFF
--- a/apps/ui/src/components/Ui/LinkPreview.vue
+++ b/apps/ui/src/components/Ui/LinkPreview.vue
@@ -48,21 +48,19 @@ debouncedWatch(
 <template>
   <div
     v-if="preview?.meta || (showDefault && !previewLoading)"
-    class="!flex items-center border rounded-lg"
+    class="flex items-center px-4 py-3 border rounded-lg"
+    :class="{ 'space-x-2': showDefault, '!space-x-4': preview?.meta?.title }"
   >
     <template v-if="preview?.meta?.title">
-      <div v-if="preview?.links?.icon?.[0]?.href" class="px-4 pr-0">
-        <div class="w-[32px]">
-          <img
-            :src="preview.links.icon[0].href"
-            width="32"
-            height="32"
-            class="bg-white rounded"
-            :alt="preview.meta.title"
-          />
-        </div>
-      </div>
-      <div class="px-4 py-3 overflow-hidden">
+      <img
+        v-if="preview?.links?.icon?.[0]?.href"
+        :src="preview.links.icon[0].href"
+        width="32"
+        height="32"
+        class="bg-white rounded shrink-0"
+        :alt="preview.meta.title"
+      />
+      <div class="flex flex-col truncate">
         <div class="text-skin-link truncate" v-text="preview.meta.title" />
         <div
           v-if="preview.meta.description"
@@ -71,12 +69,9 @@ debouncedWatch(
         />
       </div>
     </template>
-    <div
-      v-else-if="showDefault"
-      class="px-4 py-3 flex gap-2 items-center w-full"
-    >
+    <template v-else-if="showDefault">
       <IH-link class="shrink-0" />
       <div class="truncate">{{ props.url }}</div>
-    </div>
+    </template>
   </div>
 </template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR removes the extra unnecessary div and redundant class from the `UiLinkPreview` component

### How to test

1. Go to to a proposal with a discussion link (http://localhost:8080/#/s:safe.eth/proposal/0x2c2ad686e94fd97903de8ee520b90d400c98a1985e31b21416da095b28373f18)
2. It should display as before
3. Go to a proposal without preview (http://localhost:8080/#/s:test.wa0x6e.eth/proposal/0x21a2d04568291e41485d827def02f2358b981d4a060e879fb3b8b12965d5a2f1)
4. It should display as before

### Note

This is a refactoring done while debugging something else, but was finally not the cause of the issue. Submitting a PR instead of throwing those changes away.