### PR TITLE
fix: Handle strategy address comparison

### DIFF
--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -346,8 +346,10 @@ async function hasStrategyChanged(
       : [];
     previousParams = previousParams ?? [];
   }
-
-  return objectHash(params) !== objectHash(previousParams);
+  // NOTE: Params need to be lowercase when we compare them as once stored they will be stored
+  // as bytes (casing is lost).
+  const formattedParams = params.map(param => param.toLowerCase());
+  return objectHash(formattedParams) !== objectHash(previousParams);
 }
 
 async function processChanges(


### PR DESCRIPTION
### Summary

Same changes as mentioned here https://github.com/snapshot-labs/workflow/issues/197#issuecomment-2334507517
Handle strategy address comparison, Params need to be lowercase when we compare them as once stored they will be stored as bytes (casing is lost).

Closes: https://github.com/snapshot-labs/workflow/issues/197

### How to test

1. Go to http://localhost:8080/#/eth:0x6E60b6dCc2923267104Bb4a68F4766f627430664/settings/voting-strategies
2. Login with `0x8C28Cf33d9Fd3D0293f963b1cd27e3FF422B425c` using impersonator
3. Before fix you should see the "save changes" button without any changes
4. After fix you should see save changes only when you change some settings

