### PR TITLE
fix: walletconnect safe transaction doesn't trigger

### DIFF
--- a/apps/ui/src/helpers/connectors.ts
+++ b/apps/ui/src/helpers/connectors.ts
@@ -22,8 +22,7 @@ export default {
       projectId: 'e6454bd61aba40b786e866a69bd4c5c6',
       chains: [],
       optionalChains: [1, 10, 56, 100, 42161, 137, 1088, 11155111],
-      methods: ['eth_sendTransaction'],
-      optionalMethods: ['eth_signTypedData_v4'],
+      optionalMethods: ['eth_sendTransaction', 'eth_signTypedData_v4'],
       showQrModal: true
     }
   },


### PR DESCRIPTION
### Summary

Walletconnect safe transaction doesn't trigger

### How to test

1. Connect to your safe with walletconnect (with new changes make sure to disconnect if you are already connected)
2. Go to any proposal that accept eth transaction
3. Try to vote
4. Before fix. it will show error: "unknown account" 
5. After fix: it will open transaction modal on Safe
