### PR TITLE
fix: increase sub space card to accomodate larger stats

### DIFF
--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -144,7 +144,7 @@ watchEffect(() => setTitle(props.space.name));
               :key="child.id"
               :space="child"
               :show-about="false"
-              class="basis-[230px] shrink-0"
+              class="basis-[240px] shrink-0"
             />
           </div>
         </div>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Prevent UI bug on sub spaces like:

![Screenshot 2024-09-23 at 19 37 56](https://github.com/user-attachments/assets/a93b706c-476a-403e-924a-0b5299f9326d)


### How to test

1. Visit http://localhost:8080/#/s:test.wa0x6e.eth
2. All sub-spaces stats should now be on same line
