### PR TITLE
fix(ux): remove double focus and improve css class

### DIFF
--- a/apps/ui/src/components/TopicsList.vue
+++ b/apps/ui/src/components/TopicsList.vue
@@ -16,9 +16,9 @@ defineProps<{
       <TopicsListItem v-for="(topic, i) in topics" :key="i" :topic="topic" />
       <div
         v-if="!topics.length"
-        class="px-4 py-3 flex items-center text-skin-link"
+        class="px-4 py-3 flex items-center space-x-2 text-skin-link"
       >
-        <IH-exclamation-circle class="inline-block mr-2" />
+        <IH-exclamation-circle class="shrink-0" />
         <span v-text="'There are no topics here.'" />
       </div>
     </div>

--- a/apps/ui/src/views/Proposal/Discussion.vue
+++ b/apps/ui/src/views/Proposal/Discussion.vue
@@ -27,11 +27,11 @@ onMounted(async () => {
   <div>
     <div v-if="discussion" class="p-4 bg-skin-bg border-b">
       <div class="max-w-[680px] mx-auto">
-        <a :href="discussion" target="_blank">
+        <a :href="discussion" target="_blank" tabindex="-1">
           <UiButton class="flex items-center gap-2 w-full justify-center">
-            <IC-discourse class="size-[22px]" />
+            <IC-discourse class="size-[22px] shrink-0" />
             Join the discussion
-            <IH-arrow-sm-right class="inline-block -rotate-45" />
+            <IH-arrow-sm-right class="-rotate-45 shrink-0" />
           </UiButton>
         </a>
       </div>
@@ -46,15 +46,15 @@ onMounted(async () => {
         class="py-4 border-b last:border-b-0"
       >
         <div class="max-w-[680px] mx-auto">
-          <div class="flex">
+          <div class="flex gap-2.5 items-center">
             <a
               :href="reply.user_url"
               target="_blank"
-              class="w-[32px] h-[32px] shrink-0 mr-2.5 mt-0.5"
+              class="shrink-0 rounded-full"
             >
               <img
                 :src="reply.avatar_template"
-                class="rounded-full inline-block bg-skin-border w-[32px] h-[32px]"
+                class="rounded-full bg-skin-border size-[32px]"
               />
             </a>
             <div class="flex flex-col leading-4 gap-1">
@@ -72,13 +72,13 @@ onMounted(async () => {
             />
             <div class="text-sm space-x-2.5 flex">
               <div class="items-center flex gap-1">
-                <IH-thumb-up class="inline-block" /> {{ reply.like_count }}
+                <IH-thumb-up /> {{ reply.like_count }}
               </div>
               <div class="items-center flex gap-1">
-                <IH-annotation class="inline-block" /> {{ reply.reply_count }}
+                <IH-annotation /> {{ reply.reply_count }}
               </div>
               <div class="items-center flex gap-1">
-                <IH-eye class="inline-block" /> {{ reply.reads }}
+                <IH-eye /> {{ reply.reads }}
               </div>
             </div>
           </div>

--- a/apps/ui/src/views/Space/Discussions.vue
+++ b/apps/ui/src/views/Space/Discussions.vue
@@ -31,11 +31,16 @@ watchEffect(() => setTitle(`Discussions - ${props.space.name}`));
   <div>
     <div v-if="discussionsUrl" class="flex p-4">
       <div class="flex-grow">
-        <a :href="discussionsUrl" target="_blank" class="inline-block">
+        <a
+          :href="discussionsUrl"
+          target="_blank"
+          class="inline-block"
+          tabindex="-1"
+        >
           <UiButton class="flex items-center gap-2 justify-center">
-            <IC-discourse class="size-[22px]" />
+            <IC-discourse class="size-[22px] shrink-0" />
             Join the discussion
-            <IH-arrow-sm-right class="-rotate-45" />
+            <IH-arrow-sm-right class="-rotate-45 shrink-0" />
           </UiButton>
         </a>
       </div>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR:

- removes the double focus on some links
- improve CSS classes

### How to test

1. Go to a proposal discussion and space discussions page
2. Navigate through the link with the keyboard
3. All links should be focusable only once
4. UI wise, everything should remain the same
