### PR TITLE
fix: fix invalid input character count on multi-glyph character

### DIFF
--- a/apps/ui/src/components/Ui/InputString.vue
+++ b/apps/ui/src/components/Ui/InputString.vue
@@ -30,7 +30,7 @@ const inputValue = computed({
 });
 
 // From AJV string length validation
-// See https://github.com/ajv-validator/ajv/blob/master/lib/vocabularies/validation/limitLength.ts
+// See https://github.com/ajv-validator/ajv/blob/master/lib/runtime/ucs2length.ts
 const inputLength = computed(() => {
   const str = inputValue.value || '';
   const len = str.length;

--- a/apps/ui/src/components/Ui/InputString.vue
+++ b/apps/ui/src/components/Ui/InputString.vue
@@ -29,6 +29,25 @@ const inputValue = computed({
   }
 });
 
+// From AJV string length validation
+// See https://github.com/ajv-validator/ajv/blob/master/lib/vocabularies/validation/limitLength.ts
+const inputLength = computed(() => {
+  const str = inputValue.value || '';
+  const len = str.length;
+  let length = 0;
+  let pos = 0;
+  let value: number;
+  while (pos < len) {
+    length++;
+    value = str.charCodeAt(pos++);
+    if (value >= 0xd800 && value <= 0xdbff && pos < len) {
+      value = str.charCodeAt(pos);
+      if ((value & 0xfc00) === 0xdc00) pos++;
+    }
+  }
+  return length;
+});
+
 watch(model, () => {
   dirty.value = true;
 });
@@ -41,7 +60,7 @@ watch(model, () => {
     :loading="loading"
     :error="error"
     :dirty="dirty"
-    :input-value-length="inputValue?.length"
+    :input-value-length="inputLength"
   >
     <input
       :id="id"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #732 

This PR fix the invalid input characters counter when the input contains some exotic unicode characters, where some characters like 🔔 are counted as 2

This fix the issue by using (copy/paste) same logic used by AJV to validate string length

### How to test

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth/settings/profile
2. Input with exotic characters, like the voting power symbol should show the correct characters count