### PR TITLE
refactor: support any treasury with chainId

### DIFF
--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -3,6 +3,7 @@ import Draggable from 'vuedraggable';
 import { StrategyWithTreasury } from '@/composables/useTreasuries';
 import { simulate } from '@/helpers/tenderly';
 import { getExecutionName } from '@/helpers/ui';
+import { shorten } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
 import { Contact, Space, Transaction as TransactionType } from '@/types';
 
@@ -75,7 +76,13 @@ function editTx(index: number) {
 }
 
 async function handleSimulateClick() {
-  if (simulationState.value !== null || !treasury.value) return;
+  if (
+    simulationState.value !== null ||
+    !treasury.value ||
+    typeof treasury.value.network === 'string'
+  ) {
+    return;
+  }
 
   simulationState.value = 'SIMULATING';
 
@@ -128,7 +135,7 @@ watch(
             :class="{
               'text-skin-border': disabled
             }"
-            v-text="getExecutionName(props.space.network, strategy.type)"
+            v-text="treasury.name || shorten(treasury.wallet)"
           />
           <div
             class="text-skin-text text-[17px] truncate"
@@ -168,7 +175,7 @@ watch(
           </UiTooltip>
         </div>
       </div>
-      <template v-if="model.length > 0 && treasury">
+      <template v-if="model.length > 0 && treasury && treasury.networkId">
         <UiLabel label="Transactions" class="border-t" />
         <div>
           <Draggable
@@ -251,7 +258,7 @@ watch(
         @add="addTx"
       />
       <ModalSendNft
-        v-if="treasury"
+        v-if="treasury && treasury.networkId"
         :open="modalOpen.sendNft"
         :address="treasury.wallet"
         :network="treasury.network"
@@ -261,7 +268,7 @@ watch(
         @add="addTx"
       />
       <ModalStakeToken
-        v-if="treasury"
+        v-if="treasury && treasury.networkId"
         :open="modalOpen.stakeToken"
         :address="treasury.wallet"
         :network="treasury.network"
@@ -271,7 +278,7 @@ watch(
         @add="addTx"
       />
       <ModalTransaction
-        v-if="treasury"
+        v-if="treasury && treasury.networkId"
         :open="modalOpen.contractCall"
         :network="treasury.network"
         :extra-contacts="extraContacts"

--- a/apps/ui/src/components/Modal/LinkWalletConnect.vue
+++ b/apps/ui/src/components/Modal/LinkWalletConnect.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { clone } from '@/helpers/utils';
 import { validateForm } from '@/helpers/validation';
-import { NetworkID, SelectedStrategy } from '@/types';
+import { ChainId, NetworkID, SelectedStrategy } from '@/types';
 
 const DEFAULT_FORM_STATE = {
   pairingCode: ''
@@ -27,7 +27,7 @@ const definition = {
 const props = defineProps<{
   open: boolean;
   address: string;
-  network: number;
+  network: ChainId;
   networkId: NetworkID;
   spaceKey: string;
   executionStrategy: SelectedStrategy | null;
@@ -40,7 +40,7 @@ const emit = defineEmits<{
 const { transaction } = useWalletConnectTransaction();
 const { loading, logged, proposal, connect, logout } = useWalletConnect(
   props.networkId,
-  props.network,
+  Number(props.network),
   props.address,
   props.spaceKey,
   props.executionStrategy

--- a/apps/ui/src/components/Modal/SendNft.vue
+++ b/apps/ui/src/components/Modal/SendNft.vue
@@ -2,7 +2,7 @@
 import { createSendNftTransaction } from '@/helpers/transactions';
 import { clone } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
-import { Contact } from '@/types';
+import { ChainId, Contact } from '@/types';
 
 const DEFAULT_FORM_STATE = {
   to: '',
@@ -20,7 +20,7 @@ const RECIPIENT_DEFINITION = {
 const props = defineProps<{
   open: boolean;
   address: string;
-  network: number;
+  network: ChainId;
   extraContacts?: Contact[];
   initialState?: any;
 }>();

--- a/apps/ui/src/components/Modal/SendToken.vue
+++ b/apps/ui/src/components/Modal/SendToken.vue
@@ -6,7 +6,7 @@ import { ETH_CONTRACT } from '@/helpers/constants';
 import { createSendTokenTransaction } from '@/helpers/transactions';
 import { clone } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
-import { Contact, Transaction } from '@/types';
+import { ChainId, Contact, NetworkID, Transaction } from '@/types';
 
 const DEFAULT_FORM_STATE = {
   to: '',
@@ -25,8 +25,8 @@ const RECIPIENT_DEFINITION = {
 const props = defineProps<{
   open: boolean;
   address: string;
-  network: number;
-  networkId: string;
+  network: ChainId;
+  networkId: NetworkID;
   extraContacts?: Contact[];
   initialState?: any;
 }>();

--- a/apps/ui/src/components/Modal/StakeToken.vue
+++ b/apps/ui/src/components/Modal/StakeToken.vue
@@ -4,7 +4,7 @@ import { ETH_CONTRACT } from '@/helpers/constants';
 import { createStakeTokenTransaction } from '@/helpers/transactions';
 import { clone } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
-import { NetworkID, Transaction } from '@/types';
+import { ChainId, NetworkID, Transaction } from '@/types';
 
 const STAKING_CONTRACTS = {
   eth: {
@@ -42,7 +42,7 @@ const validator = getValidator({
 const props = defineProps<{
   open: boolean;
   address: string;
-  network: number;
+  network: ChainId;
   networkId: NetworkID;
   initialState?: any;
 }>();

--- a/apps/ui/src/components/Modal/Transaction.vue
+++ b/apps/ui/src/components/Modal/Transaction.vue
@@ -19,7 +19,7 @@ const DEFAULT_FORM_STATE = {
 
 const props = defineProps<{
   open: boolean;
-  network: number;
+  network: number | string;
   extraContacts?: Contact[];
   initialState?: any;
 }>();
@@ -156,6 +156,11 @@ async function handleToChange(to: string) {
 
   if (!isAddress(contractAddress)) {
     console.log('not an address');
+    return;
+  }
+
+  if (typeof props.network === 'string') {
+    console.log('network is not a number (starknet is not supported)');
     return;
   }
 

--- a/apps/ui/src/components/Modal/TreasuryConfig.vue
+++ b/apps/ui/src/components/Modal/TreasuryConfig.vue
@@ -6,8 +6,8 @@ import { SpaceMetadataTreasury } from '@/types';
 
 const DEFAULT_FORM_STATE = {
   name: '',
-  network: null,
-  address: null
+  address: '',
+  network: null
 };
 
 const props = defineProps<{

--- a/apps/ui/src/components/PickerToken.vue
+++ b/apps/ui/src/components/PickerToken.vue
@@ -7,14 +7,15 @@ import { ETH_CONTRACT } from '@/helpers/constants';
 import Multicaller from '@/helpers/multicaller';
 import { getProvider } from '@/helpers/provider';
 import { _n, shorten } from '@/helpers/utils';
+import { ChainId, NetworkID } from '@/types';
 
 const props = defineProps<{
   searchValue: string;
   loading: boolean;
   assets: Token[];
   address: string;
-  network: number;
-  networkId: string;
+  network: ChainId;
+  networkId: NetworkID;
 }>();
 
 const emit = defineEmits<{
@@ -61,6 +62,11 @@ function handlePick(token: Token) {
 
 async function fetchCustomToken(address) {
   if (props.assets.find(asset => asset.contractAddress === address)) return;
+
+  if (typeof props.network === 'string') {
+    console.log('network is not a number (starknet is not supported)');
+    return;
+  }
 
   customTokenLoading.value = true;
 

--- a/apps/ui/src/components/SpaceTreasury.vue
+++ b/apps/ui/src/components/SpaceTreasury.vue
@@ -2,7 +2,7 @@
 import { Token } from '@/helpers/alchemy';
 import { ETH_CONTRACT } from '@/helpers/constants';
 import { _c, _n, sanitizeUrl, shorten } from '@/helpers/utils';
-import { evmNetworks, getNetwork } from '@/networks';
+import { evmNetworks } from '@/networks';
 import { Contact, Space, SpaceMetadataTreasury, Transaction } from '@/types';
 
 const ETHEREUM_NETWORKS = ['eth', 'sep'];
@@ -19,7 +19,7 @@ const router = useRouter();
 const { copy, copied } = useClipboard();
 const { loading, loaded, assets, loadBalances } = useBalances();
 const { loading: nftsLoading, loaded: nftsLoaded, nfts, loadNfts } = useNfts();
-const { treasury } = useTreasury(props.treasuryData);
+const { treasury, getExplorerUrl } = useTreasury(props.treasuryData);
 const { strategiesWithTreasuries } = useTreasuries(props.space);
 const { createDraft } = useEditor();
 
@@ -34,17 +34,7 @@ const modalOpen = ref({
 });
 
 const currentNetworkId = computed(() => {
-  try {
-    return treasury.value?.networkId;
-  } catch (e) {
-    return null;
-  }
-});
-
-const currentNetwork = computed(() => {
-  if (!currentNetworkId.value) return null;
-
-  return getNetwork(currentNetworkId.value);
+  return treasury.value?.networkId ?? null;
 });
 
 const spaceKey = computed(() => `${props.space.network}:${props.space.id}`);
@@ -54,7 +44,13 @@ const executionStrategy = computed(
       strategy => strategy.treasury.address === treasury.value?.wallet
     ) ?? null
 );
-const isReadOnly = computed(() => executionStrategy.value === null);
+const isReadOnly = computed(
+  () =>
+    executionStrategy.value === null ||
+    !currentNetworkId.value ||
+    !treasury.value?.supportsTokens ||
+    !treasury.value?.supportsNfts
+);
 
 const totalQuote = computed(() =>
   assets.value.reduce((acc, asset) => {
@@ -86,18 +82,15 @@ const sortedAssets = computed(() =>
 );
 
 const treasuryExplorerUrl = computed(() => {
-  if (!currentNetwork.value || !treasury.value) return '';
+  if (!treasury.value) return '';
 
-  const url = currentNetwork.value.helpers.getExplorerUrl(
-    treasury.value.wallet,
-    'address'
-  );
-  return sanitizeUrl(url);
+  return getExplorerUrl(treasury.value.wallet, 'address') || '';
 });
 
 const hasStakeableAssets = computed(() => {
   return (
     treasury.value &&
+    treasury.value.networkId &&
     !isReadOnly.value &&
     assets.value.some(asset => asset.contractAddress === ETH_CONTRACT) &&
     ETHEREUM_NETWORKS.includes(treasury.value.networkId)
@@ -126,18 +119,20 @@ async function addTx(tx: Transaction) {
 onMounted(() => {
   if (!treasury.value) return;
 
-  loadBalances(treasury.value.wallet, treasury.value.network);
-  loadNfts(treasury.value.wallet, treasury.value.network);
+  if (treasury.value.supportsTokens) {
+    loadBalances(treasury.value.wallet, treasury.value.network);
+  }
+
+  if (treasury.value.supportsNfts) {
+    loadNfts(treasury.value.wallet, treasury.value.network);
+  }
 });
 
 watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
 </script>
 
 <template>
-  <div
-    v-if="!treasury || !currentNetwork"
-    class="p-4 flex items-center text-skin-link space-x-2"
-  >
+  <div v-if="!treasury" class="p-4 flex items-center text-skin-link space-x-2">
     <IH-exclamation-circle class="inline-block shrink-0" />
     <span>No treasury configured.</span>
   </div>
@@ -147,9 +142,9 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
 
       <UiTooltip
         v-if="
+          !isReadOnly &&
           currentNetworkId &&
-          evmNetworks.includes(currentNetworkId) &&
-          !isReadOnly
+          evmNetworks.includes(currentNetworkId)
         "
         title="Connect to apps"
       >
@@ -197,7 +192,11 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
             'pointer-events-none': !treasuryExplorerUrl
           }"
         >
-          <UiBadgeNetwork :id="treasury.networkId" class="mr-3">
+          <UiBadgeNetwork
+            :id="treasury.networkId"
+            :chain-id="treasury.network"
+            class="mr-3"
+          >
             <UiStamp
               :id="treasury.wallet"
               type="avatar"
@@ -265,7 +264,17 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
             <UiLink :is-active="page === 'nfts'" text="NFTs" />
           </AppLink>
         </div>
-        <div v-if="page === 'tokens'">
+        <div
+          v-if="
+            (page === 'tokens' && !treasury.supportsTokens) ||
+            (page === 'nfts' && !treasury.supportsNfts)
+          "
+          class="p-4 flex items-center text-skin-link space-x-2"
+        >
+          <IH-exclamation-circle class="inline-block shrink-0" />
+          <span>This treasury network is not supported.</span>
+        </div>
+        <div v-else-if="page === 'tokens'">
           <UiLoading v-if="loading && !loaded" class="px-4 py-3 block" />
           <div
             v-else-if="loaded && sortedAssets.length === 0"
@@ -279,20 +288,18 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
             v-else
             :key="i"
             :href="
-              (asset.contractAddress === ETH_CONTRACT
+              asset.contractAddress === ETH_CONTRACT
                 ? treasuryExplorerUrl
-                : sanitizeUrl(
-                    currentNetwork.helpers.getExplorerUrl(
-                      asset.contractAddress,
-                      'token'
-                    )
-                  )) || '#'
+                : getExplorerUrl(asset.contractAddress, 'token') || '#'
             "
             target="_blank"
             class="mx-4 py-3 border-b flex"
           >
             <div class="flex-auto flex items-center min-w-0 space-x-3">
-              <UiBadgeNetwork :id="treasury.networkId">
+              <UiBadgeNetwork
+                :id="treasury.networkId"
+                :chain-id="treasury.network"
+              >
                 <UiStamp
                   :id="`${treasury.networkId}:${asset.contractAddress}`"
                   type="token"
@@ -402,16 +409,17 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
     </div>
     <teleport to="#modal">
       <ModalSendToken
-        v-if="!isReadOnly"
+        v-if="!isReadOnly && currentNetworkId && treasury.supportsTokens"
         :open="modalOpen.tokens"
         :address="treasury.wallet"
         :network="treasury.network"
-        :network-id="treasury.networkId"
+        :network-id="currentNetworkId"
         :extra-contacts="extraContacts"
         @close="modalOpen.tokens = false"
         @add="addTx"
       />
       <ModalSendNft
+        v-if="currentNetworkId"
         :open="modalOpen.nfts"
         :address="treasury.wallet"
         :network="treasury.network"
@@ -420,20 +428,20 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
         @add="addTx"
       />
       <ModalStakeToken
-        v-if="hasStakeableAssets"
+        v-if="hasStakeableAssets && currentNetworkId"
         :open="modalOpen.stake"
         :address="treasury.wallet"
         :network="treasury.network"
-        :network-id="treasury.networkId"
+        :network-id="currentNetworkId"
         @close="modalOpen.stake = false"
         @add="addTx"
       />
       <ModalLinkWalletConnect
-        v-if="executionStrategy"
+        v-if="executionStrategy && currentNetworkId"
         :open="modalOpen.walletConnectLink"
         :address="treasury.wallet"
         :network="treasury.network"
-        :network-id="treasury.networkId"
+        :network-id="currentNetworkId"
         :space-key="spaceKey"
         :execution-strategy="executionStrategy"
         @close="modalOpen.walletConnectLink = false"

--- a/apps/ui/src/composables/useBalances.ts
+++ b/apps/ui/src/composables/useBalances.ts
@@ -6,13 +6,17 @@ import {
   ETH_CONTRACT
 } from '@/helpers/constants';
 import { METADATA } from '@/networks/evm';
+import { ChainId } from '@/types';
 
 const COINGECKO_API_KEY = 'CG-1z19sMoCC6LoqR4b6avyLi3U';
 const COINGECKO_API_URL = 'https://pro-api.coingecko.com/api/v3/simple';
 const COINGECKO_PARAMS = '&vs_currencies=usd&include_24hr_change=true';
 
 export const METADATA_BY_CHAIN_ID = new Map(
-  Object.entries(METADATA).map(([, metadata]) => [metadata.chainId, metadata])
+  Object.entries(METADATA).map(([, metadata]) => [
+    metadata.chainId as ChainId,
+    metadata
+  ])
 );
 
 export function useBalances() {
@@ -47,21 +51,21 @@ export function useBalances() {
     };
   }
 
-  async function loadBalances(address: string, networkId: number) {
-    const metadata = METADATA_BY_CHAIN_ID.get(networkId);
+  async function loadBalances(address: string, chainId: ChainId) {
+    const metadata = METADATA_BY_CHAIN_ID.get(chainId);
     const baseToken = metadata?.ticker
       ? { name: metadata.name, symbol: metadata.ticker }
       : { name: 'Ether', symbol: 'ETH' };
 
-    const data = await getBalances(address, networkId, baseToken);
+    const data = await getBalances(address, chainId, baseToken);
     const tokensWithBalance = data.filter(
       asset =>
         formatUnits(asset.tokenBalance, asset.decimals) !== '0.0' ||
         asset.symbol === baseToken.symbol
     );
 
-    const coingeckoAssetPlatform = COINGECKO_ASSET_PLATFORMS[networkId];
-    const coingeckoBaseAsset = COINGECKO_BASE_ASSETS[networkId];
+    const coingeckoAssetPlatform = COINGECKO_ASSET_PLATFORMS[chainId];
+    const coingeckoBaseAsset = COINGECKO_BASE_ASSETS[chainId];
 
     const coins =
       coingeckoBaseAsset && coingeckoAssetPlatform

--- a/apps/ui/src/composables/useNfts.ts
+++ b/apps/ui/src/composables/useNfts.ts
@@ -1,11 +1,12 @@
 import { getNfts } from '@/helpers/opensea';
+import { ChainId } from '@/types';
 
 export function useNfts() {
   const nfts: Ref<any[]> = ref([]);
   const loading = ref(true);
   const loaded = ref(false);
 
-  async function loadNfts(address: string, chainId: number) {
+  async function loadNfts(address: string, chainId: ChainId) {
     loading.value = true;
 
     nfts.value = await getNfts(address, chainId);

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -6,6 +6,7 @@ import { evmNetworks, getNetwork, offchainNetworks } from '@/networks';
 import { ApiSpace as OffchainApiSpace } from '@/networks/offchain/api/types';
 import {
   GeneratedMetadata,
+  Network,
   StrategyConfig,
   StrategyTemplate
 } from '@/networks/types';
@@ -510,13 +511,18 @@ export function useSpaceSettings(space: Ref<Space>) {
         network: strategy.chainId?.toString() ?? snapshotChainId.value,
         params: strategy.params
       })),
-      treasuries: form.value.treasuries.map(treasury => ({
-        address: treasury.address || '',
-        name: treasury.name || '',
-        network: treasury.network
-          ? String(getNetwork(treasury.network).chainId)
-          : '1'
-      })),
+      treasuries: form.value.treasuries.map(treasury => {
+        let network: Network | null = null;
+        try {
+          network = treasury.network && getNetwork(treasury.network);
+        } catch {}
+
+        return {
+          address: treasury.address || '',
+          name: treasury.name || '',
+          network: String(network ? network.chainId : treasury.chainId ?? '1')
+        };
+      }),
       labels: form.value.labels,
       admins: members.value
         .filter(member => member.role === 'admin')

--- a/apps/ui/src/composables/useTreasury.ts
+++ b/apps/ui/src/composables/useTreasury.ts
@@ -1,21 +1,55 @@
+import { sanitizeUrl } from '@braintree/sanitize-url';
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { SUPPORTED_CHAIN_IDS as TOKENS_SUPPORTED_CHAIN_IDS } from '@/helpers/alchemy';
 import { CHAIN_IDS } from '@/helpers/constants';
+import { SUPPORTED_CHAIN_IDS as NFTS_SUPPORTED_CHAIN_IDS } from '@/helpers/opensea';
+import { getNetwork } from '@/networks';
 import { SpaceMetadataTreasury } from '@/types';
 
 export function useTreasury(treasuryData: SpaceMetadataTreasury) {
   const treasury = computed(() => {
-    if (!treasuryData || !treasuryData.network || !treasuryData.address)
-      return null;
+    if (!treasuryData) return null;
 
-    const chainId = CHAIN_IDS[treasuryData.network];
-    if (!chainId || !treasuryData) return null;
+    const networkId = treasuryData.network;
+
+    const chainId =
+      treasuryData.chainId ?? (networkId ? CHAIN_IDS[networkId] : null);
+    if (!chainId) return null;
 
     return {
-      networkId: treasuryData.network,
+      networkId,
       network: chainId,
       wallet: treasuryData.address,
-      name: treasuryData.name
+      name: treasuryData.name,
+      supportsTokens: TOKENS_SUPPORTED_CHAIN_IDS.includes(chainId as any),
+      supportsNfts: NFTS_SUPPORTED_CHAIN_IDS.includes(chainId as any)
     };
   });
 
-  return { treasury };
+  const currentNetwork = computed(() => {
+    if (!treasury.value?.networkId) return null;
+
+    try {
+      return getNetwork(treasury.value.networkId);
+    } catch (e) {
+      return null;
+    }
+  });
+
+  function getExplorerUrl(address: string, type: 'address' | 'token') {
+    if (!treasury.value) return null;
+
+    let url = '';
+    if (currentNetwork.value) {
+      url = currentNetwork.value.helpers.getExplorerUrl(address, type);
+    } else if (treasury.value.network) {
+      url = `${networks[treasury.value.network].explorer.url}/${type}/${address}`;
+    } else {
+      return null;
+    }
+
+    return sanitizeUrl(url);
+  }
+
+  return { treasury, getExplorerUrl };
 }

--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -1,4 +1,4 @@
-import { VoteType, VoteTypeInfo } from '@/types';
+import { ChainId, NetworkID, VoteType, VoteTypeInfo } from '@/types';
 
 export const APP_NAME = 'Snapshot';
 
@@ -6,17 +6,21 @@ export const SIDEKICK_URL = 'https://sh5.co';
 
 export const ETH_CONTRACT = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 
-export const CHAIN_IDS = {
-  matic: 137,
-  arb1: 42161,
-  oeth: 10,
+export const CHAIN_IDS: Record<Exclude<NetworkID, 's' | 's-tn'>, ChainId> = {
+  // EVM
   eth: 1,
-  sep: 11155111,
-  'linea-testnet': 59140,
+  oeth: 10,
   bsc: 56,
   xdai: 100,
+  matic: 137,
   fantom: 250,
-  base: 8453
+  base: 8453,
+  arb1: 42161,
+  'linea-testnet': 59140,
+  sep: 11155111,
+  // Starknet
+  sn: '0x534e5f4d41494e',
+  'sn-sep': '0x534e5f5345504f4c4941'
 };
 
 export const COINGECKO_ASSET_PLATFORMS = {

--- a/apps/ui/src/helpers/opensea.ts
+++ b/apps/ui/src/helpers/opensea.ts
@@ -1,3 +1,5 @@
+import { ChainId } from '@/types';
+
 type ApiNft = {
   identifier: string;
   collection: string;
@@ -18,23 +20,43 @@ type ChainItem = {
   isTestnet: boolean;
 };
 
-const SUPPORTED_ABIS = ['erc721', 'erc1155'];
-const OPENSEA_CHAINS: Record<number, ChainItem> = {
-  11155111: { name: 'sepolia', isTestnet: true },
+export const SUPPORTED_CHAIN_IDS = [
+  1, // Ethereum,
+  10, // Optimism,
+  137, // Polygon,
+  1329, // Sei
+  8217, // Klaytn
+  8453, // Base
+  42161, // Arbitrum
+  42170, // Arbitrum Nova
+  43114, // Avalanche
+  81457, // Blast
+  11155111 // Sepolia
+] as const;
+
+const NETWORKS: Record<(typeof SUPPORTED_CHAIN_IDS)[number], ChainItem> = {
   1: { name: 'ethereum', isTestnet: false },
   10: { name: 'optimism', isTestnet: false },
   137: { name: 'matic', isTestnet: false },
-  42161: { name: 'arbitrum', isTestnet: false }
+  1329: { name: 'sei', isTestnet: false },
+  8217: { name: 'klaytn', isTestnet: false },
+  8453: { name: 'base', isTestnet: false },
+  42161: { name: 'arbitrum', isTestnet: false },
+  42170: { name: 'arbitrum_nova', isTestnet: false },
+  43114: { name: 'avalanche', isTestnet: false },
+  81457: { name: 'blast', isTestnet: false },
+  11155111: { name: 'sepolia', isTestnet: true }
 };
+
+const SUPPORTED_ABIS = ['erc721', 'erc1155'];
 
 export async function getNfts(
   address: string,
-  chainId: number
+  chainId: ChainId
 ): Promise<ApiNft[]> {
-  const chain = OPENSEA_CHAINS[chainId];
-  if (!chain) throw new Error('Unsupported chain for OpenSea NFTs');
-
-  const { name, isTestnet } = chain;
+  const network = NETWORKS[chainId];
+  if (!network) throw new Error('Unsupported chain for OpenSea NFTs');
+  const { name, isTestnet } = network;
 
   const endpoint = isTestnet
     ? 'https://testnets-api.opensea.io'

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -13,7 +13,6 @@ import {
   validateAndParseAddress
 } from 'starknet';
 import { RouteParamsRaw } from 'vue-router';
-import networks from '@/helpers/networks.json';
 import { VotingPowerItem } from '@/stores/votingPowers';
 import { Choice, Proposal, SpaceMetadata } from '@/types';
 import { MAX_SYMBOL_LENGTH } from './constants';
@@ -124,11 +123,6 @@ export function formatAddress(address: string) {
   } catch {
     return address;
   }
-}
-
-export function explorerUrl(network, str: string, type = 'address'): string {
-  if (network === 'starknet') type = 'contract';
-  return `${networks[network].explorer}/${type}/${str}`;
 }
 
 export function getProposalId(proposal: Proposal) {

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -62,7 +62,7 @@ const DEFAULT_AUTHENTICATOR = 'OffchainAuthenticator';
 const TREASURY_NETWORKS = new Map(
   Object.entries(CHAIN_IDS).map(([networkId, chainId]) => [
     chainId,
-    networkId as NetworkID
+    networkId as keyof typeof CHAIN_IDS
   ])
 );
 
@@ -107,18 +107,16 @@ function formatSpace(
   networkId: NetworkID,
   constants: NetworkConstants
 ): Space {
-  const treasuries: SpaceMetadataTreasury[] = space.treasuries
-    .map(treasury => {
-      const chainId = parseInt(treasury.network, 10);
+  const treasuries: SpaceMetadataTreasury[] = space.treasuries.map(treasury => {
+    const chainId = parseInt(treasury.network, 10);
 
-      return {
-        name: treasury.name,
-        network: TREASURY_NETWORKS.get(chainId) ?? null,
-        address: treasury.address,
-        chainId
-      };
-    })
-    .filter(treasury => !!treasury.network);
+    return {
+      name: treasury.name,
+      network: TREASURY_NETWORKS.get(chainId) ?? null,
+      address: treasury.address,
+      chainId
+    };
+  });
 
   let validationName = space.validation.name;
   const validationParams = clone(space.validation.params) || {};

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -27,6 +27,8 @@ export type NetworkID =
   | 'fantom'
   | 'base';
 
+export type ChainId = number | string;
+
 export type Choice =
   | 'for'
   | 'against'
@@ -63,10 +65,10 @@ export type SelectedStrategy = {
 };
 
 export type SpaceMetadataTreasury = {
-  name: string | null;
-  network: NetworkID | null;
-  address: string | null;
-  chainId?: number;
+  name: string;
+  network: Exclude<NetworkID, 's' | 's-tn'> | null;
+  address: string;
+  chainId?: ChainId;
 };
 
 export type SpaceMetadataLabel = {

--- a/apps/ui/src/views/Space/Treasury.vue
+++ b/apps/ui/src/views/Space/Treasury.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { shorten } from '@/helpers/utils';
-import { RequiredProperty, Space, SpaceMetadataTreasury } from '@/types';
+import { Space } from '@/types';
 
 const props = defineProps<{ space: Space }>();
 
@@ -14,14 +14,8 @@ const activeTreasuryId = computed(() => {
   return parseInt(route.params.index as string) - 1;
 });
 
-const filteredTreasuries = computed(
-  () =>
-    props.space.treasuries.filter(
-      t => t.address && t.network
-    ) as RequiredProperty<SpaceMetadataTreasury>[]
-);
 const treasuryData = computed(
-  () => filteredTreasuries.value[activeTreasuryId.value]
+  () => props.space.treasuries[activeTreasuryId.value]
 );
 
 // scroll to treasury tab
@@ -39,7 +33,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
 watchEffect(() => {
   const { index, tab } = route.params;
 
-  if (!filteredTreasuries.value.length) return;
+  if (!props.space.treasuries.length) return;
 
   const isValidTab = ['tokens', 'nfts'].includes(tab as string);
   if (!index || !tab || !isValidTab) {
@@ -56,7 +50,7 @@ watchEffect(() => {
 
 <template>
   <UiScrollerHorizontal
-    v-if="filteredTreasuries.length !== 1"
+    v-if="props.space.treasuries.length !== 1"
     ref="treasuriesList"
     class="z-40 sticky top-[71px] lg:top-[72px]"
     with-buttons
@@ -64,7 +58,7 @@ watchEffect(() => {
   >
     <div class="flex px-4 space-x-3 bg-skin-bg border-b min-w-max">
       <AppLink
-        v-for="(treasury, i) in filteredTreasuries"
+        v-for="(treasury, i) in props.space.treasuries"
         :key="i"
         :to="{
           name: 'space-treasury',
@@ -87,7 +81,7 @@ watchEffect(() => {
     :key="activeTreasuryId"
     :space="space"
     :treasury-data="treasuryData"
-    :extra-contacts="filteredTreasuries"
+    :extra-contacts="props.space.treasuries"
   />
   <div v-else class="flex items-center px-4 py-3 text-skin-link gap-2">
     <IH-exclamation-circle />


### PR DESCRIPTION
### Summary

This PR starts work towards making treasuries more flexible in terms of support.
- Treasury network doesn't need to be supported by the app to for treasury to show up (will be read-only, can't be used in execution at the moment)
- Treasury can have varying support for tokens/NFTs - if we only support tokens for specific treasury it will still be displayed in the UI, just message that NFTs are not supported for this network will be displayed. We might be missing support for both tokens and NFTs, and it will still be visible, you will have link to explorer to check it yourself.
- Starknet treasuries will be visible now (but they don't have balance/NFTs support at the moment).
- Treasuries for unsupported networks will be displayed in settings (but network selector won't display those unsupported networks at the moment, will be upcoming PR), if left untouched it will not be modified (previously they will be removed on save).

Towards: https://github.com/snapshot-labs/sx-monorepo/issues/830

### How to test

1. On v1 add treasuries with unsupported networks to your space.
2. On SX you can see those treasuries (including balances or NFTs if supported).
3. On SX add Starknet treasury to your onchain space.
4. On SX you can see that treasury.
5. On editor page everything looks good as well.

### Screenshots

<img width="1379" alt="image" src="https://github.com/user-attachments/assets/3cb51ac0-0321-4669-999a-031962376aa9">
<img width="1381" alt="image" src="https://github.com/user-attachments/assets/0fd4e629-2ee7-44c7-9d05-17cc218ef6fa">
<img width="1378" alt="image" src="https://github.com/user-attachments/assets/6e0e5bc5-0b9a-4852-8710-bccbb4c37b31">
