### PR TITLE
chore: bump subgraph-api to 0.0.43

### DIFF
--- a/apps/subgraph-api/package.json
+++ b/apps/subgraph-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-subgraph",
   "private": true,
-  "version": "0.0.42",
+  "version": "0.0.43",
   "scripts": {
     "test": "graph test",
     "codegen": "graph codegen",


### PR DESCRIPTION
### Summary

Already deployed. We lost this bump in choices PR because other API bumped to the same version.