### PR TITLE
fix: Format voting power in delegates page

### DIFF
--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import removeMarkdown from 'remove-markdown';
-import { _n, _p, shorten } from '@/helpers/utils';
+import { _n, _p, _vp, shorten } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
 import { Space, SpaceMetadataDelegation } from '@/types';
 
@@ -236,10 +236,10 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
               <div
                 class="w-[150px] flex flex-col sm:shrink-0 items-end justify-center leading-[22px] truncate"
               >
-                <h4
-                  class="text-skin-link"
-                  v-text="_n(delegate.delegatedVotes)"
-                />
+                <h4 class="text-skin-link">
+                  {{ _vp(Number(delegate.delegatedVotes)) }}
+                  {{ space.voting_power_symbol }}
+                </h4>
                 <div
                   class="text-[17px]"
                   v-text="_p(delegate.votesPercentage)"


### PR DESCRIPTION
### Summary
- Format voting power in delegates page to be same as votes page

### How to test

1. Go to delegates page http://localhost:8080/#/s:safe.eth/delegates
2. Notice the change in format in which we display voting power

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/870d98cb-acab-4a01-b08a-6775fa3e8091) | ![image](https://github.com/user-attachments/assets/56a3b8e9-e373-4688-a66a-d2debf5716ce) |