### PR TITLE
fix: disable vote reason on shutter proposals

### DIFF
--- a/apps/ui/src/components/Modal/Vote.vue
+++ b/apps/ui/src/components/Modal/Vote.vue
@@ -189,7 +189,7 @@ watchEffect(async () => {
           v-text="formattedVotingPower"
         />
       </dl>
-      <div class="s-box">
+      <div v-if="!proposal.privacy" class="s-box">
         <UiForm
           v-model="form"
           :error="formErrors"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #834 

This PR disables vote reason on shutter proposal

### How to test

1. Go to a shutter proposal
2. The vote modal should not have the reason textarea
3. Go to a regular proposal
4. The vote modal should have the reason textarea

