### PR TITLE
feat: use new stamp url format for space cover and avatar

### DIFF
--- a/apps/ui/src/components/FormSpaceProfile.vue
+++ b/apps/ui/src/components/FormSpaceProfile.vue
@@ -171,9 +171,7 @@ onMounted(() => {
         type: 'string',
         format: 'stamp',
         title: 'Avatar',
-        default:
-          props.id ||
-          '0x2121212121212121212121212121212121212121212121212121212121212121'
+        default: `${space?.network || 'eth'}:${props.id || '0x2121212121212121212121212121212121212121212121212121212121212121'}`
       }"
     />
     <h4 class="eyebrow mb-2 font-medium">Profile</h4>

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -138,7 +138,7 @@ watch(
 
     const faviconUrl = getStampUrl(
       'space',
-      whiteLabelSpace.value.id,
+      `${whiteLabelSpace.value.network}:${whiteLabelSpace.value.id}`,
       16,
       getCacheHash(whiteLabelSpace.value.avatar)
     );

--- a/apps/ui/src/components/SpaceAvatar.vue
+++ b/apps/ui/src/components/SpaceAvatar.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { getCacheHash } from '@/helpers/utils';
-import { offchainNetworks } from '@/networks';
 import { NetworkID } from '@/types';
 
 const props = withDefaults(
@@ -18,10 +17,10 @@ const cb = computed(() => getCacheHash(props.space.avatar));
 
 <template>
   <UiStamp
-    :id="space.id"
+    :id="`${space.network}:${space.id}`"
     :size="size"
     :cb="cb"
     class="!bg-skin-bg"
-    :type="offchainNetworks.includes(space.network) ? 'space' : 'space-sx'"
+    type="space"
   />
 </template>

--- a/apps/ui/src/components/SpaceCover.vue
+++ b/apps/ui/src/components/SpaceCover.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { getCacheHash, getStampUrl } from '@/helpers/utils';
-import { offchainNetworks } from '@/networks';
 import { NetworkID } from '@/types';
 
 const props = withDefaults(
@@ -20,15 +19,11 @@ const cb = computed(() => getCacheHash(props.space.cover));
 <template>
   <UiStamp
     v-if="space.cover"
-    :id="space.id"
+    :id="`${space.network}:${space.id}`"
     :width="width"
     :height="height"
     :cb="cb"
-    :type="
-      offchainNetworks.includes(space.network)
-        ? 'space-cover'
-        : 'space-cover-sx'
-    "
+    type="space-cover"
     class="object-cover !rounded-none size-full"
   />
   <div
@@ -36,8 +31,8 @@ const cb = computed(() => getCacheHash(props.space.cover));
     class="bg-cover bg-center w-full h-full"
     :style="{
       'background-image': `url(${getStampUrl(
-        offchainNetworks.includes(space.network) ? 'space' : 'space-sx',
-        space.id,
+        'space',
+        `${space.network}:${space.id}`,
         50,
         getCacheHash(space.avatar)
       )}`,

--- a/apps/ui/src/components/Ui/InputStamp.vue
+++ b/apps/ui/src/components/Ui/InputStamp.vue
@@ -64,7 +64,7 @@ async function handleFileChange(e: Event) {
       :id="definition.default"
       :size="80"
       class="pointer-events-none !rounded-none group-hover:opacity-80"
-      type="space-sx"
+      type="space"
       :class="{
         'opacity-80': isUploadingImage
       }"

--- a/apps/ui/src/components/Ui/Stamp.vue
+++ b/apps/ui/src/components/Ui/Stamp.vue
@@ -3,14 +3,7 @@ import { getStampUrl } from '@/helpers/utils';
 
 withDefaults(
   defineProps<{
-    type?:
-      | 'avatar'
-      | 'user-cover'
-      | 'space'
-      | 'space-cover'
-      | 'space-sx'
-      | 'space-cover-sx'
-      | 'token';
+    type?: 'avatar' | 'user-cover' | 'space' | 'space-cover' | 'token';
     id: string;
     size?: number;
     width?: number;

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -13,8 +13,9 @@ import {
   validateAndParseAddress
 } from 'starknet';
 import { RouteParamsRaw } from 'vue-router';
+import { offchainNetworks } from '@/networks';
 import { VotingPowerItem } from '@/stores/votingPowers';
-import { Choice, Proposal, SpaceMetadata } from '@/types';
+import { Choice, NetworkID, Proposal, SpaceMetadata } from '@/types';
 import { MAX_SYMBOL_LENGTH } from './constants';
 import pkg from '@/../package.json';
 import ICCoingecko from '~icons/c/coingecko';
@@ -475,14 +476,7 @@ export function getCacheHash(value?: string) {
 }
 
 export function getStampUrl(
-  type:
-    | 'avatar'
-    | 'user-cover'
-    | 'space'
-    | 'space-cover'
-    | 'space-sx'
-    | 'space-cover-sx'
-    | 'token',
+  type: 'avatar' | 'user-cover' | 'space' | 'space-cover' | 'token',
   id: string,
   size: number | { width: number; height: number },
   hash?: string
@@ -495,10 +489,13 @@ export function getStampUrl(
   }
 
   const cacheParam = hash ? `&cb=${hash}` : '';
+  const [entryNetwork] = id.split(':') as [NetworkID, string];
 
-  const formattedId = ['avatar', 'space-sx', 'space-cover-sx'].includes(type)
-    ? formatAddress(id)
-    : id;
+  const formattedId =
+    ['avatar', 'space', 'space-cover'].includes(type) &&
+    !offchainNetworks.includes(entryNetwork)
+      ? formatAddress(id)
+      : id;
 
   return `https://cdn.stamp.fyi/${type}/${formattedId}${sizeParam}${cacheParam}`;
 }

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -490,12 +490,11 @@ export function getStampUrl(
 
   const cacheParam = hash ? `&cb=${hash}` : '';
   const [entryNetwork] = id.split(':') as [NetworkID, string];
-
-  const formattedId =
-    ['avatar', 'space', 'space-cover'].includes(type) &&
-    !offchainNetworks.includes(entryNetwork)
-      ? formatAddress(id)
-      : id;
+  const isAddress =
+    type === 'avatar' ||
+    (['space', 'space-cover'].includes(type) &&
+      !offchainNetworks.includes(entryNetwork));
+  const formattedId = isAddress ? formatAddress(id) : id;
 
   return `https://cdn.stamp.fyi/${type}/${formattedId}${sizeParam}${cacheParam}`;
 }

--- a/apps/ui/src/views/Space.vue
+++ b/apps/ui/src/views/Space.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { getCacheHash, getStampUrl } from '@/helpers/utils';
-import { offchainNetworks } from '@/networks';
 
 const { setFavicon } = useFavicon();
 const { param } = useRouteParser('space');
@@ -44,8 +43,8 @@ watchEffect(() => {
   }
 
   const faviconUrl = getStampUrl(
-    offchainNetworks.includes(space.value.network) ? 'space' : 'space-sx',
-    space.value.id,
+    'space',
+    `${space.value.network}:${space.value.id}`,
     16,
     getCacheHash(space.value.avatar)
   );


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward https://github.com/snapshot-labs/workflow/issues/220

This PR moves all stamp url to the new `network:address` format, introduced in https://github.com/stamp-labs/stamp/pull/311

This new format enable space avatar and cover for offchain testnet.

This PR is will migrate all stamp type from `space-sx` and `space-cover-sx` to just `space` and `space-cover`, and will prefix all id with the space network

### How to test

1. Go to the snapshot and snapshot x explore page
2. All space avatar and cover should show as before, (all stamp url are now prefixed with network ID)

### To-Do

- [x] Depends on https://github.com/stamp-labs/stamp/pull/311

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
