### PR TITLE
refactor: get app name from useApp composable

### DIFF
--- a/apps/ui/src/composables/useApp.ts
+++ b/apps/ui/src/composables/useApp.ts
@@ -1,8 +1,10 @@
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
+import { APP_NAME } from '@/helpers/constants';
 
 const state = reactive({
   init: false,
-  loading: false
+  loading: false,
+  app_name: APP_NAME
 });
 
 const { login } = useWeb3();

--- a/apps/ui/src/composables/useSharing.ts
+++ b/apps/ui/src/composables/useSharing.ts
@@ -12,8 +12,6 @@ export type Vote = { proposal: Proposal; choice: Choice };
 export type PayloadType = 'proposal' | 'user' | 'space-user' | 'vote';
 export type Payload = Proposal | User | SpaceUser | Vote;
 
-const HASH_TAG = 'Snapshot';
-
 const SOCIAL_NETWORKS: {
   id: SocialNetwork;
   name: string;
@@ -26,6 +24,7 @@ const SOCIAL_NETWORKS: {
 
 export function useSharing() {
   const router = useRouter();
+  const { app } = useApp();
 
   function getProposalUrl(proposal: Proposal): string {
     return `${window.location.origin}/${
@@ -111,9 +110,9 @@ export function useSharing() {
     let message = encodeURIComponent(getMessage(type, payload));
 
     if (type === 'vote' && socialNetwork === 'x') {
-      message += `%20%23${HASH_TAG}`;
+      message += `%20%23${app.value.app_name}`;
     } else if (socialNetwork === 'lens') {
-      message += `&hashtags=${HASH_TAG}`;
+      message += `&hashtags=${app.value.app_name}`;
     }
 
     let url: string;

--- a/apps/ui/src/composables/useTitle.ts
+++ b/apps/ui/src/composables/useTitle.ts
@@ -1,12 +1,12 @@
-const DEFAULT_TITLE = 'Snapshot';
-
 export function useTitle(title?: string) {
+  const { app } = useApp();
+
   const setTitle = (newTitle: string) => {
     document.title = newTitle;
   };
 
   onBeforeUnmount(() => {
-    document.title = DEFAULT_TITLE;
+    document.title = app.value.app_name;
   });
 
   if (title) {

--- a/apps/ui/src/composables/useWalletConnect.ts
+++ b/apps/ui/src/composables/useWalletConnect.ts
@@ -83,7 +83,6 @@ export function useWalletConnect(
   const { setTransaction } = useWalletConnectTransaction();
 
   const key = computed(() => `${chainId}:${account}`);
-
   const connection = computed(
     () =>
       connections.value[key.value] || {

--- a/apps/ui/src/composables/useWalletConnect.ts
+++ b/apps/ui/src/composables/useWalletConnect.ts
@@ -4,7 +4,8 @@ import { formatUnits } from '@ethersproject/units';
 import { Core } from '@walletconnect/core';
 import { ProposalTypes, SessionTypes } from '@walletconnect/types';
 import { buildApprovedNamespaces, getSdkError } from '@walletconnect/utils';
-import { Web3Wallet, Web3WalletTypes } from '@walletconnect/web3wallet';
+import { Web3Wallet } from '@walletconnect/web3wallet';
+import { APP_NAME } from '@/helpers/constants';
 import { getABI } from '@/helpers/etherscan';
 import { createContractCallTransaction } from '@/helpers/transactions';
 import { NetworkID, SelectedStrategy } from '@/types';
@@ -18,14 +19,19 @@ type ConnectionData = {
 };
 
 let connector: Awaited<ReturnType<(typeof Web3Wallet)['init']>> | null = null;
-async function getConnector(metadata: Web3WalletTypes.Options['metadata']) {
+async function getConnector() {
   if (connector) return connector;
 
   connector = await Web3Wallet.init({
     core: new Core({
       projectId: import.meta.env.VITE_WC_PROJECT_ID
     }),
-    metadata
+    metadata: {
+      name: APP_NAME,
+      description: 'Where decisions get made',
+      url: 'https://snapshot.box',
+      icons: []
+    }
   });
 
   return connector;
@@ -75,18 +81,6 @@ export function useWalletConnect(
   executionStrategy: SelectedStrategy | null
 ) {
   const { setTransaction } = useWalletConnectTransaction();
-  const { app } = useApp();
-
-  const connectorMetadata = computed<Web3WalletTypes.Options['metadata']>(
-    () => {
-      return {
-        name: app.value.app_name,
-        description: 'Where decisions get made',
-        url: 'https://snapshot.box',
-        icons: []
-      };
-    }
-  );
 
   const key = computed(() => `${chainId}:${account}`);
 
@@ -143,7 +137,7 @@ export function useWalletConnect(
   async function logout() {
     if (!session.value) return;
 
-    const connector = await getConnector(connectorMetadata.value);
+    const connector = await getConnector();
     await connector.disconnectSession({
       topic: session.value.topic,
       reason: getSdkError('USER_DISCONNECTED')
@@ -184,7 +178,7 @@ export function useWalletConnect(
     loading.value = true;
 
     if (logged.value) await logout();
-    const connector = await getConnector(connectorMetadata.value);
+    const connector = await getConnector();
     await connector.core.pairing.pair({ uri });
 
     connector.on('session_proposal', async ({ id, params }) => {

--- a/apps/ui/src/helpers/connectors.ts
+++ b/apps/ui/src/helpers/connectors.ts
@@ -4,6 +4,7 @@ import metamaskIcon from '@/assets/connectors/metamask.png';
 import starknetIcon from '@/assets/connectors/starknet.png';
 import walletconnectIcon from '@/assets/connectors/walletconnect.png';
 import { getUrl } from '@/helpers/utils';
+import { APP_NAME } from './constants';
 
 export default {
   injected: {
@@ -32,7 +33,7 @@ export default {
     network: '1',
     icon: coinbaseIcon,
     options: {
-      appName: 'Snapshot',
+      appName: APP_NAME,
       darkMode: false,
       chainId: 1,
       ethJsonrpcUrl: 'https://cloudflare-eth.com'

--- a/apps/ui/src/helpers/connectors.ts
+++ b/apps/ui/src/helpers/connectors.ts
@@ -33,7 +33,7 @@ export default {
     network: '1',
     icon: coinbaseIcon,
     options: {
-      appName: APP_NAME,
+      appName: 'Snapshot',
       darkMode: false,
       chainId: 1,
       ethJsonrpcUrl: 'https://cloudflare-eth.com'

--- a/apps/ui/src/helpers/connectors.ts
+++ b/apps/ui/src/helpers/connectors.ts
@@ -4,7 +4,6 @@ import metamaskIcon from '@/assets/connectors/metamask.png';
 import starknetIcon from '@/assets/connectors/starknet.png';
 import walletconnectIcon from '@/assets/connectors/walletconnect.png';
 import { getUrl } from '@/helpers/utils';
-import { APP_NAME } from './constants';
 
 export default {
   injected: {

--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -1,5 +1,7 @@
 import { VoteType, VoteTypeInfo } from '@/types';
 
+export const APP_NAME = 'Snapshot';
+
 export const SIDEKICK_URL = 'https://sh5.co';
 
 export const ETH_CONTRACT = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Working toward https://github.com/snapshot-labs/workflow/issues/142

This PR refactors the UI to pull the `APP_NAME` from a single source (constants, then `useApp` composable).

Using the composable instead of the constant directly will allow changing the app name after initialization (e.g. for white label)

### Note 

There's still a last part, walletLink, which is getting its name directly from the constant. Making it dynamic will requires some more refactoring out-of-scope for this PR
