### PR TITLE
fix: Delegators col width

### DIFF
--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -136,7 +136,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
         </div>
         <button
           type="button"
-          class="hidden md:flex w-[80px] shrink-0 items-center justify-end hover:text-skin-link space-x-1 truncate"
+          class="hidden md:flex w-[120px] shrink-0 items-center justify-end hover:text-skin-link space-x-1 truncate"
           @click="handleSortChange('tokenHoldersRepresentedAmount')"
         >
           <span class="truncate">Delegators</span>
@@ -227,7 +227,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
                 />
               </div>
               <div
-                class="hidden md:flex shrink-0 w-[80px] flex-col items-end justify-center leading-[22px] truncate"
+                class="hidden md:flex shrink-0 w-[120px] flex-col items-end justify-center leading-[22px] truncate"
               >
                 <h4
                   class="text-skin-link"


### PR DESCRIPTION
### Summary
- Witdh of delegators is causing text to truncate
<img width="153" alt="Untitled 4" src="https://github.com/user-attachments/assets/0b9208d7-c16a-4a35-9368-0a718c32b083">


### How to test

1. Go to http://localhost:8080/#/s:balancer.eth/delegates
2. click on delegators column header to sort
3. Notice that text of header is truncated before the fix

| Before | After |
| --- | --- |
| <img width="153" alt="Untitled 4" src="https://github.com/user-attachments/assets/0b9208d7-c16a-4a35-9368-0a718c32b083"> | <img width="199" alt="Untitled 5" src="https://github.com/user-attachments/assets/5011745b-b82e-4931-aedd-d2507f26d650"> |
