### PR TITLE
fix: add page title to ecosystem

### DIFF
--- a/apps/ui/src/views/Ecosystem.vue
+++ b/apps/ui/src/views/Ecosystem.vue
@@ -3,6 +3,8 @@ const router = useRouter();
 const route = useRoute();
 const { apps, load, search, categories, loading, loaded } = useApps();
 
+useTitle('Ecosystem');
+
 const q: Ref<string> = ref((route.query.q as string) || '');
 
 const results = computed(() => search(q.value));


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR adds the missing page title for the /ecosystem page

### How to test

1. Go to http://localhost:8080/#/ecosystem
2. It should says "Ecosystem" in the page title
