### PR TITLE
fix: improve executions list design on small screens

### DIFF
--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -107,41 +107,39 @@ watch(
     <div class="overflow-hidden border rounded-lg">
       <div
         v-if="treasury && network"
-        class="w-full flex justify-between px-4 py-3 text-start"
+        class="w-full flex justify-between items-center px-4 py-3"
       >
-        <div class="flex justify-between items-center">
-          <UiBadgeNetwork
-            :id="treasury.networkId"
-            class="mr-3"
+        <UiBadgeNetwork
+          :id="treasury.networkId"
+          class="mr-3 shrink-0 size-fit"
+          :class="{
+            'opacity-40': disabled
+          }"
+        >
+          <UiStamp
+            :id="treasury.wallet"
+            type="avatar"
+            :size="32"
+            class="rounded-md"
+          />
+        </UiBadgeNetwork>
+        <div class="flex-1 leading-[22px] overflow-hidden">
+          <h4
+            class="text-skin-link truncate"
             :class="{
-              'opacity-40': disabled
+              'text-skin-border': disabled
             }"
-          >
-            <UiStamp
-              :id="treasury.wallet"
-              type="avatar"
-              :size="32"
-              class="rounded-md"
-            />
-          </UiBadgeNetwork>
-          <div class="flex-1 leading-[22px]">
-            <h4
-              class="text-skin-link"
-              :class="{
-                'text-skin-border': disabled
-              }"
-              v-text="treasury.name || shorten(treasury.wallet)"
-            />
-            <div
-              class="text-skin-text text-[17px]"
-              :class="{
-                'text-skin-border': disabled
-              }"
-              v-text="getExecutionName(props.space.network, strategy.type)"
-            />
-          </div>
+            v-text="getExecutionName(props.space.network, strategy.type)"
+          />
+          <div
+            class="text-skin-text text-[17px] truncate"
+            :class="{
+              'text-skin-border': disabled
+            }"
+            v-text="getExecutionName(props.space.network, strategy.type)"
+          />
         </div>
-        <div class="space-x-2">
+        <div class="space-x-2 shrink-0">
           <UiTooltip title="Send token">
             <UiButton
               :disabled="!treasury || disabled"

--- a/apps/ui/src/components/ProposalExecutionsList.vue
+++ b/apps/ui/src/components/ProposalExecutionsList.vue
@@ -59,7 +59,7 @@ function downloadExecution(execution: ProposalExecution) {
         )
       }"
     >
-      <UiBadgeNetwork :id="execution.networkId" class="mr-3">
+      <UiBadgeNetwork :id="execution.networkId" class="mr-3 shrink-0">
         <UiStamp
           :id="execution.safeAddress"
           type="avatar"
@@ -67,13 +67,13 @@ function downloadExecution(execution: ProposalExecution) {
           class="rounded-md"
         />
       </UiBadgeNetwork>
-      <div class="flex-1 leading-[22px]">
+      <div class="flex-1 leading-[22px] overflow-hidden">
         <h4
-          class="text-skin-link"
+          class="text-skin-link truncate"
           v-text="execution.safeName || shorten(execution.safeAddress)"
         />
         <div
-          class="text-skin-text text-[17px]"
+          class="text-skin-text text-[17px] truncate"
           v-text="
             getExecutionName(proposal.network, execution.strategyType) ||
             shorten(execution.safeAddress)
@@ -82,7 +82,7 @@ function downloadExecution(execution: ProposalExecution) {
       </div>
     </a>
     <div class="flex justify-between items-center border-y pr-3">
-      <UiLabel label="Transactions" class="border-b-0" />
+      <UiLabel label="Transactions" class="border-b-0 pr-0 truncate" />
       <UiTooltip
         v-if="execution.strategyType === 'ReadOnlyExecution'"
         title="Export transactions"

--- a/apps/ui/src/components/TransactionsListItem.vue
+++ b/apps/ui/src/components/TransactionsListItem.vue
@@ -161,12 +161,12 @@ const parsedTitle = computedAsync(
       class="w-full px-4 py-3 space-x-2 flex items-center justify-between"
       @click="expanded = !expanded"
     >
-      <div class="flex items-center max-w-[70%]">
+      <div class="flex items-center overflow-hidden">
         <slot name="left" />
-        <IH-cash v-if="tx._type === 'sendToken'" />
-        <IH-photograph v-else-if="tx._type === 'sendNft'" />
-        <IC-stake v-else-if="tx._type === 'stakeToken'" />
-        <IH-code v-else />
+        <IH-cash v-if="tx._type === 'sendToken'" class="shrink-0" />
+        <IH-photograph v-else-if="tx._type === 'sendNft'" class="shrink-0" />
+        <IC-stake v-else-if="tx._type === 'stakeToken'" class="shrink-0" />
+        <IH-code v-else class="shrink-0" />
         <div class="ml-2 truncate text-skin-link" v-html="parsedTitle" />
       </div>
       <slot name="right" />


### PR DESCRIPTION
### Summary

This PR improves of executions list is rendered on small screens by truncating text as needed.

Closes: https://github.com/snapshot-labs/workflow/issues/217

### How to test

1. Go to http://localhost:8080/#/s:0cf5e.eth/proposal/0x124cc146918a5c14e1c9fd40aaa293f5780304f6b26be1a9692160d8d4d4596e
2. Go to http://localhost:8080/#/s:0cf5e.eth/create/k3erai
3. Play with small screens.

### Screenshots

<img width="234" alt="image" src="https://github.com/user-attachments/assets/187f42bb-d759-47e8-9127-8d6ebe222708">

<img width="378" alt="image" src="https://github.com/user-attachments/assets/e5474de5-b167-4359-9e74-4e4b56c3ca4d">
