### PR TITLE
fix: show an error when discussion link is invalid

### DIFF
--- a/apps/ui/src/helpers/discourse.ts
+++ b/apps/ui/src/helpers/discourse.ts
@@ -136,6 +136,10 @@ export async function loadSingleTopic(url: string): Promise<Topic> {
   );
   const topic = await res.json();
 
+  if (topic.errors) {
+    throw new Error(topic.error_type);
+  }
+
   topic.posts_count--;
   topic.posts = formatPosts(topic.post_stream?.posts, baseUrl);
   return topic;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #767 

Show an error message when the discussion link is invalid

### How to test

1. Go to http://localhost:8080/#/s:safe.eth/discussions/25745677484848
2. It shows the message `Error while loading the topic.`, instead of empty topic list
