### PR TITLE
fix: filter out empty choices before saving

### DIFF
--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -171,6 +171,7 @@ async function handleProposeClick() {
   sending.value = true;
 
   try {
+    const choices = proposal.value.choices.filter(choice => !!choice);
     const executions = editorExecutions.value
       .filter(
         strategy =>
@@ -194,7 +195,7 @@ async function handleProposeClick() {
         proposal.value.body,
         proposal.value.discussion,
         proposal.value.type,
-        proposal.value.choices,
+        choices,
         proposal.value.labels,
         executions
       );
@@ -207,7 +208,7 @@ async function handleProposeClick() {
         proposal.value.body,
         proposal.value.discussion,
         proposal.value.type,
-        proposal.value.choices,
+        choices,
         proposal.value.labels,
         appName.length <= 128 ? appName : '',
         executions


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #886 

This PR removes blank choices before save. 

### How to test

1. Create a proposal with some empty choices
2. It should ignore the blank choices on creation
