### PR TITLE
fix: enable offchain proposal update

### DIFF
--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -46,12 +46,18 @@ const cancelling = ref(false);
 const aiSummaryOpen = ref(false);
 
 const editable = computed(() => {
+  if (!compareAddresses(props.proposal.author.id, web3.value.account))
+    return false;
+
+  if (offchainNetworks.includes(props.proposal.network)) {
+    return props.proposal.start > Math.floor(Date.now() / 1000);
+  }
+
   // HACK: here we need to use snapshot instead of start because start is artifically
   // shifted for Starknet's proposals with ERC20Votes strategies.
   return (
-    compareAddresses(props.proposal.author.id, web3.value.account) &&
     props.proposal.snapshot >
-      (getCurrent(props.proposal.network) || Number.POSITIVE_INFINITY)
+    (getCurrent(props.proposal.network) || Number.POSITIVE_INFINITY)
   );
 });
 
@@ -123,6 +129,7 @@ async function handleEditClick() {
     discussion: props.proposal.discussion,
     type: props.proposal.type,
     choices: props.proposal.choices,
+    labels: props.proposal.labels,
     executions
   });
 

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -46,18 +46,16 @@ const cancelling = ref(false);
 const aiSummaryOpen = ref(false);
 
 const editable = computed(() => {
-  if (!compareAddresses(props.proposal.author.id, web3.value.account))
-    return false;
-
-  if (offchainNetworks.includes(props.proposal.network)) {
-    return props.proposal.start > Math.floor(Date.now() / 1000);
-  }
-
-  // HACK: here we need to use snapshot instead of start because start is artifically
+  // HACK: here we need to use snapshot instead of start because start is artificially
   // shifted for Starknet's proposals with ERC20Votes strategies.
+  const pivotName = offchainNetworks.includes(props.proposal.network)
+    ? 'start'
+    : 'snapshot';
+
   return (
-    props.proposal.snapshot >
-    (getCurrent(props.proposal.network) || Number.POSITIVE_INFINITY)
+    compareAddresses(props.proposal.author.id, web3.value.account) &&
+    props.proposal[pivotName] >
+      (getCurrent(props.proposal.network) || Number.POSITIVE_INFINITY)
   );
 });
 

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -216,9 +216,20 @@ async function handleProposeClick() {
     }
     if (result) {
       proposalsStore.reset(props.space.id, props.space.network);
-      router.push({
-        name: 'space-proposals'
-      });
+
+      if (
+        proposal.value.proposalId &&
+        offchainNetworks.includes(props.space.network)
+      ) {
+        router.push({
+          name: 'space-proposal-overview',
+          params: {
+            proposal: proposal.value.proposalId
+          }
+        });
+      } else {
+        router.push({ name: 'space-proposals' });
+      }
     }
   } finally {
     sending.value = false;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #933 

This PR fix the "Edit proposal" menu not appearing for pending offchain proposals

### How to test

1. Go to a pending offchain proposals
2. Click on the 3 dot menu in the proposal heading
3. It should show the "Edit proposal" menu
4. Clicking on it should redirect to the editor, where you can edit the title, body, voting type, choices and labels
5. Submitting the form should update the proposal, and redirect to the proposal page

### Note 

- Updating an onchain proposal will still redirect back to proposals list page, because of the lag while confirming the tx
