### PR TITLE
fix: Editor title should reflect update status

### DIFF
--- a/apps/ui/src/views/Editor.vue
+++ b/apps/ui/src/views/Editor.vue
@@ -345,7 +345,10 @@ export default defineComponent({
             <IH-arrow-narrow-left class="inline-block" />
           </UiButton>
         </AppLink>
-        <h4 class="grow truncate">New proposal</h4>
+        <h4
+          class="grow truncate"
+          v-text="proposal?.proposalId ? 'Update proposal' : 'New proposal'"
+        />
         <IndicatorPendingTransactions />
         <UiLoading v-if="!space" class="block p-4" />
         <template v-else>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward #801

This PR shows the correct title in TopNav when editing a proposal

### How to test

1. Go to a proposal edition page
2. The tiltle in topnav should now says "Update proposal"
