### PR TITLE
fix(ui): force a word break on long proposal title

### DIFF
--- a/apps/ui/src/components/Modal/VoteReason.vue
+++ b/apps/ui/src/components/Modal/VoteReason.vue
@@ -18,7 +18,7 @@ defineEmits<{
       <h3 v-text="'Reason'" />
     </template>
     <div
-      class="vote-reason p-4 whitespace-pre-line text-skin-link"
+      class="vote-reason p-4 whitespace-pre-line text-skin-link break-words"
       v-html="autoLinkText(vote?.reason || '')"
     />
   </UiModal>

--- a/apps/ui/src/views/My/Notifications.vue
+++ b/apps/ui/src/views/My/Notifications.vue
@@ -57,7 +57,7 @@ onUnmounted(() => notificationsStore.markAllAsRead());
               }"
             >
               <h3
-                class="font-normal text-[21px]"
+                class="font-normal text-[21px] break-all"
                 v-text="
                   notification.proposal.title ||
                   `#${notification.proposal.proposal_id}`

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -199,7 +199,7 @@ onBeforeUnmount(() => destroyAudio());
 <template>
   <UiContainer class="pt-5 !max-w-[710px] mx-0 md:mx-auto">
     <div>
-      <h1 class="mb-3 text-[40px] leading-[1.1em]">
+      <h1 class="mb-3 text-[40px] leading-[1.1em] break-words">
         {{ proposal.title || `Proposal #${proposal.proposal_id}` }}
       </h1>
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Force word to break on long proposal title

Before fix

![Screenshot 2024-09-21 at 20 29 18](https://github.com/user-attachments/assets/bd621d84-fd65-4c8d-ae07-a3289f19eb05)

After fix

![Screenshot 2024-09-21 at 20 31 37](https://github.com/user-attachments/assets/12918b0a-17ca-466a-bd3f-badb7a4ce9d2)

Also fix same issue with long vote choice


### How to test

1. Go to  http://localhost:8080/#/s:test.wa0x6e.eth/proposal/0x690486495e089e9ecb8f2e68b95e5a988c5446bd6af101d78a3e8633532f874c
2. Open reason modal for vote in http://localhost:8080/#/s:test.wa0x6e.eth/proposal/0x062cc4845a9f7568c931afe3366bd6440b9b43061d98193fa651825f0c8b5173/votes
