### PR TITLE
fix: pass Herodotus apiKey in headers

### DIFF
--- a/apps/mana/src/stark/herodotus.ts
+++ b/apps/mana/src/stark/herodotus.ts
@@ -69,7 +69,12 @@ async function getStatus(id: string, accumulatesChainId: string) {
   const { apiUrl, apiKey } = getApi(accumulatesChainId);
 
   const res = await fetch(
-    `${apiUrl}/batch-query-status?apiKey=${apiKey}&batchQueryId=${id}`
+    `${apiUrl}/batch-query-status?apiKey=${apiKey}&batchQueryId=${id}`,
+    {
+      headers: {
+        'api-key': apiKey
+      }
+    }
   );
 
   const { queryStatus, error } = await res.json();
@@ -104,7 +109,8 @@ async function submitBatch(proposal: ApiProposal) {
   const res = await fetch(`${apiUrl}/submit-batch-query?apiKey=${apiKey}`, {
     method: 'post',
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'api-key': apiKey
     },
     body: JSON.stringify(body)
   });


### PR DESCRIPTION
### Summary

New API version uses API key in the headers.
