### PR TITLE
fix: remove left spacing on site routes

### DIFF
--- a/apps/ui/src/App.vue
+++ b/apps/ui/src/App.vue
@@ -121,7 +121,7 @@ watch(isSwiping, () => {
       >
         <router-view
           class="flex-auto mt-[72px] pl-0 lg:pl-[72px]"
-          :class="isSiteRoute && '!ml-0'"
+          :class="isSiteRoute && '!pl-0'"
         />
       </div>
     </div>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Remove the left spacing on sites-* routes.
<img width="580" alt="image-999" src="https://github.com/user-attachments/assets/19a3027f-bffe-49a6-ab05-ad4b04dd62d1">


Temp fix, #740 will fix and prevent futures issues by isolating all layouts

