### PR TITLE
chore: use production Herodotus API on sepolia

### DIFF
--- a/apps/mana/src/stark/herodotus.ts
+++ b/apps/mana/src/stark/herodotus.ts
@@ -55,8 +55,8 @@ function getApi(accumulatesChainId: string) {
   }
 
   return {
-    apiUrl: 'https://staging.api.herodotus.cloud',
-    indexerUrl: 'https://staging.rs-indexer.api.herodotus.cloud',
+    apiUrl: 'https://api.herodotus.cloud',
+    indexerUrl: 'https://rs-indexer.api.herodotus.cloud',
     apiKey: HERODOTUS_API_KEY
   };
 }


### PR DESCRIPTION
### Summary

Prod contracts match our own, so we can use it.
