### PR TITLE
fix: Show extra line on space items

### DIFF
--- a/apps/ui/src/components/SpacesListItem.vue
+++ b/apps/ui/src/components/SpacesListItem.vue
@@ -51,7 +51,7 @@ const compositeSpaceId = `${props.space.network}:${props.space.id}`;
 
       <h5
         v-if="showAbout"
-        class="mt-1 line-clamp-2 leading-6"
+        class="mt-1 line-clamp-3 leading-6"
         v-text="space.about"
       />
     </div>


### PR DESCRIPTION
### Summary

As discussed on call, 
Display extra line on space items to occupy more space 
(using `line-clamp-4` is actually occupying full empty space)

### How to test

1. Go to explore page

| Before | After |
| --- | --- |
| <img width="1001" alt="Untitled 11" src="https://github.com/user-attachments/assets/e9f6ce56-b34a-45e0-986a-fda972e7e080">| <img width="1052" alt="Untitled 12" src="https://github.com/user-attachments/assets/589234db-53e0-422e-86d1-4d48a301c9f1"> |