### PR TITLE
feat: cache controller

### DIFF
--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -124,13 +124,14 @@ export function useSpaceSettings(space: Ref<Space>) {
   const votingDelay: Ref<number | null> = ref(null);
   const minVotingPeriod: Ref<number | null> = ref(null);
   const maxVotingPeriod: Ref<number | null> = ref(null);
+  const initialController = ref('');
+  const controller = ref('');
 
   // Onchain properties
   const authenticators = ref([] as StrategyConfig[]);
   const validationStrategy = ref(null as StrategyConfig | null);
   const votingStrategies = ref([] as StrategyConfig[]);
   const initialValidationStrategyObjectHash = ref(null as string | null);
-  const controller = ref(space.value.controller);
 
   // Offchain properties
   const members = ref([] as Member[]);
@@ -527,7 +528,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     return deleteSpaceAction(space.value);
   }
 
-  async function reset() {
+  async function reset({ force = false } = {}) {
     const authenticatorsValue = await getInitialStrategiesConfig(
       space.value.authenticators,
       network.value.constants.EDITOR_AUTHENTICATORS
@@ -549,9 +550,10 @@ export function useSpaceSettings(space: Ref<Space>) {
       space.value.voting_power_validation_strategies_parsed_metadata
     );
 
-    controller.value = await network.value.helpers.getSpaceController(
-      space.value
-    );
+    controller.value = force
+      ? await network.value.helpers.getSpaceController(space.value)
+      : initialController.value;
+    initialController.value = controller.value;
 
     formErrors.value = {};
     form.value = getInitialForm(space.value);

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -207,7 +207,7 @@ function getIsMaxVotingPeriodValid(value: number) {
 
 async function reloadSpaceAndReset() {
   await spacesStore.fetchSpace(props.space.id, props.space.network);
-  await reset();
+  await reset({ force: true });
 }
 
 function handleSettingsSave() {
@@ -253,7 +253,7 @@ watch(
 watchEffect(async () => {
   loading.value = true;
 
-  await reset();
+  await reset({ force: true });
 
   loading.value = false;
 });
@@ -541,7 +541,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
         {{ error || 'You have unsaved changes' }}
       </h4>
       <div class="flex space-x-3">
-        <button type="reset" class="text-skin-heading" @click="reset">
+        <button type="reset" class="text-skin-heading" @click="reset()">
           Reset
         </button>
         <UiButton


### PR DESCRIPTION
### Summary

It takes a while to fetch controller. We can make experience better by caching it and reuse it when possible (not loading/reloading space).


Closes: https://github.com/snapshot-labs/sx-monorepo/issues/791

### How to test

1. Go to offchain space settings, change space name.
2. Click reset.
3. It is instant.
