### PR TITLE
fix: Change rpc URL domain

### DIFF
--- a/apps/mana/src/eth/dependencies.ts
+++ b/apps/mana/src/eth/dependencies.ts
@@ -15,7 +15,7 @@ export function getEthereumWallet(mnemonic: string, index: number) {
 export const createWalletProxy = (mnemonic: string, chainId: number) => {
   const signers = new Map<string, Wallet>();
   const provider = new StaticJsonRpcProvider(
-    `https://rpc.snapshotx.xyz/${chainId}`,
+    `https://rpc.snapshot.org/${chainId}`,
     chainId
   );
 

--- a/apps/ui/src/helpers/provider.ts
+++ b/apps/ui/src/helpers/provider.ts
@@ -3,7 +3,7 @@ import { StaticJsonRpcProvider } from '@ethersproject/providers';
 const providers: Record<number, StaticJsonRpcProvider | undefined> = {};
 
 export function getProvider(networkId: number): StaticJsonRpcProvider {
-  const url = `https://rpc.snapshotx.xyz/${networkId}`;
+  const url = `https://rpc.snapshot.org/${networkId}`;
 
   let provider = providers[networkId];
 

--- a/packages/sx.js/package.json
+++ b/packages/sx.js/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "yarn run lint",
     "node:evm": "anvil",
     "node:starknet": "starknet-devnet --seed 1",
-    "test": "SEPOLIA_NODE_URL=https://rpc.snapshotx.xyz/11155111 vitest run test/unit",
+    "test": "SEPOLIA_NODE_URL=https://rpc.snapshot.org/11155111 vitest run test/unit",
     "test:integration:starknet": "vitest run test/integration/starknet",
     "test:integration:evm": "vitest run test/integration/evm",
     "test:integration:offchain": "vitest run test/integration/offchain"


### PR DESCRIPTION
Reported at https://discord.com/channels/955773041898573854/1182427601046884352/1282067787845730304

we've just had a report that the proposals are showing "hasn't started" even though the users have already voted and the proposal already started.
https://snapshot.box/#/sn:0x07bd3419669f9f0cc8f19e9e2457089cdd4804a4c41a5729ee9c7fd02ab8ab62/proposal/5

![image](https://github.com/user-attachments/assets/24328ace-2174-418f-8992-368c1999bdfc)


## How to test: Go to the proposal http://localhost:8080/#/sn:0x07bd3419669f9f0cc8f19e9e2457089cdd4804a4c41a5729ee9c7fd02ab8ab62/proposal/5 
You should see that proposal is active