### PR TITLE
feat: Show hints on proposal editor to get verified or to get turbo

### DIFF
--- a/apps/ui/src/components/EditorChoices.vue
+++ b/apps/ui/src/components/EditorChoices.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import Draggable from 'vuedraggable';
-import { TURBO_URL } from '@/helpers/turbo';
 import { Draft } from '@/types';
 
 const proposal = defineModel<Draft>({ required: true });
 
 const props = defineProps<{
   error?: string;
-  errorSuffix?: boolean;
   definition: any;
 }>();
 
@@ -102,14 +100,7 @@ function handlePressDelete(event: KeyboardEvent, index: number) {
     </div>
     <div v-if="showError" class="s-input-error-message leading-6 mt-2">
       <span v-text="error" />
-      <span v-if="errorSuffix" class="ml-1">
-        <a
-          :href="TURBO_URL"
-          target="_blank"
-          class="text-skin-danger font-semibold"
-          >Increase limit</a
-        >.
-      </span>
+      <slot name="error-suffix" />
     </div>
   </div>
 </template>

--- a/apps/ui/src/components/EditorChoices.vue
+++ b/apps/ui/src/components/EditorChoices.vue
@@ -6,6 +6,7 @@ const proposal = defineModel<Draft>({ required: true });
 
 const props = defineProps<{
   error?: string;
+  definition: any;
 }>();
 
 const choices: Ref<any[]> = ref([]);

--- a/apps/ui/src/components/EditorChoices.vue
+++ b/apps/ui/src/components/EditorChoices.vue
@@ -6,7 +6,6 @@ const proposal = defineModel<Draft>({ required: true });
 
 const props = defineProps<{
   error?: string;
-  definition: any;
 }>();
 
 const choices: Ref<any[]> = ref([]);

--- a/apps/ui/src/components/EditorChoices.vue
+++ b/apps/ui/src/components/EditorChoices.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
 import Draggable from 'vuedraggable';
+import { TURBO_URL } from '@/helpers/turbo';
 import { Draft } from '@/types';
 
 const proposal = defineModel<Draft>({ required: true });
 
-defineProps<{ definition: any }>();
+const props = defineProps<{
+  error?: string;
+  errorSuffix?: boolean;
+  definition: any;
+}>();
 
 const choices: Ref<any[]> = ref([]);
+const showError = computed<boolean>(() => !!props.error);
 
 function handleAddChoice() {
   proposal.value.choices.push('');
@@ -32,7 +38,12 @@ function handlePressDelete(event: KeyboardEvent, index: number) {
 </script>
 
 <template>
-  <div class="s-base mb-5">
+  <div
+    class="s-base mb-5"
+    :class="{
+      's-error': showError
+    }"
+  >
     <h4 class="eyebrow mb-2.5">Choices</h4>
     <div class="flex flex-col">
       <Draggable
@@ -88,6 +99,17 @@ function handlePressDelete(event: KeyboardEvent, index: number) {
         <IH-plus-sm />
         <span>Add choice</span>
       </UiButton>
+    </div>
+    <div v-if="showError" class="s-input-error-message leading-6 mt-2">
+      <span v-text="error" />
+      <span v-if="errorSuffix" class="ml-1">
+        <a
+          :href="TURBO_URL"
+          target="_blank"
+          class="text-skin-danger font-semibold"
+          >Increase limit</a
+        >.
+      </span>
     </div>
   </div>
 </template>

--- a/apps/ui/src/components/Ui/Composer.vue
+++ b/apps/ui/src/components/Ui/Composer.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+import { TURBO_URL } from '@/helpers/turbo';
 import { _n } from '@/helpers/utils';
 
 const model = defineModel<string>({ required: true });
 
 const props = defineProps<{
   error?: string;
+  errorSuffix?: boolean;
   definition: any;
 }>();
 
@@ -124,7 +126,17 @@ watch(model, () => {
       :placeholder="definition?.examples ? definition.examples[0] : ''"
       class="s-input h-[260px]"
     />
-    <div v-if="showError" class="s-input-error-message" v-text="error" />
+    <div v-if="showError" class="s-input-error-message leading-6 mt-2">
+      <span v-text="error" />
+      <span v-if="errorSuffix" class="ml-1">
+        <a
+          :href="TURBO_URL"
+          target="_blank"
+          class="text-skin-danger font-semibold"
+          >Increase limit</a
+        >.
+      </span>
+    </div>
   </div>
 </template>
 

--- a/apps/ui/src/components/Ui/Composer.vue
+++ b/apps/ui/src/components/Ui/Composer.vue
@@ -6,7 +6,6 @@ const model = defineModel<string>({ required: true });
 
 const props = defineProps<{
   error?: string;
-  errorSuffix?: boolean;
   definition: any;
 }>();
 
@@ -128,14 +127,7 @@ watch(model, () => {
     />
     <div v-if="showError" class="s-input-error-message leading-6 mt-2">
       <span v-text="error" />
-      <span v-if="errorSuffix" class="ml-1">
-        <a
-          :href="TURBO_URL"
-          target="_blank"
-          class="text-skin-danger font-semibold"
-          >Increase limit</a
-        >.
-      </span>
+      <slot name="error-suffix" />
     </div>
   </div>
 </template>

--- a/apps/ui/src/components/Ui/Composer.vue
+++ b/apps/ui/src/components/Ui/Composer.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { TURBO_URL } from '@/helpers/turbo';
 import { _n } from '@/helpers/utils';
 
 const model = defineModel<string>({ required: true });

--- a/apps/ui/src/helpers/turbo.ts
+++ b/apps/ui/src/helpers/turbo.ts
@@ -1,0 +1,26 @@
+export const MAX_BODY_LENGTH = {
+  default: 10000,
+  turbo: 40000
+};
+
+export const MAX_CHOICES = {
+  default: 500,
+  turbo: 1000
+};
+
+export const MAX_1D_PROPOSALS = {
+  default: 3,
+  verified: 20,
+  turbo: 40
+};
+
+export const MAX_30D_PROPOSALS = {
+  default: 15,
+  verified: 100,
+  turbo: 200
+};
+
+export const TURBO_URL =
+  'https://docs.snapshot.org/user-guides/spaces/turbo-plan';
+export const VERIFIED_URL =
+  'https://docs.snapshot.org/user-guides/spaces/get-verified';

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -287,10 +287,6 @@ function getErrorMessage(errorObject: Partial<ErrorObject>): string {
     if (!errorObject.params) return 'Invalid format.';
     return `Must not have more than ${_n(errorObject.params.limit)} characters.`;
   }
-  if (errorObject.keyword === 'maxItems') {
-    if (!errorObject.params) return 'Invalid format.';
-    return `Must not have more than ${_n(errorObject.params.limit)} items.`;
-  }
   return `${errorObject.message.charAt(0).toLocaleUpperCase()}${errorObject.message
     .slice(1)
     .toLocaleLowerCase()}.`;

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -6,6 +6,7 @@ import ajvErrors from 'ajv-errors';
 import addFormats from 'ajv-formats';
 import { validateAndParseAddress } from 'starknet';
 import { resolver } from '@/helpers/resolver';
+import { _n } from './utils';
 
 type Opts = { skipEmptyOptionalFields: boolean };
 
@@ -271,6 +272,10 @@ function getErrorMessage(errorObject: Partial<ErrorObject>): string {
     }
   }
 
+  if (errorObject.keyword === 'maxLength') {
+    if (!errorObject.params) return 'Invalid format.';
+    return `Must not have more than ${_n(errorObject.params.limit)} characters.`;
+  }
   return `${errorObject.message.charAt(0).toLocaleUpperCase()}${errorObject.message
     .slice(1)
     .toLocaleLowerCase()}.`;
@@ -308,7 +313,9 @@ const getErrors = (errors: Partial<ErrorObject>[]) => {
     let current = output;
     for (let i = 0; i < path.length - 1; i++) {
       const subpath = path[i];
-      if (!current[subpath]) current[subpath] = {};
+      if (typeof current[subpath] !== 'object' || current[subpath] === null) {
+        current[subpath] = {};
+      }
       current = current[subpath];
     }
 

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -276,6 +276,10 @@ function getErrorMessage(errorObject: Partial<ErrorObject>): string {
     if (!errorObject.params) return 'Invalid format.';
     return `Must not have more than ${_n(errorObject.params.limit)} characters.`;
   }
+  if (errorObject.keyword === 'maxItems') {
+    if (!errorObject.params) return 'Invalid format.';
+    return `Must not have more than ${_n(errorObject.params.limit)} items.`;
+  }
   return `${errorObject.message.charAt(0).toLocaleUpperCase()}${errorObject.message
     .slice(1)
     .toLocaleLowerCase()}.`;

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -178,6 +178,8 @@ function formatSpace(
     twitter: space.twitter || '',
     discord: '',
     coingecko: space.coingecko || '',
+    proposal_count_1d: space.proposalsCount1d,
+    proposal_count_30d: space.proposalsCount30d,
     proposal_count: space.proposalsCount,
     vote_count: space.votesCount,
     follower_count: space.followersCount,

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -51,6 +51,8 @@ const SPACE_FRAGMENT = gql`
       onlyMembers
     }
     proposalsCount
+    proposalsCount1d
+    proposalsCount30d
     votesCount
     followersCount
     children {

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -58,6 +58,8 @@ export type ApiSpace = {
     onlyMembers: boolean;
   };
   proposalsCount: number;
+  proposalsCount1d: number;
+  proposalsCount30d: number;
   votesCount: number;
   followersCount: number;
   children: [ApiRelatedSpace];

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -189,6 +189,8 @@ export type Space = {
     treasury_chain: number | null;
   }[];
   proposal_count: number;
+  proposal_count_1d?: number;
+  proposal_count_30d?: number;
   vote_count: number;
   follower_count?: number;
   created: number;

--- a/apps/ui/src/views/Editor.vue
+++ b/apps/ui/src/views/Editor.vue
@@ -10,7 +10,7 @@ import {
   TURBO_URL,
   VERIFIED_URL
 } from '@/helpers/turbo';
-import { omit } from '@/helpers/utils';
+import { _n, omit } from '@/helpers/utils';
 import { validateForm } from '@/helpers/validation';
 import { getNetwork, offchainNetworks } from '@/networks';
 import { Contact, Transaction, VoteType } from '@/types';
@@ -477,12 +477,23 @@ export default defineComponent({
           v-model="proposal.body"
           :definition="bodyDefinition"
           :error="formErrors.body"
-          :error-suffix="
-            !space?.turbo &&
-            isOffchainSpace &&
-            formErrors.body?.startsWith('Must not have more than')
-          "
-        />
+        >
+          <template
+            v-if="
+              !space?.turbo &&
+              isOffchainSpace &&
+              formErrors.body?.startsWith('Must not have more than')
+            "
+            #error-suffix
+          >
+            <a
+              :href="TURBO_URL"
+              target="_blank"
+              class="ml-1 text-skin-danger font-semibold"
+              >Increase limit</a
+            >.
+          </template>
+        </UiComposer>
         <div class="s-base mb-5">
           <UiInputString
             :key="proposalKey || ''"
@@ -536,16 +547,27 @@ export default defineComponent({
         v-model="proposal"
         :definition="choicesDefinition"
         :error="
-          typeof formErrors.choices === 'string' ? formErrors.choices : ''
+          proposal.choices.length > choicesDefinition.maxItems
+            ? `Must not have more than ${_n(choicesDefinition.maxItems)} items.`
+            : ''
         "
-        :error-suffix="
-          !space?.turbo &&
-          isOffchainSpace &&
-          typeof formErrors.choices === 'string' &&
-          formErrors.choices?.startsWith('Must not have more than')
-        "
-      />
-
+      >
+        <template
+          v-if="
+            !space?.turbo &&
+            isOffchainSpace &&
+            proposal.choices.length > choicesDefinition.maxItems
+          "
+          #error-suffix
+        >
+          <a
+            :href="TURBO_URL"
+            target="_blank"
+            class="ml-1 text-skin-danger font-semibold"
+            >Increase limit</a
+          >.
+        </template>
+      </EditorChoices>
       <div>
         <h4 class="eyebrow mb-2.5" v-text="'Timeline'" />
         <ProposalTimeline :data="space" />

--- a/apps/ui/src/views/Editor.vue
+++ b/apps/ui/src/views/Editor.vue
@@ -552,14 +552,7 @@ export default defineComponent({
             : ''
         "
       >
-        <template
-          v-if="
-            !space?.turbo &&
-            isOffchainSpace &&
-            proposal.choices.length > choicesDefinition.maxItems
-          "
-          #error-suffix
-        >
+        <template v-if="!space?.turbo && isOffchainSpace" #error-suffix>
           <a
             :href="TURBO_URL"
             target="_blank"

--- a/apps/ui/src/views/Editor.vue
+++ b/apps/ui/src/views/Editor.vue
@@ -190,11 +190,7 @@ const spaceType = computed(() => {
 
 const proposalLimitReached = computed(() => {
   if (!space.value) return false;
-  console.log(space.value.proposal_count_1d, MAX_1D_PROPOSALS[spaceType.value]);
-  console.log(
-    space.value.proposal_count_30d,
-    MAX_30D_PROPOSALS[spaceType.value]
-  );
+
   return (
     (space.value.proposal_count_1d || 0) >= MAX_1D_PROPOSALS[spaceType.value] ||
     (space.value.proposal_count_30d || 0) >= MAX_30D_PROPOSALS[spaceType.value]
@@ -426,7 +422,7 @@ export default defineComponent({
             <a
               :href="VERIFIED_URL"
               target="_blank"
-              class="text-rose-500 font-semibold"
+              class="text-rose-500 dark:text-neutral-100 font-semibold"
               >Verify space</a
             >.</span
           >
@@ -444,7 +440,7 @@ export default defineComponent({
             <a
               :href="TURBO_URL"
               target="_blank"
-              class="text-rose-500 font-semibold"
+              class="text-rose-500 dark:text-neutral-100 font-semibold"
               >Increase limit</a
             >.</span
           >

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -72,9 +72,12 @@ const proposalData = computed(() => {
 
   return JSON.stringify(omit(proposal.value, ['updatedAt']));
 });
-const supportsMultipleTreasuries = computed(() => {
-  return offchainNetworks.includes(props.space.network);
-});
+const isOffchainSpace = computed(() =>
+  offchainNetworks.includes(props.space.network)
+);
+
+const supportsMultipleTreasuries = computed(() => isOffchainSpace.value);
+
 const editorExecutions = computed(() => {
   if (!proposal.value || !strategiesWithTreasuries.value) return [];
 
@@ -151,25 +154,15 @@ const canSubmit = computed(() => {
     ? votingPower.value?.canPropose
     : !web3.value.authLoading;
 });
-
-const isOffchainSpace = computed(() =>
-  offchainNetworks.includes(props.space.network)
+const spaceType = computed(() =>
+  props.space.turbo ? 'turbo' : props.space.verified ? 'verified' : 'default'
 );
 
-const spaceType = computed(() => {
-  return props.space.turbo
-    ? 'turbo'
-    : props.space.verified
-      ? 'verified'
-      : 'default';
-});
-
-const proposalLimitReached = computed(() => {
-  return (
+const proposalLimitReached = computed(
+  () =>
     (props.space.proposal_count_1d || 0) >= MAX_1D_PROPOSALS[spaceType.value] ||
     (props.space.proposal_count_30d || 0) >= MAX_30D_PROPOSALS[spaceType.value]
-  );
-});
+);
 
 async function handleProposeClick() {
   if (!proposal.value) return;


### PR DESCRIPTION
Following https://github.com/snapshot-labs/sx-monorepo/pull/773 with new design

### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/134

- Show a message when someone tries to post a proposal over the limit
- Show a message when someone tries to add more than the choices limit
- Show a message when someone tries to add more than the body chars limit
- Fix in apps/ui/src/helpers/validation.ts - Throws an error if we try to add more choices than the limit while keeping all choices empty

### How to test

1.  Update limits in apps/ui/src/helpers/turbo.ts
2. Also update `verified` or `turbo` in https://github.com/snapshot-labs/sx-monorepo/blob/feat-turbo-hints/apps/ui/src/networks/offchain/api/index.ts#L168-L169

When body chars limit is reached:
![image](https://github.com/user-attachments/assets/19c8445e-0ecc-42a9-a1d2-21812995af2b)

On turbo space:
![image](https://github.com/user-attachments/assets/d8d5901b-a686-4220-8920-544ea1b3abf7)

On Non-offchain spaces:
![image](https://github.com/user-attachments/assets/1f2072de-7382-4883-8e2a-d53ab92d9d26)

When choices limit is reached:
![image](https://github.com/user-attachments/assets/936cdaae-c5fc-42f7-8108-63072282989c)

When proposal limit is reached for non-verified spaces:
![image](https://github.com/user-attachments/assets/47982c98-1332-48d6-867b-e96223339ece)

When proposal limit is reached for verified spaces:
![image](https://github.com/user-attachments/assets/1722679d-259b-48f8-8d72-2bfab8401519)


 