### PR TITLE
fix: truncate proposal title

### DIFF
--- a/apps/ui/src/components/ProposalLabels.vue
+++ b/apps/ui/src/components/ProposalLabels.vue
@@ -35,7 +35,7 @@ watch(
 );
 </script>
 <template>
-  <div v-if="inline" class="contents">
+  <div v-if="inline" class="flex items-center">
     <div
       v-for="label in validLabels"
       :key="label.id"

--- a/apps/ui/src/components/ProposalLabels.vue
+++ b/apps/ui/src/components/ProposalLabels.vue
@@ -35,15 +35,15 @@ watch(
 );
 </script>
 <template>
-  <div v-if="inline" class="flex items-center">
-    <div
-      v-for="label in validLabels"
-      :key="label.id"
-      class="inline-flex mr-2 mb-2"
-    >
-      <UiProposalLabel :label="label.name" :color="label.color" />
+  <template v-if="inline">
+    <div v-for="label in validLabels" :key="label.id" class="inline-flex mr-2">
+      <UiProposalLabel
+        :label="label.name"
+        :color="label.color"
+        class="text-sm mb-1 max-w-[160px]"
+      />
     </div>
-  </div>
+  </template>
   <div v-else>
     <div class="flex justify-between mb-3">
       <h4 class="eyebrow" v-text="'Labels'" />

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -66,10 +66,10 @@ const space = computed(() =>
               space: `${proposal.network}:${proposal.space.id}`
             }
           }"
-          class="md:min-w-0"
+          class="md:flex"
         >
           <h3
-            class="text-[21px] inline [overflow-wrap:anywhere] md:truncate mr-2"
+            class="text-[21px] inline [overflow-wrap:anywhere] md:truncate mr-2 min-w-0"
             v-text="proposal.title || `Proposal #${proposal.proposal_id}`"
           />
           <ProposalLabels
@@ -77,6 +77,7 @@ const space = computed(() =>
             :proposal-labels="proposal.labels"
             :space-labels="space.labels"
             inline
+            class="inline-flex md:flex"
           />
           <IH-check
             v-if="

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -44,7 +44,7 @@ const space = computed(() =>
         <ProposalIconStatus size="17" :state="proposal.state" class="top-1.5" />
       </AppLink>
 
-      <div class="md:min-w-0 my-1 items-center leading-6">
+      <div class="min-w-0 my-1 items-center leading-6">
         <AppLink
           v-if="showSpace"
           :to="{
@@ -66,10 +66,9 @@ const space = computed(() =>
               space: `${proposal.network}:${proposal.space.id}`
             }
           }"
-          class="md:flex"
         >
           <h3
-            class="text-[21px] inline [overflow-wrap:anywhere] md:truncate mr-2 min-w-0"
+            class="text-[21px] inline [overflow-wrap:anywhere] mr-2 min-w-0"
             v-text="proposal.title || `Proposal #${proposal.proposal_id}`"
           />
           <ProposalLabels
@@ -77,13 +76,12 @@ const space = computed(() =>
             :proposal-labels="proposal.labels"
             :space-labels="space.labels"
             inline
-            class="inline-flex md:flex"
           />
           <IH-check
             v-if="
               showVotedIndicator && votes[`${proposal.network}:${proposal.id}`]
             "
-            class="text-skin-success inline-block shrink-0 relative top-[-1px] md:top-0.5"
+            class="text-skin-success inline-block shrink-0 relative"
           />
         </AppLink>
       </div>


### PR DESCRIPTION
### Summary

Proposal titles will be truncated again, leaving labels visible.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/872

### How to test

1. Go to http://localhost:8080/#/s:fabien.eth/proposals

### Screenshots

<img width="906" alt="image" src="https://github.com/user-attachments/assets/f0783531-6286-4e60-90cd-ffb12c979c77">
