### PR TITLE
fix: always initialize Starknet proposal labels

### DIFF
--- a/apps/api/src/ipfs.ts
+++ b/apps/api/src/ipfs.ts
@@ -145,6 +145,7 @@ export async function handleProposalMetadata(metadataUri: string) {
   if (exists) return;
 
   const proposalMetadataItem = new ProposalMetadataItem(dropIpfs(metadataUri));
+  proposalMetadataItem.labels = [];
 
   const metadata: any = await getJSON(metadataUri);
   if (metadata.title) proposalMetadataItem.title = metadata.title;


### PR DESCRIPTION
### Summary

This field is non-nullable so it has to be defined.

Currently this query is failing:
```gql
{
  proposals {
    metadata {
      labels
    }
  }
}
```
