### PR TITLE
fix: remove circular dependency

### DIFF
--- a/apps/ui/src/helpers/utils.test.ts
+++ b/apps/ui/src/helpers/utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { _d, _vp, createErc1155Metadata, uniqBy } from './utils';
+import {
+  _d,
+  _vp,
+  createErc1155Metadata,
+  formatAddress,
+  getStampUrl,
+  uniqBy
+} from './utils';
 
 describe('utils', () => {
   describe('uniqBy', () => {
@@ -137,6 +144,77 @@ describe('utils', () => {
       expect(_d(86399)).toBe('23h 59m 59s');
       expect(_d(86400)).toBe('1d');
       expect(_d(86401)).toBe('1d 1s');
+    });
+  });
+
+  describe('formatAddress', () => {
+    it('returns a checksummed evm address', () => {
+      expect(formatAddress('0x556b14cbda79a36dc33fcd461a04a5bcb5dc2a70')).toBe(
+        '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70'
+      );
+    });
+
+    it('returns a padded starknet address', () => {
+      expect(formatAddress('0x4c5dda09742520fdf5c2bbfa4aede8fb9fe6781')).toBe(
+        '0x00000000000000000000000004c5dda09742520fdf5c2bbfa4aede8fb9fe6781'
+      );
+    });
+
+    it('returns the input if it is not a valid address', () => {
+      expect(formatAddress('ens.eth')).toBe('ens.eth');
+      expect(formatAddress('')).toBe('');
+    });
+  });
+
+  describe('getStampUrl', () => {
+    it('returns a stamp url with a formatted ID', () => {
+      expect(
+        getStampUrl('avatar', '0x556b14cbda79a36dc33fcd461a04a5bcb5dc2a70', 32)
+      ).toBe(
+        'https://cdn.stamp.fyi/avatar/0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70?s=64'
+      );
+
+      expect(
+        getStampUrl('avatar', '0x4c5dda09742520fdf5c2bbfa4aede8fb9fe6781', 32)
+      ).toBe(
+        'https://cdn.stamp.fyi/avatar/0x00000000000000000000000004c5dda09742520fdf5c2bbfa4aede8fb9fe6781?s=64'
+      );
+
+      expect(getStampUrl('space', 'ens.eth', 32)).toBe(
+        'https://cdn.stamp.fyi/space/ens.eth?s=64'
+      );
+    });
+
+    it('returns a stamp with x2 size when given a single number', () => {
+      expect(
+        getStampUrl('space', '0x000000000000000000000000000000000000dead', 32)
+      ).toBe(
+        'https://cdn.stamp.fyi/space/0x000000000000000000000000000000000000dEaD?s=64'
+      );
+    });
+
+    it('returns a stamp url with the given width and height', () => {
+      expect(
+        getStampUrl('space', '0x000000000000000000000000000000000000dEaD', {
+          width: 1,
+          height: 2
+        })
+      ).toBe(
+        'https://cdn.stamp.fyi/space/0x000000000000000000000000000000000000dEaD?w=1&h=2'
+      );
+    });
+
+    it('returns a stamp url with the given hash if available', () => {
+      expect(
+        getStampUrl(
+          'space',
+          '0x000000000000000000000000000000000000dead',
+          32,
+          '1234'
+        )
+      ).toBe(
+        'https://cdn.stamp.fyi/space/0x000000000000000000000000000000000000dEaD?s=64&cb=1234'
+      );
     });
   });
 });

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -13,9 +13,8 @@ import {
   validateAndParseAddress
 } from 'starknet';
 import { RouteParamsRaw } from 'vue-router';
-import { offchainNetworks } from '@/networks';
 import { VotingPowerItem } from '@/stores/votingPowers';
-import { Choice, NetworkID, Proposal, SpaceMetadata } from '@/types';
+import { Choice, Proposal, SpaceMetadata } from '@/types';
 import { MAX_SYMBOL_LENGTH } from './constants';
 import pkg from '@/../package.json';
 import ICCoingecko from '~icons/c/coingecko';
@@ -118,9 +117,10 @@ export function shorten(
 }
 
 export function formatAddress(address: string) {
-  if (address.length === 42) return getAddress(address);
   try {
-    return validateAndParseAddress(address);
+    return address.length === 42
+      ? getAddress(address)
+      : validateAndParseAddress(address);
   } catch {
     return address;
   }
@@ -489,14 +489,8 @@ export function getStampUrl(
   }
 
   const cacheParam = hash ? `&cb=${hash}` : '';
-  const [entryNetwork] = id.split(':') as [NetworkID, string];
-  const isAddress =
-    type === 'avatar' ||
-    (['space', 'space-cover'].includes(type) &&
-      !offchainNetworks.includes(entryNetwork));
-  const formattedId = isAddress ? formatAddress(id) : id;
 
-  return `https://cdn.stamp.fyi/${type}/${formattedId}${sizeParam}${cacheParam}`;
+  return `https://cdn.stamp.fyi/${type}/${formatAddress(id)}${sizeParam}${cacheParam}`;
 }
 
 export async function imageUpload(file: File) {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fix failing tests due to circular dependency in utils.ts

This PR removes the `offchainNetwork` check, and let the try/catch just return the input as is on error

### How to test

1. Tests should pass
2. Stamp avatar should work as before: http://localhost:8080/#/explore and http://localhost:8080/#/explore?p=snapshotx
