### PR TITLE
fix: flip dropdown icons

### DIFF
--- a/apps/ui/src/components/Ui/SelectMultiple.vue
+++ b/apps/ui/src/components/Ui/SelectMultiple.vue
@@ -82,8 +82,8 @@ watch(model, () => {
         >
           {{ currentValue }}
         </span>
-        <IH-chevron-down v-if="open" />
-        <IH-chevron-up v-else />
+        <IH-chevron-up v-if="open" />
+        <IH-chevron-down v-else />
       </ListboxButton>
       <ListboxOptions
         class="top-[59px] overflow-hidden bg-skin-border rounded-b-lg border-t-skin-text/10 border absolute z-30 w-full shadow-xl"


### PR DESCRIPTION
### Summary

Those were defined wrong way around. Should point down if closed, up if opened.

<img width="690" alt="image" src="https://github.com/user-attachments/assets/1a5c6ca3-d483-44cf-884e-92a98458a91b">