### PR TITLE
fix: fix draft ignoring labels

### DIFF
--- a/apps/ui/src/composables/useEditor.ts
+++ b/apps/ui/src/composables/useEditor.ts
@@ -56,7 +56,7 @@ export function useEditor() {
 
   function removeEmpty(proposals: Drafts): Drafts {
     return Object.entries(proposals).reduce((acc, [id, proposal]) => {
-      const { executions, type, choices, ...rest } = omit(proposal, [
+      const { executions, type, choices, labels, ...rest } = omit(proposal, [
         'updatedAt'
       ]);
       const hasFormValues = Object.values(rest).some(val => !!val);
@@ -66,6 +66,7 @@ export function useEditor() {
 
       if (
         Object.keys(executions).length === 0 &&
+        labels.length === 0 &&
         !hasFormValues &&
         !hasChangedVotingType &&
         !hasFormChoices


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #903 

This PR fix the issue where deleting the current draft will create new one, in addition of not deleting the draft.

Issue is coming from draft considering all blank draft as dirtied, because of the new `labels` property

### How to test

1. Go to editor
2. dirty the form
3. open draft modal
4. delete current draft
5. It should remove the given draft from the list, without creating new one
