### PR TITLE
feat: add Strategies settings to offchain spaces.

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -49,6 +49,7 @@
     "@snapshot-labs/lock": "^0.2.7",
     "@snapshot-labs/pineapple": "^1.1.0",
     "@snapshot-labs/prettier-config": "^0.1.0-beta.18",
+    "@snapshot-labs/snapshot.js": "^0.12.13",
     "@snapshot-labs/sx": "^0.1.0",
     "@vueuse/core": "^10.4.1",
     "@walletconnect/core": "^2.11.0",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -42,6 +42,7 @@
     "@ethersproject/strings": "^5.7.0",
     "@ethersproject/units": "^5.7.0",
     "@ethersproject/wallet": "^5.7.0",
+    "@headlessui-float/vue": "^0.15.0",
     "@headlessui/vue": "^1.7.16",
     "@openzeppelin/merkle-tree": "^1.0.5",
     "@snapshot-labs/eslint-config-vue": "^0.1.0-beta.18",

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -6,6 +6,7 @@ import {
   ComboboxOption,
   ComboboxOptions
 } from '@headlessui/vue';
+import { Float } from '@headlessui-float/vue';
 import { VNode } from 'vue';
 
 export type Item<T extends string | number> = {
@@ -73,49 +74,53 @@ watch(model, () => {
     :dirty="dirty"
     class="relative mb-[14px]"
   >
-    <Combobox v-slot="{ open }" v-model="inputValue">
-      <ComboboxButton class="w-full">
-        <ComboboxInput
-          class="s-input !flex items-center justify-between !mb-0"
-          :class="{
-            '!rounded-b-none': open
-          }"
-          autocomplete="off"
-          :placeholder="definition.examples?.[0]"
-          :display-value="item => getDisplayValue(item as T)"
-          @change="e => (query = e.target.value)"
-          @focus="event => handleFocus(event, open)"
-        />
-      </ComboboxButton>
-      <ComboboxButton class="absolute right-3 bottom-[14px]">
-        <IH-chevron-up v-if="open" />
-        <IH-chevron-down v-else />
-      </ComboboxButton>
-      <ComboboxOptions
-        class="top-[59px] overflow-hidden bg-skin-border rounded-b-lg border-t-skin-text/10 border absolute z-30 w-full shadow-xl"
-      >
-        <div class="max-h-[208px] overflow-y-auto px-3">
-          <ComboboxOption
-            v-for="item in filteredOptions"
-            v-slot="{ selected, disabled }"
-            :key="item.id"
-            :value="item.id"
-            class="flex items-center justify-between"
-          >
-            <component :is="item.icon" class="size-[20px] mr-2" />
-            <span
-              class="w-full py-2 text-skin-link"
+    <Combobox v-slot="{ open }" v-model="inputValue" as="div">
+      <Float adaptive-width strategy="fixed" placement="bottom-end">
+        <div>
+          <ComboboxButton class="w-full">
+            <ComboboxInput
+              class="s-input !flex items-center justify-between !mb-0"
               :class="{
-                'opacity-40': disabled,
-                'cursor-pointer': !disabled
+                '!rounded-b-none': open
               }"
-            >
-              {{ item.name }}
-            </span>
-            <IH-check v-if="selected" class="text-skin-success" />
-          </ComboboxOption>
+              autocomplete="off"
+              :placeholder="definition.examples?.[0]"
+              :display-value="item => getDisplayValue(item as T)"
+              @change="e => (query = e.target.value)"
+              @focus="event => handleFocus(event, open)"
+            />
+          </ComboboxButton>
+          <ComboboxButton class="absolute right-3 bottom-[14px]">
+            <IH-chevron-up v-if="open" />
+            <IH-chevron-down v-else />
+          </ComboboxButton>
         </div>
-      </ComboboxOptions>
+        <ComboboxOptions
+          class="w-full bg-skin-border rounded-b-lg border-t-skin-text/10 border shadow-xl"
+        >
+          <div class="max-h-[208px] px-3 overflow-y-auto">
+            <ComboboxOption
+              v-for="item in filteredOptions"
+              v-slot="{ selected, disabled }"
+              :key="item.id"
+              :value="item.id"
+              class="flex items-center justify-between"
+            >
+              <component :is="item.icon" class="size-[20px] mr-2" />
+              <span
+                class="w-full py-2 text-skin-link"
+                :class="{
+                  'opacity-40': disabled,
+                  'cursor-pointer': !disabled
+                }"
+              >
+                {{ item.name }}
+              </span>
+              <IH-check v-if="selected" class="text-skin-success" />
+            </ComboboxOption>
+          </div>
+        </ComboboxOptions>
+      </Float>
     </Combobox>
   </UiWrapperInput>
 </template>

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -50,6 +50,12 @@ const inputValue = computed({
   }
 });
 
+function handleFocus(event: FocusEvent, open: boolean) {
+  if (!event.target || open) return;
+
+  (event.target as HTMLInputElement).select();
+}
+
 function getDisplayValue(value: T) {
   const option = props.definition.options.find(option => option.id === value);
   return option ? option.name : '';
@@ -78,6 +84,7 @@ watch(model, () => {
           :placeholder="definition.examples?.[0]"
           :display-value="item => getDisplayValue(item as T)"
           @change="e => (query = e.target.value)"
+          @focus="event => handleFocus(event, open)"
         />
       </ComboboxButton>
       <ComboboxButton class="absolute right-3 bottom-[14px]">

--- a/apps/ui/src/components/FormSpaceStrategies.vue
+++ b/apps/ui/src/components/FormSpaceStrategies.vue
@@ -63,7 +63,11 @@ function handleRemoveStrategy(strategy: StrategyConfig) {
 <template>
   <h4 class="eyebrow mb-2 font-medium">Strategies</h4>
   <div class="s-box mb-4">
-    <UiSelectorNetwork v-model="snapshotChainId" :network-id="networkId" />
+    <UiSelectorNetwork
+      v-model="snapshotChainId"
+      :network-id="networkId"
+      tooltip="The default network used for this space. Networks can also be specified in individual strategies"
+    />
   </div>
   <UiContainerSettings
     title="Select up to 8 strategies"

--- a/apps/ui/src/components/FormSpaceStrategies.vue
+++ b/apps/ui/src/components/FormSpaceStrategies.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { getUrl } from '@/helpers/utils';
+import { StrategyConfig } from '@/networks/types';
 import { NetworkID } from '@/types';
 
 const snapshotChainId = defineModel<string>('snapshotChainId', {
+  required: true
+});
+const strategies = defineModel<StrategyConfig[]>('strategies', {
   required: true
 });
 
@@ -47,6 +51,13 @@ const SPACE_CATEGORIES = Object.entries(networks)
     title="Select up to 8 strategies"
     description="(Voting power is cumulative)"
   >
+    <FormStrategiesStrategyActive
+      v-for="strategy in strategies"
+      :key="strategy.id"
+      class="mb-3"
+      :network-id="networkId"
+      :strategy="strategy"
+    />
     <UiButton class="w-full flex items-center justify-center gap-1">
       <IH-plus class="shrink-0 size-[16px]" />
       Add strategy

--- a/apps/ui/src/components/FormSpaceStrategies.vue
+++ b/apps/ui/src/components/FormSpaceStrategies.vue
@@ -15,6 +15,8 @@ const props = defineProps<{
   networkId: NetworkID;
 }>();
 
+const isStrategiesModalOpen = ref(false);
+
 function removeStrategy(strategy: StrategyConfig) {
   strategies.value = strategies.value.filter(s => s.id !== strategy.id);
 }
@@ -66,9 +68,19 @@ const SPACE_CATEGORIES = Object.entries(networks)
         @delete-strategy="removeStrategy"
       />
     </div>
-    <UiButton class="w-full flex items-center justify-center gap-1">
+    <UiButton
+      class="w-full flex items-center justify-center gap-1"
+      @click="isStrategiesModalOpen = true"
+    >
       <IH-plus class="shrink-0 size-[16px]" />
       Add strategy
     </UiButton>
   </UiContainerSettings>
+  <teleport to="#modal">
+    <ModalStrategies
+      :open="isStrategiesModalOpen"
+      :network-id="networkId"
+      @close="isStrategiesModalOpen = false"
+    />
+  </teleport>
 </template>

--- a/apps/ui/src/components/FormSpaceStrategies.vue
+++ b/apps/ui/src/components/FormSpaceStrategies.vue
@@ -2,6 +2,8 @@
 import { StrategyConfig, StrategyTemplate } from '@/networks/types';
 import { NetworkID } from '@/types';
 
+const LIMIT = 8;
+
 const snapshotChainId = defineModel<string>('snapshotChainId', {
   required: true
 });
@@ -70,7 +72,7 @@ function handleRemoveStrategy(strategy: StrategyConfig) {
     />
   </div>
   <UiContainerSettings
-    title="Select up to 8 strategies"
+    :title="`Select up to ${LIMIT} strategies`"
     description="(Voting power is cumulative)"
   >
     <div class="space-y-3 mb-3">
@@ -86,6 +88,7 @@ function handleRemoveStrategy(strategy: StrategyConfig) {
       />
     </div>
     <UiButton
+      v-if="strategies.length < LIMIT"
       class="w-full flex items-center justify-center gap-1"
       @click="isStrategiesModalOpen = true"
     >

--- a/apps/ui/src/components/FormSpaceStrategies.vue
+++ b/apps/ui/src/components/FormSpaceStrategies.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
+import { MAX_STRATEGIES } from '@/helpers/turbo';
 import { StrategyConfig, StrategyTemplate } from '@/networks/types';
-import { NetworkID } from '@/types';
-
-const LIMIT = 8;
+import { NetworkID, Space } from '@/types';
 
 const snapshotChainId = defineModel<string>('snapshotChainId', {
   required: true
@@ -11,13 +10,24 @@ const strategies = defineModel<StrategyConfig[]>('strategies', {
   required: true
 });
 
-defineProps<{
+const props = defineProps<{
   networkId: NetworkID;
+  space: Space;
 }>();
 
 const isStrategiesModalOpen = ref(false);
 const isEditStrategyModalOpen = ref(false);
 const editedStrategy: Ref<StrategyConfig | null> = ref(null);
+
+const strategiesLimit = computed(() => {
+  const spaceType = props.space.turbo
+    ? 'turbo'
+    : props.space.verified
+      ? 'verified'
+      : 'default';
+
+  return MAX_STRATEGIES[spaceType];
+});
 
 function handleAddStrategy(strategy: StrategyTemplate) {
   editedStrategy.value = {
@@ -72,7 +82,7 @@ function handleRemoveStrategy(strategy: StrategyConfig) {
     />
   </div>
   <UiContainerSettings
-    :title="`Select up to ${LIMIT} strategies`"
+    :title="`Select up to ${strategiesLimit} strategies`"
     description="(Voting power is cumulative)"
   >
     <div class="space-y-3 mb-3">
@@ -88,7 +98,7 @@ function handleRemoveStrategy(strategy: StrategyConfig) {
       />
     </div>
     <UiButton
-      v-if="strategies.length < LIMIT"
+      v-if="strategies.length < strategiesLimit"
       class="w-full flex items-center justify-center gap-1"
       @click="isStrategiesModalOpen = true"
     >

--- a/apps/ui/src/components/FormSpaceStrategies.vue
+++ b/apps/ui/src/components/FormSpaceStrategies.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import objectHash from 'object-hash';
 import { MAX_STRATEGIES } from '@/helpers/turbo';
 import { StrategyConfig, StrategyTemplate } from '@/networks/types';
 import { NetworkID, Space } from '@/types';
@@ -78,6 +79,24 @@ function handleSaveStrategy(params: Record<string, any>, network: string) {
   });
 }
 
+function validateStrategy(params: Record<string, any>, network: string) {
+  const editedStrategyValue = editedStrategy.value;
+  if (editedStrategyValue === null) return;
+
+  const otherStrategies = strategies.value.filter(
+    s => s.id !== editedStrategyValue.id
+  );
+
+  const hasDuplicates = otherStrategies.some(
+    s =>
+      s.address === editedStrategyValue.address &&
+      s.chainId === network &&
+      objectHash(s.params) === objectHash(params)
+  );
+
+  if (hasDuplicates) return 'Two identical strategies are not allowed.';
+}
+
 function handleRemoveStrategy(strategy: StrategyConfig) {
   strategies.value = strategies.value.filter(s => s.id !== strategy.id);
 }
@@ -146,6 +165,7 @@ watchEffect(() => {
       :strategy-address="editedStrategy.address"
       :definition="editedStrategy.paramsDefinition"
       :initial-state="editedStrategy.params"
+      :custom-error-validation="validateStrategy"
       @save="handleSaveStrategy"
       @close="isEditStrategyModalOpen = false"
     />

--- a/apps/ui/src/components/FormSpaceStrategies.vue
+++ b/apps/ui/src/components/FormSpaceStrategies.vue
@@ -15,6 +15,10 @@ const props = defineProps<{
   networkId: NetworkID;
 }>();
 
+function removeStrategy(strategy: StrategyConfig) {
+  strategies.value = strategies.value.filter(s => s.id !== strategy.id);
+}
+
 const SPACE_CATEGORIES = Object.entries(networks)
   .filter(([, network]) => {
     if (props.networkId === 's' && 'testnet' in network && network.testnet) {
@@ -51,13 +55,17 @@ const SPACE_CATEGORIES = Object.entries(networks)
     title="Select up to 8 strategies"
     description="(Voting power is cumulative)"
   >
-    <FormStrategiesStrategyActive
-      v-for="strategy in strategies"
-      :key="strategy.id"
-      class="mb-3"
-      :network-id="networkId"
-      :strategy="strategy"
-    />
+    <div class="space-y-3 mb-3">
+      <div v-if="strategies.length === 0">No strategies selected</div>
+      <FormStrategiesStrategyActive
+        v-for="strategy in strategies"
+        :key="strategy.id"
+        class="mb-3"
+        :network-id="networkId"
+        :strategy="strategy"
+        @delete-strategy="removeStrategy"
+      />
+    </div>
     <UiButton class="w-full flex items-center justify-center gap-1">
       <IH-plus class="shrink-0 size-[16px]" />
       Add strategy

--- a/apps/ui/src/components/FormSpaceStrategies.vue
+++ b/apps/ui/src/components/FormSpaceStrategies.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { getUrl } from '@/helpers/utils';
+import { NetworkID } from '@/types';
+
+const snapshotChainId = defineModel<string>('snapshotChainId', {
+  required: true
+});
+
+const props = defineProps<{
+  networkId: NetworkID;
+}>();
+
+const SPACE_CATEGORIES = Object.entries(networks)
+  .filter(([, network]) => {
+    if (props.networkId === 's' && 'testnet' in network && network.testnet) {
+      return false;
+    }
+
+    return true;
+  })
+  .map(([id, network]) => ({
+    id,
+    name: network.name,
+    icon: h('img', {
+      src: getUrl(network.logo),
+      alt: network.name
+    })
+  }));
+</script>
+
+<template>
+  <h4 class="eyebrow mb-2 font-medium">Strategies</h4>
+  <div class="s-box mb-4">
+    <Combobox
+      v-model="snapshotChainId"
+      :definition="{
+        type: 'string',
+        enum: SPACE_CATEGORIES.map(c => c.id),
+        title: 'Network',
+        options: SPACE_CATEGORIES,
+        examples: ['Select network']
+      }"
+    />
+  </div>
+  <UiContainerSettings
+    title="Select up to 8 strategies"
+    description="(Voting power is cumulative)"
+  >
+    <UiButton class="w-full flex items-center justify-center gap-1">
+      <IH-plus class="shrink-0 size-[16px]" />
+      Add strategy
+    </UiButton>
+  </UiContainerSettings>
+</template>

--- a/apps/ui/src/components/FormStrategiesStrategyActive.vue
+++ b/apps/ui/src/components/FormStrategiesStrategyActive.vue
@@ -99,7 +99,7 @@ const strategyNetworkDetails = computed<NetworkDetails>(() => {
         <div class="flex gap-1 items-center">
           <img
             :src="getUrl(strategyNetworkDetails.logo) || undefined"
-            class="size-3"
+            class="size-3 rounded-full"
           />
           <span class="text-skin-text truncate">
             {{ strategyNetworkDetails.name }}

--- a/apps/ui/src/components/FormStrategiesStrategyActive.vue
+++ b/apps/ui/src/components/FormStrategiesStrategyActive.vue
@@ -31,7 +31,7 @@ defineEmits<{
 }>();
 
 const network = computed(() => getNetwork(props.networkId));
-
+const hasAddress = computed(() => props.strategy.address.startsWith('0x'));
 const strategyNetworkDetails = computed<NetworkDetails>(() => {
   if (!props.strategy.chainId) return null;
   if (!(props.strategy.chainId in networks)) return null;
@@ -66,7 +66,7 @@ const strategyNetworkDetails = computed<NetworkDetails>(() => {
           <IH-trash />
         </button>
         <a
-          v-if="strategy.address"
+          v-if="!hasAddress"
           :href="network.helpers.getExplorerUrl(strategy.address, 'strategy')"
           target="_blank"
           class="text-skin-link"
@@ -75,6 +75,21 @@ const strategyNetworkDetails = computed<NetworkDetails>(() => {
         </a>
       </div>
     </div>
+    <a
+      v-if="hasAddress"
+      :href="network.helpers.getExplorerUrl(strategy.address, 'contract')"
+      target="_blank"
+      class="flex items-center text-skin-text leading-5 mt-1"
+    >
+      <UiStamp
+        :id="strategy.address"
+        type="avatar"
+        :size="18"
+        class="mr-2 !rounded"
+      />
+      {{ shorten(strategy.address) }}
+      <IH-arrow-sm-right class="-rotate-45" />
+    </a>
     <div class="flex flex-col gap-2 mt-3 empty:mt-0">
       <div
         v-if="strategyNetworkDetails"

--- a/apps/ui/src/components/FormStrategiesStrategyActive.vue
+++ b/apps/ui/src/components/FormStrategiesStrategyActive.vue
@@ -1,12 +1,22 @@
 <script setup lang="ts">
-import { shorten } from '@/helpers/utils';
-import { getNetwork } from '@/networks';
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { getUrl, shorten } from '@/helpers/utils';
+import { getNetwork, offchainNetworks } from '@/networks';
 import { StrategyConfig } from '@/networks/types';
 import { NetworkID } from '@/types';
 
+type Networks = typeof networks;
+type NetworkDetails = Networks[keyof Networks];
+
 type Strategy = Pick<
   StrategyConfig,
-  'id' | 'address' | 'name' | 'params' | 'generateSummary' | 'paramsDefinition'
+  | 'id'
+  | 'address'
+  | 'name'
+  | 'chainId'
+  | 'params'
+  | 'generateSummary'
+  | 'paramsDefinition'
 >;
 
 const props = defineProps<{
@@ -21,14 +31,19 @@ defineEmits<{
 }>();
 
 const network = computed(() => getNetwork(props.networkId));
+
+const strategyNetworkDetails = computed<NetworkDetails>(() => {
+  if (!props.strategy.chainId) return null;
+  if (!(props.strategy.chainId in networks)) return null;
+
+  return networks[props.strategy.chainId];
+});
 </script>
 
 <template>
-  <div
-    class="flex justify-between items-center rounded-lg border px-4 py-3 text-skin-link"
-  >
-    <div class="flex flex-col">
-      <div class="flex min-w-0 leading-5 mb-1">
+  <div class="rounded-lg border px-4 py-3 text-skin-link leading-[18px]">
+    <div class="flex justify-between items-center">
+      <div class="flex min-w-0">
         <div class="whitespace-nowrap">{{ strategy.name }}</div>
         <div
           v-if="strategy.generateSummary"
@@ -37,39 +52,54 @@ const network = computed(() => getNetwork(props.networkId));
           {{ strategy.generateSummary(strategy.params) }}
         </div>
       </div>
-      <a
-        v-if="strategy.address"
-        :href="network.helpers.getExplorerUrl(strategy.address, 'contract')"
-        target="_blank"
-        class="flex items-center text-skin-text leading-5"
-      >
-        <UiStamp
-          :id="strategy.address"
-          type="avatar"
-          :size="18"
-          class="mr-2 !rounded"
-        />
-        {{ shorten(strategy.address) }}
-        <IH-arrow-sm-right class="-rotate-45" />
-      </a>
+      <div v-if="!readOnly" class="flex gap-3">
+        <button
+          v-if="
+            strategy.paramsDefinition || offchainNetworks.includes(networkId)
+          "
+          type="button"
+          @click="$emit('editStrategy', strategy)"
+        >
+          <IH-pencil />
+        </button>
+        <button type="button" @click="$emit('deleteStrategy', strategy)">
+          <IH-trash />
+        </button>
+        <a
+          v-if="strategy.address"
+          :href="network.helpers.getExplorerUrl(strategy.address, 'strategy')"
+          target="_blank"
+          class="text-skin-link"
+        >
+          <IH-information-circle />
+        </a>
+      </div>
     </div>
-    <div
-      v-if="!readOnly"
-      class="flex gap-3"
-      :class="{
-        'self-start': strategy.address
-      }"
-    >
-      <button
-        v-if="strategy.paramsDefinition"
-        type="button"
-        @click="$emit('editStrategy', strategy)"
+    <div class="flex flex-col gap-2 mt-3 empty:mt-0">
+      <div
+        v-if="strategyNetworkDetails"
+        class="flex gap-2 justify-between items-center overflow-hidden"
       >
-        <IH-pencil />
-      </button>
-      <button type="button" @click="$emit('deleteStrategy', strategy)">
-        <IH-trash />
-      </button>
+        <span class="font-medium">Network</span>
+        <div class="flex gap-1 items-center">
+          <img
+            :src="getUrl(strategyNetworkDetails.logo) || undefined"
+            class="size-3"
+          />
+          <span class="text-skin-text truncate">
+            {{ strategyNetworkDetails.name }}
+          </span>
+        </div>
+      </div>
+      <div
+        v-if="strategy.params.symbol"
+        class="flex gap-2 justify-between items-center"
+      >
+        <span class="font-medium">Symbol</span>
+        <span class="text-skin-text">
+          {{ shorten(strategy.params.symbol, 'symbol') }}
+        </span>
+      </div>
     </div>
   </div>
 </template>

--- a/apps/ui/src/components/FormValidation.vue
+++ b/apps/ui/src/components/FormValidation.vue
@@ -99,6 +99,7 @@ function handleStrategySave(value: Record<string, any>) {
     <teleport to="#modal">
       <ModalEditStrategy
         :open="editStrategyModalOpen"
+        :network-id="networkId"
         :definition="editedStrategy?.paramsDefinition"
         :initial-state="editedStrategy?.params"
         @close="editStrategyModalOpen = false"

--- a/apps/ui/src/components/FormValidation.vue
+++ b/apps/ui/src/components/FormValidation.vue
@@ -98,10 +98,12 @@ function handleStrategySave(value: Record<string, any>) {
     </div>
     <teleport to="#modal">
       <ModalEditStrategy
+        v-if="editedStrategy"
         :open="editStrategyModalOpen"
         :network-id="networkId"
-        :definition="editedStrategy?.paramsDefinition"
-        :initial-state="editedStrategy?.params"
+        :strategy-address="editedStrategy.address"
+        :definition="editedStrategy.paramsDefinition"
+        :initial-state="editedStrategy.params"
         @close="editStrategyModalOpen = false"
         @save="handleStrategySave"
       />

--- a/apps/ui/src/components/Modal/EditStrategy.vue
+++ b/apps/ui/src/components/Modal/EditStrategy.vue
@@ -171,3 +171,9 @@ watchEffect(() => {
     </template>
   </UiModal>
 </template>
+
+<style lang="scss" scoped>
+:deep(textarea) {
+  min-height: 140px !important;
+}
+</style>

--- a/apps/ui/src/components/Modal/EditStrategy.vue
+++ b/apps/ui/src/components/Modal/EditStrategy.vue
@@ -1,14 +1,17 @@
 <script setup lang="ts">
+import { clone } from '@/helpers/utils';
 import { validateForm } from '@/helpers/validation';
+import { getNetwork } from '@/networks';
 import { NetworkID } from '@/types';
 
 const props = withDefaults(
   defineProps<{
     open: boolean;
     networkId: NetworkID;
+    strategyAddress: string;
     initialState?: any;
     initialNetwork?: string;
-    definition: any;
+    definition?: any;
     withNetworkSelector?: boolean;
   }>(),
   {
@@ -18,25 +21,54 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: 'close');
-  (e: 'save', value: Record<string, any>);
+  (e: 'save', value: Record<string, any>, network: string);
 }>();
 
-const networkValue = ref('');
+const network = ref('');
 const showPicker = ref(false);
+const isDefinitionLoading = ref(false);
 const pickerField: Ref<string | null> = ref(null);
 const searchValue = ref('');
 const form: Ref<Record<string, any>> = ref({});
+const rawParams = ref('');
+
+const definition = computedAsync(
+  async () => {
+    if (props.definition) return props.definition;
+
+    const network = getNetwork(props.networkId);
+
+    const strategy = await network.api.loadStrategy(props.strategyAddress);
+    if (!strategy) return null;
+
+    return strategy.paramsDefinition;
+  },
+  null,
+  { evaluating: isDefinitionLoading }
+);
 
 const formErrors = computed(() => {
-  const errors = validateForm(props.definition, form.value, {
-    skipEmptyOptionalFields: true
-  });
+  let errors = {} as Record<string, string>;
 
-  if (props.withNetworkSelector && !networkValue.value) {
+  if (props.withNetworkSelector && !network.value) {
     errors.network = 'Network is required';
   }
 
-  return errors;
+  if (!props.definition) {
+    try {
+      JSON.parse(rawParams.value);
+      return {};
+    } catch (e) {
+      return { rawParams: 'Invalid JSON' };
+    }
+  }
+
+  return {
+    ...errors,
+    ...validateForm(props.definition, form.value, {
+      skipEmptyOptionalFields: true
+    })
+  };
 });
 
 function handlePickerClick(field: string) {
@@ -53,21 +85,23 @@ function handlePickerSelect(value: string) {
 }
 
 async function handleSubmit() {
-  emit('save', form.value);
+  const value = definition.value ? form.value : JSON.parse(rawParams.value);
+
+  emit('save', value, network.value);
 }
 
-watch(
-  () => props.open,
-  () => {
-    if (props.initialNetwork) {
-      networkValue.value = props.initialNetwork;
-    }
-
-    if (props.initialState) {
-      form.value = props.initialState;
-    }
+watchEffect(() => {
+  if (props.initialNetwork) {
+    network.value = props.initialNetwork;
   }
-);
+});
+
+watchEffect(() => {
+  if (props.initialState) {
+    form.value = clone(props.initialState);
+    rawParams.value = JSON.stringify(props.initialState, null, 2);
+  }
+});
 </script>
 
 <template>
@@ -100,20 +134,33 @@ watch(
       :search-value="searchValue"
       @pick="handlePickerSelect"
     />
+    <div v-if="isDefinitionLoading" class="p-4 flex">
+      <UiLoading class="m-auto" />
+    </div>
     <div v-else class="s-box p-4">
       <UiSelectorNetwork
         v-if="withNetworkSelector"
-        v-model="networkValue"
+        v-model="network"
         :network-id="networkId"
       />
       <UiForm
+        v-if="definition"
         v-model="form"
         :error="formErrors"
         :definition="definition"
         @pick="handlePickerClick"
       />
+      <UiTextarea
+        v-else
+        v-model:model-value="rawParams"
+        :definition="{
+          type: 'string',
+          title: 'Strategy parameters'
+        }"
+        :error="formErrors.rawParams"
+      />
     </div>
-    <template v-if="!showPicker" #footer>
+    <template v-if="!showPicker && !isDefinitionLoading" #footer>
       <UiButton
         class="w-full"
         :disabled="Object.keys(formErrors).length > 0"

--- a/apps/ui/src/components/Modal/EditStrategy.vue
+++ b/apps/ui/src/components/Modal/EditStrategy.vue
@@ -91,13 +91,13 @@ async function handleSubmit() {
 }
 
 watchEffect(() => {
-  if (props.initialNetwork) {
+  if (props.open && props.initialNetwork) {
     network.value = props.initialNetwork;
   }
 });
 
 watchEffect(() => {
-  if (props.initialState) {
+  if (props.open && props.initialState) {
     form.value = clone(props.initialState);
     rawParams.value = JSON.stringify(props.initialState, null, 2);
   }

--- a/apps/ui/src/components/Modal/EditStrategy.vue
+++ b/apps/ui/src/components/Modal/EditStrategy.vue
@@ -60,25 +60,28 @@ const formErrors = computed(() => {
     errors.network = 'Network is required';
   }
 
-  const value = definition.value ? form.value : JSON.parse(rawParams.value);
-  const customError = props.customErrorValidation?.(value, network.value);
-  if (customError) errors[CUSTOM_ERROR_SYMBOL] = customError;
-
   if (!props.definition) {
     try {
       JSON.parse(rawParams.value);
-      return errors;
     } catch (e) {
       return { rawParams: 'Invalid JSON' };
     }
   }
 
-  return {
-    ...errors,
-    ...validateForm(props.definition, form.value, {
-      skipEmptyOptionalFields: true
-    })
-  };
+  const value = definition.value ? form.value : JSON.parse(rawParams.value);
+  const customError = props.customErrorValidation?.(value, network.value);
+  if (customError) errors[CUSTOM_ERROR_SYMBOL] = customError;
+
+  if (props.definition) {
+    return {
+      ...errors,
+      ...validateForm(props.definition, form.value, {
+        skipEmptyOptionalFields: true
+      })
+    };
+  }
+
+  return errors;
 });
 
 function handlePickerClick(field: string) {

--- a/apps/ui/src/components/Modal/Strategies.vue
+++ b/apps/ui/src/components/Modal/Strategies.vue
@@ -30,19 +30,8 @@ const filteredStrategies = computed(() => {
 });
 
 async function handleStrategySelected(strategy: StrategyTemplate) {
-  isLoading.value = true;
-
-  try {
-    const extended = await network.value.api.loadStrategy(strategy.address);
-    if (!extended) throw new Error('Failed to load strategy details');
-
-    emit('addStrategy', extended);
-    emit('close');
-  } catch (e) {
-    console.log('failed to load strategy', e);
-  } finally {
-    isLoading.value = false;
-  }
+  emit('addStrategy', strategy);
+  emit('close');
 }
 
 watchEffect(async () => {

--- a/apps/ui/src/components/Modal/Strategies.vue
+++ b/apps/ui/src/components/Modal/Strategies.vue
@@ -45,7 +45,9 @@ watchEffect(async () => {
   hasError.value = false;
 
   try {
-    strategies.value = await network.value.api.loadStrategies();
+    strategies.value = (await network.value.api.loadStrategies()).sort(
+      (a, b) => (b.spaceCount || 0) - (a.spaceCount || 0)
+    );
   } catch (e) {
     console.log('failed to load strategies', e);
     hasError.value = true;

--- a/apps/ui/src/components/Modal/Strategies.vue
+++ b/apps/ui/src/components/Modal/Strategies.vue
@@ -1,3 +1,7 @@
+<script lang="ts">
+const strategies = ref([] as StrategyTemplate[]);
+</script>
+
 <script setup lang="ts">
 import { getNetwork } from '@/networks';
 import { StrategyTemplate } from '@/networks/types';
@@ -16,7 +20,6 @@ const emit = defineEmits<{
 const searchValue = ref('');
 const isLoading = ref(false);
 const hasError = ref(false);
-const strategies = ref([] as StrategyTemplate[]);
 
 const network = computed(() => getNetwork(props.networkId));
 const filteredStrategies = computed(() => {
@@ -36,6 +39,7 @@ async function handleStrategySelected(strategy: StrategyTemplate) {
 
 watchEffect(async () => {
   if (!props.open) return;
+  if (strategies.value.length) return;
 
   isLoading.value = true;
   hasError.value = false;

--- a/apps/ui/src/components/Modal/Strategies.vue
+++ b/apps/ui/src/components/Modal/Strategies.vue
@@ -98,7 +98,9 @@ watch(
           @click="handleStrategySelected(strategy)"
         >
           <div class="flex items-center gap-1">
-            <span class="text-skin-link font-semibold leading-5 truncate">
+            <span
+              class="text-md text-skin-link font-semibold leading-5 truncate"
+            >
               {{ strategy.name }}
             </span>
             <span v-if="strategy.version" class="leading-[18px]">

--- a/apps/ui/src/components/Modal/Strategies.vue
+++ b/apps/ui/src/components/Modal/Strategies.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { getNetwork } from '@/networks';
+import { StrategyTemplate } from '@/networks/types';
+import { NetworkID } from '@/types';
+
+const props = defineProps<{
+  open: boolean;
+  networkId: NetworkID;
+}>();
+
+const emit = defineEmits<{
+  (e: 'close');
+}>();
+
+const searchValue = ref('');
+const isLoading = ref(true);
+const hasError = ref(false);
+const strategies = ref([] as StrategyTemplate[]);
+
+const network = computed(() => getNetwork(props.networkId));
+const filteredStrategies = computed(() => {
+  return strategies.value.filter(strategy => {
+    if (!searchValue.value) return true;
+
+    return strategy.name
+      .toLowerCase()
+      .includes(searchValue.value.toLowerCase());
+  });
+});
+
+watchEffect(async () => {
+  if (!props.open) return;
+
+  isLoading.value = true;
+  hasError.value = false;
+
+  try {
+    strategies.value = await network.value.api.loadStrategies();
+  } catch (e) {
+    console.log('failed to load strategies', e);
+    hasError.value = true;
+  } finally {
+    isLoading.value = false;
+  }
+});
+
+watch(
+  () => props.open,
+  () => {
+    searchValue.value = '';
+  }
+);
+</script>
+
+<template>
+  <UiModal :open="open" @close="emit('close')">
+    <template #header>
+      <h3>Add strategy</h3>
+      <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
+        <IH-search class="mx-2" />
+        <input
+          ref="searchInput"
+          v-model="searchValue"
+          type="text"
+          placeholder="Search"
+          class="flex-auto bg-transparent text-skin-link"
+        />
+      </div>
+    </template>
+    <div class="p-4 flex">
+      <UiLoading v-if="isLoading" class="m-auto" />
+      <div
+        v-else-if="hasError"
+        class="flex w-full justify-center items-center gap-2 text-skin-text"
+      >
+        <IH-exclamation-circle class="inline-block shrink-0" />
+        <span>Failed to load strategies.</span>
+      </div>
+      <div v-else class="flex flex-col flex-1 gap-3 overflow-hidden">
+        <button
+          v-for="strategy in filteredStrategies"
+          :key="strategy.address"
+          type="button"
+          class="flex flex-col gap-2 p-[20px] border rounded-md"
+        >
+          <div class="flex items-center gap-1">
+            <span class="text-skin-link font-semibold leading-5 truncate">
+              {{ strategy.name }}
+            </span>
+            <span v-if="strategy.version" class="leading-[18px]">
+              {{ strategy.version }}
+            </span>
+          </div>
+          <div v-if="strategy.author" class="flex items-center gap-1">
+            <IC-github class="shrink-0" />
+            <span class="leading-[18px] truncate">{{ strategy.author }}</span>
+          </div>
+          <div v-if="strategy.spaceCount !== undefined" class="leading-[18px]">
+            In {{ strategy.spaceCount }} space(s)
+          </div>
+        </button>
+      </div>
+    </div>
+  </UiModal>
+</template>

--- a/apps/ui/src/components/Modal/Strategies.vue
+++ b/apps/ui/src/components/Modal/Strategies.vue
@@ -99,7 +99,7 @@ watch(
           class="flex flex-col gap-2 p-[20px] border rounded-md"
           @click="handleStrategySelected(strategy)"
         >
-          <div class="flex items-center gap-1">
+          <div class="flex items-center gap-1 w-full">
             <span
               class="text-md text-skin-link font-semibold leading-5 truncate"
             >

--- a/apps/ui/src/components/StrategiesConfigurator.vue
+++ b/apps/ui/src/components/StrategiesConfigurator.vue
@@ -105,10 +105,12 @@ function handleStrategySave(value: Record<string, any>) {
     </div>
     <teleport to="#modal">
       <ModalEditStrategy
+        v-if="editedStrategy"
         :open="editStrategyModalOpen"
         :network-id="networkId"
-        :definition="editedStrategy?.paramsDefinition"
-        :initial-state="editedStrategy?.params"
+        :strategy-address="editedStrategy.address"
+        :definition="editedStrategy.paramsDefinition"
+        :initial-state="editedStrategy.params"
         @close="editStrategyModalOpen = false"
         @save="handleStrategySave"
       />

--- a/apps/ui/src/components/StrategiesConfigurator.vue
+++ b/apps/ui/src/components/StrategiesConfigurator.vue
@@ -106,6 +106,7 @@ function handleStrategySave(value: Record<string, any>) {
     <teleport to="#modal">
       <ModalEditStrategy
         :open="editStrategyModalOpen"
+        :network-id="networkId"
         :definition="editedStrategy?.paramsDefinition"
         :initial-state="editedStrategy?.params"
         @close="editStrategyModalOpen = false"

--- a/apps/ui/src/components/Ui/Form.vue
+++ b/apps/ui/src/components/Ui/Form.vue
@@ -13,9 +13,9 @@ import InputDuration from './InputDuration.vue';
 import InputNumber from './InputNumber.vue';
 import InputStamp from './InputStamp.vue';
 import InputString from './InputString.vue';
+import Select from './Select.vue';
 import SelectMultiple from './SelectMultiple.vue';
 import Textarea from './Textarea.vue';
-import Combobox from '../Combobox.vue';
 
 const model = defineModel<any>({ required: true });
 
@@ -73,7 +73,7 @@ const getComponent = (property: {
       if (property.format === 'address') return InputAddress;
       if (property.format === 'ens-or-address') return InputAddress;
       if (property.format === 'stamp') return InputStamp;
-      if (property.enum) return Combobox;
+      if (property.enum) return Select;
       return InputString;
     case 'number':
     case 'integer':

--- a/apps/ui/src/components/Ui/Form.vue
+++ b/apps/ui/src/components/Ui/Form.vue
@@ -13,9 +13,9 @@ import InputDuration from './InputDuration.vue';
 import InputNumber from './InputNumber.vue';
 import InputStamp from './InputStamp.vue';
 import InputString from './InputString.vue';
-import Select from './Select.vue';
 import SelectMultiple from './SelectMultiple.vue';
 import Textarea from './Textarea.vue';
+import Combobox from '../Combobox.vue';
 
 const model = defineModel<any>({ required: true });
 
@@ -73,7 +73,7 @@ const getComponent = (property: {
       if (property.format === 'address') return InputAddress;
       if (property.format === 'ens-or-address') return InputAddress;
       if (property.format === 'stamp') return InputStamp;
-      if (property.enum) return Select;
+      if (property.enum) return Combobox;
       return InputString;
     case 'number':
     case 'integer':

--- a/apps/ui/src/components/Ui/SelectorNetwork.vue
+++ b/apps/ui/src/components/Ui/SelectorNetwork.vue
@@ -25,7 +25,8 @@ const spaceCategories = computed(() =>
       name: network.name,
       icon: h('img', {
         src: getUrl(network.logo),
-        alt: network.name
+        alt: network.name,
+        class: 'rounded-full'
       })
     }))
 );

--- a/apps/ui/src/components/Ui/SelectorNetwork.vue
+++ b/apps/ui/src/components/Ui/SelectorNetwork.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { getUrl } from '@/helpers/utils';
+
+const network = defineModel<string>({
+  required: true
+});
+
+const props = defineProps<{
+  networkId: string;
+}>();
+
+const spaceCategories = computed(() =>
+  Object.entries(networks)
+    .filter(([, network]) => {
+      if (props.networkId === 's' && 'testnet' in network && network.testnet) {
+        return false;
+      }
+
+      return true;
+    })
+    .map(([id, network]) => ({
+      id,
+      name: network.name,
+      icon: h('img', {
+        src: getUrl(network.logo),
+        alt: network.name
+      })
+    }))
+);
+</script>
+
+<template>
+  <Combobox
+    v-model="network"
+    :definition="{
+      type: 'string',
+      enum: spaceCategories.map(c => c.id),
+      title: 'Network',
+      options: spaceCategories,
+      examples: ['Select network']
+    }"
+  />
+</template>

--- a/apps/ui/src/components/Ui/SelectorNetwork.vue
+++ b/apps/ui/src/components/Ui/SelectorNetwork.vue
@@ -8,6 +8,7 @@ const network = defineModel<string>({
 
 const props = defineProps<{
   networkId: string;
+  tooltip?: string;
 }>();
 
 const spaceCategories = computed(() =>
@@ -38,6 +39,7 @@ const spaceCategories = computed(() =>
       enum: spaceCategories.map(c => c.id),
       title: 'Network',
       options: spaceCategories,
+      tooltip,
       examples: ['Select network']
     }"
   />

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -151,6 +151,7 @@ export function useSpaceSettings(space: Ref<Space>) {
   const privacy = ref('none' as 'none' | 'shutter');
   const ignoreAbstainVotes = ref(false);
   const snapshotChainId = ref('');
+  const strategies = ref([] as StrategyConfig[]);
   const members = ref([] as Member[]);
   const parent = ref('');
   const children = ref([] as string[]);
@@ -610,6 +611,20 @@ export function useSpaceSettings(space: Ref<Space>) {
       ignoreAbstainVotes.value = initialVotingProperties.ignoreAbstainVotes;
 
       snapshotChainId.value = space.value.snapshot_chain_id?.toString() ?? '1';
+
+      if (space.value.additionalRawData?.type === 'offchain') {
+        strategies.value = space.value.additionalRawData.strategies.map(
+          strategy => ({
+            id: crypto.randomUUID(),
+            chainId: strategy.network,
+            address: strategy.name,
+            name: strategy.name,
+            paramsDefinition: null,
+            params: strategy.params
+          })
+        );
+      }
+
       members.value = getInitialMembers(space.value);
       parent.value = space.value.parent?.id ?? '';
       children.value = space.value.children.map(child => child.id);
@@ -821,6 +836,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     privacy,
     ignoreAbstainVotes,
     snapshotChainId,
+    strategies,
     members,
     parent,
     children,

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -150,6 +150,7 @@ export function useSpaceSettings(space: Ref<Space>) {
   );
   const privacy = ref('none' as 'none' | 'shutter');
   const ignoreAbstainVotes = ref(false);
+  const snapshotChainId = ref('');
   const members = ref([] as Member[]);
   const parent = ref('');
   const children = ref([] as string[]);
@@ -436,7 +437,7 @@ export function useSpaceSettings(space: Ref<Space>) {
         form.value.categories ?? space.value.additionalRawData.categories,
       avatar: form.value.avatar ?? space.value.avatar,
       cover: form.value.cover ?? space.value.cover,
-      network: space.value.snapshot_chain_id?.toString() ?? '1',
+      network: snapshotChainId.value,
       symbol: form.value.votingPowerSymbol ?? space.value.voting_power_symbol,
       terms: termsOfServices.value,
       website: form.value.externalUrl ?? space.value.external_url,
@@ -608,6 +609,7 @@ export function useSpaceSettings(space: Ref<Space>) {
       privacy.value = initialVotingProperties.privacy;
       ignoreAbstainVotes.value = initialVotingProperties.ignoreAbstainVotes;
 
+      snapshotChainId.value = space.value.snapshot_chain_id?.toString() ?? '1';
       members.value = getInitialMembers(space.value);
       parent.value = space.value.parent?.id ?? '';
       children.value = space.value.children.map(child => child.id);
@@ -635,6 +637,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     const votingTypeValue = voteType.value;
     const privacyValue = privacy.value;
     const ignoreAbstainVotesValue = ignoreAbstainVotes.value;
+    const snapshotChainIdValue = snapshotChainId.value;
     const membersValue = members.value;
     const parentValue = parent.value;
     const childrenValue = children.value;
@@ -705,6 +708,14 @@ export function useSpaceSettings(space: Ref<Space>) {
 
       if (
         ignoreAbstainVotesValue !== initialVotingProperties.ignoreAbstainVotes
+      ) {
+        isModified.value = true;
+        return;
+      }
+
+      if (
+        snapshotChainIdValue !==
+        (space.value.snapshot_chain_id?.toString() ?? '1')
       ) {
         isModified.value = true;
         return;
@@ -809,6 +820,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     votingType: voteType,
     privacy,
     ignoreAbstainVotes,
+    snapshotChainId,
     members,
     parent,
     children,

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -424,29 +424,23 @@ export function useSpaceSettings(space: Ref<Space>) {
     currentStrategies: StrategyConfig[],
     existingStrategies: StrategyConfig[]
   ) {
-    const hasNewStrategy =
-      currentStrategies.findIndex(current => {
-        return !existingStrategies.find(
-          existing =>
-            current.address === existing.address &&
-            current.chainId === existing.chainId &&
-            objectHash(current.params) === objectHash(existing.params)
-        );
-      }) !== -1;
+    const existing = [...existingStrategies];
+    for (const current of currentStrategies) {
+      const matchingStrategy = existing.findIndex(
+        existing =>
+          current.address === existing.address &&
+          current.chainId === existing.chainId &&
+          objectHash(current.params) === objectHash(existing.params)
+      );
 
-    if (hasNewStrategy) return true;
+      if (matchingStrategy !== -1) {
+        existing.splice(matchingStrategy, 1);
+      } else {
+        return true;
+      }
+    }
 
-    const hasRemovedStrategy =
-      existingStrategies.findIndex(existing => {
-        return !currentStrategies.find(
-          current =>
-            current.address === existing.address &&
-            current.chainId === existing.chainId &&
-            objectHash(current.params) === objectHash(existing.params)
-        );
-      }) !== -1;
-
-    return hasRemovedStrategy;
+    return existing.length > 0;
   }
 
   async function saveOffchain() {

--- a/apps/ui/src/helpers/turbo.ts
+++ b/apps/ui/src/helpers/turbo.ts
@@ -20,6 +20,12 @@ export const MAX_30D_PROPOSALS = {
   turbo: 200
 };
 
+export const MAX_STRATEGIES = {
+  default: 8,
+  verified: 8,
+  turbo: 10
+};
+
 export const TURBO_URL =
   'https://docs.snapshot.org/user-guides/spaces/turbo-plan';
 export const VERIFIED_URL =

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -657,6 +657,9 @@ export function createApi(
     },
     loadStrategies: async () => {
       return [];
+    },
+    loadStrategy: async () => {
+      return null;
     }
   };
 }

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -654,6 +654,9 @@ export function createApi(
     },
     loadStatements: async () => {
       return [];
+    },
+    loadStrategies: async () => {
+      return [];
     }
   };
 }

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -33,6 +33,7 @@ import {
 } from '@/types';
 import {
   ALIASES_QUERY,
+  EXTENDED_STRATEGY_QUERY,
   LEADERBOARD_QUERY,
   PROPOSAL_QUERY,
   PROPOSALS_QUERY,
@@ -754,6 +755,52 @@ export function createApi(
         version: `v${strategy.version}`,
         spaceCount: strategy.spacesCount
       }));
+    },
+    loadStrategy: async (id: string) => {
+      const { data } = await apollo.query({
+        query: EXTENDED_STRATEGY_QUERY,
+        variables: { id }
+      });
+
+      const hasDefinition = data.strategy.schema;
+
+      const defaultParams = !hasDefinition
+        ? {
+            params: JSON.stringify(
+              data.strategy.examples?.[0]?.strategy?.params || {
+                symbol: 'DAI',
+                address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+                decimals: 18
+              },
+              null,
+              4
+            )
+          }
+        : {};
+
+      const paramsDefinition = hasDefinition
+        ? data.strategy.schema.definitions.Strategy
+        : {
+            title: 'Raw config',
+            type: 'object',
+            properties: {
+              params: {
+                title: 'Strategy parameters',
+                type: 'string',
+                format: 'long'
+              }
+            }
+          };
+
+      return {
+        address: data.strategy.id,
+        name: data.strategy.id,
+        about: data.strategy.about,
+        author: data.strategy.author,
+        version: `v${data.strategy.version}`,
+        defaultParams,
+        paramsDefinition
+      };
     }
   };
 }

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -40,6 +40,7 @@ import {
   SPACE_QUERY,
   SPACES_QUERY,
   STATEMENTS_QUERY,
+  STRATEGIES_QUERY,
   USER_FOLLOWS_QUERY,
   USER_QUERY,
   USER_VOTES_QUERY,
@@ -740,6 +741,19 @@ export function createApi(
       });
 
       return statements;
+    },
+    loadStrategies: async () => {
+      const { data } = await apollo.query({
+        query: STRATEGIES_QUERY
+      });
+
+      return data.strategies.map((strategy: any) => ({
+        address: strategy.id,
+        name: strategy.id,
+        author: strategy.author,
+        version: `v${strategy.version}`,
+        spaceCount: strategy.spacesCount
+      }));
     }
   };
 }

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -12,7 +12,8 @@ import {
   NetworkConstants,
   PaginationOpts,
   ProposalsFilter,
-  SpacesFilter
+  SpacesFilter,
+  StrategyTemplate
 } from '@/networks/types';
 import {
   Alias,
@@ -33,7 +34,6 @@ import {
 } from '@/types';
 import {
   ALIASES_QUERY,
-  EXTENDED_STRATEGY_QUERY,
   LEADERBOARD_QUERY,
   PROPOSAL_QUERY,
   PROPOSALS_QUERY,
@@ -42,12 +42,19 @@ import {
   SPACES_QUERY,
   STATEMENTS_QUERY,
   STRATEGIES_QUERY,
+  STRATEGY_QUERY,
   USER_FOLLOWS_QUERY,
   USER_QUERY,
   USER_VOTES_QUERY,
   VOTES_QUERY
 } from './queries';
-import { ApiProposal, ApiRelatedSpace, ApiSpace, ApiVote } from './types';
+import {
+  ApiProposal,
+  ApiRelatedSpace,
+  ApiSpace,
+  ApiStrategy,
+  ApiVote
+} from './types';
 import { DEFAULT_VOTING_DELAY } from '../constants';
 
 const DEFAULT_AUTHENTICATOR = 'OffchainAuthenticator';
@@ -388,6 +395,29 @@ function formatDelegations(space: ApiSpace): SpaceMetadataDelegation[] {
 
   return delegations;
 }
+
+function formatStrategy(strategy: ApiStrategy): StrategyTemplate {
+  const hasDefinition = 'schema' in strategy && strategy.schema;
+
+  return {
+    address: strategy.id,
+    name: strategy.id,
+    author: strategy.author,
+    version: `v${strategy.version}`,
+    defaultParams: !hasDefinition
+      ? strategy.examples?.[0]?.strategy?.params || {
+          symbol: 'DAI',
+          address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+          decimals: 18
+        }
+      : {},
+    spaceCount: strategy.spacesCount,
+    paramsDefinition: hasDefinition
+      ? strategy.schema.definitions?.Strategy
+      : null
+  };
+}
+
 export function createApi(
   uri: string,
   networkId: NetworkID,
@@ -748,59 +778,19 @@ export function createApi(
         query: STRATEGIES_QUERY
       });
 
-      return data.strategies.map((strategy: any) => ({
-        address: strategy.id,
-        name: strategy.id,
-        author: strategy.author,
-        version: `v${strategy.version}`,
-        spaceCount: strategy.spacesCount
-      }));
+      return data.strategies.map((strategy: ApiStrategy) =>
+        formatStrategy(strategy)
+      );
     },
     loadStrategy: async (id: string) => {
       const { data } = await apollo.query({
-        query: EXTENDED_STRATEGY_QUERY,
+        query: STRATEGY_QUERY,
         variables: { id }
       });
 
-      const hasDefinition = data.strategy.schema;
+      if (!data.strategy) return null;
 
-      const defaultParams = !hasDefinition
-        ? {
-            params: JSON.stringify(
-              data.strategy.examples?.[0]?.strategy?.params || {
-                symbol: 'DAI',
-                address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
-                decimals: 18
-              },
-              null,
-              4
-            )
-          }
-        : {};
-
-      const paramsDefinition = hasDefinition
-        ? data.strategy.schema.definitions.Strategy
-        : {
-            title: 'Raw config',
-            type: 'object',
-            properties: {
-              params: {
-                title: 'Strategy parameters',
-                type: 'string',
-                format: 'long'
-              }
-            }
-          };
-
-      return {
-        address: data.strategy.id,
-        name: data.strategy.id,
-        about: data.strategy.about,
-        author: data.strategy.author,
-        version: `v${data.strategy.version}`,
-        defaultParams,
-        paramsDefinition
-      };
+      return formatStrategy(data.strategy as ApiStrategy);
     }
   };
 }

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -324,27 +324,32 @@ export const LEADERBOARD_QUERY = gql`
   }
 `;
 
-export const STRATEGIES_QUERY = gql`
-  query Strategies {
-    strategies {
-      id
-      author
-      version
-      spacesCount
-    }
+const STRATEGY_FRAGMENT = gql`
+  fragment offchainStrategyFragment on StrategyItem {
+    id
+    author
+    about
+    version
+    spacesCount
+    examples
+    schema
   }
 `;
 
-export const EXTENDED_STRATEGY_QUERY = gql`
-  query Strategy($id: String!) {
-    strategy(id: $id) {
-      id
-      author
-      version
-      spacesCount
-      about
-      schema
-      examples
+export const STRATEGIES_QUERY = gql`
+  query Strategies {
+    strategies {
+      ...offchainStrategyFragment
     }
   }
+  ${STRATEGY_FRAGMENT}
+`;
+
+export const STRATEGY_QUERY = gql`
+  query Strategy($id: String!) {
+    strategy(id: $id) {
+      ...offchainStrategyFragment
+    }
+  }
+  ${STRATEGY_FRAGMENT}
 `;

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -334,3 +334,17 @@ export const STRATEGIES_QUERY = gql`
     }
   }
 `;
+
+export const EXTENDED_STRATEGY_QUERY = gql`
+  query Strategy($id: String!) {
+    strategy(id: $id) {
+      id
+      author
+      version
+      spacesCount
+      about
+      schema
+      examples
+    }
+  }
+`;

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -323,3 +323,14 @@ export const LEADERBOARD_QUERY = gql`
     }
   }
 `;
+
+export const STRATEGIES_QUERY = gql`
+  query Strategies {
+    strategies {
+      id
+      author
+      version
+      spacesCount
+    }
+  }
+`;

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -133,3 +133,12 @@ export type ApiVote = {
   reason: string;
   created: number;
 };
+
+export type ApiStrategy = {
+  id: string;
+  author: string;
+  version: string;
+  spacesCount: number;
+  examples: any;
+  schema: any;
+};

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -80,6 +80,7 @@ export type StrategyTemplate = {
 
 export type StrategyConfig = StrategyTemplate & {
   id: string;
+  chainId?: string;
   params: Record<string, any>;
 };
 

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -53,6 +53,9 @@ export type StrategyTemplate = {
   address: string;
   name: string;
   about?: string;
+  author?: string;
+  version?: string;
+  spaceCount?: number;
   link?: string;
   icon?: FunctionalComponent;
   type?: string;
@@ -306,6 +309,7 @@ export type NetworkApi = {
     spaceId: string,
     userIds: string[]
   ): Promise<Statement[]>;
+  loadStrategies(): Promise<StrategyTemplate[]>;
 };
 
 export type NetworkConstants = {

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -59,6 +59,7 @@ export type StrategyTemplate = {
   link?: string;
   icon?: FunctionalComponent;
   type?: string;
+  defaultParams?: any;
   paramsDefinition: any;
   validate?: (params: Record<string, any>) => boolean;
   generateSummary?: (params: Record<string, any>) => string;
@@ -310,6 +311,7 @@ export type NetworkApi = {
     userIds: string[]
   ): Promise<Statement[]>;
   loadStrategies(): Promise<StrategyTemplate[]>;
+  loadStrategy(address: string): Promise<StrategyTemplate | null>;
 };
 
 export type NetworkConstants = {

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -312,6 +312,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
         v-model:snapshot-chain-id="snapshotChainId"
         v-model:strategies="strategies"
         :network-id="space.network"
+        :space="space"
       />
     </UiContainerSettings>
     <FormStrategies

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -45,6 +45,7 @@ const spacesStore = useSpacesStore();
 const { setTitle } = useTitle();
 
 const hasAdvancedErrors = ref(false);
+const hasStrategiesErrors = ref(false);
 const changeControllerModalOpen = ref(false);
 const executeFn = ref(save);
 const saving = ref(false);
@@ -176,6 +177,10 @@ const error = computed(() => {
   } else {
     if (!strategies.value.length) {
       return 'At least one strategy is required';
+    }
+
+    if (hasStrategiesErrors.value) {
+      return 'Strategies are invalid';
     }
   }
 
@@ -313,6 +318,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
         v-model:strategies="strategies"
         :network-id="space.network"
         :space="space"
+        @update-validity="v => (hasStrategiesErrors = !v)"
       />
     </UiContainerSettings>
     <FormStrategies
@@ -439,7 +445,13 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
       />
     </UiContainerSettings>
     <UiToolbarBottom
-      v-if="(isModified && canModifySettings && !hasAdvancedErrors) || error"
+      v-if="
+        (isModified &&
+          canModifySettings &&
+          !hasAdvancedErrors &&
+          !hasStrategiesErrors) ||
+        error
+      "
       class="px-4 py-3 flex flex-col xs:flex-row justify-between items-center"
     >
       <h4

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -28,6 +28,7 @@ const {
   votingType,
   privacy,
   ignoreAbstainVotes,
+  snapshotChainId,
   members,
   parent,
   children,
@@ -52,6 +53,7 @@ type Tab = {
     | 'profile'
     | 'delegations'
     | 'treasuries'
+    | 'strategies'
     | 'authenticators'
     | 'proposal-validation'
     | 'voting-strategies'
@@ -90,6 +92,11 @@ const tabs = computed<Tab[]>(
         id: 'authenticators',
         name: 'Authenticators',
         visible: !isOffchainNetwork.value
+      },
+      {
+        id: 'strategies',
+        name: 'Strategies',
+        visible: isOffchainNetwork.value
       },
       {
         id: 'proposal-validation',
@@ -289,6 +296,16 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
       <FormSpaceTreasuries
         v-model="form.treasuries"
         :limit="isOffchainNetwork ? 10 : undefined"
+      />
+    </UiContainerSettings>
+    <UiContainerSettings
+      v-else-if="activeTab === 'strategies'"
+      title="Strategies"
+      description="Office ipsum you must be muted. Boy ocean define crank new."
+    >
+      <FormSpaceStrategies
+        v-model:snapshot-chain-id="snapshotChainId"
+        :network-id="space.network"
       />
     </UiContainerSettings>
     <FormStrategies

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -29,6 +29,7 @@ const {
   privacy,
   ignoreAbstainVotes,
   snapshotChainId,
+  strategies,
   members,
   parent,
   children,
@@ -305,6 +306,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
     >
       <FormSpaceStrategies
         v-model:snapshot-chain-id="snapshotChainId"
+        v-model:strategies="strategies"
         :network-id="space.network"
       />
     </UiContainerSettings>

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -311,7 +311,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
     <UiContainerSettings
       v-else-if="activeTab === 'strategies'"
       title="Strategies"
-      description="Office ipsum you must be muted. Boy ocean define crank new."
+      description="Strategies are sets of conditions used to calculate user's voting power."
     >
       <FormSpaceStrategies
         v-model:snapshot-chain-id="snapshotChainId"

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -173,6 +173,10 @@ const error = computed(() => {
     if (!authenticators.value.length) {
       return 'At least one authenticator is required';
     }
+  } else {
+    if (!strategies.value.length) {
+      return 'At least one strategy is required';
+    }
   }
 
   return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -837,7 +837,7 @@
     "@ethersproject/properties" "^5.0.3"
     "@ethersproject/strings" "^5.0.4"
 
-"@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.7.0":
+"@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.6.4", "@ethersproject/abi@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
   integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
@@ -911,7 +911,7 @@
     "@ethersproject/logger" "^5.7.0"
     bn.js "^5.2.1"
 
-"@ethersproject/bytes@5.7.0", "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.7.0":
+"@ethersproject/bytes@5.7.0", "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.6.1", "@ethersproject/bytes@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
   integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
@@ -925,7 +925,7 @@
   dependencies:
     "@ethersproject/bignumber" "^5.7.0"
 
-"@ethersproject/contracts@5.7.0", "@ethersproject/contracts@^5.7.0":
+"@ethersproject/contracts@5.7.0", "@ethersproject/contracts@^5.6.2", "@ethersproject/contracts@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.7.0.tgz#c305e775abd07e48aa590e1a877ed5c316f8bd1e"
   integrity sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==
@@ -1037,7 +1037,7 @@
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/providers@5.7.2", "@ethersproject/providers@^5.7.0", "@ethersproject/providers@^5.7.2":
+"@ethersproject/providers@5.7.2", "@ethersproject/providers@^5.6.8", "@ethersproject/providers@^5.7.0", "@ethersproject/providers@^5.7.2":
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
   integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
@@ -1145,7 +1145,7 @@
     "@ethersproject/constants" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/wallet@5.7.0", "@ethersproject/wallet@^5.7.0":
+"@ethersproject/wallet@5.7.0", "@ethersproject/wallet@^5.6.2", "@ethersproject/wallet@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.7.0.tgz#4e5d0790d96fe21d61d38fb40324e6c7ef350b2d"
   integrity sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==
@@ -2512,6 +2512,29 @@
   version "0.1.0-beta.18"
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.18.tgz#fcbd86d4557821bff774d60e5c636ad47ed85d77"
   integrity sha512-v6tj7l19KJUWjBbsWpwxaYO2mlIDBFyAG0OMSPhUgrhltO7b6R4Ejxn2k4Qgi/NtlnOrj+3Gt3eQRry8Jfgjrg==
+
+"@snapshot-labs/snapshot.js@^0.12.13":
+  version "0.12.13"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.12.13.tgz#40b6cbf20ec4f1222bb231d1b3e26e5f702bf912"
+  integrity sha512-e9pXdQA45tO5+af42PkOYI01WAPPR7IrQDejjUdhz3y98e7m/Na9Foqlbj6nIksnTJ4GubcmOZV7iQzcrNw/kw==
+  dependencies:
+    "@ensdomains/eth-ens-namehash" "^2.0.15"
+    "@ethersproject/abi" "^5.6.4"
+    "@ethersproject/address" "^5.6.1"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/contracts" "^5.6.2"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/providers" "^5.6.8"
+    "@ethersproject/units" "^5.7.0"
+    "@ethersproject/wallet" "^5.6.2"
+    ajv "^8.11.0"
+    ajv-errors "^3.0.0"
+    ajv-formats "^2.1.1"
+    cross-fetch "^3.1.6"
+    json-to-graphql-query "^2.2.4"
+    lodash.set "^4.3.2"
+    starknet "^5.24.3"
 
 "@stablelib/aead@^1.0.1":
   version "1.0.1"
@@ -3933,6 +3956,38 @@ abbrev@^2.0.0:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
   integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
 
+"abi-wan-kanabi-v1@npm:abi-wan-kanabi@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-1.0.3.tgz#0d8607f2a2ccb2151a69debea1c3bb68b76c5aa2"
+  integrity sha512-Xwva0AnhXx/IVlzo3/kwkI7Oa7ZX7codtcSn+Gmoa2PmjGPF/0jeVud9puasIPtB7V50+uBdUj4Mh3iATqtBvg==
+  dependencies:
+    abi-wan-kanabi "^1.0.1"
+    fs-extra "^10.0.0"
+    rome "^12.1.3"
+    typescript "^4.9.5"
+    yargs "^17.7.2"
+
+"abi-wan-kanabi-v2@npm:abi-wan-kanabi@^2.1.1":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-2.2.3.tgz#d1c410325aac866f31f3d589279a87b341e5641f"
+  integrity sha512-JlqiAl9CPvTm5kKG0QXmVCWNWoC/XyRMOeT77cQlbxXWllgjf6SqUmaNqFon72C2o5OSZids+5FvLdsw6dvWaw==
+  dependencies:
+    ansicolors "^0.3.2"
+    cardinal "^2.1.1"
+    fs-extra "^10.0.0"
+    yargs "^17.7.2"
+
+abi-wan-kanabi@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-1.0.3.tgz#0d8607f2a2ccb2151a69debea1c3bb68b76c5aa2"
+  integrity sha512-Xwva0AnhXx/IVlzo3/kwkI7Oa7ZX7codtcSn+Gmoa2PmjGPF/0jeVud9puasIPtB7V50+uBdUj4Mh3iATqtBvg==
+  dependencies:
+    abi-wan-kanabi "^1.0.1"
+    fs-extra "^10.0.0"
+    rome "^12.1.3"
+    typescript "^4.9.5"
+    yargs "^17.7.2"
+
 abi-wan-kanabi@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-2.2.0.tgz#5f231bde43849f8ea85fb8c3c3250aea2fc20aea"
@@ -4077,6 +4132,16 @@ ajv@^8.0.0, ajv@^8.12.0:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
+
+ajv@^8.11.0:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 ansi-colors@^4.1.1, ansi-colors@^4.1.3:
   version "4.1.3"
@@ -5358,7 +5423,7 @@ cross-fetch@^2.1.0:
     node-fetch "^2.6.7"
     whatwg-fetch "^2.0.4"
 
-cross-fetch@^3.1.4, cross-fetch@^3.1.5:
+cross-fetch@^3.1.4, cross-fetch@^3.1.5, cross-fetch@^3.1.6:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
   integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
@@ -6873,6 +6938,11 @@ fast-safe-stringify@^2.0.6, fast-safe-stringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
+fast-uri@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.1.tgz#cddd2eecfc83a71c1be2cc2ef2061331be8a7134"
+  integrity sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==
 
 fast-url-parser@^1.1.3:
   version "1.1.3"
@@ -12041,6 +12111,21 @@ starknet@^5.19.3:
     pako "^2.0.4"
     url-join "^4.0.1"
 
+starknet@^5.24.3:
+  version "5.29.0"
+  resolved "https://registry.yarnpkg.com/starknet/-/starknet-5.29.0.tgz#26d8074340f26a2da4bc373169a1a5ed6dc9bedf"
+  integrity sha512-eEcd6uiYIwGvl8MtHOsXGBhREqjJk84M/qUkvPLQ3n/JAMkbKBGnygDlh+HAsvXJsGlMQfwrcVlm6KpDoPha7w==
+  dependencies:
+    "@noble/curves" "~1.3.0"
+    "@scure/base" "~1.1.3"
+    "@scure/starknet" "~1.0.0"
+    abi-wan-kanabi-v1 "npm:abi-wan-kanabi@^1.0.3"
+    abi-wan-kanabi-v2 "npm:abi-wan-kanabi@^2.1.1"
+    isomorphic-fetch "^3.0.0"
+    lossless-json "^2.0.8"
+    pako "^2.0.4"
+    url-join "^4.0.1"
+
 starknetkit@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/starknetkit/-/starknetkit-1.1.9.tgz#92ff7536b2bdc36017e4b16067f4c5ba264b4981"
@@ -12874,6 +12959,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
+
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 typescript@^5.2.2:
   version "5.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1208,6 +1208,35 @@
     graphql-import-node "^0.0.5"
     js-yaml "^4.1.0"
 
+"@floating-ui/core@^1.5.3", "@floating-ui/core@^1.6.0":
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.8.tgz#aa43561be075815879305965020f492cdb43da12"
+  integrity sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==
+  dependencies:
+    "@floating-ui/utils" "^0.2.8"
+
+"@floating-ui/dom@^1.0.0", "@floating-ui/dom@^1.5.4":
+  version "1.6.11"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.11.tgz#8631857838d34ee5712339eb7cbdfb8ad34da723"
+  integrity sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.8"
+
+"@floating-ui/utils@^0.2.8":
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.8.tgz#21a907684723bbbaa5f0974cf7730bd797eb8e62"
+  integrity sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==
+
+"@floating-ui/vue@^1.0.3":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@floating-ui/vue/-/vue-1.1.5.tgz#dcbb5d7a2f9035b0c96a9c30cdf794977d360809"
+  integrity sha512-ynL1p5Z+woPVSwgMGqeDrx6HrJfGIDzFyESFkyqJKilGW1+h/8yVY29Khn0LaU6wHBRwZ13ntG6reiHWK6jyzw==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+    "@floating-ui/utils" "^0.2.8"
+    vue-demi ">=0.13.0"
+
 "@graphprotocol/graph-cli@0.72.1":
   version "0.72.1"
   resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.72.1.tgz#d80bb8459a60ab34a49ede34ee5e022ee88124ea"
@@ -1303,6 +1332,15 @@
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
+
+"@headlessui-float/vue@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@headlessui-float/vue/-/vue-0.15.0.tgz#0fb10d9c1d6c4c47e745f3268f13500d6edaa5ec"
+  integrity sha512-sGnnA+sTcMAl6kdjpyOYG71rQZrQDaFifE7zAIr8PdBizSNbd0LIIGslzV4nyvXUgc4RKUvfxKVC45VuqrNJCg==
+  dependencies:
+    "@floating-ui/core" "^1.5.3"
+    "@floating-ui/dom" "^1.5.4"
+    "@floating-ui/vue" "^1.0.3"
 
 "@headlessui/vue@^1.7.16":
   version "1.7.18"
@@ -13426,6 +13464,11 @@ vue-component-type-helpers@^2.0.0:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/vue-component-type-helpers/-/vue-component-type-helpers-2.0.10.tgz#4bca46356312450c4f228d043895dd256bad305c"
   integrity sha512-FC5fKJjDks3Ue/KRSYBdsiCaZa0kUPQfs8yQpb8W9mlO6BenV8G1z58xobeRMzevnmEcDa09LLwuXDwb4f6NMQ==
+
+vue-demi@>=0.13.0:
+  version "0.14.10"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.10.tgz#afc78de3d6f9e11bf78c55e8510ee12814522f04"
+  integrity sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==
 
 vue-demi@>=0.14.5, vue-demi@>=0.14.6:
   version "0.14.7"


### PR DESCRIPTION
### Summary

This PR adds support for configuring strategies on offchain networks. With this you can add, edit or delete strategies.

There are few changes compared to the [designs](https://www.figma.com/design/hmHTau1Y1KYzrBBKLQr5QV/%23design?node-id=6966-14342&node-type=frame&m=dev):
- Voting symbol is not in this section (it's in the profile).
- Strategy item is not exactly the same as per designs (which used Snapshot v1 design) as it was more unified with existing item.
- No learn more link in Edit strategy modal (as in v1).

### How to test

1. Go to offchain space's you control settings.
2. You can modify strategy settings.

### Screenshots

<img width="1048" alt="image" src="https://github.com/user-attachments/assets/caa471e3-158e-448d-aac8-d98abec96be6">
