### PR TITLE
feat: enable delegations on all networks

### DIFF
--- a/.changeset/gentle-peas-nail.md
+++ b/.changeset/gentle-peas-nail.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+remove networks with empty config

--- a/apps/ui/src/components/FormSpaceDelegations.vue
+++ b/apps/ui/src/components/FormSpaceDelegations.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import Draggable from 'vuedraggable';
-import { SpaceMetadataDelegation } from '@/types';
+import { NetworkID, SpaceMetadataDelegation } from '@/types';
 
 const model = defineModel<SpaceMetadataDelegation[]>({
   required: true
 });
 
 defineProps<{
+  networkId: NetworkID;
   limit?: number;
 }>();
 
@@ -89,6 +90,7 @@ function deleteDelegation(index: number) {
   <teleport to="#modal">
     <ModalDelegationConfig
       :open="modalOpen"
+      :network-id="networkId"
       :initial-state="delegationInitialState ?? undefined"
       @close="modalOpen = false"
       @add="addDelegationConfig"

--- a/apps/ui/src/components/Modal/Delegate.vue
+++ b/apps/ui/src/components/Modal/Delegate.vue
@@ -47,11 +47,7 @@ const sending = ref(false);
 const formErrors = ref({} as Record<string, any>);
 
 async function handleSubmit() {
-  if (
-    !props.delegation.apiType ||
-    !props.delegation.contractNetwork ||
-    !props.delegation.contractAddress
-  ) {
+  if (!props.delegation.apiType || !props.delegation.contractAddress) {
     return;
   }
 
@@ -63,7 +59,8 @@ async function handleSubmit() {
       props.delegation.contractNetwork,
       props.delegation.apiType,
       form.delegatee,
-      `${props.delegation.contractNetwork}:${props.delegation.contractAddress}`
+      `${props.delegation.contractNetwork}:${props.delegation.contractAddress}`,
+      props.delegation.chainId ?? undefined
     );
     emit('close');
   } catch (e) {

--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import removeMarkdown from 'remove-markdown';
-import { _n, _p, _vp, getGenericExplorerUrl, shorten } from '@/helpers/utils';
+import { getGenericExplorerUrl } from '@/helpers/explorer';
+import { _n, _p, _vp, shorten } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
 import { DelegationType, Space, SpaceMetadataDelegation } from '@/types';
 
@@ -57,7 +58,6 @@ function getExplorerUrl(address: string, type: 'address' | 'token') {
     url = currentNetwork.value.helpers.getExplorerUrl(address, type);
   } else if (props.delegation.chainId) {
     url = getGenericExplorerUrl(props.delegation.chainId, address, type);
-    console.log('generic', url);
   } else {
     return null;
   }

--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { sanitizeUrl } from '@braintree/sanitize-url';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import removeMarkdown from 'remove-markdown';
-import { _n, _p, _vp, shorten } from '@/helpers/utils';
+import { _n, _p, _vp, getGenericExplorerUrl, shorten } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
 import { DelegationType, Space, SpaceMetadataDelegation } from '@/types';
 
@@ -53,14 +52,17 @@ const currentNetwork = computed(() => {
 const spaceKey = computed(() => `${props.space.network}:${props.space.id}`);
 
 function getExplorerUrl(address: string, type: 'address' | 'token') {
-  let url = '';
+  let url: string | null = null;
   if (currentNetwork.value) {
     url = currentNetwork.value.helpers.getExplorerUrl(address, type);
   } else if (props.delegation.chainId) {
-    url = `${networks[props.delegation.chainId].explorer.url}/${type}/${address}`;
+    url = getGenericExplorerUrl(props.delegation.chainId, address, type);
+    console.log('generic', url);
   } else {
     return null;
   }
+
+  if (!url) return null;
 
   return sanitizeUrl(url);
 }

--- a/apps/ui/src/components/Ui/SelectorNetwork.vue
+++ b/apps/ui/src/components/Ui/SelectorNetwork.vue
@@ -41,8 +41,8 @@ const options = computed(() => {
 
     return [
       ...baseNetworks,
-      ...Object.entries(STARKNET_NETWORK_METADATA).map(([key, metadata]) => ({
-        id: key,
+      ...Object.values(STARKNET_NETWORK_METADATA).map(metadata => ({
+        id: metadata.chainId,
         name: metadata.name,
         icon: h('img', {
           src: getUrl(metadata.avatar),

--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -2,6 +2,7 @@ import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
 import { registerTransaction } from '@/helpers/mana';
 import { getNetwork, getReadWriteNetwork, metadataNetwork } from '@/networks';
 import { STARKNET_CONNECTORS } from '@/networks/common/constants';
+import { METADATA } from '@/networks/starknet';
 import { Connector, ExecutionInfo, StrategyConfig } from '@/networks/types';
 import {
   ChainId,
@@ -570,7 +571,12 @@ export function useActions() {
     if (!web3.value.account) return await forceLogin();
 
     const isEvmNetwork = typeof chainIdOverride === 'number';
-    const actionNetwork = networkId ?? isEvmNetwork ? 'eth' : null;
+    const actionNetwork =
+      networkId ?? isEvmNetwork
+        ? 'eth'
+        : (Object.entries(METADATA).find(
+            ([, metadata]) => metadata.chainId === chainIdOverride
+          )?.[0] as NetworkID);
     if (!actionNetwork) throw new Error('Failed to detect action network');
 
     const network = getReadWriteNetwork(actionNetwork);

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -464,7 +464,6 @@ export function useSpaceSettings(space: Ref<Space>) {
     let delegationPortal: OffchainSpaceSettings['delegationPortal'] = null;
     if (
       form.value.delegations.length > 0 &&
-      form.value.delegations[0].contractNetwork &&
       form.value.delegations[0].contractAddress &&
       form.value.delegations[0].apiUrl &&
       form.value.delegations[0].apiType
@@ -475,9 +474,7 @@ export function useSpaceSettings(space: Ref<Space>) {
           : form.value.delegations[0].apiType;
 
       delegationPortal = {
-        delegationNetwork: String(
-          getNetwork(form.value.delegations[0].contractNetwork).chainId
-        ),
+        delegationNetwork: String(form.value.delegations[0].chainId ?? '1'),
         delegationContract: form.value.delegations[0].contractAddress,
         delegationApi: form.value.delegations[0].apiUrl,
         delegationType: apiType

--- a/apps/ui/src/composables/useTreasury.ts
+++ b/apps/ui/src/composables/useTreasury.ts
@@ -1,8 +1,8 @@
 import { sanitizeUrl } from '@braintree/sanitize-url';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { SUPPORTED_CHAIN_IDS as TOKENS_SUPPORTED_CHAIN_IDS } from '@/helpers/alchemy';
 import { CHAIN_IDS } from '@/helpers/constants';
 import { SUPPORTED_CHAIN_IDS as NFTS_SUPPORTED_CHAIN_IDS } from '@/helpers/opensea';
+import { getGenericExplorerUrl } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
 import { SpaceMetadataTreasury } from '@/types';
 
@@ -39,14 +39,14 @@ export function useTreasury(treasuryData: SpaceMetadataTreasury) {
   function getExplorerUrl(address: string, type: 'address' | 'token') {
     if (!treasury.value) return null;
 
-    let url = '';
+    let url: string | null = null;
     if (currentNetwork.value) {
       url = currentNetwork.value.helpers.getExplorerUrl(address, type);
     } else if (treasury.value.network) {
-      url = `${networks[treasury.value.network].explorer.url}/${type}/${address}`;
-    } else {
-      return null;
+      url = getGenericExplorerUrl(treasury.value.network, address, type);
     }
+
+    if (!url) return null;
 
     return sanitizeUrl(url);
   }

--- a/apps/ui/src/composables/useTreasury.ts
+++ b/apps/ui/src/composables/useTreasury.ts
@@ -1,8 +1,8 @@
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import { SUPPORTED_CHAIN_IDS as TOKENS_SUPPORTED_CHAIN_IDS } from '@/helpers/alchemy';
 import { CHAIN_IDS } from '@/helpers/constants';
+import { getGenericExplorerUrl } from '@/helpers/explorer';
 import { SUPPORTED_CHAIN_IDS as NFTS_SUPPORTED_CHAIN_IDS } from '@/helpers/opensea';
-import { getGenericExplorerUrl } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
 import { SpaceMetadataTreasury } from '@/types';
 

--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -10,11 +10,7 @@ export const CHAIN_IDS: Record<Exclude<NetworkID, 's' | 's-tn'>, ChainId> = {
   // EVM
   eth: 1,
   oeth: 10,
-  bsc: 56,
-  xdai: 100,
   matic: 137,
-  fantom: 250,
-  base: 8453,
   arb1: 42161,
   'linea-testnet': 59140,
   sep: 11155111,

--- a/apps/ui/src/helpers/explorer.ts
+++ b/apps/ui/src/helpers/explorer.ts
@@ -1,0 +1,30 @@
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { getNetwork } from '@/networks';
+import { METADATA as STARKNET_NETWORKS_METADATA } from '@/networks/starknet';
+import { ChainId, NetworkID } from '@/types';
+
+// NOTE: This function has to be outside regular utils as it imports from @/networks
+// which would cause a circular dependency if it was in utils
+
+export function getGenericExplorerUrl(
+  chainId: ChainId,
+  address: string,
+  type: 'address' | 'token'
+) {
+  if (typeof chainId === 'number') {
+    return `${networks[chainId].explorer.url}/${type}/${address}`;
+  }
+
+  const starknetNetwork = Object.entries(STARKNET_NETWORKS_METADATA).find(
+    ([, { chainId: starknetChainId }]) => starknetChainId === chainId
+  )?.[0];
+
+  if (!starknetNetwork) return null;
+
+  try {
+    const network = getNetwork(starknetNetwork as NetworkID);
+    return network.helpers.getExplorerUrl(address, type);
+  } catch {
+    return null;
+  }
+}

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -2,7 +2,6 @@ import { sanitizeUrl as baseSanitizeUrl } from '@braintree/sanitize-url';
 import { getAddress, isAddress } from '@ethersproject/address';
 import { Web3Provider } from '@ethersproject/providers';
 import { upload as pin } from '@snapshot-labs/pineapple';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import Autolinker from 'autolinker';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
@@ -14,10 +13,8 @@ import {
   validateAndParseAddress
 } from 'starknet';
 import { RouteParamsRaw } from 'vue-router';
-import { getNetwork } from '@/networks';
-import { METADATA } from '@/networks/starknet';
 import { VotingPowerItem } from '@/stores/votingPowers';
-import { ChainId, Choice, NetworkID, Proposal, SpaceMetadata } from '@/types';
+import { Choice, Proposal, SpaceMetadata } from '@/types';
 import { MAX_SYMBOL_LENGTH } from './constants';
 import pkg from '@/../package.json';
 import ICCoingecko from '~icons/c/coingecko';
@@ -354,29 +351,6 @@ export function uniqBy<T>(arr: T[], predicate: keyof T | ((o: T) => any)): T[] {
 
 export function clone<T>(obj: T): T {
   return JSON.parse(JSON.stringify(obj));
-}
-
-export function getGenericExplorerUrl(
-  chainId: ChainId,
-  address: string,
-  type: 'address' | 'token'
-) {
-  if (typeof chainId === 'number') {
-    return `${networks[chainId].explorer.url}/${type}/${address}`;
-  }
-
-  const starknetNetwork = Object.entries(METADATA).find(
-    ([, { chainId: starknetChainId }]) => starknetChainId === chainId
-  )?.[0];
-
-  if (!starknetNetwork) return null;
-
-  try {
-    const network = getNetwork(starknetNetwork as NetworkID);
-    return network.helpers.getExplorerUrl(address, type);
-  } catch {
-    return null;
-  }
 }
 
 export async function verifyNetwork(

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -2,6 +2,7 @@ import { sanitizeUrl as baseSanitizeUrl } from '@braintree/sanitize-url';
 import { getAddress, isAddress } from '@ethersproject/address';
 import { Web3Provider } from '@ethersproject/providers';
 import { upload as pin } from '@snapshot-labs/pineapple';
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import Autolinker from 'autolinker';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
@@ -13,8 +14,10 @@ import {
   validateAndParseAddress
 } from 'starknet';
 import { RouteParamsRaw } from 'vue-router';
+import { getNetwork } from '@/networks';
+import { METADATA } from '@/networks/starknet';
 import { VotingPowerItem } from '@/stores/votingPowers';
-import { Choice, Proposal, SpaceMetadata } from '@/types';
+import { ChainId, Choice, NetworkID, Proposal, SpaceMetadata } from '@/types';
 import { MAX_SYMBOL_LENGTH } from './constants';
 import pkg from '@/../package.json';
 import ICCoingecko from '~icons/c/coingecko';
@@ -351,6 +354,29 @@ export function uniqBy<T>(arr: T[], predicate: keyof T | ((o: T) => any)): T[] {
 
 export function clone<T>(obj: T): T {
   return JSON.parse(JSON.stringify(obj));
+}
+
+export function getGenericExplorerUrl(
+  chainId: ChainId,
+  address: string,
+  type: 'address' | 'token'
+) {
+  if (typeof chainId === 'number') {
+    return `${networks[chainId].explorer.url}/${type}/${address}`;
+  }
+
+  const starknetNetwork = Object.entries(METADATA).find(
+    ([, { chainId: starknetChainId }]) => starknetChainId === chainId
+  )?.[0];
+
+  if (!starknetNetwork) return null;
+
+  try {
+    const network = getNetwork(starknetNetwork as NetworkID);
+    return network.helpers.getExplorerUrl(address, type);
+  } catch {
+    return null;
+  }
 }
 
 export async function verifyNetwork(

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -202,7 +202,8 @@ function formatSpace(
         apiType: api_type,
         apiUrl: api_url,
         contractNetwork: network === 'null' ? null : network,
-        contractAddress: address === 'null' ? null : address
+        contractAddress: address === 'null' ? null : address,
+        chainId: CHAIN_IDS[network]
       };
     }),
     executors: space.metadata.executors,

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -12,7 +12,6 @@ import {
   evmSepolia,
   getEvmStrategy
 } from '@snapshot-labs/sx';
-import { CHAIN_IDS } from '@/helpers/constants';
 import { vote as highlightVote } from '@/helpers/highlight';
 import { getSwapLink } from '@/helpers/link';
 import { executionCall, MANA_URL } from '@/helpers/mana';
@@ -36,6 +35,7 @@ import {
   VotingPower
 } from '@/networks/types';
 import {
+  ChainId,
   Choice,
   DelegationType,
   NetworkID,
@@ -595,9 +595,15 @@ export function createActions(
       networkId: NetworkID,
       delegationType: DelegationType,
       delegatee: string,
-      delegationContract: string
+      delegationContract: string,
+      chainIdOverride?: ChainId
     ) => {
-      await verifyNetwork(web3, CHAIN_IDS[networkId]);
+      if (typeof chainIdOverride === 'string') {
+        throw new Error('Chain ID must be a number for EVM networks');
+      }
+
+      const currentChainId = chainIdOverride || chainId;
+      await verifyNetwork(web3, currentChainId);
 
       let contractParams: {
         address: string;

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -76,35 +76,6 @@ export const METADATA: Record<string, Metadata> = {
     avatar:
       'ipfs://bafkreibn4mjs54bnmvkrkiaiwp47gvcz6bervg2kr5ubknytfyz6l5wbs4',
     blockTime: 13.52926
-  },
-  bsc: {
-    name: 'BNB Smart Chain',
-    chainId: 56,
-    apiUrl: '',
-    avatar:
-      'ipfs://bafkreibll4la7wqerzs7zwxjne2j7ayynbg2wlenemssoahxxj5rbt6c64',
-    blockTime: 0
-  },
-  xdai: {
-    name: 'Gnosis Chain',
-    chainId: 100,
-    apiUrl: '',
-    avatar: 'ipfs://QmZeiy8Ax4133wzxUQM9ky8z5XFVf6YLFjJMmTWbWVniZR',
-    blockTime: 0
-  },
-  fantom: {
-    name: 'Fantom Opera',
-    chainId: 250,
-    apiUrl: '',
-    avatar: 'ipfs://QmVEgNeQDKnXygeGxfY9FywZpNGQu98ktZtRJ9bToYF6g7',
-    blockTime: 0
-  },
-  base: {
-    name: 'Base',
-    chainId: 8453,
-    apiUrl: '',
-    avatar: 'ipfs://QmaxRoHpxZd8PqccAynherrMznMufG6sdmHZLihkECXmZv',
-    blockTime: 0
   }
 };
 

--- a/apps/ui/src/networks/index.ts
+++ b/apps/ui/src/networks/index.ts
@@ -4,8 +4,6 @@ import { createOffchainNetwork } from './offchain';
 import { createStarknetNetwork } from './starknet';
 import { ExplorePageProtocol, ProtocolConfig, ReadWriteNetwork } from './types';
 
-type GetNetworkOptions = { allowDisabledNetwork: boolean };
-
 const snapshotNetwork = createOffchainNetwork('s');
 const snapshotTestnetNetwork = createOffchainNetwork('s-tn');
 const starknetNetwork = createStarknetNetwork('sn');
@@ -15,10 +13,6 @@ const arbitrumNetwork = createEvmNetwork('arb1');
 const optimismNetwork = createEvmNetwork('oeth');
 const ethereumNetwork = createEvmNetwork('eth');
 const sepoliaNetwork = createEvmNetwork('sep');
-const bnbNetwork = createEvmNetwork('bsc');
-const gnosisNetwork = createEvmNetwork('xdai');
-const fantomNetwork = createEvmNetwork('fantom');
-const baseNetwork = createEvmNetwork('base');
 const lineaTestnetNetwork = createEvmNetwork('linea-testnet');
 
 export const enabledNetworks: NetworkID[] = import.meta.env
@@ -32,11 +26,7 @@ export const evmNetworks: NetworkID[] = [
   'arb1',
   'oeth',
   'sep',
-  'linea-testnet',
-  'bsc',
-  'xdai',
-  'fantom',
-  'base'
+  'linea-testnet'
 ];
 export const offchainNetworks: NetworkID[] = ['s', 's-tn'];
 export const starknetNetworks: NetworkID[] = ['sn', 'sn-sep'];
@@ -44,10 +34,8 @@ export const starknetNetworks: NetworkID[] = ['sn', 'sn-sep'];
 export const metadataNetwork: NetworkID =
   import.meta.env.VITE_METADATA_NETWORK || 's';
 
-export const getNetwork = (id: NetworkID, options?: GetNetworkOptions) => {
-  const opts = { allowDisabledNetwork: false, ...options };
-
-  if (!enabledNetworks.includes(id) && !opts.allowDisabledNetwork)
+export const getNetwork = (id: NetworkID) => {
+  if (!enabledNetworks.includes(id))
     throw new Error(`Network ${id} is not enabled`);
 
   if (id === 's') return snapshotNetwork;
@@ -60,19 +48,12 @@ export const getNetwork = (id: NetworkID, options?: GetNetworkOptions) => {
   if (id === 'linea-testnet') return lineaTestnetNetwork;
   if (id === 'sn') return starknetNetwork;
   if (id === 'sn-sep') return starknetSepoliaNetwork;
-  if (id === 'bsc') return bnbNetwork;
-  if (id === 'xdai') return gnosisNetwork;
-  if (id === 'fantom') return fantomNetwork;
-  if (id === 'base') return baseNetwork;
 
   throw new Error(`Unknown network ${id}`);
 };
 
-export const getReadWriteNetwork = (
-  id: NetworkID,
-  options?: GetNetworkOptions
-): ReadWriteNetwork => {
-  const network = getNetwork(id, options);
+export const getReadWriteNetwork = (id: NetworkID): ReadWriteNetwork => {
+  const network = getNetwork(id);
   if (network.readOnly) throw new Error(`Network ${id} is read-only`);
 
   return network;

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -369,26 +369,28 @@ function formatDelegations(space: ApiSpace): SpaceMetadataDelegation[] {
         ? (['governor-subgraph', 'ERC-20 Votes'] as const)
         : [space.delegationPortal.delegationType, 'Split Delegation'];
 
+    const chainId = parseInt(space.delegationPortal.delegationNetwork, 10);
+
     delegations.push({
       name,
       apiType,
       apiUrl: space.delegationPortal.delegationApi,
-      contractNetwork:
-        CHAIN_IDS_TO_NETWORKS[
-          parseInt(space.delegationPortal.delegationNetwork, 10)
-        ] || null,
-      contractAddress: space.delegationPortal.delegationContract
+      contractNetwork: CHAIN_IDS_TO_NETWORKS[chainId] || null,
+      contractAddress: space.delegationPortal.delegationContract,
+      chainId
     });
   }
 
   if (spaceDelegationStrategy) {
+    const chainId = parseInt(space.network, 10);
+
     delegations.push({
       name: 'Delegate registry',
       apiType: 'delegate-registry',
       apiUrl: DELEGATE_REGISTRY_URL,
-      contractNetwork:
-        CHAIN_IDS_TO_NETWORKS[parseInt(space.network, 10)] || null,
-      contractAddress: space.id
+      contractNetwork: CHAIN_IDS_TO_NETWORKS[chainId] || null,
+      contractAddress: space.id,
+      chainId
     });
   }
 

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -85,7 +85,9 @@ function formatSpace(
   constants: NetworkConstants
 ): Space {
   const treasuries: SpaceMetadataTreasury[] = space.treasuries.map(treasury => {
-    const chainId = parseInt(treasury.network, 10);
+    const chainId = treasury.network.startsWith('0x')
+      ? treasury.network
+      : parseInt(treasury.network, 10);
 
     return {
       name: treasury.name,
@@ -346,7 +348,9 @@ function formatDelegations(space: ApiSpace): SpaceMetadataDelegation[] {
         ? (['governor-subgraph', 'ERC-20 Votes'] as const)
         : [space.delegationPortal.delegationType, 'Split Delegation'];
 
-    const chainId = parseInt(space.delegationPortal.delegationNetwork, 10);
+    const chainId = space.delegationPortal.delegationNetwork.startsWith('0x')
+      ? space.delegationPortal.delegationNetwork
+      : parseInt(space.delegationPortal.delegationNetwork, 10);
 
     delegations.push({
       name,

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -59,35 +59,12 @@ import { DEFAULT_VOTING_DELAY } from '../constants';
 
 const DEFAULT_AUTHENTICATOR = 'OffchainAuthenticator';
 
-const TREASURY_NETWORKS = new Map(
-  Object.entries(CHAIN_IDS).map(([networkId, chainId]) => [
-    chainId,
-    networkId as keyof typeof CHAIN_IDS
-  ])
-);
-
 const DELEGATION_STRATEGIES = [
   'delegation',
   'erc20-balance-of-delegation',
   'delegation-with-cap',
   'delegation-with-overrides'
 ];
-
-const SUPPORTED_DELEGATION_NETWORKS: NetworkID[] = [
-  'eth',
-  'oeth',
-  'bsc',
-  'xdai',
-  'matic',
-  'fantom',
-  'base',
-  'arb1',
-  'sep'
-];
-
-const CHAIN_IDS_TO_NETWORKS: Record<number, NetworkID> = Object.fromEntries(
-  SUPPORTED_DELEGATION_NETWORKS.map(network => [CHAIN_IDS[network], network])
-);
 
 const DELEGATE_REGISTRY_URL = 'https://delegate-registry-api.snapshot.box';
 
@@ -112,7 +89,7 @@ function formatSpace(
 
     return {
       name: treasury.name,
-      network: TREASURY_NETWORKS.get(chainId) ?? null,
+      network: null,
       address: treasury.address,
       chainId
     };
@@ -375,7 +352,7 @@ function formatDelegations(space: ApiSpace): SpaceMetadataDelegation[] {
       name,
       apiType,
       apiUrl: space.delegationPortal.delegationApi,
-      contractNetwork: CHAIN_IDS_TO_NETWORKS[chainId] || null,
+      contractNetwork: null,
       contractAddress: space.delegationPortal.delegationContract,
       chainId
     });
@@ -388,7 +365,7 @@ function formatDelegations(space: ApiSpace): SpaceMetadataDelegation[] {
       name: 'Delegate registry',
       apiType: 'delegate-registry',
       apiUrl: DELEGATE_REGISTRY_URL,
-      contractNetwork: CHAIN_IDS_TO_NETWORKS[chainId] || null,
+      contractNetwork: null,
       contractAddress: space.id,
       chainId
     });

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -250,7 +250,8 @@ export type NetworkActions = ReadOnlyNetworkActions & {
     networkId: NetworkID,
     delegationType: DelegationType,
     delegatee: string,
-    delegationContract: string
+    delegationContract: string,
+    chainIdOverride?: ChainId
   );
 };
 

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -21,11 +21,7 @@ export type NetworkID =
   | 'sep'
   | 'linea-testnet'
   | 'sn'
-  | 'sn-sep'
-  | 'bsc'
-  | 'xdai'
-  | 'fantom'
-  | 'base';
+  | 'sn-sep';
 
 export type ChainId = number | string;
 
@@ -84,6 +80,7 @@ export type SpaceMetadataDelegation = {
   apiUrl: string | null;
   contractNetwork: NetworkID | null;
   contractAddress: string | null;
+  chainId?: ChainId | null;
 };
 
 export type SpaceMetadata = {

--- a/apps/ui/src/views/Create.vue
+++ b/apps/ui/src/views/Create.vue
@@ -215,6 +215,7 @@ watchEffect(() => setTitle('Create space'));
               />
               <FormSpaceDelegations
                 v-model="metadataForm.delegations"
+                :network-id="selectedNetworkId"
                 class="mt-2"
               />
             </div>

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -327,6 +327,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
     >
       <FormSpaceDelegations
         v-model="form.delegations"
+        :network-id="space.network"
         :limit="isOffchainNetwork ? 1 : undefined"
       />
     </UiContainerSettings>

--- a/packages/sx.js/src/evmNetworks.ts
+++ b/packages/sx.js/src/evmNetworks.ts
@@ -46,35 +46,6 @@ function createStandardConfig(
   };
 }
 
-function createEmptyConfig(eip712ChainId: number) {
-  return {
-    Meta: {
-      eip712ChainId,
-      proxyFactory: '',
-      masterSpace: ''
-    },
-    Authenticators: {
-      EthSig: '',
-      EthTx: ''
-    },
-    Strategies: {
-      Vanilla: '',
-      Comp: '',
-      OZVotes: '',
-      Whitelist: ''
-    },
-    ProposalValidations: {
-      VotingPower: ''
-    },
-    ExecutionStrategies: {
-      SimpleQuorumAvatar: '',
-      SimpleQuorumTimelock: '',
-      Axiom: null,
-      Isokratia: null
-    }
-  };
-}
-
 function createEvmConfig(
   networkId: keyof typeof evmNetworks
 ): EvmNetworkConfig {
@@ -161,11 +132,7 @@ export const evmNetworks = {
       Axiom: null,
       Isokratia: null
     }
-  },
-  bsc: createEmptyConfig(56),
-  xdai: createEmptyConfig(100),
-  fantom: createEmptyConfig(250),
-  base: createEmptyConfig(8453)
+  }
 } as const;
 
 export const evmMainnet = createEvmConfig('eth');
@@ -174,7 +141,3 @@ export const evmOptimism = createEvmConfig('oeth');
 export const evmPolygon = createEvmConfig('matic');
 export const evmArbitrum = createEvmConfig('arb1');
 export const evmLineaGoerli = createEvmConfig('linea-testnet');
-export const evmBnb = createEvmConfig('bsc');
-export const evmGnosis = createEvmConfig('xdai');
-export const evmFantom = createEvmConfig('fantom');
-export const evmBase = createEvmConfig('base');


### PR DESCRIPTION
### Summary

Previously delegations would only work for few networks that we have enabled, but with this change we will allow all networks to function by leveraging ETH as base action network that can act on different chainIds.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/830

### How to test

1. Add some unusual network to your Metamask using https://chainlist.org/ (we don't really handle case if user doesn't have some network added currently, might be another issue to take a look into).
2. Add delegation to your offchain space using this network (I only used dummy contract as I couldn't find erc20-votes tokens on different networks).
3. Go to delegations, you see them, you can start delegating (if you have correct contract).
