### PR TITLE
fix: set network on offchain treasuries

### DIFF
--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -59,6 +59,13 @@ import { DEFAULT_VOTING_DELAY } from '../constants';
 
 const DEFAULT_AUTHENTICATOR = 'OffchainAuthenticator';
 
+const TREASURY_NETWORKS = new Map(
+  Object.entries(CHAIN_IDS).map(([networkId, chainId]) => [
+    chainId,
+    networkId as keyof typeof CHAIN_IDS
+  ])
+);
+
 const DELEGATION_STRATEGIES = [
   'delegation',
   'erc20-balance-of-delegation',
@@ -91,7 +98,7 @@ function formatSpace(
 
     return {
       name: treasury.name,
-      network: null,
+      network: TREASURY_NETWORKS.get(chainId) ?? null,
       address: treasury.address,
       chainId
     };


### PR DESCRIPTION
### Summary

Network is required to be able to create execution on the UI (required for Stamp in token pickers etc.)

We removed it previously, but it caused treasuries to become unusable in proposals.

Closes: https://github.com/snapshot-labs/workflow/issues/256

### How to test

1. Go to https://snapshot.box/#/s:jbdao.eth/treasury/1/tokens
2. You see buttons to create execution.

<img width="848" alt="image" src="https://github.com/user-attachments/assets/a3f10171-a8be-4607-850b-3091b22c690a">
