### PR TITLE
fix: omit strategy name in change detection

### DIFF
--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -1,7 +1,7 @@
 import objectHash from 'object-hash';
 import { Ref } from 'vue';
 import { ENSChainId, getNameOwner } from '@/helpers/ens';
-import { clone, compareAddresses } from '@/helpers/utils';
+import { clone, compareAddresses, omit } from '@/helpers/utils';
 import { evmNetworks, getNetwork, offchainNetworks } from '@/networks';
 import { ApiSpace as OffchainApiSpace } from '@/networks/offchain/api/types';
 import {
@@ -275,7 +275,16 @@ export function useSpaceSettings(space: Ref<Space>) {
       ? await strategy.generateMetadata(strategy.params)
       : {};
 
-    if (objectHash(metadata) !== objectHash(previousMetadata)) return true;
+    const coreMetadata =
+      'name' in metadata ? omit(metadata, ['name']) : metadata;
+    const previousCoreMetadata =
+      'name' in previousMetadata
+        ? omit(previousMetadata, ['name'])
+        : previousMetadata;
+
+    if (objectHash(coreMetadata) !== objectHash(previousCoreMetadata)) {
+      return true;
+    }
     if (strategy.type === 'MerkleWhitelist') {
       // NOTE: MerkleWhitelist params are expensive to compute so we try to skip this step if possible.
       // If metadata has changed then we already know strategy has changed, if metadata is the same


### PR DESCRIPTION
### Summary

Name shouldn't cause change in strategies to be detected.

Those might not be stable (like addition of (trace 224) to OZ Votes Strategy).

We already compare addresses which are canonical.

Closes: https://github.com/snapshot-labs/workflow/issues/248

### How to test

1. Apply diff from below.
2. Go to http://localhost:8080/#/sn:0x0041ada9121061198b52ae28edeec8ace7c23f2ba8d66938c129af1a2245701c/settings/profile
3. You don't see save bar without any changes.

```diff
diff --git a/apps/ui/src/composables/useSpaceSettings.ts b/apps/ui/src/composables/useSpaceSettings.ts
index bb5fbe0d..c677d3b2 100644
--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -97,7 +97,7 @@ export function useSpaceSettings(space: Ref<Space>) {
       space.value
     );
 
-    return compareAddresses(controller, account);
+    return true;
   }, false);
   const isOwner = computedAsync(async () => {
     if (!offchainNetworks.includes(space.value.network)) {
```
