### PR TITLE
fix: replace home route instead of pushing to allow going back

### DIFF
--- a/apps/ui/src/views/My/Home.vue
+++ b/apps/ui/src/views/My/Home.vue
@@ -114,7 +114,7 @@ watch(
   [() => web3.value.account, () => web3.value.authLoading],
   ([account, authLoading]) => {
     if (!account && !authLoading) {
-      router.push({ name: 'my-explore' });
+      router.replace({ name: 'my-explore' });
     }
   },
   { immediate: true }


### PR DESCRIPTION
### Summary

Currently if we navigate to /home and we get redirected to /explore going back will take us back to /home (which will automatically redirect us to /explore again) getting stuck.

### How to test

1. Can't really be tested at the moment, needs to be on landing page PR.
