### PR TITLE
feat: add size props to UiLoading

### DIFF
--- a/apps/ui/src/components/Modal/TransactionProgress.vue
+++ b/apps/ui/src/components/Modal/TransactionProgress.vue
@@ -108,7 +108,7 @@ watch(
         v-if="['approve', 'confirming'].includes(step)"
         class="bg-skin-border rounded-full p-[12px]"
       >
-        <UiLoading :width="28" :height="28" />
+        <UiLoading :size="28" />
       </div>
 
       <div

--- a/apps/ui/src/components/ProposalIconStatus.vue
+++ b/apps/ui/src/components/ProposalIconStatus.vue
@@ -13,17 +13,19 @@ const props = withDefaults(
   defineProps<{
     width?: number | string;
     height?: number | string;
+    size?: number | string;
     state: ProposalState;
   }>(),
   {
     width: 24,
-    height: 24
+    height: 24,
+    size: 24
   }
 );
 
 const style = computed(() => ({
-  width: `${props.width}px`,
-  height: `${props.height}px`
+  width: `${props.width || props.size}px`,
+  height: `${props.height || props.size}px`
 }));
 </script>
 

--- a/apps/ui/src/components/ProposalIconStatus.vue
+++ b/apps/ui/src/components/ProposalIconStatus.vue
@@ -11,21 +11,17 @@ const titles: Record<ProposalState, string> = {
 
 const props = withDefaults(
   defineProps<{
-    width?: number | string;
-    height?: number | string;
     size?: number | string;
     state: ProposalState;
   }>(),
   {
-    width: 24,
-    height: 24,
     size: 24
   }
 );
 
 const style = computed(() => ({
-  width: `${props.width || props.size}px`,
-  height: `${props.height || props.size}px`
+  width: `${props.size}px`,
+  height: `${props.size}px`
 }));
 </script>
 

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -38,12 +38,7 @@ const totalProgress = computed(() => quorumProgress(props.proposal));
           }
         }"
       >
-        <ProposalIconStatus
-          width="17"
-          height="17"
-          :state="proposal.state"
-          class="top-1.5"
-        />
+        <ProposalIconStatus size="17" :state="proposal.state" class="top-1.5" />
       </AppLink>
 
       <div class="md:flex md:min-w-0 my-1 items-center leading-6">

--- a/apps/ui/src/components/Ui/Composer.vue
+++ b/apps/ui/src/components/Ui/Composer.vue
@@ -111,8 +111,7 @@ watch(model, () => {
           />
           <UiLoading
             v-if="editor.uploading.value"
-            :width="14"
-            :height="14"
+            :size="14"
             class="inline-block"
           />
           <IS-photo v-else class="size-[18px]" />

--- a/apps/ui/src/components/Ui/Loading.vue
+++ b/apps/ui/src/components/Ui/Loading.vue
@@ -4,11 +4,13 @@ withDefaults(
     inverse?: boolean;
     width?: number;
     height?: number;
+    size?: number;
   }>(),
   {
     inverse: false,
     width: 20,
-    height: 20
+    height: 20,
+    size: 20
   }
 );
 </script>
@@ -17,8 +19,8 @@ withDefaults(
   <span class="loading" :class="{ inverse: !!inverse }">
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      :width="width"
-      :height="height"
+      :width="width || size"
+      :height="height || size"
       class="inline-block align-middle"
       viewBox="0 0 24 24"
     >

--- a/apps/ui/src/components/Ui/Loading.vue
+++ b/apps/ui/src/components/Ui/Loading.vue
@@ -2,14 +2,10 @@
 withDefaults(
   defineProps<{
     inverse?: boolean;
-    width?: number;
-    height?: number;
     size?: number;
   }>(),
   {
     inverse: false,
-    width: 20,
-    height: 20,
     size: 20
   }
 );
@@ -19,8 +15,8 @@ withDefaults(
   <span class="loading" :class="{ inverse: !!inverse }">
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      :width="width || size"
-      :height="height || size"
+      :width="size"
+      :height="size"
       class="inline-block align-middle"
       viewBox="0 0 24 24"
     >

--- a/apps/ui/src/views/My/Home.vue
+++ b/apps/ui/src/views/My/Home.vue
@@ -22,8 +22,7 @@ const proposals = ref<Proposal[]>([]);
 const state = ref<NonNullable<ProposalsFilter['state']>>('any');
 
 const selectIconBaseProps = {
-  width: 16,
-  height: 16
+  size: 16
 };
 
 // TODO: Support multiple networks

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -17,8 +17,7 @@ const proposalsStore = useProposalsStore();
 const state = ref<NonNullable<ProposalsFilter['state']>>('any');
 
 const selectIconBaseProps = {
-  width: 16,
-  height: 16
+  size: 16
 };
 
 const proposalsRecord = computed(


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Add a new `size` props to UiLoading and ProposalIconStatus components, to set the `width` and `height` at the same time, and avoid duplication.

This props is already used in some component like Stamp and Nft

- Go to a onchain proposal
- it should show proposal status as before
- all loading icon should have the same size as before