### PR TITLE
fix: use proposal network to get execution name

### DIFF
--- a/apps/ui/src/components/ProposalExecutionsList.vue
+++ b/apps/ui/src/components/ProposalExecutionsList.vue
@@ -75,7 +75,7 @@ function downloadExecution(execution: ProposalExecution) {
         <div
           class="text-skin-text text-[17px]"
           v-text="
-            getExecutionName(execution.networkId, execution.strategyType) ||
+            getExecutionName(proposal.network, execution.strategyType) ||
             shorten(execution.safeAddress)
           "
         />


### PR DESCRIPTION
### Summary

Executions depend on proposal network, not where it's going to be executed.

### How to test

1. Go to http://localhost:8080/#/sn-sep:0x00a330d13703f0af4f87e65d95c898297f8ce6e88ac7e9bff3b3bd270d2f6d5b/proposal/6
2. It shows "Eth relayer execution"

