### PR TITLE
fix: handle empty post

### DIFF
--- a/apps/ui/src/components/ProposalExecutionsList.vue
+++ b/apps/ui/src/components/ProposalExecutionsList.vue
@@ -75,7 +75,7 @@ function downloadExecution(execution: ProposalExecution) {
         <div
           class="text-skin-text text-[17px]"
           v-text="
-            getExecutionName(execution.networkId, execution.strategyType) ||
+            getExecutionName(proposal.network, execution.strategyType) ||
             shorten(execution.safeAddress)
           "
         />

--- a/apps/ui/src/helpers/discourse.ts
+++ b/apps/ui/src/helpers/discourse.ts
@@ -110,7 +110,7 @@ export async function loadTopics(url: string): Promise<Topic[]> {
 }
 
 function formatPosts(posts: any[], baseUrl: string): Reply[] {
-  if (!posts || !posts.length) return [];
+  if (!posts?.length) return [];
 
   return posts.map(post => {
     post.avatar_template = post.avatar_template.replace('{size}', '64');
@@ -137,7 +137,7 @@ export async function loadSingleTopic(url: string): Promise<Topic> {
   const topic = await res.json();
 
   topic.posts_count--;
-  topic.posts = formatPosts(topic.post_stream.posts, baseUrl);
+  topic.posts = formatPosts(topic.post_stream?.posts, baseUrl);
   return topic;
 }
 
@@ -151,5 +151,5 @@ export async function loadReplies(url: string): Promise<Reply[]> {
   );
   const data = await res.json();
 
-  return formatPosts(data.post_stream.posts, baseUrl);
+  return formatPosts(data?.post_stream?.posts, baseUrl);
 }

--- a/apps/ui/src/helpers/discourse.ts
+++ b/apps/ui/src/helpers/discourse.ts
@@ -109,7 +109,9 @@ export async function loadTopics(url: string): Promise<Topic[]> {
   });
 }
 
-function formatPosts(posts, baseUrl) {
+function formatPosts(posts: any[], baseUrl: string): Reply[] {
+  if (!posts || !posts.length) return [];
+
   return posts.map(post => {
     post.avatar_template = post.avatar_template.replace('{size}', '64');
     if (post.avatar_template.startsWith('/'))
@@ -135,9 +137,7 @@ export async function loadSingleTopic(url: string): Promise<Topic> {
   const topic = await res.json();
 
   topic.posts_count--;
-  topic.posts = topic?.post_stream?.posts?.length
-    ? formatPosts(topic.post_stream.posts, baseUrl)
-    : [];
+  topic.posts = formatPosts(topic.post_stream.posts, baseUrl);
   return topic;
 }
 
@@ -151,7 +151,5 @@ export async function loadReplies(url: string): Promise<Reply[]> {
   );
   const data = await res.json();
 
-  return data?.post_stream?.posts?.length
-    ? formatPosts(data.post_stream.posts, baseUrl)
-    : [];
+  return formatPosts(data.post_stream.posts, baseUrl);
 }

--- a/apps/ui/src/helpers/discourse.ts
+++ b/apps/ui/src/helpers/discourse.ts
@@ -135,8 +135,9 @@ export async function loadSingleTopic(url: string): Promise<Topic> {
   const topic = await res.json();
 
   topic.posts_count--;
-  topic.posts = formatPosts(topic.post_stream.posts, baseUrl);
-
+  topic.posts = topic?.post_stream?.posts?.length
+    ? formatPosts(topic.post_stream.posts, baseUrl)
+    : [];
   return topic;
 }
 
@@ -150,5 +151,7 @@ export async function loadReplies(url: string): Promise<Reply[]> {
   );
   const data = await res.json();
 
-  return formatPosts(data.post_stream.posts, baseUrl);
+  return data?.post_stream?.posts?.length
+    ? formatPosts(data.post_stream.posts, baseUrl)
+    : [];
 }


### PR DESCRIPTION
### Summary

- Issue: Throwing error if post doesn't exist
- Fix: Checks if post exist before maping

### How to test

1. Go to https://snapshot.box/#/s:nation3.eth/proposal/0x9c7b2dc6c9f309e7d67b1c590f9c44adecb91d43ad51454b373e6b6d58e5f74e
2. Notice error: 
3. <img width="587" alt="Untitled 4" src="https://github.com/user-attachments/assets/5cc7fa74-a2ce-4887-a702-96a9d9885227">
4. After fix, you should not see `TypeError: Cannot read properties of undefined (reading 'posts')` error
