### PR TITLE
Add ambire wallet to known hosts

### DIFF
--- a/apps/ui/src/main.ts
+++ b/apps/ui/src/main.ts
@@ -6,7 +6,7 @@ import options from '@/helpers/auth';
 import router from '@/router';
 import '@/style.scss';
 
-const knownHosts = ['app.safe.global', 'pilot.gnosisguild.org'];
+const knownHosts = ['app.safe.global', 'pilot.gnosisguild.org', 'wallet.ambire.com'];
 const parentUrl =
   window.location != window.parent.location
     ? document.referrer ||


### PR DESCRIPTION
### Summary

Adds ambire web wallet to known hosts


### How to test

1. Add snapshot.box in wallet.ambire.com dapps catalog
2. Try to open snapshot.box from dapp catalog

