### PR TITLE
fix: use networkId if available

### DIFF
--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -578,11 +578,12 @@ export function useActions() {
 
     const isEvmNetwork = typeof chainIdOverride === 'number';
     const actionNetwork =
-      networkId ?? isEvmNetwork
+      networkId ??
+      (isEvmNetwork
         ? 'eth'
         : (Object.entries(METADATA).find(
             ([, metadata]) => metadata.chainId === chainIdOverride
-          )?.[0] as NetworkID);
+          )?.[0] as NetworkID));
     if (!actionNetwork) throw new Error('Failed to detect action network');
 
     const network = getReadWriteNetwork(actionNetwork);


### PR DESCRIPTION
### Summary

due to operator preference networkId was actually ignored

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/917

### How to test

1. Go to http://localhost:8080/#/sn:0x07c251045154318a2376a3bb65be47d3c90df1740d8e35c9b9d943aa3f240e50/delegates
2. Sign in with Starknet mainnet account.
3. You can delegate.
