### PR TITLE
fix: do not use null as snapshot for EVM spaces

### DIFF
--- a/apps/ui/src/composables/useVotingPower.ts
+++ b/apps/ui/src/composables/useVotingPower.ts
@@ -25,7 +25,9 @@ export function useVotingPower() {
   const proposalSnapshot = computed(() => {
     if (!proposal.value) return null;
 
-    return proposal.value.state === 'pending' ? null : proposal.value.snapshot;
+    return proposal.value.state === 'pending'
+      ? latestBlock(proposal.value)
+      : proposal.value.snapshot;
   });
 
   const votingPower = computed(
@@ -36,10 +38,10 @@ export function useVotingPower() {
       )
   );
 
-  function latestBlock(space: Space) {
-    return supportsNullCurrent(space.network)
+  function latestBlock(spaceOrProposal: Space | Proposal) {
+    return supportsNullCurrent(spaceOrProposal.network)
       ? null
-      : getCurrent(space.network) ?? 0;
+      : getCurrent(spaceOrProposal.network) ?? 0;
   }
 
   function reset() {


### PR DESCRIPTION
### Summary

I don't remember exactly why, but for EVM we don't support null as block (issue to investigate it: https://github.com/snapshot-labs/sx-monorepo/issues/805).

But we did use null for pending proposals. This PR prevents it.

### How to test

1. You see your VP here: http://localhost:8080/#/sep:0xb58B05A1c8263441Bd74454544fD66CE25D300AD/proposal/61

