### PR TITLE
style: Improve label selection

### DIFF
--- a/apps/ui/src/components/PickerLabel.vue
+++ b/apps/ui/src/components/PickerLabel.vue
@@ -33,8 +33,14 @@ const filteredLabels = computed(() =>
 
 <template>
   <Popover v-slot="{ open }" class="relative contents">
-    <PopoverButton :class="open ? 'text-skin-link' : 'text-skin-text'">
-      <IH-pencil />
+    <PopoverButton
+      class="outline-none focus-within:text-skin-link w-full"
+      :class="open ? 'text-skin-link' : 'text-skin-text'"
+    >
+      <div class="flex justify-between mb-3">
+        <h4 class="eyebrow" v-text="'Labels'" />
+        <IH-pencil />
+      </div>
     </PopoverButton>
 
     <transition
@@ -47,7 +53,7 @@ const filteredLabels = computed(() =>
     >
       <PopoverPanel
         focus
-        class="absolute z-10 left-0 mt-5 mx-4 pb-3"
+        class="absolute z-10 left-0 -mt-2 mx-4 pb-3"
         style="width: calc(100% - 48px)"
       >
         <Combobox

--- a/apps/ui/src/components/ProposalLabels.vue
+++ b/apps/ui/src/components/ProposalLabels.vue
@@ -5,11 +5,11 @@ const props = withDefaults(
   defineProps<{
     spaceLabels: SpaceMetadataLabel[];
     proposalLabels?: string[];
-    showEdit?: boolean;
+    viewOnly?: boolean;
     inline?: boolean;
   }>(),
   {
-    showEdit: false,
+    viewOnly: true,
     inline: false
   }
 );
@@ -45,13 +45,13 @@ watch(
     </div>
   </div>
   <div v-else>
-    <div class="flex justify-between mb-3">
-      <h4 class="eyebrow" v-text="'Labels'" />
-      <PickerLabel v-if="showEdit" v-model="labels" :labels="spaceLabels" />
-    </div>
+    <h4 v-if="viewOnly" class="eyebrow mb-3" v-text="'Labels'" />
+    <PickerLabel v-else v-model="labels" :labels="spaceLabels" />
     <div v-if="validLabels.length" class="flex flex-wrap">
       <div v-for="label in validLabels" :key="label.id" class="mr-2 mb-2">
-        <UiProposalLabel :label="label.name" :color="label.color" />
+        <UiTooltip :title="label.description" class="inline">
+          <UiProposalLabel :label="label.name" :color="label.color" />
+        </UiTooltip>
       </div>
     </div>
     <div v-else class="mt-1">No labels yet</div>

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -501,7 +501,7 @@ watchEffect(() => {
         v-if="space.labels?.length"
         v-model="proposal.labels"
         :space-labels="space.labels"
-        show-edit
+        :view-only="false"
       />
       <div>
         <h4 class="eyebrow mb-2.5" v-text="'Timeline'" />


### PR DESCRIPTION
### Summary
- When clicking out from the dropdown, pencil icon will not have a outline, instead, we change its color when focused
- when mouse over a label, we should show a tooltip with the description (if available)
- Entire Labels div is clickable to open dropdown

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/873

### How to test

1. Go to a proposal creation page
2. try above fixes