### PR TITLE
feat: allow for longer vote reason on Starknet API

### DIFF
--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -163,7 +163,7 @@ type Vote {
 
 type VoteMetadataItem {
   id: String!
-  reason: String!
+  reason: Text!
 }
 
 type User {


### PR DESCRIPTION
### Summary

Towards https://github.com/snapshot-labs/workflow/issues/260

String type only supports 256 characters in checkpoint so we have to use different type.
