### PR TITLE
feat: add explore page Category and Network filters

### DIFF
--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -12,8 +12,6 @@ import { DefinitionWithOptions } from '@/types';
 
 const NULL_SYMBOL = Symbol('null');
 
-defineOptions({ inheritAttrs: false });
-
 const model = defineModel<T | null>({ required: true });
 
 const props = defineProps<{
@@ -82,7 +80,8 @@ watch(model, () => {
             <ComboboxInput
               class="s-input !flex items-center justify-between !mb-0"
               :class="{
-                '!rounded-b-none': open
+                '!rounded-b-none': open,
+                'h-[42px]': inline
               }"
               autocomplete="off"
               :placeholder="definition.examples?.[0]"

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -18,6 +18,7 @@ const props = defineProps<{
   error?: string;
   inline?: boolean;
   definition: DefinitionWithOptions<T | null>;
+  gap?: number;
 }>();
 
 const dirty = ref(false);
@@ -73,7 +74,12 @@ watch(model, () => {
     class="relative mb-[14px] w-auto"
   >
     <Combobox v-slot="{ open }" v-model="inputValue" as="div" nullable>
-      <Float adaptive-width strategy="fixed" placement="bottom-end">
+      <Float
+        adaptive-width
+        strategy="fixed"
+        placement="bottom-end"
+        :offset="gap && inline ? gap : 0"
+      >
         <div
           :class="{
             relative: inline
@@ -83,7 +89,7 @@ watch(model, () => {
             <ComboboxInput
               class="s-input !flex items-center justify-between !mb-0"
               :class="{
-                '!rounded-b-none': open,
+                '!rounded-b-none': !gap && open,
                 'h-[42px]': inline
               }"
               autocomplete="off"
@@ -106,7 +112,8 @@ watch(model, () => {
           </div>
         </div>
         <ComboboxOptions
-          class="w-full bg-skin-border rounded-b-lg border-t-skin-text/10 border shadow-xl overflow-hidden"
+          class="w-full bg-skin-border border-t-skin-text/10 border shadow-xl overflow-hidden"
+          :class="inline ? 'rounded-lg' : 'rounded-b-lg'"
         >
           <div class="max-h-[208px] overflow-y-auto">
             <div

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -73,7 +73,11 @@ watch(model, () => {
   >
     <Combobox v-slot="{ open }" v-model="inputValue" as="div" nullable>
       <Float adaptive-width strategy="fixed" placement="bottom-end">
-        <div class="relative">
+        <div
+          :class="{
+            relative: inline
+          }"
+        >
           <ComboboxButton class="w-full">
             <ComboboxInput
               class="s-input !flex items-center justify-between !mb-0"

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -7,6 +7,7 @@ import {
   ComboboxOptions
 } from '@headlessui/vue';
 import { Float } from '@headlessui-float/vue';
+import { omit } from '@/helpers/utils';
 import { DefinitionWithOptions } from '@/types';
 
 const NULL_SYMBOL = Symbol('null');
@@ -17,6 +18,7 @@ const model = defineModel<T | null>({ required: true });
 
 const props = defineProps<{
   error?: string;
+  inline?: boolean;
   definition: DefinitionWithOptions<T | null>;
 }>();
 
@@ -64,14 +66,14 @@ watch(model, () => {
 
 <template>
   <UiWrapperInput
-    :definition="definition"
+    :definition="inline ? omit(definition, ['title']) : definition"
     :error="error"
     :dirty="dirty"
-    class="relative mb-[14px]"
+    class="relative mb-[14px] w-auto"
   >
     <Combobox v-slot="{ open }" v-model="inputValue" as="div" nullable>
       <Float adaptive-width strategy="fixed" placement="bottom-end">
-        <div>
+        <div class="relative">
           <ComboboxButton class="w-full">
             <ComboboxInput
               class="s-input !flex items-center justify-between !mb-0"
@@ -86,10 +88,16 @@ watch(model, () => {
               @focus="event => handleFocus(event, open)"
             />
           </ComboboxButton>
-          <ComboboxButton class="absolute right-3 bottom-[14px]">
+          <ComboboxButton v-if="!inline" class="absolute right-3 bottom-[14px]">
             <IH-chevron-up v-if="open" />
             <IH-chevron-down v-else />
           </ComboboxButton>
+          <div
+            v-if="inline"
+            class="absolute top-[-7px] bg-skin-bg px-1 left-2.5 text-sm text-skin-text leading-4"
+          >
+            {{ definition.title }}
+          </div>
         </div>
         <ComboboxOptions
           class="w-full bg-skin-border rounded-b-lg border-t-skin-text/10 border shadow-xl overflow-hidden"

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -49,7 +49,10 @@ function handleFocus(event: FocusEvent, open: boolean) {
   if (!event.target || open) return;
 
   query.value = '';
-  (event.target as HTMLInputElement).select();
+
+  requestAnimationFrame(() => {
+    (event.target as HTMLInputElement).select();
+  });
 }
 
 function getDisplayValue(value: T) {

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -46,6 +46,30 @@ const inputValue = computed({
   }
 });
 
+const inputWidth = computed(() => {
+  if (!props.inline) return null;
+
+  const PADDING = 32;
+  const BORDER_WIDTH = 2;
+
+  const contents = query.value || getDisplayValue(model.value);
+
+  const temp = document.createElement('span');
+  temp.style.font = 'inherit';
+  temp.style.fontSize = 'inherit';
+  temp.style.padding = '0';
+  temp.style.position = 'absolute';
+  temp.style.visibility = 'hidden';
+  temp.style.whiteSpace = 'pre';
+  temp.textContent = contents;
+
+  document.body.appendChild(temp);
+  const width = temp.getBoundingClientRect().width;
+  document.body.removeChild(temp);
+
+  return Math.max(width + PADDING + BORDER_WIDTH, 90);
+});
+
 function handleFocus(event: FocusEvent, open: boolean) {
   if (!event.target || open) return;
 
@@ -56,7 +80,9 @@ function handleFocus(event: FocusEvent, open: boolean) {
   });
 }
 
-function getDisplayValue(value: T) {
+function getDisplayValue(value: T | null) {
+  if (value === null) return '';
+
   const option = props.definition.options.find(option => option.id === value);
   return option ? option.name || String(option.id) : '';
 }
@@ -91,6 +117,9 @@ watch(model, () => {
               :class="{
                 '!rounded-b-none': !gap && open,
                 'h-[42px]': inline
+              }"
+              :style="{
+                width: inputWidth ? `${inputWidth}px` : '100%'
               }"
               autocomplete="off"
               :placeholder="definition.examples?.[0]"

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -46,29 +46,7 @@ const inputValue = computed({
   }
 });
 
-const inputWidth = computed(() => {
-  if (!props.inline) return null;
-
-  const PADDING = 32;
-  const BORDER_WIDTH = 2;
-
-  const contents = query.value || getDisplayValue(model.value);
-
-  const temp = document.createElement('span');
-  temp.style.font = 'inherit';
-  temp.style.fontSize = 'inherit';
-  temp.style.padding = '0';
-  temp.style.position = 'absolute';
-  temp.style.visibility = 'hidden';
-  temp.style.whiteSpace = 'pre';
-  temp.textContent = contents;
-
-  document.body.appendChild(temp);
-  const width = temp.getBoundingClientRect().width;
-  document.body.removeChild(temp);
-
-  return Math.max(width + PADDING + BORDER_WIDTH, 90);
-});
+const content = computed(() => query.value || getDisplayValue(model.value));
 
 function handleFocus(event: FocusEvent, open: boolean) {
   if (!event.target || open) return;
@@ -111,16 +89,21 @@ watch(model, () => {
             relative: inline
           }"
         >
-          <ComboboxButton class="w-full" as="div">
+          <ComboboxButton
+            class="w-full"
+            as="div"
+            :data-value="content"
+            :class="{
+              sizer: inline
+            }"
+          >
             <ComboboxInput
               class="s-input !flex items-center justify-between !mb-0"
               :class="{
                 '!rounded-b-none': !gap && open,
-                'h-[42px]': inline
+                'h-[42px] min-w-11': inline
               }"
-              :style="{
-                width: inputWidth ? `${inputWidth}px` : '100%'
-              }"
+              :size="'1'"
               autocomplete="off"
               :placeholder="definition.examples?.[0]"
               :display-value="item => getDisplayValue(item as T)"
@@ -186,3 +169,20 @@ watch(model, () => {
     </Combobox>
   </UiWrapperInput>
 </template>
+
+<style lang="scss" scoped>
+.sizer {
+  @apply inline-grid items-center;
+
+  input {
+    @apply col-start-1 row-start-1;
+  }
+
+  &::after {
+    content: attr(data-value);
+    @apply px-3 border-x col-start-1 row-start-1;
+    visibility: hidden;
+    white-space: pre-wrap;
+  }
+}
+</style>

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -149,9 +149,9 @@ watch(model, () => {
           <div class="max-h-[208px] overflow-y-auto">
             <div
               v-if="filteredOptions.length === 0 && query !== ''"
-              class="relative cursor-default select-none text-center py-2"
+              class="relative cursor-default select-none text-center py-2 px-3"
             >
-              No result for your search query
+              No results for your search
             </div>
 
             <ComboboxOption

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -75,9 +75,9 @@ watch(model, () => {
   >
     <Combobox v-slot="{ open }" v-model="inputValue" as="div" nullable>
       <Float
-        adaptive-width
+        :adaptive-width="inline ? false : true"
         strategy="fixed"
-        placement="bottom-end"
+        placement="bottom-start"
         :offset="gap && inline ? gap : 0"
       >
         <div
@@ -113,7 +113,9 @@ watch(model, () => {
         </div>
         <ComboboxOptions
           class="w-full bg-skin-border border-t-skin-text/10 border shadow-xl overflow-hidden"
-          :class="inline ? 'rounded-lg' : 'rounded-b-lg'"
+          :class="
+            inline ? 'max-w-[80vw] sm:max-w-[300px] rounded-lg' : 'rounded-b-lg'
+          "
         >
           <div class="max-h-[208px] overflow-y-auto">
             <div
@@ -138,7 +140,7 @@ watch(model, () => {
               >
                 <component :is="item.icon" class="size-[20px] mr-2" />
                 <span
-                  class="w-full py-2 text-skin-link"
+                  class="w-full py-2 text-skin-link truncate"
                   :class="{
                     'opacity-40': disabled,
                     'cursor-pointer': !disabled

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -111,7 +111,7 @@ watch(model, () => {
             relative: inline
           }"
         >
-          <ComboboxButton class="w-full">
+          <ComboboxButton class="w-full" as="div">
             <ComboboxInput
               class="s-input !flex items-center justify-between !mb-0"
               :class="{

--- a/apps/ui/src/components/FormSpaceProfile.vue
+++ b/apps/ui/src/components/FormSpaceProfile.vue
@@ -1,19 +1,8 @@
 <script setup lang="ts">
-import { MAX_SYMBOL_LENGTH } from '@/helpers/constants';
+import { MAX_SYMBOL_LENGTH, SPACE_CATEGORIES } from '@/helpers/constants';
 import { validateForm } from '@/helpers/validation';
 import { offchainNetworks } from '@/networks';
 import { NetworkID } from '@/types';
-
-const SPACE_CATEGORIES = [
-  { id: 'protocol', name: 'Protocol' },
-  { id: 'social', name: 'Social' },
-  { id: 'investment', name: 'Investment' },
-  { id: 'grant', name: 'Grant' },
-  { id: 'service', name: 'Service' },
-  { id: 'media', name: 'Media' },
-  { id: 'creator', name: 'Creator' },
-  { id: 'collector', name: 'Collector' }
-];
 
 const props = defineProps<{
   form: any;

--- a/apps/ui/src/components/Ui/Dropdown.vue
+++ b/apps/ui/src/components/Ui/Dropdown.vue
@@ -18,7 +18,12 @@ withDefaults(
 
 <template>
   <Menu as="div" class="relative">
-    <Float :placement="`bottom-${placement}`" :offset="Number(gap)" portal>
+    <Float
+      :placement="`bottom-${placement}`"
+      :offset="Number(gap)"
+      portal
+      z-index="10"
+    >
       <MenuButton :disabled="disabled" as="template" class="cursor-pointer">
         <slot name="button" />
       </MenuButton>

--- a/apps/ui/src/components/Ui/Dropdown.vue
+++ b/apps/ui/src/components/Ui/Dropdown.vue
@@ -31,9 +31,11 @@ withDefaults(
         leave-to-class="transform scale-95 opacity-0"
       >
         <MenuItems
-          :class="`rounded-md bg-skin-border text-skin-link shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none`"
+          class="rounded-md bg-skin-border text-skin-link shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none overflow-hidden"
         >
-          <slot name="items" />
+          <div class="max-h-[208px] overflow-y-auto">
+            <slot name="items" />
+          </div>
         </MenuItems>
       </transition>
     </Float>

--- a/apps/ui/src/components/Ui/SelectorNetwork.vue
+++ b/apps/ui/src/components/Ui/SelectorNetwork.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { getUrl } from '@/helpers/utils';
 import { enabledNetworks, getNetwork } from '@/networks';
 import { METADATA as STARKNET_NETWORK_METADATA } from '@/networks/starknet';
@@ -16,10 +15,14 @@ const props = defineProps<{
   };
 }>();
 
+const { networks, getUsage } = useOffchainNetworksList(
+  props.definition.networkId
+);
+
 const options = computed(() => {
   if (props.definition.networksListKind === 'full') {
-    const baseNetworks = Object.entries(networks)
-      .filter(([, network]) => {
+    const baseNetworks = networks.value
+      .filter(network => {
         if (
           props.definition.networkId === 's' &&
           'testnet' in network &&
@@ -30,8 +33,8 @@ const options = computed(() => {
 
         return true;
       })
-      .map(([id, network]) => ({
-        id: Number(id),
+      .map(network => ({
+        id: network.chainId,
         name: network.name,
         icon: h('img', {
           src: getUrl(network.logo),
@@ -81,6 +84,10 @@ const options = computed(() => {
       };
     })
     .filter(network => !network.readOnly);
+});
+
+onMounted(() => {
+  getUsage();
 });
 </script>
 

--- a/apps/ui/src/composables/useOffchainNetworksList.ts
+++ b/apps/ui/src/composables/useOffchainNetworksList.ts
@@ -1,0 +1,41 @@
+import snapshotJsNetworks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { getNetwork } from '@/networks';
+import { ChainId, NetworkID } from '@/types';
+
+const usage = ref<Record<ChainId, number | undefined> | null>(null);
+const loaded = ref(false);
+
+export function useOffchainNetworksList(
+  networkId: NetworkID,
+  hideUnused = false
+) {
+  async function getUsage() {
+    if (loaded.value) return;
+
+    const network = getNetwork(networkId);
+
+    usage.value = await network.api.getNetworksUsage();
+  }
+
+  const networks = computed(() => {
+    const rawNetworks = Object.values(snapshotJsNetworks);
+    const usageValue = usage.value;
+    if (!usageValue) return rawNetworks;
+
+    return [
+      ...(hideUnused
+        ? rawNetworks.filter(network => (usageValue[network.chainId] || 0) > 0)
+        : rawNetworks)
+    ].sort((a, b) => {
+      const aUsage = usageValue[a.chainId] || 0;
+      const bUsage = usageValue[b.chainId] || 0;
+
+      return bUsage - aUsage;
+    });
+  });
+
+  return {
+    getUsage,
+    networks
+  };
+}

--- a/apps/ui/src/composables/useSpaces.ts
+++ b/apps/ui/src/composables/useSpaces.ts
@@ -98,8 +98,17 @@ export function useSpaces() {
   }
 
   async function _fetchSpaces(overwrite: boolean, filter?: SpacesFilter) {
-    const { networks, limit } = explorePageProtocols[protocol.value];
+    const { limit } = explorePageProtocols[protocol.value];
+    let { networks } = explorePageProtocols[protocol.value];
     let unsortedExplorePageSpaces = overwrite ? [] : explorePageSpaces.value;
+
+    if (
+      protocol.value === 'snapshotx' &&
+      filter?.network &&
+      filter.network !== 'all'
+    ) {
+      networks = [filter.network as NetworkID];
+    }
 
     const results = await Promise.all(
       networks.map(async id => {

--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -36,6 +36,17 @@ export const COINGECKO_BASE_ASSETS = {
 
 export const MAX_SYMBOL_LENGTH = 12;
 
+export const SPACE_CATEGORIES = [
+  { id: 'protocol', name: 'Protocol' },
+  { id: 'social', name: 'Social' },
+  { id: 'investment', name: 'Investment' },
+  { id: 'grant', name: 'Grant' },
+  { id: 'service', name: 'Service' },
+  { id: 'media', name: 'Media' },
+  { id: 'creator', name: 'Creator' },
+  { id: 'collector', name: 'Collector' }
+] as const;
+
 export const BASIC_CHOICES = ['For', 'Against', 'Abstain'];
 export const SUPPORTED_VOTING_TYPES: VoteType[] = [
   'basic',

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -532,6 +532,7 @@ export function createApi(
       }
       delete _filter.searchQuery;
       delete _filter.category;
+      delete _filter.network;
 
       const { data } = await apollo.query({
         query: SPACES_QUERY,

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -680,6 +680,9 @@ export function createApi(
     },
     loadStrategy: async () => {
       return null;
+    },
+    getNetworksUsage: async () => {
+      return {};
     }
   };
 }

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -531,6 +531,7 @@ export function createApi(
         _filter.metadata_ = { name_contains_nocase: _filter.searchQuery };
       }
       delete _filter.searchQuery;
+      delete _filter.category;
 
       const { data } = await apollo.query({
         query: SPACES_QUERY,

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -567,11 +567,15 @@ export function createApi(
       if (
         !filter ||
         filter.hasOwnProperty('searchQuery') ||
-        filter.hasOwnProperty('category')
+        filter.hasOwnProperty('category') ||
+        filter.hasOwnProperty('network')
       ) {
         const where = {};
         if (filter?.searchQuery) where['search'] = filter.searchQuery;
         if (filter?.category) where['category'] = filter.category;
+        if (filter?.network && filter.network !== 'all') {
+          where['network'] = filter.network;
+        }
 
         const { data } = await apollo.query({
           query: RANKING_QUERY,

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -564,13 +564,21 @@ export function createApi(
       { limit, skip = 0 }: PaginationOpts,
       filter?: SpacesFilter
     ): Promise<Space[]> => {
-      if (!filter || filter.hasOwnProperty('searchQuery')) {
+      if (
+        !filter ||
+        filter.hasOwnProperty('searchQuery') ||
+        filter.hasOwnProperty('category')
+      ) {
+        const where = {};
+        if (filter?.searchQuery) where['search'] = filter.searchQuery;
+        if (filter?.category) where['category'] = filter.category;
+
         const { data } = await apollo.query({
           query: RANKING_QUERY,
           variables: {
             first: Math.min(limit, 20),
             skip,
-            where: filter?.searchQuery ? { search: filter.searchQuery } : {}
+            where
           }
         });
         return data.ranking.items.map(space =>

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -35,6 +35,7 @@ import {
 import {
   ALIASES_QUERY,
   LEADERBOARD_QUERY,
+  NETWORKS_USAGE_QUERY,
   PROPOSAL_QUERY,
   PROPOSALS_QUERY,
   RANKING_QUERY,
@@ -795,6 +796,18 @@ export function createApi(
       if (!data.strategy) return null;
 
       return formatStrategy(data.strategy as ApiStrategy);
+    },
+    getNetworksUsage: async () => {
+      const { data } = await apollo.query({
+        query: NETWORKS_USAGE_QUERY
+      });
+
+      return Object.fromEntries(
+        data.networks.map((network: any) => [
+          Number(network.id),
+          network.spacesCount
+        ])
+      );
     }
   };
 }

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -360,3 +360,12 @@ export const STRATEGY_QUERY = gql`
   }
   ${STRATEGY_FRAGMENT}
 `;
+
+export const NETWORKS_USAGE_QUERY = gql`
+  query Networks {
+    networks {
+      id
+      spacesCount
+    }
+  }
+`;

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -27,6 +27,7 @@ export type SpacesFilter = {
   searchQuery?: string;
   domain?: string;
   category?: string;
+  network?: string;
 };
 export type ProposalsFilter = {
   state?: 'any' | 'active' | 'pending' | 'closed';

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -26,6 +26,7 @@ export type SpacesFilter = {
   id_in?: string[];
   searchQuery?: string;
   domain?: string;
+  category?: string;
 };
 export type ProposalsFilter = {
   state?: 'any' | 'active' | 'pending' | 'closed';

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -322,6 +322,7 @@ export type NetworkApi = {
   ): Promise<Statement[]>;
   loadStrategies(): Promise<StrategyTemplate[]>;
   loadStrategy(address: string): Promise<StrategyTemplate | null>;
+  getNetworksUsage(): Promise<Record<ChainId, number | undefined>>;
 };
 
 export type NetworkConstants = {

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -139,9 +139,10 @@ watchEffect(() => setTitle('Explore'));
 
 <template>
   <div class="flex justify-between">
-    <div class="flex flex-row p-4 space-x-2">
+    <div class="flex flex-row flex-wrap p-4 gap-2">
       <UiSelectDropdown
         v-model="protocol"
+        class="min-h-[46px]"
         title="Protocol"
         gap="12"
         placement="start"
@@ -149,6 +150,7 @@ watchEffect(() => setTitle('Explore'));
       />
       <Combobox
         v-model="network"
+        class="mb-0"
         inline
         :definition="{
           type: 'string',
@@ -161,6 +163,7 @@ watchEffect(() => setTitle('Explore'));
       <UiSelectDropdown
         v-if="protocol === 'snapshot'"
         v-model="category"
+        class="min-h-[46px]"
         title="Category"
         gap="12"
         placement="start"

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -152,6 +152,7 @@ watchEffect(() => setTitle('Explore'));
         v-model="network"
         class="mb-0"
         inline
+        :gap="12"
         :definition="{
           type: 'string',
           title: 'Network',

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import snapshotNetworks from '@snapshot-labs/snapshot.js/src/networks.json';
-import { Item } from '@/components/Ui/SelectDropdown.vue';
 import { SPACE_CATEGORIES } from '@/helpers/constants';
 import { getUrl } from '@/helpers/utils';
 import { explorePageProtocols, getNetwork } from '@/networks';
 import { ExplorePageProtocol, ProtocolConfig } from '@/networks/types';
+import { SelectItem } from '@/types';
 
 type SpaceCategory = 'all' | (typeof SPACE_CATEGORIES)[number]['id'];
 
@@ -39,7 +39,7 @@ const category = ref<SpaceCategory>(DEFAULT_CATEGORY);
 const networks = computed(() => {
   const explorePageNetworks = explorePageProtocols[protocol.value].networks;
 
-  let protocolNetworks: Item<string>[] = [];
+  let protocolNetworks: SelectItem<string>[] = [];
   if (protocol.value === 'snapshot') {
     const shouldShowTestnetNetworks = explorePageNetworks.includes('s-tn');
 
@@ -56,9 +56,9 @@ const networks = computed(() => {
         return true;
       })
       .map(([id, network]) => ({
-        key: id,
-        label: network.name,
-        component: h('img', {
+        id,
+        name: network.name,
+        icon: h('img', {
           src: getUrl(network.logo),
           alt: network.name,
           class: 'rounded-full size-3.5'
@@ -69,9 +69,9 @@ const networks = computed(() => {
       const network = getNetwork(networkId);
 
       return {
-        key: networkId,
-        label: network.name,
-        component: h('img', {
+        id: networkId,
+        name: network.name,
+        icon: h('img', {
           src: getUrl(network.avatar),
           alt: network.name,
           class: 'rounded-full size-3.5'
@@ -80,11 +80,11 @@ const networks = computed(() => {
     });
   }
 
-  return [{ key: 'all', label: 'All networks' }, ...protocolNetworks];
+  return [{ id: 'all', name: 'All networks' }, ...protocolNetworks];
 });
 
 function isValidNetwork(network: string): network is string {
-  return network === 'all' || networks.value.some(n => n.key === network);
+  return network === 'all' || networks.value.some(n => n.id === network);
 }
 
 function isValidCategory(category: string): category is SpaceCategory {
@@ -147,12 +147,16 @@ watchEffect(() => setTitle('Explore'));
         placement="start"
         :items="protocols"
       />
-      <UiSelectDropdown
+      <Combobox
         v-model="network"
-        title="Network"
-        gap="12"
-        placement="start"
-        :items="networks"
+        inline
+        :definition="{
+          type: 'string',
+          title: 'Network',
+          enum: networks.map(c => c.id),
+          options: networks,
+          examples: ['Select network']
+        }"
       />
       <UiSelectDropdown
         v-if="protocol === 'snapshot'"

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import snapshotNetworks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { SPACE_CATEGORIES } from '@/helpers/constants';
 import { getUrl } from '@/helpers/utils';
-import { explorePageProtocols, getNetwork } from '@/networks';
+import { explorePageProtocols, getNetwork, metadataNetwork } from '@/networks';
 import { ExplorePageProtocol, ProtocolConfig } from '@/networks/types';
 import { SelectItem } from '@/types';
 
@@ -36,6 +35,11 @@ const protocol = ref<ExplorePageProtocol>(DEFAULT_PROTOCOL);
 const network = ref<string>(DEFAULT_NETWORK);
 const category = ref<SpaceCategory>(DEFAULT_CATEGORY);
 
+const { networks: offchainNetworks, getUsage } = useOffchainNetworksList(
+  metadataNetwork,
+  true
+);
+
 const networks = computed(() => {
   const explorePageNetworks = explorePageProtocols[protocol.value].networks;
 
@@ -43,8 +47,8 @@ const networks = computed(() => {
   if (protocol.value === 'snapshot') {
     const shouldShowTestnetNetworks = explorePageNetworks.includes('s-tn');
 
-    protocolNetworks = Object.entries(snapshotNetworks)
-      .filter(([, network]) => {
+    protocolNetworks = offchainNetworks.value
+      .filter(network => {
         if (
           shouldShowTestnetNetworks &&
           'testnet' in network &&
@@ -55,8 +59,8 @@ const networks = computed(() => {
 
         return true;
       })
-      .map(([id, network]) => ({
-        id,
+      .map(network => ({
+        id: network.key,
         name: network.name,
         icon: h('img', {
           src: getUrl(network.logo),
@@ -135,6 +139,10 @@ watch(
 );
 
 watchEffect(() => setTitle('Explore'));
+
+onMounted(() => {
+  getUsage();
+});
 </script>
 
 <template>

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -157,8 +157,7 @@ watchEffect(() => setTitle('Explore'));
           type: 'string',
           title: 'Network',
           enum: networks.map(c => c.id),
-          options: networks,
-          examples: ['Select network']
+          options: networks
         }"
       />
       <UiSelectDropdown

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -45,12 +45,10 @@ const networks = computed(() => {
 
   let protocolNetworks: SelectItem<string>[] = [];
   if (protocol.value === 'snapshot') {
-    const shouldShowTestnetNetworks = explorePageNetworks.includes('s-tn');
-
     protocolNetworks = offchainNetworks.value
       .filter(network => {
         if (
-          shouldShowTestnetNetworks &&
+          metadataNetwork === 's' &&
           'testnet' in network &&
           network.testnet
         ) {


### PR DESCRIPTION
### Summary

This PR adds ability to filter by Network and Category on explore page.

Closes: https://github.com/snapshot-labs/workflow/issues/213

@bonustrack original issue calls for multi-selection on category, but API only supports single category filter, do we want to implement it with multi-selection (would also require changes on the API).

### How to test

1. Go to http://localhost:8080/#/explore
2. Try different filters.

### Screenshots


https://github.com/user-attachments/assets/2ea101a2-4a5c-42e0-b18d-7aac3f199bf6


