### PR TITLE
fix: add missing cached_timestamps method in EVMSlotValue ABI

### DIFF
--- a/.changeset/eight-icons-explain.md
+++ b/.changeset/eight-icons-explain.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+fix evm slot value strategy cached_timestamps lookup

--- a/packages/sx.js/src/strategies/starknet/abis/EVMSlotValue.json
+++ b/packages/sx.js/src/strategies/starknet/abis/EVMSlotValue.json
@@ -91,6 +91,22 @@
     ]
   },
   {
+    "name": "cached_timestamps",
+    "type": "function",
+    "inputs": [
+      {
+        "name": "timestamp",
+        "type": "core::integer::u32"
+      }
+    ],
+    "outputs": [
+      {
+        "type": "core::integer::u256"
+      }
+    ],
+    "state_mutability": "view"
+  },
+  {
     "type": "constructor",
     "name": "constructor",
     "inputs": [


### PR DESCRIPTION
### Summary

For some reason Scarb doesn't generate this method in ABI. Added it manually.

### How to test

1. You see your VP here: http://localhost:8080/#/sn-sep:0x06001fefa235867a03ebcc02b82265762ae475c19ad3373e92cb6562ffc6fe61/proposal/6

