### PR TITLE
fix: change settings header z-index

### DIFF
--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -591,7 +591,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
   </div>
   <template v-else>
     <UiScrollerHorizontal
-      class="sticky top-[72px] z-50"
+      class="sticky top-[72px] z-40"
       with-buttons
       gradient="xxl"
     >


### PR DESCRIPTION
### Summary
Change settings header z-index to `40` similar to other sticky headers
<img width="527" alt="image" src="https://github.com/user-attachments/assets/63caf394-a820-4420-8f17-2c59e2d00e92">


Closes: https://github.com/snapshot-labs/workflow/issues/203

### How to test

1. Go to settings page and scroll down with keypad
2. Settings header should go below navbar like all other places

