### PR TITLE
chore: disable reset on API

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -65,7 +65,7 @@ async function run() {
     await sleep(PRODUCTION_INDEXER_DELAY);
   }
 
-  await checkpoint.reset();
+  // await checkpoint.reset();
   checkpoint.start();
 }
 


### PR DESCRIPTION
### Summary

So we can swap instances.