### PR TITLE
refactor: avoid confusing isPrivate variable name

### DIFF
--- a/apps/ui/src/composables/useSharing.ts
+++ b/apps/ui/src/composables/useSharing.ts
@@ -93,9 +93,9 @@ export function useSharing() {
     const choiceText = getChoiceText(proposal.choices, choice);
     const isSingleChoice =
       proposal.type === 'single-choice' || proposal.type === 'basic';
-    const isPrivate = proposal.privacy === 'shutter';
+    const hasPrivacy = proposal.privacy === 'shutter';
     const votedText =
-      isSingleChoice && !isPrivate
+      isSingleChoice && !hasPrivacy
         ? `I just voted "${choiceText}"`
         : `I just voted`;
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR renames the `isPrivate` variable to `hasPrivacy`, to reflect its purpose.

`isPrivate` is a property of space, and is used for hiding space from homepage.

This is to avoid confusion, particularly when searching the code for this keyword
