### PR TITLE
feat: update Starknet's EthTx

### DIFF
--- a/.changeset/neat-falcons-pay.md
+++ b/.changeset/neat-falcons-pay.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+disable estimation for initialize EthTx calls

--- a/apps/mana/src/db.ts
+++ b/apps/mana/src/db.ts
@@ -18,8 +18,10 @@ export async function createTables() {
       t.boolean('failed').defaultTo(false).index();
       t.string('network').index();
       t.string('type').index();
+      t.string('sender');
       t.string('hash');
       t.json('data');
+      t.unique(['sender', 'hash']);
     });
   }
 
@@ -39,15 +41,20 @@ export async function createTables() {
 export async function registerTransaction(
   network: string,
   type: string,
+  sender: string,
   hash: string,
   data: any
 ) {
-  return knex(REGISTERED_TRANSACTIONS).insert({
-    network,
-    type,
-    hash,
-    data
-  });
+  return knex(REGISTERED_TRANSACTIONS)
+    .insert({
+      network,
+      type,
+      sender,
+      hash,
+      data
+    })
+    .onConflict()
+    .ignore();
 }
 
 export async function getTransactionsToProcess() {

--- a/apps/mana/src/stark/registered.ts
+++ b/apps/mana/src/stark/registered.ts
@@ -10,6 +10,7 @@ type Transaction = {
   id: number;
   network: string;
   type: 'Propose' | 'UpdateProposal' | 'Vote';
+  sender: string;
   hash: string;
   data: any;
 };
@@ -19,7 +20,8 @@ const failedCounter: Record<string, number | undefined> = {};
 async function processTransaction(transaction: Transaction) {
   const storageAddress = utils.encoding.getStorageVarAddress(
     '_commits',
-    transaction.hash
+    transaction.hash,
+    transaction.sender
   );
 
   const { provider, getAccount, client } = getClient(transaction.network);
@@ -31,7 +33,7 @@ async function processTransaction(transaction: Transaction) {
 
   const payload = {
     signatureData: {
-      address: value
+      address: transaction.sender
     },
     data: transaction.data
   };

--- a/apps/mana/src/stark/rpc.ts
+++ b/apps/mana/src/stark/rpc.ts
@@ -84,11 +84,11 @@ export const createNetworkHandler = (chainId: string) => {
 
   async function registerTransaction(id: number, params: any, res: Response) {
     try {
-      const { type, hash, payload } = params;
+      const { type, sender, hash, payload } = params;
 
-      console.log('Registering transaction', type, hash, payload);
+      console.log('Registering transaction', type, sender, hash, payload);
 
-      await db.registerTransaction(chainId, type, hash, payload);
+      await db.registerTransaction(chainId, type, sender, hash, payload);
 
       return rpcSuccess(res, true, id);
     } catch (e) {

--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -68,6 +68,7 @@ export function useActions() {
     if (envelope?.signatureData?.commitHash && network.baseNetworkId) {
       await registerTransaction(network.chainId, {
         type: envelope.signatureData.primaryType,
+        sender: envelope.signatureData.address,
         hash: envelope.signatureData.commitHash,
         payload: envelope.data
       });

--- a/apps/ui/src/helpers/mana.ts
+++ b/apps/ui/src/helpers/mana.ts
@@ -25,6 +25,7 @@ export async function registerTransaction(
   chainId: number | string,
   params: {
     type: string;
+    sender: string;
     hash: string;
     payload: any;
   }

--- a/packages/sx.js/src/clients/evm/ethereum-tx/index.ts
+++ b/packages/sx.js/src/clients/evm/ethereum-tx/index.ts
@@ -527,7 +527,7 @@ export class EthereumTx {
       envelope.signatureData?.address || (await signer.getAddress());
 
     const userVotingStrategies = await getStrategiesWithParams(
-      'propose',
+      'vote',
       envelope.data.strategies,
       voterAddress,
       envelope.data,

--- a/packages/sx.js/src/clients/starknet/ethereum-tx/index.ts
+++ b/packages/sx.js/src/clients/starknet/ethereum-tx/index.ts
@@ -339,7 +339,8 @@ export class EthereumTx {
     const { overall_fee } = await this.estimateProposeFee(signer, data);
 
     const promise = commitContract.commit(data.authenticator, hash, {
-      value: overall_fee
+      value: overall_fee,
+      gasLimit: opts.noWait ? 0 : undefined
     });
     const res = opts.noWait ? null : await promise;
 
@@ -369,7 +370,8 @@ export class EthereumTx {
     const { overall_fee } = await this.estimateVoteFee(signer, data);
 
     const promise = commitContract.commit(data.authenticator, hash, {
-      value: overall_fee
+      value: overall_fee,
+      gasLimit: opts.noWait ? 0 : undefined
     });
     const res = opts.noWait ? null : await promise;
 
@@ -399,7 +401,8 @@ export class EthereumTx {
     const { overall_fee } = await this.estimateUpdateProposalFee(signer, data);
 
     const promise = commitContract.commit(data.authenticator, hash, {
-      value: overall_fee
+      value: overall_fee,
+      gasLimit: opts.noWait ? 0 : undefined
     });
     const res = opts.noWait ? null : await promise;
 

--- a/packages/sx.js/src/clients/starknet/ethereum-tx/index.ts
+++ b/packages/sx.js/src/clients/starknet/ethereum-tx/index.ts
@@ -284,7 +284,7 @@ export class EthereumTx {
     const address = await signer.getAddress();
 
     const userVotingStrategies = await getStrategiesWithParams(
-      'propose',
+      'vote',
       data.strategies,
       address,
       data,


### PR DESCRIPTION
### Summary

This PR contains following fixes for EthTx:
1. Initialize transaction is now also possible to be added to Safe without funds.
2. Vote transaction always uses `vote` call to build strategies.
3. Commit is read using (hash, sender) as it was updated on the contracts.

### How to test

1. Run local mana, update `VITE_MANA_URL=http://localhost:3001`.
2. Use Starknet or Starknet sepolia space with EthTx authenticator and your safe whitelisted.
3. Connect to app with Safe's WC.
4. Try starting a vote without funds, you can prepare transaction.
5. Execute vote on Safe (after you have funds).
6. Wait.
7. After a while mana completes transaction, vote is visible on UI.

### Notes

We will need to update database on production before merging (or we could drop old table entirely after we back it up)