### PR TITLE
fix: do not poll notifications when follow list is empty

### DIFF
--- a/apps/ui/src/stores/notifications.ts
+++ b/apps/ui/src/stores/notifications.ts
@@ -134,6 +134,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
         }
       } else if (!followedSpacesIds.length && refreshNotificationInterval) {
         clearInterval(refreshNotificationInterval);
+        refreshNotificationInterval = 0;
       }
     },
     { immediate: true }

--- a/apps/ui/src/stores/notifications.ts
+++ b/apps/ui/src/stores/notifications.ts
@@ -117,8 +117,8 @@ export const useNotificationsStore = defineStore('notifications', () => {
       () => followedSpacesStore.followedSpacesLoaded,
       () => followedSpacesStore.followedSpacesIds
     ],
-    async ([followedSpacesLoaded]) => {
-      if (!followedSpacesLoaded) return;
+    async ([followedSpacesLoaded, followedSpacesIds]) => {
+      if (!followedSpacesLoaded || followedSpacesIds.length === 0) return;
 
       loading.value = true;
       notifications.value = [];


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #785 

This PR start and stop the notification polling only when relevant.

- It starts the poller only when follow list is not empty
- It stops the poller when follow list is empty

### How to test

1. Apply diff to print console

```diff
diff --git a/apps/ui/src/stores/notifications.ts b/apps/ui/src/stores/notifications.ts
index 24638e43..b920bd95 100644
--- a/apps/ui/src/stores/notifications.ts
+++ b/apps/ui/src/stores/notifications.ts
@@ -127,12 +127,14 @@ export const useNotificationsStore = defineStore('notifications', () => {
         loading.value = false;

         if (!refreshNotificationInterval) {
+          console.log('start poller');
           refreshNotificationInterval = window.setInterval(
             loadNotifications,
             REFRESH_INTERVAL * 1000
           );
         }
       } else if (!followedSpacesIds.length && refreshNotificationInterval) {
+        console.log('stop poller');
         clearInterval(refreshNotificationInterval);
         refreshNotificationInterval = 0;
       }
```

2. Connect to your account with some follow list
3. It should print `start poller`
4. Switch wallet to an account without empty follow list
5. It should stop the poller
6. Try testing going back and forth account with/without follow list, logging out, logging in
7. It should start the poller only when there is some spaces in follow list
8. It should stop the poller when it was previously started, and there is currently no items in the follow list
