### PR TITLE
refactor: use gap-2 instead of mr-2

### DIFF
--- a/apps/ui/src/components/ProposalExecutionActions.vue
+++ b/apps/ui/src/components/ProposalExecutionActions.vue
@@ -66,31 +66,31 @@ const network = computed(() => getNetwork(props.proposal.network));
     <div v-else class="space-y-2">
       <UiButton
         v-if="hasFinalize"
-        class="w-full flex justify-center items-center"
+        class="w-full flex justify-center items-center gap-2"
         :loading="finalizeProposalSending"
         @click="finalizeProposal"
       >
-        <IH-check-circle class="inline-block mr-2" />
+        <IH-check-circle />
         Finalize proposal
       </UiButton>
       <UiButton
         v-else-if="proposal.state !== 'executed'"
-        class="w-full flex justify-center items-center"
+        class="w-full flex justify-center items-center gap-2"
         :loading="executeProposalSending"
         @click="executeProposal"
       >
-        <IH-play class="inline-block mr-2" />
+        <IH-play />
         Execute transactions
       </UiButton>
       <UiButton
         v-if="hasExecuteQueued"
         :disabled="executionCountdown > 0"
         :title="executionCountdown === 0 ? '' : 'Veto period has not ended yet'"
-        class="w-full flex justify-center items-center"
+        class="w-full flex justify-center items-center gap-2"
         :loading="executeQueuedProposalSending"
         @click="executeQueuedProposal"
       >
-        <IH-play class="inline-block mr-2 shrink-0" />
+        <IH-play class="shrink-0" />
         <template v-if="executionCountdown === 0"
           >Execute queued transactions</template
         >
@@ -108,11 +108,11 @@ const network = computed(() => getNetwork(props.proposal.network));
           compareAddresses(proposal.timelock_veto_guardian, web3.account)
         "
         :disabled="executionCountdown === 0"
-        class="w-full flex justify-center items-center"
+        class="w-full flex justify-center items-center gap-2"
         :loading="vetoProposalSending"
         @click="vetoProposal"
       >
-        <IH-play class="inline-block mr-2 shrink-0" />
+        <IH-play class="shrink-0" />
         Veto execution
       </UiButton>
     </div>

--- a/apps/ui/src/components/ProposalsList.vue
+++ b/apps/ui/src/components/ProposalsList.vue
@@ -51,9 +51,9 @@ const currentLimit = computed(() => {
       </UiContainerInfiniteScroll>
       <div
         v-if="!proposals.length"
-        class="px-4 py-3 flex items-center text-skin-link"
+        class="px-4 py-3 flex items-center text-skin-link gap-2"
       >
-        <IH-exclamation-circle class="inline-block mr-2" />
+        <IH-exclamation-circle />
         <span v-text="'There are no proposals here.'" />
       </div>
       <router-link

--- a/apps/ui/src/views/Ecosystem.vue
+++ b/apps/ui/src/views/Ecosystem.vue
@@ -40,8 +40,8 @@ watch(
         >
           <AppsListItem v-for="(app, i) in results" :key="i" :app="app" />
         </div>
-        <div v-else class="flex items-center text-skin-link">
-          <IH-exclamation-circle class="inline-block mr-2" />
+        <div v-else class="flex items-center text-skin-link gap-2">
+          <IH-exclamation-circle />
           <span v-text="'There are no integrations here.'" />
         </div>
       </div>

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -326,8 +326,8 @@ watchEffect(() => {
             proposal.vote_count
           "
         >
-          <h4 class="mb-2.5 eyebrow flex items-center">
-            <IH-chart-square-bar class="inline-block mr-2" />
+          <h4 class="mb-2.5 eyebrow flex items-center gap-2">
+            <IH-chart-square-bar />
             <span>Results</span>
           </h4>
           <ProposalResults
@@ -337,8 +337,8 @@ watchEffect(() => {
           />
         </div>
         <div>
-          <h4 class="mb-2.5 eyebrow flex items-center">
-            <IH-clock class="inline-block mr-2" />
+          <h4 class="mb-2.5 eyebrow flex items-center gap-2">
+            <IH-clock />
             <span>Timeline</span>
           </h4>
           <ProposalTimeline :data="proposal" />

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -335,8 +335,8 @@ onBeforeUnmount(() => destroyAudio());
       </div>
 
       <div v-if="aiSummaryOpen" class="mb-6">
-        <h4 class="mb-2 eyebrow flex items-center">
-          <IH-sparkles class="inline-block mr-2" />
+        <h4 class="mb-2 eyebrow flex items-center gap-2">
+          <IH-sparkles />
           <span>AI summary</span>
         </h4>
         <div class="text-md text-skin-link mb-2">{{ aiSummaryContent }}</div>
@@ -347,8 +347,8 @@ onBeforeUnmount(() => destroyAudio());
       </div>
       <UiMarkdown v-if="proposal.body" class="mb-4" :body="proposal.body" />
       <div v-if="discussion">
-        <h4 class="mb-3 eyebrow flex items-center">
-          <IH-chat-alt class="inline-block mr-2" />
+        <h4 class="mb-3 eyebrow flex items-center gap-2">
+          <IH-chat-alt />
           <span>Discussion</span>
         </h4>
         <a :href="discussion" target="_blank" class="block mb-5">
@@ -356,8 +356,8 @@ onBeforeUnmount(() => destroyAudio());
         </a>
       </div>
       <div v-if="proposal.executions && proposal.executions.length > 0">
-        <h4 class="mb-3 eyebrow flex items-center">
-          <IH-play class="inline-block mr-2" />
+        <h4 class="mb-3 eyebrow flex items-center gap-2">
+          <IH-play />
           <span>Execution</span>
         </h4>
         <div class="mb-4">

--- a/apps/ui/src/views/Settings/Contacts.vue
+++ b/apps/ui/src/views/Settings/Contacts.vue
@@ -65,8 +65,11 @@ function handleContactEdit(contact) {
         </button>
       </div>
     </div>
-    <div v-if="!contactsStore.contacts.length" class="px-4 py-3 text-skin-link">
-      <IH-exclamation-circle class="inline-block mr-2" />
+    <div
+      v-if="!contactsStore.contacts.length"
+      class="flex items-center px-4 py-3 text-skin-link gap-2"
+    >
+      <IH-exclamation-circle />
       <span v-text="'There are no contacts here.'" />
     </div>
   </div>


### PR DESCRIPTION
### Summary
Continued from https://github.com/snapshot-labs/sx-monorepo/pull/593#discussion_r1710730620
Use `gap-2`  instead of `inline-block mr-2`

### How to test

 Some places where you can test:
1. Go to http://localhost:8080/#/s:daoxperience.eth/proposals
2. <img width="299" alt="Untitled 2" src="https://github.com/user-attachments/assets/98b920f1-4277-42bc-8a14-96a263cadf8f">
3. Go to http://localhost:8080/#/settings/contacts
4. <img width="412" alt="Untitled 4" src="https://github.com/user-attachments/assets/b7a9928c-c877-434f-8f0f-116ff9f79e70">
5. Go to http://localhost:8080/#/s:shutterdao0x36.eth/proposal/0xfd0e80f5c1b2460f73f63319db5faf9061df263553e38bdc9ab1a4cca946d556
6. 
<img width="260" alt="Untitled 5" src="https://github.com/user-attachments/assets/f0784da5-3ec2-4bbd-9096-898c4afa6f79">
<img width="287" alt="Untitled 6" src="https://github.com/user-attachments/assets/72b22d53-f523-4256-aa6c-cfc991c79bc0">
<img width="297" alt="Untitled 7" src="https://github.com/user-attachments/assets/1beeede3-1580-464d-91c6-f8d296e5a16a">
<img width="315" alt="Untitled 8" src="https://github.com/user-attachments/assets/72e32534-55d2-4f21-a700-b4b9f128898a">





