### PR TITLE
feat: add network switcher for starknet wallet

### DIFF
--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -8,7 +8,10 @@ import duration from 'dayjs/plugin/duration';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import updateLocale from 'dayjs/plugin/updateLocale';
 import sha3 from 'js-sha3';
-import { validateAndParseAddress } from 'starknet';
+import {
+  constants as starknetConstants,
+  validateAndParseAddress
+} from 'starknet';
 import networks from '@/helpers/networks.json';
 import { VotingPowerItem } from '@/stores/votingPowers';
 import { Choice, Proposal, SpaceMetadata } from '@/types';
@@ -375,6 +378,26 @@ export async function verifyNetwork(
       );
       (error as any).code = 4001;
       throw error;
+    }
+  }
+}
+
+export async function verifyStarknetNetwork(
+  web3: any,
+  chainId: starknetConstants.StarknetChainId
+) {
+  if (!web3.provider.request) return;
+
+  try {
+    await web3.provider.request({
+      type: 'wallet_switchStarknetChain',
+      params: {
+        chainId
+      }
+    });
+  } catch (e) {
+    if (!e.message.toLowerCase().includes('not implemented')) {
+      throw new Error(e.message);
     }
   }
 }

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -5,11 +5,22 @@ import {
   starknetMainnet,
   starknetSepolia
 } from '@snapshot-labs/sx';
-import { Account, AllowArray, Call, CallData, RpcProvider } from 'starknet';
+import {
+  Account,
+  AllowArray,
+  Call,
+  CallData,
+  RpcProvider,
+  constants as starknetConstants
+} from 'starknet';
 import { executionCall, MANA_URL } from '@/helpers/mana';
 import { getProvider } from '@/helpers/provider';
 import { convertToMetaTransactions } from '@/helpers/transactions';
-import { createErc1155Metadata, verifyNetwork } from '@/helpers/utils';
+import {
+  createErc1155Metadata,
+  verifyNetwork,
+  verifyStarknetNetwork
+} from '@/helpers/utils';
 import {
   EVM_CONNECTORS,
   STARKNET_CONNECTORS
@@ -54,7 +65,11 @@ export function createActions(
     chainId,
     l1ChainId,
     ethUrl
-  }: { chainId: string; l1ChainId: number; ethUrl: string }
+  }: {
+    chainId: starknetConstants.StarknetChainId;
+    l1ChainId: number;
+    ethUrl: string;
+  }
 ): NetworkActions {
   const networkConfig = CONFIGS[networkId];
   if (!networkConfig) throw new Error(`Unsupported network ${networkId}`);
@@ -230,6 +245,8 @@ export function createActions(
 
       if (relayerType && ['evm', 'evm-tx'].includes(relayerType)) {
         await verifyNetwork(web3, l1ChainId);
+      } else {
+        await verifyStarknetNetwork(web3, chainId);
       }
 
       let selectedExecutionStrategy;
@@ -331,6 +348,8 @@ export function createActions(
 
       if (relayerType && ['evm', 'evm-tx'].includes(relayerType)) {
         await verifyNetwork(web3, l1ChainId);
+      } else {
+        await verifyStarknetNetwork(web3, chainId);
       }
 
       let selectedExecutionStrategy;
@@ -407,6 +426,8 @@ export function createActions(
 
       if (relayerType && ['evm', 'evm-tx'].includes(relayerType)) {
         await verifyNetwork(web3, l1ChainId);
+      } else {
+        await verifyStarknetNetwork(web3, chainId);
       }
 
       const strategiesWithMetadata = await Promise.all(
@@ -467,7 +488,7 @@ export function createActions(
         convertToMetaTransactions(proposal.executions[0].transactions)
       );
 
-      return executionCall('stark', chainId, 'execute', {
+      return executionCall('stark', chainId as string, 'execute', {
         space: proposal.space.id,
         proposalId: proposal.proposal_id,
         executionParams: executionData.executionParams

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -108,14 +108,16 @@ export function createActions(
         saltNonce: salt
       });
     },
-    async deployDependency(
+    deployDependency: async (
       web3: any,
       params: {
         controller: string;
         spaceAddress: string;
         strategy: StrategyConfig;
       }
-    ) {
+    ) => {
+      await verifyStarknetNetwork(web3, chainId);
+
       if (!params.strategy.deploy) {
         throw new Error('This strategy is not deployable');
       }
@@ -144,6 +146,8 @@ export function createActions(
         metadata: SpaceMetadata;
       }
     ) {
+      await verifyStarknetNetwork(web3, chainId);
+
       const pinned = await helpers.pin(
         createErc1155Metadata(params.metadata, {
           execution_strategies: params.executionStrategies.map(
@@ -193,6 +197,8 @@ export function createActions(
       });
     },
     setMetadata: async (web3: any, space: Space, metadata: SpaceMetadata) => {
+      await verifyStarknetNetwork(web3, chainId);
+
       const pinned = await helpers.pin(
         createErc1155Metadata(metadata, {
           execution_strategies: space.executors,
@@ -398,7 +404,9 @@ export function createActions(
         data
       });
     },
-    cancelProposal: (web3: any, proposal: Proposal) => {
+    cancelProposal: async (web3: any, proposal: Proposal) => {
+      await verifyStarknetNetwork(web3, chainId);
+
       return client.cancelProposal({
         signer: web3.provider.account,
         space: proposal.space.id,
@@ -481,6 +489,8 @@ export function createActions(
     },
     finalizeProposal: () => null,
     executeTransactions: async (web3: any, proposal: Proposal) => {
+      await verifyStarknetNetwork(web3, chainId);
+
       const executionData = getExecutionData(
         proposal.space,
         proposal.execution_strategy,
@@ -495,6 +505,8 @@ export function createActions(
       });
     },
     executeQueuedProposal: async (web3: any, proposal: Proposal) => {
+      await verifyStarknetNetwork(web3, chainId);
+
       if (!proposal.execution_destination)
         throw new Error('Execution destination is missing');
 
@@ -549,6 +561,8 @@ export function createActions(
     },
     vetoProposal: () => null,
     setVotingDelay: async (web3: any, space: Space, votingDelay: number) => {
+      await verifyStarknetNetwork(web3, chainId);
+
       return client.setVotingDelay({
         signer: web3.provider.account,
         space: space.id,
@@ -560,6 +574,8 @@ export function createActions(
       space: Space,
       minVotingDuration: number
     ) => {
+      await verifyStarknetNetwork(web3, chainId);
+
       return client.setMinVotingDuration({
         signer: web3.provider.account,
         space: space.id,
@@ -571,6 +587,8 @@ export function createActions(
       space: Space,
       maxVotingDuration: number
     ) => {
+      await verifyStarknetNetwork(web3, chainId);
+
       return client.setMaxVotingDuration({
         signer: web3.provider.account,
         space: space.id,
@@ -578,6 +596,8 @@ export function createActions(
       });
     },
     transferOwnership: async (web3: any, space: Space, owner: string) => {
+      await verifyStarknetNetwork(web3, chainId);
+
       return client.transferOwnership({
         signer: web3.provider.account,
         space: space.id,
@@ -597,6 +617,8 @@ export function createActions(
       minVotingDuration: number | null,
       maxVotingDuration: number | null
     ) => {
+      await verifyStarknetNetwork(web3, chainId);
+
       const pinned = await helpers.pin(
         createErc1155Metadata(metadata, {
           execution_strategies: space.executors,
@@ -658,6 +680,8 @@ export function createActions(
       delegatee: string,
       delegationContract: string
     ) => {
+      await verifyStarknetNetwork(web3, chainId);
+
       const [, contractAddress] = delegationContract.split(':');
 
       const { account }: { account: Account } = web3.provider;
@@ -733,7 +757,9 @@ export function createActions(
     },
     followSpace: () => {},
     unfollowSpace: () => {},
-    setAlias(web3: any, alias: string) {
+    setAlias: async (web3: any, alias: string) => {
+      await verifyStarknetNetwork(web3, chainId);
+
       return starkSigClient.setAlias({
         signer: web3.provider.account,
         data: { alias }

--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -14,7 +14,7 @@ import { createApi } from '../common/graphqlApi';
 
 type Metadata = {
   name: string;
-  chainId: string;
+  chainId: starknetConstants.StarknetChainId;
   baseChainId: number;
   baseNetworkId: NetworkID;
   rpcUrl: string;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #546 

This PR adds a network switcher (sn_main <-> sn_sepolia) to argent X wallet (braavos don't support this feature)

### How to test

1. Trigger some action requiring starknet signature
2. If your wallet is on the expected network, argent X should show the signature popup (existing behavior)
3. If the wallet is not on the expected network, argent X should show the network switcher popup
4. If REJECTING the switch, it should cancel the signature
5. if APPROVING the switch, it should switch to the correct network, and show the signature popup

### Note 

- For those using Braavos wallet, the network switcher will be skipped since unsupported, and will directly show the signature popup using the wallet current network (existing behavior)
- If the target network does not exist, argent X will skip the network switcher popup, and just show the signature popup with the wallet existing network (existing behavior)
