### PR TITLE
fix: fix offchain proposal search ignoring space id

### DIFF
--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -526,7 +526,13 @@ export function createApi(
         variables: { id: proposalId }
       });
 
-      if (!data.proposal || data.proposal?.metadata === null) return null;
+      if (
+        !data.proposal ||
+        data.proposal.metadata === null ||
+        data.proposal.space?.id !== spaceId
+      ) {
+        return null;
+      }
 
       return formatProposal(data.proposal, networkId);
     },

--- a/apps/ui/src/stores/proposals.ts
+++ b/apps/ui/src/stores/proposals.ts
@@ -51,13 +51,6 @@ export const useProposalsStore = defineStore('proposals', () => {
     proposalId: number | string,
     networkId: NetworkID
   ): Proposal | undefined => {
-    console.log(
-      'getting proposal',
-      spaceId,
-      proposalId,
-      networkId,
-      getUniqueSpaceId(spaceId, networkId)
-    );
     console.log(proposals.value);
     const record = proposals.value[getUniqueSpaceId(spaceId, networkId)];
     if (!record) return undefined;

--- a/apps/ui/src/stores/proposals.ts
+++ b/apps/ui/src/stores/proposals.ts
@@ -1,4 +1,3 @@
-import { net } from 'electron';
 import { defineStore } from 'pinia';
 import { getNames } from '@/helpers/stamp';
 import { getNetwork } from '@/networks';
@@ -51,7 +50,6 @@ export const useProposalsStore = defineStore('proposals', () => {
     proposalId: number | string,
     networkId: NetworkID
   ): Proposal | undefined => {
-    console.log(proposals.value);
     const record = proposals.value[getUniqueSpaceId(spaceId, networkId)];
     if (!record) return undefined;
 

--- a/apps/ui/src/stores/proposals.ts
+++ b/apps/ui/src/stores/proposals.ts
@@ -1,3 +1,4 @@
+import { net } from 'electron';
 import { defineStore } from 'pinia';
 import { getNames } from '@/helpers/stamp';
 import { getNetwork } from '@/networks';
@@ -50,6 +51,14 @@ export const useProposalsStore = defineStore('proposals', () => {
     proposalId: number | string,
     networkId: NetworkID
   ): Proposal | undefined => {
+    console.log(
+      'getting proposal',
+      spaceId,
+      proposalId,
+      networkId,
+      getUniqueSpaceId(spaceId, networkId)
+    );
+    console.log(proposals.value);
     const record = proposals.value[getUniqueSpaceId(spaceId, networkId)];
     if (!record) return undefined;
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #817 

This PR fix an issue where searching for an offchain proposal is not honoring the space ID params.

This means that these 2 urls for 2 different spaces but same proposal id will still show the same proposal

- http://localhost:8080/#/s:safe.eth/proposal/0x24fbb1d77f8ba561a3d77903b68c0c0a6d495eb394465f93a8d94aa537be80dc
- http://localhost:8080/#/s:aave.eth/proposal/0x24fbb1d77f8ba561a3d77903b68c0c0a6d495eb394465f93a8d94aa537be80dc

### How to test

1. Go to the 2 urls above
2. It should show the proposal only on the correct space
