### PR TITLE
fix: set page title in all sites pages

### DIFF
--- a/apps/ui/src/views/App.vue
+++ b/apps/ui/src/views/App.vue
@@ -3,9 +3,16 @@ import { getUrl, simplifyURL } from '@/helpers/utils';
 
 const route = useRoute();
 const { load, get, loading, loaded } = useApps();
+const { setTitle } = useTitle();
 
 const id = route.params.id as string;
 const app = computed(() => get(id));
+
+watchEffect(() => {
+  if (!app.value.name) return;
+
+  setTitle(app.value.name);
+});
 
 onMounted(() => load());
 </script>

--- a/apps/ui/src/views/Landing.vue
+++ b/apps/ui/src/views/Landing.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+useTitle('Snapshot');
+</script>
+
 <template>
   <div class="relative">
     <LandingHero />

--- a/apps/ui/src/views/Network.vue
+++ b/apps/ui/src/views/Network.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { getUrl } from '@/helpers/utils';
 
+useTitle('Network');
+
 const CUSTOMERS = [
   {
     name: 'Blast',
@@ -87,13 +89,9 @@ const LINK = 'https://tally.so/r/31ApGb';
 
 const currentQuestion = ref();
 
-const { setTitle } = useTitle();
-
 function toggleQuestion(id) {
   currentQuestion.value = currentQuestion.value === id ? '' : id;
 }
-
-watchEffect(() => setTitle('Network'));
 </script>
 <template>
   <div class="space-y-[80px] pt-12 mb-8 blocks">

--- a/apps/ui/src/views/Policy.vue
+++ b/apps/ui/src/views/Policy.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+useTitle('Privacy policy');
+
 const terms = `
 This Privacy Notice (“Privacy Notice”) explains and sets out the basis for our collection of personal data when you visit our website(s), platform, use our services, interact with us in relation to a contract, communicate with us or otherwise deal with us, how we use it, the conditions under which we may disclose it to others and the measures we take to keep it secure. In addition, we may inform you about the processing of your data separately, for example in consent forms, terms and conditions, additional privacy notices, forms, and other notices. We use the word “data” here interchangeably with “personal data”.
 

--- a/apps/ui/src/views/Site.vue
+++ b/apps/ui/src/views/Site.vue
@@ -1,7 +1,3 @@
-<script setup lang="ts">
-useTitle('Snapshot');
-</script>
-
 <template>
   <router-view class="min-h-[calc(100vh-320px)]" />
 </template>

--- a/apps/ui/src/views/Site.vue
+++ b/apps/ui/src/views/Site.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+useTitle('Snapshot');
+</script>
+
 <template>
   <router-view class="min-h-[calc(100vh-320px)]" />
 </template>

--- a/apps/ui/src/views/Terms.vue
+++ b/apps/ui/src/views/Terms.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+useTitle('Terms of use');
+
 const terms = `
 ## PREAMBLE
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Working toward https://github.com/snapshot-labs/workflow/issues/142

This PR will set the page title properly inside each page in views/*.vue (except root page containing `<router-view>`), instead of relying on the default one (hardcoded in index.html).

### How to test

1. Visit all the routes from `site-`
2. There should be a page title reflecting the page content, instead of just 'Snapshot'
3. Homepage is the only one with `Snapshot` as title (which should be fetched from useApp, once https://github.com/snapshot-labs/sx-monorepo/pull/763 is merged)
