### PR TITLE
fix: prevent saving space settings without authenticators

### DIFF
--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -124,6 +124,10 @@ const error = computed(() => {
     return 'Proposal validation strategy is required';
   }
 
+  if (!authenticators.value.length) {
+    return 'At least one authenticator is required';
+  }
+
   return null;
 });
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #634

This PR prevents saving a space settings without any authenticators set

We're already ensuring that at least one authenticator is present when creating a space.
This PR will also ensure the same when saving a space, and prevent spaces with invalid settings

### How to test

1. Go to a space settings
2. Delete all authenticators
3. It should show an error message, and disable the save button
4. The save button should be enabled only when at least one authenticator is present
