### PR TITLE
fix: handle github URL in ecosystem page

### DIFF
--- a/apps/ui/src/composables/useApps.ts
+++ b/apps/ui/src/composables/useApps.ts
@@ -47,7 +47,20 @@ export function useApps() {
   }
 
   function get(id: string) {
-    return apps.value.find(app => app.id === id) || {};
+    const app = apps.value.find(app => app.id === id);
+    if (!app) {
+      return {};
+    }
+
+    if (app.github && !app.github.startsWith('https://')) {
+      app.github = `https://github.com/${app.github}`;
+    }
+
+    if (app.x?.startsWith('@')) {
+      app.x = app.x.slice(1);
+    }
+
+    return app;
   }
 
   function search(q: string) {

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -507,8 +507,13 @@ export async function imageUpload(file: File) {
 }
 
 export function simplifyURL(fullURL: string): string {
-  const url = new URL(fullURL);
-  return `${url.hostname}${url.pathname.replace(/\/$/, '')}`;
+  try {
+    const url = new URL(fullURL);
+    return `${url.hostname}${url.pathname.replace(/\/$/, '')}`;
+  } catch (error) {
+    console.log('Error simplifying URL', error);
+    return '';
+  }
 }
 
 export function getChoiceWeight(

--- a/apps/ui/src/views/App.vue
+++ b/apps/ui/src/views/App.vue
@@ -95,7 +95,7 @@ onMounted(() => load());
               </div>
               <div v-if="app.x">
                 <h4 class="eyebrow" v-text="'X (Twitter)'" />
-                <a :href="`https://twitter.com/${app.x}`" target="_blank">
+                <a :href="`https://x.com/${app.x}`" target="_blank">
                   {{ app.x }}
                   <IH-arrow-sm-right class="inline-block -rotate-45" />
                 </a>


### PR DESCRIPTION
### Summary
- Sometimes github field is just username, example `UMAprotocol` instead of `https://github.com/UMAprotocol`
- Sometimes x field starts with `@`, example `@UMAprotocol` instead of `UMAprotocol`

Closes: #

### How to test

1. Go to http://localhost:8080/#/ecosystem/osnap
2. Before fix, page will fail with error:
3. <img width="867" alt="Untitled 7" src="https://github.com/user-attachments/assets/dcb9926b-74af-401e-864b-4d637e854d32">
4. After the fix, page should open without any errors
5. <img width="227" alt="Untitled 8" src="https://github.com/user-attachments/assets/94e37813-7f7f-452e-a156-12db822cfe41">

