### PR TITLE
fix: fix blank link preview when url has no page title

### DIFF
--- a/apps/ui/src/components/Ui/LinkPreview.vue
+++ b/apps/ui/src/components/Ui/LinkPreview.vue
@@ -58,9 +58,12 @@ debouncedWatch(
   <div
     v-if="preview?.meta || (showDefault && !previewLoading)"
     class="flex items-center px-4 py-3 border rounded-lg"
-    :class="{ 'gap-2': showDefault, '!gap-4': preview?.meta?.title }"
+    :class="{
+      'gap-2': showDefault,
+      '!gap-4': preview?.meta?.title || previewIconResolved
+    }"
   >
-    <template v-if="preview?.meta?.title">
+    <template v-if="preview && (preview?.meta?.title || previewIconResolved)">
       <img
         v-if="previewIconResolved"
         :src="preview.links.icon[0].href"
@@ -70,7 +73,10 @@ debouncedWatch(
         :alt="preview.meta.title"
       />
       <div class="flex flex-col truncate">
-        <div class="text-skin-link truncate" v-text="preview.meta.title" />
+        <div
+          class="text-skin-link truncate"
+          v-text="preview.meta.title || props.url"
+        />
         <div
           v-if="preview.meta.description"
           class="text-[17px] text-skin-text truncate"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #891 

This PR fix an issue where the LinkPreview component is showing nothing when the given website has no page title

Before fix

![Screenshot 2024-10-17 at 11 54 59](https://github.com/user-attachments/assets/0f8e99af-afa1-4b7b-b2bb-192d1146e9f4)

After fix

![Screenshot 2024-10-17 at 21 09 19](https://github.com/user-attachments/assets/049d7b9a-f64c-4a1c-8d52-ac48ac771364)

### How to test

1. Go to Editor
2. In the discussion input, type `https://snapshot.box`
3. It should show a link preview, with the url in place of the blank page title
4. Create a proposal with this url
5. It should show the same link preview