### PR TITLE
fix: fix contact picker not opening address book

### DIFF
--- a/apps/ui/src/components/Modal/DelegationConfig.vue
+++ b/apps/ui/src/components/Modal/DelegationConfig.vue
@@ -158,6 +158,7 @@ watch(
         :model-value="form"
         :error="formErrors"
         :definition="definition"
+        @pick="showPicker = true"
       />
     </div>
     <template #footer>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #893

This PR fix an issue where the contact picker in the space settings delegation modal was not opening the address book on click

### How to test

1. Go to a space settings -> delegation
2. Add/edit a delegation
3. Go to the address field
4. Click on the contact picker icon
5. It should open the contact list
