### PR TITLE
fix: fix z-index issue on sidemenu open

### DIFF
--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -63,6 +63,10 @@ const hasPlaceHolderSidebar = computed(
     !['space-editor', 'space-proposal'].includes(String(route.matched[1]?.name))
 );
 
+const hasTopNav = computed(() => {
+  return 'space-editor' !== String(route.matched[1]?.name);
+});
+
 const bottomPadding = computed(
   () => !['space-proposal-votes'].includes(String(route.name))
 );
@@ -176,7 +180,7 @@ router.afterEach(() => {
           { '!flex app-sidebar-open': uiStore.sideMenuOpen }
         ]"
       />
-      <AppTopnav :has-app-nav="hasAppNav">
+      <AppTopnav v-if="hasTopNav" :has-app-nav="hasAppNav">
         <template #toggle-sidebar-button>
           <button
             v-if="hasSwipeableContent"
@@ -244,10 +248,6 @@ $placeholderSidebarWidth: 240px;
         }
       }
 
-      & ~ :deep(main) {
-        @apply z-[51];
-      }
-
       &:has(~ .app-nav) ~ .app-nav ~ :deep(*) {
         @apply translate-x-[#{$sidebarWidth + $navWidth}];
       }
@@ -266,10 +266,6 @@ $placeholderSidebarWidth: 240px;
         .app-toolbar-bottom {
           @apply hidden;
         }
-      }
-
-      & ~ :deep(main) {
-        @apply z-[51];
       }
     }
   }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/251

Fix issue with topnav z-index, when sidemenu is open.

Forcing content z-index to always be on top of menu was introduced to fix https://github.com/snapshot-labs/sx-monorepo/pull/800

To prevent this issue from happening, this PR is now using hiding the topnav when not relevant, instead of relying on css z-index.

Hiding the menu will also fix an accessibility issue, where navigating with keyboard was focusing on hidden topnav element

### How to test

On a small screen

1. Go to a long proposal page
2. scroll down
3. Open the sidemenu
4. Proposal content should not be on top of topnav
5. Go to editor page
6. Open the sidemenu
7. Default topnav should disappear, and only editor topnav should remain
