### PR TITLE
bug(ux): fix missing vote modal on proposal list

### DIFF
--- a/apps/ui/src/components/ProposalsListItem.vue
+++ b/apps/ui/src/components/ProposalsListItem.vue
@@ -62,4 +62,13 @@ const handleVoteClick = (choice: Choice) => {
       </div>
     </div>
   </div>
+  <teleport to="#modal">
+    <ModalVote
+      :choice="selectedChoice"
+      :proposal="proposal"
+      :open="modalOpenVote"
+      @close="modalOpenVote = false"
+      @voted="selectedChoice = null"
+    />
+  </teleport>
 </template>

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -119,12 +119,5 @@ const totalProgress = computed(() => quorumProgress(props.proposal));
       :proposal="proposal"
       @close="modalOpenTimeline = false"
     />
-    <ModalVote
-      :choice="selectedChoice"
-      :proposal="proposal"
-      :open="modalOpenVote"
-      @close="modalOpenVote = false"
-      @voted="selectedChoice = null"
-    />
   </teleport>
 </template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an issue where clicking on the basic voting choice in the proposal list do not open the voting modal (and not nothing)

### How to test

1. Go to a space with basic choices proposal
2. Go to the /proposals page
3. The basic choice vote form in the proposal list should now work (clicking on any choice should open the vote modal)