### PR TITLE
feat: add Advanced settings for offchain spaces.

### DIFF
--- a/.changeset/sweet-papayas-provide.md
+++ b/.changeset/sweet-papayas-provide.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+add deleteSpace method to offchain ethSig client

--- a/apps/ui/src/assets/icons/switch-disabled.svg
+++ b/apps/ui/src/assets/icons/switch-disabled.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+  <path d="M7 11L11 7M7 7L11 11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/ui/src/assets/icons/switch-enabled.svg
+++ b/apps/ui/src/assets/icons/switch-enabled.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+  <path d="M6 9L8 11L12 7" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -101,6 +101,10 @@ const formErrors = computed(() => {
     errors.childInput = 'Space cannot be a sub-space of itself';
   }
 
+  if (children.value.includes(childInput.value)) {
+    errors.childInput = 'Space already configured as sub-space';
+  }
+
   return errors;
 });
 const parentSpaceError = computed(() => {
@@ -198,7 +202,7 @@ watchEffect(() => {
     />
     <UiButton
       v-if="children.length < CHILDREN_LIMIT"
-      :disabled="!canAddChildSpace || formErrors.childInput"
+      :disabled="!canAddChildSpace || !!formErrors.childInput"
       :loading="isAddingChild"
       class="w-full"
       @click="addChild"

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -25,11 +25,21 @@ const TERMS_OF_SERVICES_DEFINITION = {
   examples: ['https://example.com/terms']
 };
 
+const CUSTOM_DOMAIN_DEFINITION = {
+  type: 'string',
+  format: 'uri',
+  title: 'Domain name',
+  maxLength: 64,
+  examples: ['vote.balancer.fi']
+};
+
 const parent = defineModel<string>('parent', { required: true });
 const children = defineModel<string[]>('children', { required: true });
 const termsOfServices = defineModel<string>('termsOfServices', {
   required: true
 });
+const customDomain = defineModel<string>('customDomain', { required: true });
+const isPrivate = defineModel<boolean>('isPrivate', { required: true });
 
 const props = defineProps<{
   networkId: NetworkID;
@@ -95,7 +105,7 @@ function deleteChild(i: number) {
 <template>
   <h4 class="eyebrow mb-2 font-medium">Sub-spaces</h4>
   <UiMessage
-    :type="'info'"
+    type="info"
     :learn-more-link="'https://docs.snapshot.org/user-guides/spaces/sub-spaces'"
   >
     Add a sub-space to display its proposals within your space. If you want the
@@ -150,5 +160,21 @@ function deleteChild(i: number) {
       :definition="TERMS_OF_SERVICES_DEFINITION"
       :error="formErrors.termsOfServices"
     />
+  </div>
+  <h4 class="eyebrow mb-2 font-medium mt-4">Custom domain</h4>
+  <UiMessage
+    type="info"
+    :learn-more-link="'https://docs.snapshot.org/spaces/add-custom-domain'"
+  >
+    To setup a custom domain you additionally need to open a pull request on
+    github after you have created the space.
+  </UiMessage>
+  <div class="s-box mt-3">
+    <UiInputString
+      v-model="customDomain"
+      :definition="CUSTOM_DOMAIN_DEFINITION"
+      :error="formErrors.customDomain"
+    />
+    <UiSwitch v-model="isPrivate" title="Hide space from homepage" />
   </div>
 </template>

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -8,13 +8,16 @@ const CHILDREN_LIMIT = 16;
 const PARENT_SPACE_DEFINITION = {
   type: 'string',
   title: 'Main space',
-  examples: ['pistachiodao.eth']
+  examples: ['pistachiodao.eth'],
+  tooltip:
+    'The space that this space is a sub-space of will be displayed on the space page'
 };
 
 const SUB_SPACE_DEFINITION = {
   type: 'string',
   title: 'Sub-space(s)',
-  examples: ['pistachiodao.eth']
+  examples: ['pistachiodao.eth'],
+  tooltip: 'Related Sub-spaces listed here will be displayed on the space page'
 };
 
 const TERMS_OF_SERVICES_DEFINITION = {
@@ -22,7 +25,9 @@ const TERMS_OF_SERVICES_DEFINITION = {
   format: 'uri',
   title: 'Terms of services',
   maxLength: 256,
-  examples: ['https://example.com/terms']
+  examples: ['https://example.com/terms'],
+  tooltip:
+    'Users will be required to accept these terms once before they can create a proposal or cast a vote'
 };
 
 const CUSTOM_DOMAIN_DEFINITION = {

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -118,7 +118,7 @@ const formErrors = computed(() => {
     errors.child = 'Space already configured as sub-space';
   }
 
-  if (children.value.length >= CHILDREN_LIMIT) {
+  if (child.value && children.value.length >= CHILDREN_LIMIT) {
     errors.child = 'Maximum number of sub-spaces reached';
   }
 

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -43,12 +43,19 @@ const isPrivate = defineModel<boolean>('isPrivate', { required: true });
 
 const props = defineProps<{
   networkId: NetworkID;
+  spaceId: string;
+  isController: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'deleteSpace');
 }>();
 
 const { addNotification } = useUiStore();
 
 const childInput = ref('');
 const isAddingChild = ref(false);
+const isDeleteSpaceModalOpen = ref(false);
 
 const network = computed(() => getNetwork(props.networkId));
 const canAddParentSpace = computed(() => children.value.length === 0);
@@ -177,4 +184,31 @@ function deleteChild(i: number) {
     />
     <UiSwitch v-model="isPrivate" title="Hide space from homepage" />
   </div>
+  <h4 class="eyebrow mb-2 font-medium mt-4">Danger zone</h4>
+  <div
+    class="flex flex-col md:flex-row gap-3 md:gap-1 items-center border rounded-md px-4 py-3"
+  >
+    <div class="flex flex-col">
+      <h4 class="text-base">Delete space</h4>
+      <span class="leading-5">
+        Delete this space and all its content. This cannot be undone and you
+        will not be able to create a new space with the same ENS domain name.
+      </span>
+    </div>
+    <UiButton
+      :disabled="!isController"
+      class="w-full md:w-auto flex-shrink-0 border-skin-danger !text-skin-danger"
+      @click="isDeleteSpaceModalOpen = true"
+    >
+      Delete space
+    </UiButton>
+  </div>
+  <teleport to="#modal">
+    <ModalDeleteSpace
+      :open="isDeleteSpaceModalOpen"
+      :space-id="spaceId"
+      @confirm="emit('deleteSpace')"
+      @close="isDeleteSpaceModalOpen = false"
+    />
+  </teleport>
 </template>

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -236,7 +236,7 @@ watchEffect(() => {
     :learn-more-link="'https://docs.snapshot.org/spaces/add-custom-domain'"
   >
     To setup a custom domain you additionally need to open a pull request on
-    github after you have created the space.
+    GitHub after you have created the space.
   </UiMessage>
   <div class="s-box mt-3">
     <UiInputString

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -31,6 +31,7 @@ const TERMS_OF_SERVICES_DEFINITION = {
 
 const CUSTOM_DOMAIN_DEFINITION = {
   type: 'string',
+  format: 'domain',
   title: 'Domain name',
   maxLength: 64,
   examples: ['vote.balancer.fi']

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -129,7 +129,13 @@ function deleteChild(i: number) {
 watchDebounced(
   parent,
   async parent => {
-    if (!parent) return;
+    if (!parent) {
+      parentSpaceValidationResult.value = {
+        value: '',
+        valid: true
+      };
+      return;
+    }
 
     const space = await network.value.api.loadSpace(parent);
 
@@ -138,7 +144,7 @@ watchDebounced(
       valid: !!space
     };
   },
-  { debounce: 500 }
+  { debounce: 500, immediate: true }
 );
 
 watchEffect(() => {

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -259,7 +259,10 @@ watchEffect(() => {
     </div>
     <UiButton
       :disabled="!isController"
-      class="w-full md:w-auto flex-shrink-0 border-skin-danger !text-skin-danger"
+      class="w-full md:w-auto flex-shrink-0"
+      :class="{
+        'border-skin-danger !text-skin-danger': isController
+      }"
       @click="isDeleteSpaceModalOpen = true"
     >
       Delete space

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { getNetwork } from '@/networks';
+import { NetworkID } from '@/types';
+
+const CHILDREN_LIMIT = 16;
+
+const PARENT_SPACE_DEFINITION = {
+  type: 'string',
+  title: 'Main space',
+  minLength: 1,
+  examples: ['pistachiodao.eth']
+};
+
+const SUB_SPACE_DEFINITION = {
+  type: 'string',
+  title: 'Sub-space(s)',
+  minLength: 1,
+  examples: ['pistachiodao.eth']
+};
+
+const parent = defineModel<string>('parent', { required: true });
+const children = defineModel<string[]>('children', { required: true });
+
+const props = defineProps<{
+  networkId: NetworkID;
+}>();
+
+const { addNotification } = useUiStore();
+
+const childInput = ref('');
+const isAddingChild = ref(false);
+
+const network = computed(() => getNetwork(props.networkId));
+const canAddParentSpace = computed(() => children.value.length === 0);
+const canAddChildSpace = computed(() => parent.value.length === 0);
+
+async function addChild() {
+  try {
+    isAddingChild.value = true;
+
+    const space = await network.value.api.loadSpace(childInput.value);
+
+    if (!space) {
+      throw new Error('Space not found');
+    }
+
+    children.value.push(childInput.value);
+    childInput.value = '';
+  } catch (e) {
+    addNotification('error', `Space ${childInput.value} not found`);
+  } finally {
+    isAddingChild.value = false;
+  }
+}
+
+function deleteChild(i: number) {
+  children.value = children.value.filter((_, index) => index !== i);
+}
+</script>
+
+<template>
+  <h4 class="eyebrow mb-2 font-medium">Sub-spaces</h4>
+  <UiMessage
+    :type="'info'"
+    :learn-more-link="'https://docs.snapshot.org/user-guides/spaces/sub-spaces'"
+  >
+    Add a sub-space to display its proposals within your space. If you want the
+    current space to be displayed on the sub-space's page, the space need to be
+    added as main space in the subs-space settings to make relation mutual.
+  </UiMessage>
+  <div class="s-box my-3">
+    <UiInputString
+      v-model="parent"
+      :disabled="!canAddParentSpace"
+      :class="{
+        'cursor-not-allowed': !canAddParentSpace
+      }"
+      :definition="PARENT_SPACE_DEFINITION"
+    />
+    <UiInputString
+      v-model="childInput"
+      :disabled="!canAddChildSpace"
+      :class="{
+        'cursor-not-allowed': !canAddChildSpace
+      }"
+      :definition="SUB_SPACE_DEFINITION"
+    />
+    <UiButton
+      v-if="children.length < CHILDREN_LIMIT"
+      :disabled="!canAddChildSpace"
+      :loading="isAddingChild"
+      class="w-full"
+      @click="addChild"
+    >
+      Add space
+    </UiButton>
+  </div>
+  <div class="flex flex-wrap gap-2">
+    <div
+      v-for="(child, i) in children"
+      :key="child"
+      class="flex items-center gap-2 rounded-lg border px-3 py-2 w-fit"
+    >
+      <span>{{ child }}</span>
+      <button type="button" @click="deleteChild(i)">
+        <IH-x-mark class="w-[16px]" />
+      </button>
+    </div>
+  </div>
+</template>

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -71,8 +71,6 @@ const {
 
 const isDeleteSpaceModalOpen = ref(false);
 
-const canAddParentSpace = computed(() => children.value.length === 0);
-const canAddChildSpace = computed(() => parent.value.length === 0);
 const addSubSpaceButtonEnabled = computed(() => {
   if (!child.value) return false;
 
@@ -153,29 +151,19 @@ watchEffect(() => {
   <div class="s-box my-3">
     <UiInputString
       v-model="parent"
-      :disabled="!canAddParentSpace"
       :loading="isParentLoading"
-      :class="{
-        'cursor-not-allowed': !canAddParentSpace
-      }"
       :definition="PARENT_SPACE_DEFINITION"
       :error="formErrors.parent ?? parentValidationError"
     />
     <UiInputString
       v-model="child"
-      :disabled="!canAddChildSpace"
       :loading="isChildLoading"
-      :class="{
-        'cursor-not-allowed': !canAddChildSpace
-      }"
       :definition="CHILD_DEFINITION"
       :error="formErrors.child ?? childValidationError"
     />
     <UiButton
       v-if="children.length < CHILDREN_LIMIT"
-      :disabled="
-        !canAddChildSpace || !!formErrors.child || !addSubSpaceButtonEnabled
-      "
+      :disabled="!!formErrors.child || !addSubSpaceButtonEnabled"
       class="w-full"
       @click="addChild"
     >

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -31,7 +31,6 @@ const TERMS_OF_SERVICES_DEFINITION = {
 
 const CUSTOM_DOMAIN_DEFINITION = {
   type: 'string',
-  format: 'uri',
   title: 'Domain name',
   maxLength: 64,
   examples: ['vote.balancer.fi']
@@ -89,7 +88,8 @@ const formErrors = computed(() => {
     properties: {
       parent: PARENT_SPACE_DEFINITION,
       child: CHILD_DEFINITION,
-      termsOfServices: TERMS_OF_SERVICES_DEFINITION
+      termsOfServices: TERMS_OF_SERVICES_DEFINITION,
+      customDomain: CUSTOM_DOMAIN_DEFINITION
     }
   });
 
@@ -97,7 +97,8 @@ const formErrors = computed(() => {
     {
       parent: parent.value,
       child: child.value,
-      termsOfServices: termsOfServices.value
+      termsOfServices: termsOfServices.value,
+      customDomain: customDomain.value
     },
     {
       skipEmptyOptionalFields: true

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -106,7 +106,7 @@ const formErrors = computed(() => {
   );
 
   if (parent.value === props.spaceId) {
-    errors.parent = 'Space cannot be a sub-space of itself';
+    errors.parent = 'Space cannot be a parent of itself';
   }
 
   if (child.value === props.spaceId) {

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -118,6 +118,10 @@ const formErrors = computed(() => {
     errors.child = 'Space already configured as sub-space';
   }
 
+  if (children.value.length >= CHILDREN_LIMIT) {
+    errors.child = 'Maximum number of sub-spaces reached';
+  }
+
   return errors;
 });
 

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -82,7 +82,7 @@ const formErrors = computed(() => {
     }
   });
 
-  return validator.validate(
+  const errors = validator.validate(
     {
       parent: parent.value,
       childInput: childInput.value,
@@ -92,6 +92,16 @@ const formErrors = computed(() => {
       skipEmptyOptionalFields: true
     }
   );
+
+  if (parent.value === props.spaceId) {
+    errors.parent = 'Space cannot be a sub-space of itself';
+  }
+
+  if (childInput.value === props.spaceId) {
+    errors.childInput = 'Space cannot be a sub-space of itself';
+  }
+
+  return errors;
 });
 const parentSpaceError = computed(() => {
   if (formErrors.value.parent) return formErrors.value.parent as string;
@@ -188,7 +198,7 @@ watchEffect(() => {
     />
     <UiButton
       v-if="children.length < CHILDREN_LIMIT"
-      :disabled="!canAddChildSpace"
+      :disabled="!canAddChildSpace || formErrors.childInput"
       :loading="isAddingChild"
       class="w-full"
       @click="addChild"

--- a/apps/ui/src/components/Modal/DeleteSpace.vue
+++ b/apps/ui/src/components/Modal/DeleteSpace.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { clone } from '@/helpers/utils';
+
+const DEFAULT_FORM_STATE = {
+  id: '',
+  confirmed: false
+};
+
+const props = defineProps<{
+  open: boolean;
+  spaceId: string;
+  initialState?: any;
+}>();
+
+const emit = defineEmits<{
+  (e: 'confirm');
+  (e: 'close');
+}>();
+
+const form: Ref<{
+  id: string;
+  confirmed: boolean;
+}> = ref(clone(DEFAULT_FORM_STATE));
+
+const isValid = computed(
+  () => form.value.confirmed && form.value.id === props.spaceId
+);
+
+function handleSubmit() {
+  emit('confirm');
+  emit('close');
+}
+
+watch(
+  () => props.open,
+  () => {
+    form.value = clone(DEFAULT_FORM_STATE);
+  }
+);
+</script>
+
+<template>
+  <UiModal :open="open" @close="$emit('close')">
+    <template #header>
+      <h3>Confirm action</h3>
+    </template>
+    <div class="s-box p-4">
+      <UiMessage type="danger">
+        Do you really want to delete this space? This action cannot be undone
+        and you will not be able to use {{ spaceId }} again to create another
+        space.
+      </UiMessage>
+      <UiInputString
+        v-model="form.id"
+        class="my-3"
+        :definition="{
+          type: 'string',
+          title: `Enter ${spaceId} to continue`,
+          minLength: 1
+        }"
+      />
+      <UiCheckbox
+        v-model="form.confirmed"
+        :title="`I acknowledge that I will not be able to use ${spaceId} again to create a new space.`"
+      />
+    </div>
+    <template #footer>
+      <UiButton class="w-full" :disabled="!isValid" @click="handleSubmit">
+        Confirm
+      </UiButton>
+    </template>
+  </UiModal>
+</template>

--- a/apps/ui/src/components/Ui/Checkbox.vue
+++ b/apps/ui/src/components/Ui/Checkbox.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { Switch, SwitchGroup, SwitchLabel } from '@headlessui/vue';
+
+const enabled = defineModel<boolean>({ required: true });
+
+defineProps<{
+  title: string;
+}>();
+</script>
+
+<template>
+  <SwitchGroup>
+    <div class="flex items-top gap-1">
+      <Switch
+        v-model="enabled"
+        :class="enabled ? 'bg-skin-primary' : 'border bg-skin-input-bg'"
+        class="flex items-center justify-center h-[20px] w-[20px] shrink-0 cursor-pointer rounded-md border-skin-border transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-white/75"
+      >
+        <IC-switch-enabled v-if="enabled" class="text-skin-bg" />
+      </Switch>
+      <SwitchLabel class="leading-[18px]">
+        {{ title }}
+      </SwitchLabel>
+    </div>
+  </SwitchGroup>
+</template>

--- a/apps/ui/src/components/Ui/Checkbox.vue
+++ b/apps/ui/src/components/Ui/Checkbox.vue
@@ -10,11 +10,11 @@ defineProps<{
 
 <template>
   <SwitchGroup>
-    <div class="flex items-top gap-1">
+    <div class="flex items-top gap-2">
       <Switch
         v-model="enabled"
         :class="enabled ? 'bg-skin-primary' : 'border bg-skin-input-bg'"
-        class="flex items-center justify-center h-[20px] w-[20px] shrink-0 cursor-pointer rounded-md border-skin-border transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-white/75"
+        class="flex items-center justify-center size-[20px] shrink-0 cursor-pointer rounded-md border-skin-border transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-white/75"
       >
         <IC-switch-enabled v-if="enabled" class="text-skin-bg" />
       </Switch>

--- a/apps/ui/src/components/Ui/ContainerSettings.vue
+++ b/apps/ui/src/components/Ui/ContainerSettings.vue
@@ -1,14 +1,21 @@
 <script setup lang="ts">
 defineProps<{
   title: string;
-  description: string;
+  description?: string;
 }>();
 </script>
 
 <template>
   <div class="mb-4">
-    <h3 class="text-md leading-6">{{ title }}</h3>
-    <span class="mb-4 inline-block">
+    <h3
+      class="text-md leading-6"
+      :class="{
+        'mb-4': !description
+      }"
+    >
+      {{ title }}
+    </h3>
+    <span v-if="description" class="mb-4 inline-block">
       {{ description }}
     </span>
     <slot />

--- a/apps/ui/src/components/Ui/InputString.vue
+++ b/apps/ui/src/components/Ui/InputString.vue
@@ -8,6 +8,7 @@ export default {
 const model = defineModel<string>();
 
 const props = defineProps<{
+  loading?: boolean;
   error?: string;
   definition: any;
 }>();
@@ -37,6 +38,7 @@ watch(model, () => {
   <UiWrapperInput
     v-slot="{ id }"
     :definition="definition"
+    :loading="loading"
     :error="error"
     :dirty="dirty"
     :input-value-length="inputValue?.length"

--- a/apps/ui/src/components/Ui/Message.vue
+++ b/apps/ui/src/components/Ui/Message.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+defineProps<{
+  type: 'info';
+  learnMoreLink?: string;
+}>();
+</script>
+
+<template>
+  <div class="border rounded-md p-[20px] flex gap-1">
+    <IH-information-circle class="shrink-0" />
+    <div class="leading-5">
+      <slot />
+      <a
+        v-if="learnMoreLink"
+        :href="learnMoreLink"
+        target="_blank"
+        class="flex items-center text-skin-link mt-1 gap-1 w-fit"
+      >
+        Learn more
+        <IH-arrow-top-right-on-square />
+      </a>
+    </div>
+  </div>
+</template>

--- a/apps/ui/src/components/Ui/Message.vue
+++ b/apps/ui/src/components/Ui/Message.vue
@@ -1,12 +1,17 @@
 <script setup lang="ts">
 defineProps<{
-  type: 'info';
+  type: 'info' | 'danger';
   learnMoreLink?: string;
 }>();
 </script>
 
 <template>
-  <div class="border rounded-md p-[20px] flex gap-1">
+  <div
+    class="border rounded-md p-[20px] flex gap-1"
+    :class="{
+      'text-skin-danger border-skin-danger': type === 'danger'
+    }"
+  >
     <IH-information-circle class="shrink-0" />
     <div class="leading-5">
       <slot />

--- a/apps/ui/src/components/Ui/Message.vue
+++ b/apps/ui/src/components/Ui/Message.vue
@@ -7,12 +7,12 @@ defineProps<{
 
 <template>
   <div
-    class="border rounded-md p-[20px] flex gap-1"
+    class="border rounded-md p-[20px]"
     :class="{
       'text-skin-danger border-skin-danger': type === 'danger'
     }"
   >
-    <IH-information-circle class="shrink-0" />
+    <IH-information-circle class="float-left mr-1" />
     <div class="leading-5">
       <slot />
       <a

--- a/apps/ui/src/components/Ui/Message.vue
+++ b/apps/ui/src/components/Ui/Message.vue
@@ -22,7 +22,7 @@ defineProps<{
         class="flex items-center text-skin-link mt-1 gap-1 w-fit"
       >
         Learn more
-        <IH-arrow-top-right-on-square />
+        <IH-arrow-sm-right class="-rotate-45" />
       </a>
     </div>
   </div>

--- a/apps/ui/src/components/Ui/Switch.vue
+++ b/apps/ui/src/components/Ui/Switch.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { Switch, SwitchGroup, SwitchLabel } from '@headlessui/vue';
+
+const enabled = defineModel<boolean>({ required: true });
+
+defineProps<{
+  title: string;
+}>();
+</script>
+
+<template>
+  <SwitchGroup>
+    <div class="flex items-center gap-2">
+      <Switch
+        v-model="enabled"
+        :class="enabled ? 'bg-skin-primary' : 'bg-skin-border'"
+        class="relative inline-flex h-[22px] w-[38px] shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-white/75"
+      >
+        <span
+          :class="enabled ? 'translate-x-[16px]' : 'translate-x-0'"
+          class="flex justify-center items-center pointer-events-none h-[18px] w-[18px] transform rounded-full bg-skin-bg shadow-lg ring-0 transition duration-200 ease-in-out"
+        >
+          <IC-switch-enabled v-if="enabled" class="text-skin-primary" />
+          <IC-switch-disabled v-else class="text-skin-text" />
+        </span>
+      </Switch>
+      <SwitchLabel class="text-skin-link">
+        {{ title }}
+      </SwitchLabel>
+    </div>
+  </SwitchGroup>
+</template>

--- a/apps/ui/src/components/Ui/WrapperInput.vue
+++ b/apps/ui/src/components/Ui/WrapperInput.vue
@@ -22,9 +22,13 @@ const showError = computed(() => props.error && props.dirty);
       <label
         v-if="definition.title"
         :for="id"
-        class="truncate"
-        v-text="definition.title"
-      />
+        class="truncate flex items-center gap-1"
+      >
+        {{ definition.title }}
+        <UiTooltip v-if="definition.tooltip" :title="definition.tooltip">
+          <IH-question-mark-circle class="shrink-0" />
+        </UiTooltip>
+      </label>
       <div
         v-if="inputValueLength >= 0 && definition.maxLength"
         class="text-sm hidden grow text-right s-label-char-count whitespace-nowrap"

--- a/apps/ui/src/components/Ui/WrapperInput.vue
+++ b/apps/ui/src/components/Ui/WrapperInput.vue
@@ -3,6 +3,7 @@ import { _n } from '@/helpers/utils';
 
 const props = withDefaults(
   defineProps<{
+    loading?: boolean;
     definition: any;
     inputValueLength?: number;
     error?: string;
@@ -18,25 +19,28 @@ const showError = computed(() => props.error && props.dirty);
 
 <template>
   <div class="s-base" :class="showError ? 's-error' : ''">
-    <div class="!flex s-label w-full gap-1">
-      <label
-        v-if="definition.title"
-        :for="id"
-        class="truncate flex items-center gap-1"
-      >
-        {{ definition.title }}
-        <UiTooltip v-if="definition.tooltip" :title="definition.tooltip">
-          <IH-question-mark-circle class="shrink-0" />
-        </UiTooltip>
-      </label>
-      <div
-        v-if="inputValueLength >= 0 && definition.maxLength"
-        class="text-sm hidden grow text-right s-label-char-count whitespace-nowrap"
-      >
-        {{ _n(inputValueLength) }} / {{ _n(definition.maxLength) }}
+    <div class="relative">
+      <div class="!flex justify-between s-label w-full gap-1">
+        <label
+          v-if="definition.title"
+          :for="id"
+          class="truncate flex items-center gap-1"
+        >
+          {{ definition.title }}
+          <UiTooltip v-if="definition.tooltip" :title="definition.tooltip">
+            <IH-question-mark-circle class="shrink-0" />
+          </UiTooltip>
+        </label>
+        <UiLoading v-if="loading" :size="16" />
+        <div
+          v-else-if="inputValueLength >= 0 && definition.maxLength"
+          class="text-sm hidden grow text-right s-label-char-count whitespace-nowrap"
+        >
+          {{ _n(inputValueLength) }} / {{ _n(definition.maxLength) }}
+        </div>
       </div>
+      <slot :id="id" />
     </div>
-    <slot :id="id" />
     <span v-if="showError" class="s-input-error-message">{{ error }}</span>
     <legend v-if="definition.description" v-text="definition.description" />
   </div>

--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -541,6 +541,23 @@ export function useActions() {
     );
   }
 
+  async function deleteSpace(space: Space) {
+    if (!web3.value.account) {
+      await forceLogin();
+      return null;
+    }
+
+    const network = getNetwork(space.network);
+    if (!network.managerConnectors.includes(web3.value.type as Connector)) {
+      throw new Error(`${web3.value.type} is not supported for this actions`);
+    }
+
+    return wrapPromise(
+      space.network,
+      network.actions.deleteSpace(auth.web3, space)
+    );
+  }
+
   async function delegate(
     space: Space,
     networkId: NetworkID,
@@ -668,6 +685,7 @@ export function useActions() {
     transferOwnership: wrapWithErrors(transferOwnership),
     updateSettings: wrapWithErrors(updateSettings),
     updateSettingsRaw: wrapWithErrors(updateSettingsRaw),
+    deleteSpace: wrapWithErrors(deleteSpace),
     delegate: wrapWithErrors(delegate),
     followSpace: wrapWithErrors(followSpace),
     unfollowSpace: wrapWithErrors(unfollowSpace),

--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -199,7 +199,7 @@ export function useActions() {
 
     const network = getReadWriteNetwork(networkId);
     if (!network.managerConnectors.includes(web3.value.type as Connector)) {
-      throw new Error(`${web3.value.type} is not supported for this actions`);
+      throw new Error(`${web3.value.type} is not supported for this action`);
     }
 
     const receipt = await network.actions.createSpace(auth.web3, salt, {
@@ -231,7 +231,7 @@ export function useActions() {
 
     const network = getReadWriteNetwork(space.network);
     if (!network.managerConnectors.includes(web3.value.type as Connector)) {
-      throw new Error(`${web3.value.type} is not supported for this actions`);
+      throw new Error(`${web3.value.type} is not supported for this action`);
     }
 
     await wrapPromise(
@@ -349,7 +349,7 @@ export function useActions() {
 
     const network = getNetwork(proposal.network);
     if (!network.managerConnectors.includes(web3.value.type as Connector)) {
-      throw new Error(`${web3.value.type} is not supported for this actions`);
+      throw new Error(`${web3.value.type} is not supported for this action`);
     }
 
     await wrapPromise(
@@ -412,7 +412,7 @@ export function useActions() {
 
     const network = getReadWriteNetwork(space.network);
     if (!network.managerConnectors.includes(web3.value.type as Connector)) {
-      throw new Error(`${web3.value.type} is not supported for this actions`);
+      throw new Error(`${web3.value.type} is not supported for this action`);
     }
 
     await wrapPromise(
@@ -430,7 +430,7 @@ export function useActions() {
 
     const network = getReadWriteNetwork(space.network);
     if (!network.managerConnectors.includes(web3.value.type as Connector)) {
-      throw new Error(`${web3.value.type} is not supported for this actions`);
+      throw new Error(`${web3.value.type} is not supported for this action`);
     }
 
     await wrapPromise(
@@ -448,7 +448,7 @@ export function useActions() {
 
     const network = getReadWriteNetwork(space.network);
     if (!network.managerConnectors.includes(web3.value.type as Connector)) {
-      throw new Error(`${web3.value.type} is not supported for this actions`);
+      throw new Error(`${web3.value.type} is not supported for this action`);
     }
 
     await wrapPromise(
@@ -469,7 +469,7 @@ export function useActions() {
 
     const network = getNetwork(space.network);
     if (!network.managerConnectors.includes(web3.value.type as Connector)) {
-      throw new Error(`${web3.value.type} is not supported for this actions`);
+      throw new Error(`${web3.value.type} is not supported for this action`);
     }
 
     return wrapPromise(
@@ -497,7 +497,7 @@ export function useActions() {
 
     const network = getReadWriteNetwork(space.network);
     if (!network.managerConnectors.includes(web3.value.type as Connector)) {
-      throw new Error(`${web3.value.type} is not supported for this actions`);
+      throw new Error(`${web3.value.type} is not supported for this action`);
     }
 
     return wrapPromise(
@@ -532,7 +532,7 @@ export function useActions() {
 
     const network = getNetwork(space.network);
     if (!network.managerConnectors.includes(web3.value.type as Connector)) {
-      throw new Error(`${web3.value.type} is not supported for this actions`);
+      throw new Error(`${web3.value.type} is not supported for this action`);
     }
 
     return wrapPromise(
@@ -549,7 +549,7 @@ export function useActions() {
 
     const network = getNetwork(space.network);
     if (!network.managerConnectors.includes(web3.value.type as Connector)) {
-      throw new Error(`${web3.value.type} is not supported for this actions`);
+      throw new Error(`${web3.value.type} is not supported for this action`);
     }
 
     return wrapPromise(

--- a/apps/ui/src/composables/useSpaceInputValidation.ts
+++ b/apps/ui/src/composables/useSpaceInputValidation.ts
@@ -1,0 +1,60 @@
+import { getNetwork } from '@/networks';
+import { NetworkID } from '@/types';
+
+type SpaceValidationResult = { value: string; valid: boolean };
+
+export function useSpaceInputValidation(
+  networkId: Ref<NetworkID>,
+  value: Ref<string>
+) {
+  const loading = ref(false);
+  const validationResult = ref(null as SpaceValidationResult | null);
+
+  const network = computed(() => getNetwork(networkId.value));
+  const error = computed(() => {
+    if (validationResult.value === null) return null;
+    if (validationResult.value.value !== value.value) return null;
+    if (validationResult.value.valid) return null;
+
+    return `Space ${validationResult.value.value} not found`;
+  });
+
+  watchDebounced(
+    value,
+    async value => {
+      loading.value = true;
+
+      try {
+        if (!value || value === validationResult.value?.value) {
+          validationResult.value = {
+            value,
+            valid: true
+          };
+          return;
+        }
+
+        const space = await network.value.api.loadSpace(value);
+        validationResult.value = {
+          value,
+          valid: !!space
+        };
+      } catch (e) {
+        console.error(e);
+
+        validationResult.value = {
+          value,
+          valid: false
+        };
+      } finally {
+        loading.value = false;
+      }
+    },
+    { debounce: 500, immediate: true }
+  );
+
+  return {
+    loading,
+    validationResult,
+    error
+  };
+}

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -88,7 +88,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     );
 
     return compareAddresses(controller, account);
-  });
+  }, false);
   const isOwner = computedAsync(async () => {
     if (!offchainNetworks.includes(space.value.network)) {
       return isController.value;
@@ -102,7 +102,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     );
 
     return compareAddresses(owner, account);
-  });
+  }, false);
   const isAdmin = computed(() => {
     if (!offchainNetworks.includes(space.value.network)) return false;
 

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -131,6 +131,7 @@ export function useSpaceSettings(space: Ref<Space>) {
   const members = ref([] as Member[]);
   const parent = ref('');
   const children = ref([] as string[]);
+  const termsOfServices = ref('');
 
   function currentToMinutesOnly(value: number) {
     const duration = getDurationFromCurrent(space.value.network, value);
@@ -399,7 +400,7 @@ export function useSpaceSettings(space: Ref<Space>) {
       cover: form.value.cover ?? space.value.cover,
       network: space.value.snapshot_chain_id?.toString() ?? '1',
       symbol: form.value.votingPowerSymbol ?? space.value.voting_power_symbol,
-      terms: space.value.additionalRawData.terms,
+      terms: termsOfServices.value,
       website: form.value.externalUrl ?? space.value.external_url,
       twitter: form.value.twitter ?? space.value.twitter,
       github: form.value.github ?? space.value.github,
@@ -559,6 +560,7 @@ export function useSpaceSettings(space: Ref<Space>) {
       members.value = getInitialMembers(space.value);
       parent.value = space.value.parent?.id ?? '';
       children.value = space.value.children.map(child => child.id);
+      termsOfServices.value = space.value.additionalRawData?.terms ?? '';
     }
   }
 
@@ -578,6 +580,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     const membersValue = members.value;
     const parentValue = parent.value;
     const childrenValue = children.value;
+    const termsOfServicesValue = termsOfServices.value;
 
     if (loading.value) {
       isModified.value = false;
@@ -641,6 +644,13 @@ export function useSpaceSettings(space: Ref<Space>) {
         isModified.value = true;
         return;
       }
+
+      if (
+        termsOfServicesValue !== (space.value.additionalRawData?.terms ?? '')
+      ) {
+        isModified.value = true;
+        return;
+      }
     } else {
       const [authenticatorsToAdd, authenticatorsToRemove] =
         await processChanges(
@@ -698,6 +708,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     members,
     parent,
     children,
+    termsOfServices,
     save,
     saveController,
     reset

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -69,7 +69,12 @@ const DEFAULT_FORM_STATE: Form = {
 export function useSpaceSettings(space: Ref<Space>) {
   const { web3 } = useWeb3();
   const { getDurationFromCurrent } = useMetaStore();
-  const { updateSettings, updateSettingsRaw, transferOwnership } = useActions();
+  const {
+    updateSettings,
+    updateSettingsRaw,
+    transferOwnership,
+    deleteSpace: deleteSpaceAction
+  } = useActions();
 
   const loading = ref(true);
   const isModified = ref(false);
@@ -518,9 +523,8 @@ export function useSpaceSettings(space: Ref<Space>) {
     return transferOwnership(space.value, controller.value);
   }
 
-  async function deleteSpace(id: string) {
-    console.log('deleting space', id);
-    return null;
+  async function deleteSpace() {
+    return deleteSpaceAction(space.value);
   }
 
   async function reset() {

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -129,6 +129,8 @@ export function useSpaceSettings(space: Ref<Space>) {
 
   // Offchain properties
   const members = ref([] as Member[]);
+  const parent = ref('');
+  const children = ref([] as string[]);
 
   function currentToMinutesOnly(value: number) {
     const duration = getDurationFromCurrent(space.value.network, value);
@@ -402,8 +404,8 @@ export function useSpaceSettings(space: Ref<Space>) {
       twitter: form.value.twitter ?? space.value.twitter,
       github: form.value.github ?? space.value.github,
       coingecko: form.value.coingecko ?? space.value.coingecko,
-      parent: space.value.parent?.id ?? null,
-      children: space.value.children.map(child => child.id),
+      parent: parent.value || null,
+      children: children.value,
       private: space.value.additionalRawData.private,
       domain: space.value.additionalRawData.domain,
       skin: space.value.additionalRawData.skin,
@@ -555,6 +557,8 @@ export function useSpaceSettings(space: Ref<Space>) {
 
     if (offchainNetworks.includes(space.value.network)) {
       members.value = getInitialMembers(space.value);
+      parent.value = space.value.parent?.id ?? '';
+      children.value = space.value.children.map(child => child.id);
     }
   }
 
@@ -572,6 +576,8 @@ export function useSpaceSettings(space: Ref<Space>) {
     const initialValidationStrategyObjectHashValue =
       initialValidationStrategyObjectHash.value;
     const membersValue = members.value;
+    const parentValue = parent.value;
+    const childrenValue = children.value;
 
     if (loading.value) {
       isModified.value = false;
@@ -615,6 +621,22 @@ export function useSpaceSettings(space: Ref<Space>) {
       if (
         objectHash(membersValue, ignoreOrderOpts) !==
         objectHash(getInitialMembers(space.value), ignoreOrderOpts)
+      ) {
+        isModified.value = true;
+        return;
+      }
+
+      if (parentValue !== (space.value.parent?.id ?? '')) {
+        isModified.value = true;
+        return;
+      }
+
+      if (
+        objectHash(childrenValue, ignoreOrderOpts) !==
+        objectHash(
+          space.value.children.map(child => child.id),
+          ignoreOrderOpts
+        )
       ) {
         isModified.value = true;
         return;
@@ -674,6 +696,8 @@ export function useSpaceSettings(space: Ref<Space>) {
     validationStrategy,
     votingStrategies,
     members,
+    parent,
+    children,
     save,
     saveController,
     reset

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -518,6 +518,11 @@ export function useSpaceSettings(space: Ref<Space>) {
     return transferOwnership(space.value, controller.value);
   }
 
+  async function deleteSpace(id: string) {
+    console.log('deleting space', id);
+    return null;
+  }
+
   async function reset() {
     const authenticatorsValue = await getInitialStrategiesConfig(
       space.value.authenticators,
@@ -729,6 +734,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     isPrivate,
     save,
     saveController,
+    deleteSpace,
     reset
   };
 }

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -132,6 +132,8 @@ export function useSpaceSettings(space: Ref<Space>) {
   const parent = ref('');
   const children = ref([] as string[]);
   const termsOfServices = ref('');
+  const customDomain = ref('');
+  const isPrivate = ref(false);
 
   function currentToMinutesOnly(value: number) {
     const duration = getDurationFromCurrent(space.value.network, value);
@@ -405,10 +407,10 @@ export function useSpaceSettings(space: Ref<Space>) {
       twitter: form.value.twitter ?? space.value.twitter,
       github: form.value.github ?? space.value.github,
       coingecko: form.value.coingecko ?? space.value.coingecko,
-      parent: parent.value || null,
+      parent: parent.value,
       children: children.value,
-      private: space.value.additionalRawData.private,
-      domain: space.value.additionalRawData.domain,
+      private: isPrivate.value,
+      domain: customDomain.value,
       skin: space.value.additionalRawData.skin,
       guidelines: space.value.additionalRawData.guidelines,
       template: space.value.additionalRawData.template,
@@ -561,6 +563,8 @@ export function useSpaceSettings(space: Ref<Space>) {
       parent.value = space.value.parent?.id ?? '';
       children.value = space.value.children.map(child => child.id);
       termsOfServices.value = space.value.additionalRawData?.terms ?? '';
+      customDomain.value = space.value.additionalRawData?.domain ?? '';
+      isPrivate.value = space.value.additionalRawData?.private ?? false;
     }
   }
 
@@ -581,6 +585,8 @@ export function useSpaceSettings(space: Ref<Space>) {
     const parentValue = parent.value;
     const childrenValue = children.value;
     const termsOfServicesValue = termsOfServices.value;
+    const customDomainValue = customDomain.value;
+    const isPrivateValue = isPrivate.value;
 
     if (loading.value) {
       isModified.value = false;
@@ -651,6 +657,16 @@ export function useSpaceSettings(space: Ref<Space>) {
         isModified.value = true;
         return;
       }
+
+      if (customDomainValue !== (space.value.additionalRawData?.domain ?? '')) {
+        isModified.value = true;
+        return;
+      }
+
+      if (isPrivateValue !== space.value.additionalRawData?.private) {
+        isModified.value = true;
+        return;
+      }
     } else {
       const [authenticatorsToAdd, authenticatorsToRemove] =
         await processChanges(
@@ -709,6 +725,8 @@ export function useSpaceSettings(space: Ref<Space>) {
     parent,
     children,
     termsOfServices,
+    customDomain,
+    isPrivate,
     save,
     saveController,
     reset

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -200,6 +200,14 @@ ajv.addFormat('farcaster-handle', {
   }
 });
 
+ajv.addFormat('domain', {
+  validate: (value: string) => {
+    if (!value) return false;
+
+    return !!value.match(/^[a-zA-Z0-9\-\.]+$/);
+  }
+});
+
 ajv.addFormat('ethValue', {
   validate: value => {
     if (!value.match(/^([0-9]|[1-9][0-9]+)(\.[0-9]+)?$/)) return false;
@@ -241,6 +249,8 @@ function getErrorMessage(errorObject: Partial<ErrorObject>): string {
     switch (errorObject.params.format) {
       case 'uri':
         return 'Must be a valid URL.';
+      case 'domain':
+        return 'Must be a valid domain.';
       case 'address':
       case 'ethAddress':
         return 'Must be a valid address.';

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -230,6 +230,7 @@ ajv.addKeyword({
   }
 });
 ajv.addKeyword('options');
+ajv.addKeyword('tooltip');
 
 function getErrorMessage(errorObject: Partial<ErrorObject>): string {
   if (!errorObject.message) return 'Invalid field.';

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -705,6 +705,9 @@ export function createActions(
     updateSettingsRaw: () => {
       throw new Error('Not implemented');
     },
+    deleteSpace: () => {
+      throw new Error('Not implemented');
+    },
     send: (envelope: any) => ethSigClient.send(envelope),
     getVotingPower: async (
       spaceId: string,

--- a/apps/ui/src/networks/offchain/actions.ts
+++ b/apps/ui/src/networks/offchain/actions.ts
@@ -353,6 +353,12 @@ export function createActions(
         signer: web3 instanceof Web3Provider ? web3.getSigner() : web3,
         data: { space: space.id, settings }
       });
+    },
+    deleteSpace: (web3: Web3Provider | Wallet, space: Space) => {
+      return client.deleteSpace({
+        signer: web3 instanceof Web3Provider ? web3.getSigner() : web3,
+        data: { space: space.id }
+      });
     }
   };
 }

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -672,9 +672,6 @@ export function createActions(
         }
       });
     },
-    updateSettingsRaw: () => {
-      throw new Error('Not implemented');
-    },
     delegate: async (
       web3: any,
       space: Space,
@@ -770,6 +767,12 @@ export function createActions(
     },
     updateUser: () => {},
     updateStatement: () => {},
+    updateSettingsRaw: () => {
+      throw new Error('Not implemented');
+    },
+    deleteSpace: () => {
+      throw new Error('Not implemented');
+    },
     send: (envelope: any) => starkSigClient.send(envelope) // TODO: extract it out of client to common helper
   };
 }

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -175,6 +175,7 @@ export type ReadOnlyNetworkActions = {
   );
   transferOwnership(web3: Web3Provider, space: Space, owner: string);
   updateSettingsRaw(web3: Web3Provider, space: Space, settings: string);
+  deleteSpace(web3: Web3Provider, space: Space);
   send(envelope: any): Promise<any>;
 };
 

--- a/apps/ui/src/style.scss
+++ b/apps/ui/src/style.scss
@@ -308,7 +308,8 @@ input:placeholder-shown {
   }
 
   textarea.s-input {
-    &, :focus {
+    &,
+    :focus {
       @apply outline outline-1 outline-offset-[-1px] outline-skin-danger border-transparent;
     }
   }
@@ -326,7 +327,7 @@ input:placeholder-shown {
   // Adding the gradient fade to the top of the input
   .s-label:has(+ textarea),
   .s-base:has(textarea:only-child) {
-     &::before {
+    &::before {
       @apply block bg-gradient-to-b from-skin-border to-transparent h-[8px] absolute top-3.5 left-[1px] right-[1px];
 
       content: '';

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -23,6 +23,8 @@ const {
   validationStrategy,
   votingStrategies,
   members,
+  parent,
+  children,
   save,
   saveController,
   reset
@@ -47,7 +49,8 @@ type Tab = {
     | 'voting'
     | 'members'
     | 'execution'
-    | 'controller';
+    | 'controller'
+    | 'advanced';
   name: string;
   visible: boolean;
 };
@@ -108,6 +111,11 @@ const tabs = computed<Tab[]>(
         id: 'controller',
         name: 'Controller',
         visible: true
+      },
+      {
+        id: 'advanced',
+        name: 'Advanced',
+        visible: isOffchainNetwork.value
       }
     ] as const
 );
@@ -488,6 +496,17 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
           @save="handleControllerSave"
         />
       </teleport>
+    </UiContainerSettings>
+    <UiContainerSettings
+      v-else-if="activeTab === 'advanced'"
+      title="Advanced"
+      description="Office ipsum you must be muted. Boy ocean define crank new."
+    >
+      <FormSpaceAdvanced
+        v-model:parent="parent"
+        v-model:children="children"
+        :network-id="space.network"
+      />
     </UiContainerSettings>
     <div
       v-if="

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -26,6 +26,8 @@ const {
   parent,
   children,
   termsOfServices,
+  customDomain,
+  isPrivate,
   save,
   saveController,
   reset
@@ -507,6 +509,8 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
         v-model:parent="parent"
         v-model:children="children"
         v-model:terms-of-services="termsOfServices"
+        v-model:custom-domain="customDomain"
+        v-model:is-private="isPrivate"
         :network-id="space.network"
       />
     </UiContainerSettings>

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -5,6 +5,7 @@ import { Space } from '@/types';
 
 const props = defineProps<{ space: Space }>();
 
+const router = useRouter();
 const route = useRoute();
 const {
   loading,
@@ -225,7 +226,12 @@ function handleControllerSave(value: string) {
 
 function handleSpaceDelete() {
   saving.value = true;
-  executeFn.value = () => deleteSpace(props.space.id);
+  executeFn.value = async () => {
+    await deleteSpace();
+    router.push({ name: 'my-home' });
+
+    return null;
+  };
 }
 
 function handleTabFocus(event: FocusEvent) {

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -30,6 +30,7 @@ const {
   isPrivate,
   save,
   saveController,
+  deleteSpace,
   reset
 } = useSpaceSettings(toRef(props, 'space'));
 const spacesStore = useSpacesStore();
@@ -220,6 +221,11 @@ function handleControllerSave(value: string) {
 
   saving.value = true;
   executeFn.value = saveController;
+}
+
+function handleSpaceDelete() {
+  saving.value = true;
+  executeFn.value = () => deleteSpace(props.space.id);
 }
 
 function handleTabFocus(event: FocusEvent) {
@@ -512,6 +518,9 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
         v-model:custom-domain="customDomain"
         v-model:is-private="isPrivate"
         :network-id="space.network"
+        :space-id="space.id"
+        :is-controller="isController"
+        @delete-space="handleSpaceDelete"
       />
     </UiContainerSettings>
     <div

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -513,11 +513,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
         />
       </teleport>
     </UiContainerSettings>
-    <UiContainerSettings
-      v-else-if="activeTab === 'advanced'"
-      title="Advanced"
-      description="Office ipsum you must be muted. Boy ocean define crank new."
-    >
+    <UiContainerSettings v-else-if="activeTab === 'advanced'" title="Advanced">
       <FormSpaceAdvanced
         v-model:parent="parent"
         v-model:children="children"

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -513,7 +513,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
         />
       </teleport>
     </UiContainerSettings>
-    <UiContainerSettings v-else-if="activeTab === 'advanced'" title="Advanced">
+    <UiContainerSettings v-show="activeTab === 'advanced'" title="Advanced">
       <FormSpaceAdvanced
         v-model:parent="parent"
         v-model:children="children"

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -25,6 +25,7 @@ const {
   members,
   parent,
   children,
+  termsOfServices,
   save,
   saveController,
   reset
@@ -505,6 +506,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
       <FormSpaceAdvanced
         v-model:parent="parent"
         v-model:children="children"
+        v-model:terms-of-services="termsOfServices"
         :network-id="space.network"
       />
     </UiContainerSettings>

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -39,6 +39,7 @@ const { setTitle } = useTitle();
 const uiStore = useUiStore();
 const { getDurationFromCurrent, getCurrentFromDuration } = useMetaStore();
 
+const hasAdvancedErrors = ref(false);
 const changeControllerModalOpen = ref(false);
 const executeFn = ref(save);
 const saving = ref(false);
@@ -527,11 +528,13 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
         :space-id="space.id"
         :is-controller="isController"
         @delete-space="handleSpaceDelete"
+        @update-validity="v => (hasAdvancedErrors = !v)"
       />
     </UiContainerSettings>
     <div
       v-if="
-        !uiStore.sidebarOpen && ((isModified && canModifySettings) || error)
+        !uiStore.sidebarOpen &&
+        ((isModified && canModifySettings && !hasAdvancedErrors) || error)
       "
       class="fixed bg-skin-bg bottom-0 left-0 right-0 lg:left-[312px] xl:right-[240px] border-y px-4 py-3 flex flex-col xs:flex-row justify-between items-center"
     >

--- a/packages/sx.js/src/clients/offchain/ethereum-sig/index.ts
+++ b/packages/sx.js/src/clients/offchain/ethereum-sig/index.ts
@@ -8,6 +8,7 @@ import {
   approvalVoteTypes,
   basicVoteTypes,
   cancelProposalTypes,
+  deleteSpaceTypes,
   domain,
   encryptedVoteTypes,
   followSpaceTypes,
@@ -25,7 +26,9 @@ import { offchainGoerli } from '../../../offchainNetworks';
 import { OffchainNetworkConfig, SignatureData } from '../../../types';
 import {
   CancelProposal,
+  DeleteSpace,
   EIP712CancelProposalMessage,
+  EIP712DeleteSpaceMessage,
   EIP712FollowSpaceMessage,
   EIP712Message,
   EIP712ProposeMessage,
@@ -86,6 +89,7 @@ export class EthereumSig {
       | EIP712UpdateUserMessage
       | EIP712UpdateStatementMessage
       | EIP712UpdateSpaceMessage
+      | EIP712DeleteSpaceMessage
   >(
     signer: Signer & TypedDataSigner,
     message: T,
@@ -355,6 +359,21 @@ export class EthereumSig {
     data: UpdateSpace;
   }) {
     const signatureData = await this.sign(signer, data, updateSpaceTypes);
+
+    return {
+      signatureData,
+      data
+    };
+  }
+
+  public async deleteSpace({
+    signer,
+    data
+  }: {
+    signer: Signer & TypedDataSigner;
+    data: DeleteSpace;
+  }) {
+    const signatureData = await this.sign(signer, data, deleteSpaceTypes);
 
     return {
       signatureData,

--- a/packages/sx.js/src/clients/offchain/ethereum-sig/types.ts
+++ b/packages/sx.js/src/clients/offchain/ethereum-sig/types.ts
@@ -156,3 +156,11 @@ export const updateSpaceTypes = {
     { name: 'settings', type: 'string' }
   ]
 };
+
+export const deleteSpaceTypes = {
+  DeleteSpace: [
+    { name: 'from', type: 'address' },
+    { name: 'space', type: 'string' },
+    { name: 'timestamp', type: 'uint64' }
+  ]
+};

--- a/packages/sx.js/src/clients/offchain/types.ts
+++ b/packages/sx.js/src/clients/offchain/types.ts
@@ -129,6 +129,12 @@ export type EIP712UpdateSpaceMessage = {
   settings: string;
 };
 
+export type EIP712DeleteSpaceMessage = {
+  from?: string;
+  space: string;
+  timestamp?: number;
+};
+
 export type EIP712Message = Required<
   | EIP712VoteMessage
   | EIP712ProposeMessage
@@ -140,6 +146,7 @@ export type EIP712Message = Required<
   | EIP712UpdateUserMessage
   | EIP712UpdateStatementMessage
   | EIP712UpdateSpaceMessage
+  | EIP712DeleteSpaceMessage
 >;
 
 export type Vote = {
@@ -229,4 +236,10 @@ export type UpdateSpace = {
   timestamp?: number;
   space: string;
   settings: string;
+};
+
+export type DeleteSpace = {
+  from?: string;
+  timestamp?: number;
+  space: string;
 };


### PR DESCRIPTION
### Summary

Adding advanced settings page for offchain spaces with following options:
- Sub-spaces (parent and child spaces)
- Terms of services
- Custom domain
- Hide from homepage
- Delete space

Had to make some adjustments from the design, as not everything was clear:
- Not extraneous modals for parent-space, sub-space, custom-domain (in designs we have input, but also modal that opens for you to type in, which I'm not sure makes sense, here I just use inputs directly avoiding modals.
- Designs didn't cover how already added sub-spaces should look like, so I improvised.
- No tooltip for custom domain input as we don't have it either on v1 so I didn't have text to use.

Closes: #

### How to test

1. Create new space (if you want to delete it, **you will lose ability to recreate space under that domain**).
2. Go to your space, enter settings, you can modify advanced settings.
3. You can delete your space.

### Screenshots

![localhost_8080_ (9)](https://github.com/user-attachments/assets/32a672de-fd48-421f-8b3c-df42c844d334)
