### PR TITLE
fix: fix strategy form not hiding on picker open

### DIFF
--- a/apps/ui/src/components/Modal/EditStrategy.vue
+++ b/apps/ui/src/components/Modal/EditStrategy.vue
@@ -141,15 +141,16 @@ watchEffect(() => {
         </div>
       </template>
     </template>
+    <div v-if="isDefinitionLoading" class="p-4 flex">
+      <UiLoading class="m-auto" />
+    </div>
     <PickerContact
-      v-if="showPicker"
+      v-else-if="showPicker"
       :loading="false"
       :search-value="searchValue"
       @pick="handlePickerSelect"
     />
-    <div v-if="isDefinitionLoading" class="p-4 flex">
-      <UiLoading class="m-auto" />
-    </div>
+
     <div v-else class="s-box p-4">
       <UiMessage
         v-if="formErrors[CUSTOM_ERROR_SYMBOL]"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/243

### How to test

1. Go to the space creation form, and strategy tab
2. Choose a strategy with contact picker
3. Pick a contact
4. If should show your contact list, and hide the strategy form
