### PR TITLE
fix: Can't connect and vote with argent mobile app

### DIFF
--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -89,6 +89,7 @@ export function useWeb3() {
         } else if (STARKNET_CONNECTORS.includes(connector)) {
           network = {
             chainId:
+              auth.provider.value.chainId ||
               auth.provider.value.provider.chainId ||
               auth.provider.value.provider.provider.chainId
           };

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -387,7 +387,9 @@ export async function verifyStarknetNetwork(
   chainId: starknetConstants.StarknetChainId
 ) {
   if (!web3.provider.request) return;
-
+  // Skip network switch for Argent Mobile,
+  // only SN_MAIN is supported (getting `unknown request` error inside in-built browser)
+  if (web3.provider.name === 'Argent Mobile') return;
   try {
     await web3.provider.request({
       type: 'wallet_switchStarknetChain',


### PR DESCRIPTION
### Issue
- Unable to connect to Argent mobile app (unable to pick `chainId`)
- Unable to vote with inbuilt browser inside Argent mobile app (getting `unknow request` error

### Summary
- While connecting, Pick chainId using `auth.provider.value.chainId`
- While voting inside the inbuilt browser, `wallet_switchStarknetChain` doesn't work, so ignoring it for now (as only SN_MAIN is supported)

### How to test

1. Connect and with Argent mobile app
2. Test in desktop
3. Test in mobile chrome
4. Test in inbuild browser 

