### PR TITLE
fix: fix passing extraneous props to component

### DIFF
--- a/apps/ui/src/components/ProposalVote.vue
+++ b/apps/ui/src/components/ProposalVote.vue
@@ -56,29 +56,27 @@ const isEditable = computed(() => {
 
 <template>
   <slot v-if="currentVote && !editMode" name="voted" :vote="currentVote">
-    <div v-bind="$attrs">
-      <UiButton
-        class="!h-[48px] text-left w-full flex items-center rounded-lg space-x-2"
-        :disabled="!isEditable"
-        @click="$emit('enterEditMode')"
+    <UiButton
+      class="!h-[48px] text-left w-full flex items-center rounded-lg space-x-2"
+      :disabled="!isEditable"
+      @click="$emit('enterEditMode')"
+    >
+      <div
+        v-if="proposal.privacy"
+        class="flex space-x-2 items-center grow truncate"
+        :class="{ 'text-skin-text': !isEditable }"
       >
-        <div
-          v-if="proposal.privacy"
-          class="flex space-x-2 items-center grow truncate"
-          :class="{ 'text-skin-text': !isEditable }"
-        >
-          <IH-lock-closed class="size-[16px] shrink-0" />
-          <span class="truncate">Encrypted choice</span>
-        </div>
-        <div
-          v-else
-          class="grow truncate"
-          :class="{ 'text-skin-text': !isEditable }"
-          v-text="getChoiceText(proposal.choices, currentVote.choice)"
-        />
-        <IH-pencil v-if="isEditable" class="shrink-0" />
-      </UiButton>
-    </div>
+        <IH-lock-closed class="size-[16px] shrink-0" />
+        <span class="truncate">Encrypted choice</span>
+      </div>
+      <div
+        v-else
+        class="grow truncate"
+        :class="{ 'text-skin-text': !isEditable }"
+        v-text="getChoiceText(proposal.choices, currentVote.choice)"
+      />
+      <IH-pencil v-if="isEditable" class="shrink-0" />
+    </UiButton>
   </slot>
   <slot
     v-else-if="
@@ -112,7 +110,7 @@ const isEditable = computed(() => {
   <slot v-else-if="isInvalidNetwork" name="wrong-safe-network">
     Safe's network should be same as space's network
   </slot>
-  <div v-else v-bind="$attrs">
+  <div v-else>
     <slot />
   </div>
 </template>

--- a/apps/ui/src/components/ProposalsListItem.vue
+++ b/apps/ui/src/components/ProposalsListItem.vue
@@ -33,7 +33,7 @@ const handleVoteClick = (choice: Choice) => {
         class="flex-auto mr-4 w-0"
       />
       <div class="hidden md:block">
-        <ProposalVote :proposal="proposal" class="py-2">
+        <ProposalVote :proposal="proposal">
           <template #wrong-safe-network><div /></template>
           <template #unsupported><div /></template>
           <template #waiting><div /></template>
@@ -53,11 +53,9 @@ const handleVoteClick = (choice: Choice) => {
             />
             <div v-else />
           </template>
-          <ProposalVoteBasic
-            v-if="proposal.type === 'basic'"
-            :size="40"
-            @vote="handleVoteClick"
-          />
+          <div v-if="proposal.type === 'basic'" class="py-2">
+            <ProposalVoteBasic :size="40" @vote="handleVoteClick" />
+          </div>
         </ProposalVote>
       </div>
     </div>

--- a/apps/ui/src/components/ProposalsListItem.vue
+++ b/apps/ui/src/components/ProposalsListItem.vue
@@ -53,9 +53,12 @@ const handleVoteClick = (choice: Choice) => {
             />
             <div v-else />
           </template>
-          <div v-if="proposal.type === 'basic'" class="py-2">
-            <ProposalVoteBasic :size="40" @vote="handleVoteClick" />
-          </div>
+          <ProposalVoteBasic
+            v-if="proposal.type === 'basic'"
+            :size="40"
+            class="py-2"
+            @vote="handleVoteClick"
+          />
         </ProposalVote>
       </div>
     </div>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fix following error when using `ProposaVote` component

```
proposals.ts:103 [Vue warn]: Extraneous non-props attributes (class) were passed to component but could not be automatically inherited because component renders fragment or text root nodes. 
  at <ProposalVote proposal=
```

### How to test

1. Open a space proposals page
2. No more error in the console.log
3. Proposals with basic vote still have `py-2` class, only on proposals list

![Screenshot 2024-10-22 at 19 26 01](https://github.com/user-attachments/assets/618593b0-adfc-4b57-8c0f-bae571370f16)

