### PR TITLE
fix: break long username

### DIFF
--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { quorumLabel, quorumProgress } from '@/helpers/quorum';
 import { _n, _p, _rt, getProposalId, shortenAddress } from '@/helpers/utils';
-import { Choice, Proposal as ProposalType } from '@/types';
+import { Proposal as ProposalType } from '@/types';
 
 const props = withDefaults(
   defineProps<{
@@ -21,8 +21,6 @@ const { getTsFromCurrent } = useMetaStore();
 
 const { votes } = useAccount();
 const modalOpenTimeline = ref(false);
-const modalOpenVote = ref(false);
-const selectedChoice = ref<Choice | null>(null);
 
 const totalProgress = computed(() => quorumProgress(props.proposal));
 </script>

--- a/apps/ui/src/views/SpaceUser.vue
+++ b/apps/ui/src/views/SpaceUser.vue
@@ -203,7 +203,7 @@ watch(
           :cb="cb"
           class="relative mb-2 border-4 border-skin-bg !bg-skin-border !rounded-full -left-1"
         />
-        <h1 v-text="user.name || shortenAddress(user.id)" />
+        <h1 class="break-words" v-text="user.name || shortenAddress(user.id)" />
         <div class="mb-3 text-skin-text">
           <span class="text-skin-link" v-text="userActivity.proposal_count" />
           proposals ·

--- a/apps/ui/src/views/User.vue
+++ b/apps/ui/src/views/User.vue
@@ -147,7 +147,7 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
           :cb="cb"
           class="relative mb-2 border-[4px] border-skin-bg !bg-skin-border !rounded-full left-[-4px]"
         />
-        <h1 v-text="user.name || shortenAddress(user.id)" />
+        <h1 class="break-words" v-text="user.name || shortenAddress(user.id)" />
         <div class="mb-3 flex items-center space-x-2">
           <span class="text-skin-text" v-text="shortenAddress(user.id)" />
           <UiTooltip title="Copy address">


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR break long username into multiple lines when necessary, to avoid UI issues like

![Screenshot 2024-09-22 at 11 18 32](https://github.com/user-attachments/assets/99e52cd0-6be0-4a46-b65f-675465df5be4)


### How to test

1. Go to http://localhost:8080/#/profile/0xab54624A67E8c018a06B176bAAE76a40a385A464
2. Go to https://snapshot.box/#/s:test.wa0x6e.eth/profile/0xab54624A67E8c018a06B176bAAE76a40a385A464
3. Username should not overflow