### PR TITLE
fix: fix error when logging out by locking argent x wallet

### DIFF
--- a/apps/ui/src/helpers/argentx.ts
+++ b/apps/ui/src/helpers/argentx.ts
@@ -48,6 +48,8 @@ export default class Connector extends LockConnector {
       await argentx.disconnect({
         clearLastWallet: true
       });
-    } catch (e) {}
+    } catch (e) {
+      console.log(e)
+    }
   }
 }

--- a/apps/ui/src/helpers/argentx.ts
+++ b/apps/ui/src/helpers/argentx.ts
@@ -43,8 +43,11 @@ export default class Connector extends LockConnector {
 
   async logout() {
     const argentx = await get();
-    await argentx.disconnect({
-      clearLastWallet: true
-    });
+
+    try {
+      await argentx.disconnect({
+        clearLastWallet: true
+      });
+    } catch (e) {}
   }
 }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an error when locking the argent X wallet, when the user is connected with it.

Locking the wallet will disconnect the wallet, but the subsequent `logout()` call will crash with

![Screenshot 2024-10-22 at 21 49 41](https://github.com/user-attachments/assets/5d8df8b6-261b-4a71-9956-b68869774925)

And result in the user menu being in an invalid state

![Screenshot 2024-10-22 at 21 57 51](https://github.com/user-attachments/assets/5f6f8026-c6ff-4d47-be17-c042240a6005)

### How to test

1. Connect with an argent X wallet
2. Lock the wallet
3. It should log you out properly, without any errors in the console
