### PR TITLE
refactor: remove unecessary watch

### DIFF
--- a/apps/ui/src/views/SpaceUser.vue
+++ b/apps/ui/src/views/SpaceUser.vue
@@ -15,9 +15,6 @@ const props = defineProps<{ space: Space }>();
 
 const route = useRoute();
 const usersStore = useUsersStore();
-const spacesStore = useSpacesStore();
-const { param } = useRouteParser('id');
-const { resolved, address, networkId } = useResolve(param);
 const { getCurrent } = useMetaStore();
 
 const userActivity = ref<UserActivity>({
@@ -157,15 +154,6 @@ watch(
     loaded.value = true;
   },
   { immediate: true }
-);
-
-watch(
-  [resolved, networkId, address],
-  async ([resolved, networkId, address]) => {
-    if (!resolved || !networkId || !address) return;
-
-    spacesStore.networksMap[networkId].spaces[address];
-  }
 );
 </script>
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Working toward https://github.com/snapshot-labs/workflow/issues/142

This PR removes the unnecessary `watch` on the address, since the SpaceUser view is already getting the `space` object from the parent Space view, which already have a watcher on the address there.

This PR aims to remove all the unnecessary watcher, to have everything in one place, since watcher on url will not work anymore on white label spaces. Extracting as much unrelated changes as possible in external PR to lighten the whitelabel PR

### How to test

1. Go to a space user profile
2. Change the user address in the url
3. the content should refresh
4. Change the space in the url
5. the content should refesh
