### PR TITLE
fix: disable controller edition when no permission

### DIFF
--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -481,7 +481,14 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
             <IH-arrow-sm-right class="-rotate-45" />
           </a>
         </div>
-        <button type="button" @click="changeControllerModalOpen = true">
+        <button
+          type="button"
+          :disabled="!isController"
+          :class="{
+            'opacity-40 cursor-not-allowed text-skin-text': !isController
+          }"
+          @click="changeControllerModalOpen = true"
+        >
           <IH-pencil />
         </button>
       </div>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/814

This PR disables the space settings controller edition, when the current user is not the controller.

Previously, we could open the modal, change the controller, but clicking on the "Confirm" button was doing nothing.

### How to test

1. Go to a space settings you are not controller
2. In the controller tab, the edit button to edit the controller should be disabled
3. Go to a space settings you are controller
4. You should be able to edit the space controller
