### PR TITLE
fix: standardize spacing in editor sidebar

### DIFF
--- a/apps/ui/src/components/EditorChoices.vue
+++ b/apps/ui/src/components/EditorChoices.vue
@@ -37,7 +37,7 @@ function handlePressDelete(event: KeyboardEvent, index: number) {
 
 <template>
   <div
-    class="s-base mb-5"
+    class="s-base"
     :class="{
       's-error': showError
     }"

--- a/apps/ui/src/components/EditorVotingType.vue
+++ b/apps/ui/src/components/EditorVotingType.vue
@@ -47,7 +47,7 @@ watch(
 </script>
 
 <template>
-  <div class="s-base mb-4">
+  <div class="s-base">
     <h4 class="eyebrow mb-2.5">Voting system</h4>
     <button
       type="button"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Elements in the Editor right sidebar have a mix of different spacing, set in different places.

This PR will make sure that:

- the same spacing `space-y-4` (already present in the sidebar container) is always used
- remove all custom spacing inside the components (EditorXXX components)

### How to test

1. Go to Editor page
2. All elements in the right sidebar should have the same `4` spacing
