### PR TITLE
fix: remove html to markdown conversion on user statement

### DIFF
--- a/apps/ui/src/views/SpaceUser/Statement.vue
+++ b/apps/ui/src/views/SpaceUser/Statement.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import turndownService from '@/helpers/turndownService';
 import { compareAddresses } from '@/helpers/utils';
 import { enabledNetworks, getNetwork, offchainNetworks } from '@/networks';
 import { Space, Statement, User } from '@/types';
@@ -29,7 +28,6 @@ const loading = ref(false);
 const statement = ref<Statement | null>(null);
 
 const userId = computed(() => route.params.user as string);
-const toMarkdown = computed(() => turndownService());
 
 async function loadStatement() {
   loading.value = true;
@@ -101,7 +99,7 @@ watchEffect(() =>
         <template v-if="statement.statement">
           <UiMarkdown
             class="text-skin-heading max-w-[592px]"
-            :body="toMarkdown(statement.statement)"
+            :body="statement.statement"
           />
           <div v-if="statement.source">
             <h4 class="eyebrow text-skin-text mb-2">Source</h4>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fixes https://github.com/snapshot-labs/workflow/issues/242

This PR removes the HTML to Markdown conversion on user statement.

Conversion has issue when statement is already markdown formatted, as it's removing new line

### How to test

1. Go to https://snapshot.box/#/s:fabien.eth/profile/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7
2. Markdown content should be formatted properly


### TODO 

- [x] Merge after https://github.com/snapshot-labs/snapshot-sequencer/pull/457