### PR TITLE
refactor: migrate subspaces to uiscrollerhorizontal

### DIFF
--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -131,25 +131,17 @@ watchEffect(() => setTitle(props.space.name));
     </div>
     <template v-if="space.children.length">
       <UiLabel :label="'Sub-spaces'" />
-      <div class="relative">
-        <div
-          class="bg-gradient-to-r from-skin-bg left-0 top-0 bottom-0 w-3 absolute z-10 pointer-events-none"
-        />
-        <div class="overflow-x-auto no-scrollbar flex">
-          <div class="px-4 py-3 flex gap-3" data-no-sidebar-swipe>
-            <SpacesListItem
-              v-for="child in space.children"
-              :key="child.id"
-              :space="child"
-              :show-about="false"
-              class="basis-[240px] shrink-0"
-            />
-          </div>
+      <UiScrollerHorizontal gradient="md">
+        <div class="px-4 py-3 flex gap-3 min-w-max">
+          <SpacesListItem
+            v-for="child in space.children"
+            :key="child.id"
+            :space="child"
+            :show-about="false"
+            class="w-[240px]"
+          />
         </div>
-        <div
-          class="bg-gradient-to-l from-skin-bg right-0 top-0 bottom-0 w-3 absolute z-10 pointer-events-none"
-        />
-      </div>
+      </UiScrollerHorizontal>
     </template>
     <div>
       <ProposalsList


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR migrates the children spaces to the scrollerHorizontal component

### How to test

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth
2. It should behave as before
