### PR TITLE
fix: toString() error on strategy metadata

### DIFF
--- a/apps/subgraph-api/package.json
+++ b/apps/subgraph-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-subgraph",
   "private": true,
-  "version": "0.0.41",
+  "version": "0.0.42",
   "scripts": {
     "test": "graph test",
     "codegen": "graph codegen",

--- a/apps/subgraph-api/src/ipfs.ts
+++ b/apps/subgraph-api/src/ipfs.ts
@@ -1,4 +1,4 @@
-import { Bytes, dataSource, json } from '@graphprotocol/graph-ts'
+import { Bytes, dataSource, json, JSONValueKind } from '@graphprotocol/graph-ts'
 import { JSON } from 'assemblyscript-json'
 import {
   SpaceMetadata,
@@ -202,7 +202,7 @@ export function handleVotingPowerValidationStrategyMetadata(content: Bytes): voi
 
   updateStrategiesParsedMetadata(
     spaceId,
-    strategies_metadata.toArray().map<string>((metadata) => metadata.toString()),
+    strategies_metadata.toArray().filter(metadata => metadata.kind === JSONValueKind.STRING).map<string>((metadata) => metadata.toString()),
     0,
     blockNumber,
     'VotingPowerValidationStrategiesParsedMetadata'


### PR DESCRIPTION
Context https://discord.com/channels/955773041898573854/1030772407226601522/1297968753719640124

### Summary
Filter out non-string values before doing a .toString()

### Issue 
sepolia subgraph is stuck at block 6,914,255
with error:
```js
A non-deterministic fatal error occured at block 6914256: error while executing at wasm backtrace: 0: 0x2a14 - 
<unknown>!~lib/@graphprotocol/graph-ts/common/value/JSONValue#toString 1: 0x60ec - 
<unknown>!src/ipfs/handleSpaceMetadata~anonymous|3 2: 0x5135 - <unknown>!~lib/array/Array<~lib/assemblyscript-
json/JSON/Value>#map<~lib/string/String> 3: 0x7c20 - <unknown>!src/ipfs/handleVotingPowerValidationStrategyMetadata: Mapping aborted at ~lib/@graphprotocol/graph-
ts/common/value.ts, line 570, column 5, with message: JSON value is not a string. in handler 
`handleVotingPowerValidationStrategyMetadata` at block #6914239 ()
```

### How to test

1. yarn dev:full
2. wait for index
3. indexing should not stop at block 6,914,255