### PR TITLE
fix: fix network api error when proposal do not exist

### DIFF
--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -488,11 +488,13 @@ export function createApi(
           .catch(() => null)
       ]);
 
-      if (data.proposal.metadata === null) return null;
+      if (data.proposal?.metadata === null) return null;
       data.proposal = joinHighlightProposal(
         data.proposal,
         highlightResult?.data.sxproposal
       );
+
+      if (!data.proposal) return null;
 
       return formatProposal(
         data.proposal,

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -524,7 +524,7 @@ export function createApi(
         variables: { id: proposalId }
       });
 
-      if (data.proposal.metadata === null) return null;
+      if (!data.proposal || data.proposal?.metadata === null) return null;
 
       return formatProposal(data.proposal, networkId);
     },


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

When loading an invalid proposal like this http://localhost:8080/#/sep:0xb58B05A1c8263441Bd74454544fD66CE25D300AD/proposal/58sdfdsdsff

The page is crashing with 

```
TypeError: Cannot read properties of null (reading 'metadata')
```

This PR ensures proposal object exist before any handling

### How to test

1. Go to http://localhost:8080/#/sep:0xb58B05A1c8263441Bd74454544fD66CE25D300AD/proposal/58sdfdsdsff
2. There's no more error in the console (page still stuck on loading state, but out-of-scope of this PR)
