### PR TITLE
fix: allow voting power indicator to shrink

### DIFF
--- a/apps/ui/src/components/IndicatorVotingPower.vue
+++ b/apps/ui/src/components/IndicatorVotingPower.vue
@@ -31,39 +31,38 @@ function handleModalOpen() {
 </script>
 
 <template>
-  <div>
-    <slot
-      :voting-power="votingPower"
-      :formatted-voting-power="formattedVotingPower"
-      :on-click="handleModalOpen"
-    >
-      <UiTooltip title="Your voting power">
-        <UiButton
-          v-if="
-            web3.account &&
-            !(evmNetworks.includes(networkId) && web3.type === 'argentx')
-          "
-          :loading="loading"
-          class="flex flex-row items-center justify-center"
-          @click="handleModalOpen"
-        >
-          <IH-lightning-bolt class="inline-block -ml-1" />
-          <IH-exclamation
-            v-if="props.votingPower?.status === 'error'"
-            class="inline-block ml-1 text-rose-500"
-          />
-          <span v-else class="ml-1">{{ formattedVotingPower }}</span>
-        </UiButton>
-      </UiTooltip>
-    </slot>
-    <teleport to="#modal">
-      <ModalVotingPower
-        :open="modalOpen"
-        :network-id="networkId"
-        :voting-power="props.votingPower"
-        @close="modalOpen = false"
-        @fetch-voting-power="$emit('fetchVotingPower')"
-      />
-    </teleport>
-  </div>
+  <slot
+    :voting-power="votingPower"
+    :formatted-voting-power="formattedVotingPower"
+    :on-click="handleModalOpen"
+    v-bind="$attrs"
+  >
+    <UiTooltip title="Your voting power" class="flex truncate">
+      <UiButton
+        v-if="
+          web3.account &&
+          !(evmNetworks.includes(networkId) && web3.type === 'argentx')
+        "
+        :loading="loading"
+        class="flex flex-row items-center justify-center gap-1 truncate"
+        @click="handleModalOpen"
+      >
+        <IH-lightning-bolt class="inline-block -ml-1 shrink-0" />
+        <IH-exclamation
+          v-if="props.votingPower?.status === 'error'"
+          class="inline-block text-rose-500"
+        />
+        <span v-else class="truncate">{{ formattedVotingPower }}</span>
+      </UiButton>
+    </UiTooltip>
+  </slot>
+  <teleport to="#modal">
+    <ModalVotingPower
+      :open="modalOpen"
+      :network-id="networkId"
+      :voting-power="props.votingPower"
+      @close="modalOpen = false"
+      @fetch-voting-power="$emit('fetchVotingPower')"
+    />
+  </teleport>
 </template>

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -238,9 +238,13 @@ watchEffect(() => {
                 Please allow few minutes for the voting power to be collected
                 from Ethereum.
               </div>
-              <template v-else>
-                <span class="mr-1.5">Voting power:</span>
-                <button type="button" @click="votingPowerProps.onClick">
+              <div v-else class="flex gap-1.5 items-center">
+                <span class="shrink-0">Voting power:</span>
+                <button
+                  type="button"
+                  class="truncate"
+                  @click="votingPowerProps.onClick"
+                >
                   <UiLoading
                     v-if="!votingPower || votingPower.status === 'loading'"
                   />
@@ -261,11 +265,10 @@ watchEffect(() => {
                   "
                   href="https://help.snapshot.box/en/articles/9566904-why-do-i-have-0-voting-power"
                   target="_blank"
-                  class="ml-1.5"
                 >
                   <IH-question-mark-circle />
                 </a>
-              </template>
+              </div>
             </IndicatorVotingPower>
             <ProposalVote
               v-if="proposal"

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -64,8 +64,8 @@ watchEffect(() => setTitle(`Proposals - ${props.space.name}`));
 
 <template>
   <div>
-    <div class="flex justify-between">
-      <div class="flex flex-row p-4 space-x-2">
+    <div class="flex justify-between p-4 gap-2">
+      <div class="flex gap-2">
         <UiSelectDropdown
           v-model="state"
           title="Status"
@@ -97,7 +97,7 @@ watchEffect(() => setTitle(`Proposals - ${props.space.name}`));
           ]"
         />
       </div>
-      <div class="flex flex-row p-4 space-x-2">
+      <div class="flex gap-2 truncate">
         <IndicatorVotingPower
           :network-id="space.network"
           :voting-power="votingPower"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward https://github.com/snapshot-labs/workflow/issues/254

This PR will allow the Voting power indicator to shrink and truncate when needed. This fix will allow all elements to be flexible, and neatly shrink when needed, and allow more room for the upcoming labels filter

Before fix
![snapshot box_](https://github.com/user-attachments/assets/fef2ec0c-6bfd-4b3e-9884-e03c3ca19ebe)
![snapshot box_ (1)](https://github.com/user-attachments/assets/44e45d2e-eab2-4bc5-96b7-a0ae1ae83eeb)

After fix
![localhost_8080_](https://github.com/user-attachments/assets/2427b612-8a2c-4371-a0d8-930708fe321c)

![localhost_8080_ (1)](https://github.com/user-attachments/assets/fb00ced2-c303-45ad-b404-1210462b6e17)

### How to test

On a mobile device

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth/proposals
2. Go to http://localhost:8080/#/s:test.wa0x6e.eth/proposal/0xbe1481bc1a5cfaa4a19979b950faadd7919d913b87f03115750fc3463d1349d9
3. The voting power indicator should stay on the same line, and will be truncated when needed
