### PR TITLE
fix: use raw bytes for params when comparing

### DIFF
--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -253,9 +253,11 @@ export function useSpaceSettings(space: Ref<Space>) {
       previousParams = previousParams ?? [];
     }
 
-    // NOTE: Params need to be lowercase when we compare them as once stored they will be stored
-    // as bytes (casing is lost).
-    const formattedParams = params.map(param => param.toLowerCase());
+    // NOTE: Params need to be kept in raw bytes when we compare them as once stored they will be stored
+    // as bytes (casing and padding are lost).
+    const formattedParams = params.map(param =>
+      param === '0x' ? param : `0x${BigInt(param).toString(16)}`
+    );
     return objectHash(formattedParams) !== objectHash(previousParams);
   }
 


### PR DESCRIPTION
### Summary

Now our params not only will be lowercase-only, but also:
1. stored as hex
2. unpadded

### How to test

1. Apply diff from below.
2. Go to http://localhost:8080/#/eth:0x6E60b6dCc2923267104Bb4a68F4766f627430664/settings/voting-strategies
3. You don't see save settings prompt.
4. Go to http://localhost:8080/#/sn:0x06f7d16cda7166d007289940ffdf85f18ada9e3fe94f7d75ea260d2bc0ad5a84/settings/authenticators
5. You don't see save settings prompt.

```diff
diff --git a/apps/ui/src/views/Space/Settings.vue b/apps/ui/src/views/Space/Settings.vue
index 1977471f..e70ebc0d 100644
--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -490,9 +490,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
       </teleport>
     </UiContainerSettings>
     <div
-      v-if="
-        !uiStore.sidebarOpen && ((isModified && canModifySettings) || error)
-      "
+      v-if="!uiStore.sidebarOpen && (isModified || error)"
       class="fixed bg-skin-bg bottom-0 left-0 right-0 lg:left-[312px] xl:right-[240px] border-y px-4 py-3 flex flex-col xs:flex-row justify-between items-center"
     >
       <h4
```