### PR TITLE
feat: manage space settings tabs via routes

### DIFF
--- a/apps/ui/src/router.ts
+++ b/apps/ui/src/router.ts
@@ -48,7 +48,7 @@ const routes: any[] = [
       },
       { path: 'search', name: 'space-search', component: SpaceSearch },
       {
-        path: 'settings',
+        path: 'settings/:tab?',
         name: 'space-settings',
         component: SpaceSettings
       },


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/179

With this change tabs are accessed via URL path (`settings/profile`, `settings/voting` etc.)

### How to test

1. Go to your onchain space settings.
2. Switch tabs, URL updates.
3. Open some URL in new tab, you get redirected to that tab specifically.
