### PR TITLE
style: labels should always use text-sm

### DIFF
--- a/apps/ui/src/components/ProposalLabels.vue
+++ b/apps/ui/src/components/ProposalLabels.vue
@@ -40,7 +40,7 @@ watch(
       <UiProposalLabel
         :label="label.name"
         :color="label.color"
-        class="text-sm mb-1 max-w-[160px]"
+        class="mb-1 max-w-[160px]"
       />
     </div>
   </template>

--- a/apps/ui/src/components/Ui/ProposalLabel.vue
+++ b/apps/ui/src/components/Ui/ProposalLabel.vue
@@ -47,7 +47,7 @@ function checkColorProximity(color: string): {
 
 <template>
   <div
-    class="px-2 py-[6px] rounded-full leading-3 whitespace-nowrap truncate w-fit max-w-[220px] shrink-0"
+    class="px-2 py-[6px] rounded-full leading-3 whitespace-nowrap truncate w-fit max-w-[220px] shrink-0 text-sm"
     :class="{
       border: colorProperties.showBorder
     }"


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/259

### How to test

1. Go to proposals, proposal, settings and editor
2. Text size on all labels everywhere should be same
