### PR TITLE
fix: logout users on Braavos wallet lock

### DIFF
--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -176,7 +176,7 @@ export function useWeb3() {
     if (!provider.on) return;
 
     provider.on('accountsChanged', async accounts => {
-      if (!accounts.length) {
+      if (!accounts?.length) {
         logout();
         return;
       }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Currently, on Metamask and ArgentX, when a connected user lock his wallet, he's being logged out.

This PR fix an issue, where this behavior is not working on Braavos wallet.

NOTE: Even after the fix, there's some unrelated issue when reconnecting with Braavos, see note below

### How to test

1. Connect with your Braavos wallet
2. Lock the wallet
3. It should log you out
4. You can log in again with other wallet type (reconnecting to braavos wallet again has somme issue)

### NOTE

This PR is only fixing the issue where the log out on wallet lock does not work.

When reconnecting with a Braavos wallet, the connector is able to log in, but has some issue like argent x wallet modal not closing, or opening multiple time, etc ...

Those issues are out of scope of this PR, and are probably related to https://github.com/argentlabs/starknetkit/issues/140 (Braavos support is very flimsy)