### PR TITLE
fix: Remove invisible links in discussion topic

### DIFF
--- a/apps/ui/src/helpers/turndownService.ts
+++ b/apps/ui/src/helpers/turndownService.ts
@@ -63,21 +63,23 @@ export default function (options: { discussion?: string } = {}) {
     turndownService.addRule('mention', {
       filter: ['a'],
       replacement: function (content, node) {
-        if (node.classList.contains('mention')) {
+        const classList: string[] = Array.from(node.classList);
+        if (classList.includes('anchor')) return '';
+        if (classList.includes('mention')) {
           const baseUrl = options.discussion?.match(
             /^(https?:\/\/[^\/]+\/)/
           )?.[1];
           const username = node.href.match(/\/u\/(.*)/)?.[1];
           return `[${node.textContent}](${baseUrl}u/${username})`;
         }
-        if (node.classList.contains('mention-group')) {
+        if (classList.includes('mention-group')) {
           const baseUrl = options.discussion?.match(
             /^(https?:\/\/[^\/]+\/)/
           )?.[1];
           const groupIdentifier = node.href.match(/\/(groups|g)\/(.*)/)?.[2];
           return `[${node.textContent}](${baseUrl}g/${groupIdentifier})`;
         }
-        if (node.classList.contains('badge-category__wrapper')) {
+        if (classList.includes('badge-category__wrapper')) {
           return `- [${node.textContent}](${node.href})`;
         }
 


### PR DESCRIPTION
Reported on https://discord.com/channels/955773041898573854/1280493918957473822/1281133931432906788

### Summary
- On this proposal (http://localhost:8080/#/s:safe.eth/proposal/0x2c2ad686e94fd97903de8ee520b90d400c98a1985e31b21416da095b28373f18/discussion), there is some links without content
![image](https://github.com/user-attachments/assets/b425610a-667b-4700-8c7e-93802e182193)
Navigate with TAB key, and you will notice that it sometimes does not highlight visible text/links

- This proposal will delete them

### How to test

1. Go to http://localhost:8080/#/s:safe.eth/proposal/0x2c2ad686e94fd97903de8ee520b90d400c98a1985e31b21416da095b28373f18/discussion
2. you should not see localhost links in console anymore
