### PR TITLE
feat: persist proposals state filter in url

### DIFF
--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { LocationQueryRaw } from 'vue-router';
 import ProposalIconStatus from '@/components/ProposalIconStatus.vue';
 import { ProposalsFilter } from '@/networks/types';
 import { Space } from '@/types';
@@ -12,6 +13,8 @@ const {
   reset: resetVotingPower
 } = useVotingPower();
 const { web3 } = useWeb3();
+const router = useRouter();
+const route = useRoute();
 const proposalsStore = useProposalsStore();
 
 const state = ref<NonNullable<ProposalsFilter['state']>>('any');
@@ -35,11 +38,27 @@ function handleFetchVotingPower() {
 }
 
 watch(
+  [() => route.query.state as string],
+  ([toState]) => {
+    state.value = ['any', 'active', 'pending', 'closed'].includes(toState)
+      ? (toState as NonNullable<ProposalsFilter['state']>)
+      : 'any';
+    proposalsStore.reset(props.space.id, props.space.network);
+    proposalsStore.fetch(props.space.id, props.space.network, state.value);
+  },
+  { immediate: true }
+);
+
+watch(
   [props.space, state],
   ([toSpace, toState], [fromSpace, fromState]) => {
     if (toSpace.id !== fromSpace?.id || toState !== fromState) {
-      proposalsStore.reset(toSpace.id, toSpace.network);
-      proposalsStore.fetch(toSpace.id, toSpace.network, toState);
+      const query: LocationQueryRaw = {
+        ...route.query,
+        state: toState === 'any' ? undefined : toState
+      };
+
+      router.push({ query });
     }
   },
   { immediate: true }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR uses the `?state=X` query param to persist the proposals page `state` filter

### How to test

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth/proposals?state=active
2. It should show only active proposals
3. Select another filter in the state dropdown
4. It should refresh the proposals list, and the state query param
5. Passing an invalid value to state query param will be considered as `any`
