### PR TITLE
fix: break long words in proposal title

### DIFF
--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -41,7 +41,7 @@ const totalProgress = computed(() => quorumProgress(props.proposal));
         <ProposalIconStatus size="17" :state="proposal.state" class="top-1.5" />
       </AppLink>
 
-      <div class="flex min-w-0 my-1 items-center leading-6">
+      <div class="md:flex md:min-w-0 my-1 items-center leading-6">
         <AppLink
           v-if="showSpace"
           :to="{
@@ -63,7 +63,7 @@ const totalProgress = computed(() => quorumProgress(props.proposal));
               space: `${proposal.network}:${proposal.space.id}`
             }
           }"
-          class="flex min-w-0"
+          class="md:flex md:min-w-0"
         >
           <h3
             class="text-[21px] inline [overflow-wrap:anywhere] md:truncate mr-2"

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -41,7 +41,7 @@ const totalProgress = computed(() => quorumProgress(props.proposal));
         <ProposalIconStatus size="17" :state="proposal.state" class="top-1.5" />
       </AppLink>
 
-      <div class="md:flex md:min-w-0 my-1 items-center leading-6">
+      <div class="flex min-w-0 my-1 items-center leading-6">
         <AppLink
           v-if="showSpace"
           :to="{
@@ -63,10 +63,10 @@ const totalProgress = computed(() => quorumProgress(props.proposal));
               space: `${proposal.network}:${proposal.space.id}`
             }
           }"
-          class="md:flex md:min-w-0"
+          class="flex min-w-0"
         >
           <h3
-            class="text-[21px] inline break-all md:truncate mr-2"
+            class="text-[21px] inline [overflow-wrap:anywhere] md:truncate mr-2"
             v-text="proposal.title || `Proposal #${proposal.proposal_id}`"
           />
           <IH-check

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -66,7 +66,7 @@ const totalProgress = computed(() => quorumProgress(props.proposal));
           class="md:flex md:min-w-0"
         >
           <h3
-            class="text-[21px] inline md:truncate mr-2"
+            class="text-[21px] inline break-all md:truncate mr-2"
             v-text="proposal.title || `Proposal #${proposal.proposal_id}`"
           />
           <IH-check

--- a/apps/ui/src/views/My/Notifications.vue
+++ b/apps/ui/src/views/My/Notifications.vue
@@ -57,7 +57,7 @@ onUnmounted(() => notificationsStore.markAllAsRead());
               }"
             >
               <h3
-                class="font-normal text-[21px] break-all"
+                class="font-normal text-[21px] [overflow-wrap:anywhere]"
                 v-text="
                   notification.proposal.title ||
                   `#${notification.proposal.proposal_id}`

--- a/apps/ui/src/views/SpaceUser/Votes.vue
+++ b/apps/ui/src/views/SpaceUser/Votes.vue
@@ -130,7 +130,7 @@ watchEffect(() =>
         :show-author="true"
         :show-space="false"
         :show-voted-indicator="false"
-        class="grow truncate"
+        class="grow truncate w-[65%]"
       />
       <div class="w-[35%] md:w-[220px] shrink-0 flex items-center">
         <ProposalVoteChoice

--- a/apps/ui/src/views/SpaceUser/Votes.vue
+++ b/apps/ui/src/views/SpaceUser/Votes.vue
@@ -130,7 +130,7 @@ watchEffect(() =>
         :show-author="true"
         :show-space="false"
         :show-voted-indicator="false"
-        class="grow truncate w-[65%]"
+        class="grow truncate"
       />
       <div class="w-[35%] md:w-[220px] shrink-0 flex items-center">
         <ProposalVoteChoice


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR break long words in proposal title

Before fix 

![Screenshot 2024-09-22 at 13 25 14](https://github.com/user-attachments/assets/a751133f-181e-4658-864b-1094322ce487)

After fix

![Screenshot 2024-09-22 at 13 22 58](https://github.com/user-attachments/assets/2699c9a8-51d3-4bd0-a9f4-17744514f813)

This uses the `[overflow-wrap:anywhere]` class to break words properly, since the `break-words` class by tailwind does not cover this use case. See https://github.com/tailwindlabs/tailwindcss/discussions/2213

### How to test

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth/proposals
2. On wide screen, proposal title should be truncated
3. On small screen, proposal title should be on multiple lines
