### PR TITLE
ci: run tests on Ubuntu 22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   lint-build-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
### Summary

24.04 is not supported by graph-cli

### How to test

1. Tests should pass.
