### PR TITLE
feat: index verified spaces

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -65,7 +65,7 @@ async function run() {
     await sleep(PRODUCTION_INDEXER_DELAY);
   }
 
-  // await checkpoint.reset();
+  await checkpoint.reset();
   checkpoint.start();
 }
 

--- a/apps/api/src/overrrides.ts
+++ b/apps/api/src/overrrides.ts
@@ -7,6 +7,18 @@ export const networkNodeUrl =
 
 export const manaRpcUrl = process.env.VITE_MANA_URL || 'https://mana.box';
 
+const verifiedSpaces = {
+  sn: [
+    '0x009fedaf0d7a480d21a27683b0965c0f8ded35b3f1cac39827a25a06a8a682a4',
+    '0x05ea5ef0c54c84dc7382629684c6e536c0b06246b3b0981c426b42372e3ef263',
+    '0x07c251045154318a2376a3bb65be47d3c90df1740d8e35c9b9d943aa3f240e50',
+    '0x07bd3419669f9f0cc8f19e9e2457089cdd4804a4c41a5729ee9c7fd02ab8ab62'
+  ],
+  'sn-sep': [
+    '0x0141464688e48ae5b7c83045edb10ecc242ce0e1ad4ff44aca3402f7f47c1ab9'
+  ]
+};
+
 const createConfig = (
   networkId: keyof typeof starknetNetworks,
   { startBlock }: { startBlock: number }
@@ -21,6 +33,7 @@ const createConfig = (
     propositionPowerValidationStrategyAddress:
       config.ProposalValidations.VotingPower,
     spaceClassHash: config.Meta.masterSpace,
+    verifiedSpaces: verifiedSpaces[networkId],
     herodotusStrategies: [
       config.Strategies.OZVotesStorageProof,
       config.Strategies.OZVotesTrace208StorageProof,

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -5,6 +5,8 @@ scalar BigDecimalVP
 
 type Space {
   id: String!
+  verified: Boolean!
+  turbo: Boolean!
   metadata: SpaceMetadataItem
   controller: String!
   voting_delay: Int!
@@ -16,7 +18,8 @@ type Space {
   strategies: [String]!
   strategies_params: [String]!
   strategies_metadata: [String]!
-  strategies_parsed_metadata: [StrategiesParsedMetadataItem]! @derivedFrom(field: "space")
+  strategies_parsed_metadata: [StrategiesParsedMetadataItem]!
+    @derivedFrom(field: "space")
   authenticators: [String]!
   validation_strategy: String!
   validation_strategy_params: Text!

--- a/apps/api/src/writer.ts
+++ b/apps/api/src/writer.ts
@@ -71,7 +71,11 @@ export const handleSpaceCreated: starknet.Writer = async ({
     (array: string[]) => longStringToText(array)
   );
 
-  const space = new Space(validateAndParseAddress(event.space));
+  const id = validateAndParseAddress(event.space);
+
+  const space = new Space(id);
+  space.verified = networkProperties.verifiedSpaces.includes(id);
+  space.turbo = false;
   space.metadata = null;
   space.controller = validateAndParseAddress(event.owner);
   space.voting_delay = Number(BigInt(event.voting_delay).toString());

--- a/apps/subgraph-api/schema.graphql
+++ b/apps/subgraph-api/schema.graphql
@@ -1,5 +1,7 @@
 type Space @entity {
   id: ID!
+  verified: Boolean!
+  turbo: Boolean!
   metadata: SpaceMetadata
   controller: String!
   voting_delay: Int!

--- a/apps/subgraph-api/src/mapping.ts
+++ b/apps/subgraph-api/src/mapping.ts
@@ -152,6 +152,8 @@ export function handleProxyDeployed(event: ProxyDeployed): void {
 
 export function handleSpaceCreated(event: SpaceCreated): void {
   let space = new Space(toChecksumAddress(event.params.space.toHexString()))
+  space.verified = false
+  space.turbo = false
   space.controller = toChecksumAddress(event.params.input.owner.toHexString())
   space.voting_delay = event.params.input.votingDelay.toI32()
   space.min_voting_period = event.params.input.minVotingDuration.toI32()


### PR DESCRIPTION
### Summary

This just `verified` (and for future `turbo` property so schema is ready) to API, on Starknet it will set this flag for some spaces. 

Towards: https://github.com/snapshot-labs/workflow/issues/215 (UI changes in future PR once APIs are deployed).

### How to test

1. Run local API, check verified flag on Nostra (demo) for sepolia.
