### PR TITLE
fix: only verify starknet networks when starknet connector is required

### DIFF
--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -175,11 +175,15 @@ export function useActions() {
     }
 
     const network = getReadWriteNetwork(networkId);
-    return network.actions.deployDependency(auth.web3, {
-      controller,
-      spaceAddress,
-      strategy: dependencyConfig
-    });
+    return network.actions.deployDependency(
+      auth.web3,
+      web3.value.type as Connector,
+      {
+        controller,
+        spaceAddress,
+        strategy: dependencyConfig
+      }
+    );
   }
 
   async function createSpace(

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -90,6 +90,7 @@ export function createActions(
     },
     async deployDependency(
       web3: Web3Provider,
+      connectorType: Connector,
       params: {
         controller: string;
         spaceAddress: string;

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -111,13 +111,16 @@ export function createActions(
     },
     deployDependency: async (
       web3: any,
+      connectorType: Connector,
       params: {
         controller: string;
         spaceAddress: string;
         strategy: StrategyConfig;
       }
     ) => {
-      await verifyStarknetNetwork(web3, chainId);
+      if (STARKNET_CONNECTORS.includes(connectorType)) {
+        await verifyStarknetNetwork(web3, chainId);
+      }
 
       if (!params.strategy.deploy) {
         throw new Error('This strategy is not deployable');
@@ -496,8 +499,6 @@ export function createActions(
     },
     finalizeProposal: () => null,
     executeTransactions: async (web3: any, proposal: Proposal) => {
-      await verifyStarknetNetwork(web3, chainId);
-
       const executionData = getExecutionData(
         proposal.space,
         proposal.execution_strategy,
@@ -512,8 +513,6 @@ export function createActions(
       });
     },
     executeQueuedProposal: async (web3: any, proposal: Proposal) => {
-      await verifyStarknetNetwork(web3, chainId);
-
       if (!proposal.execution_destination)
         throw new Error('Execution destination is missing');
 

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -197,6 +197,7 @@ export type NetworkActions = ReadOnlyNetworkActions & {
   ): Promise<string | null>;
   deployDependency(
     web3: Web3Provider,
+    connectorType: Connector,
     params: {
       controller: string;
       spaceAddress: string;


### PR DESCRIPTION
### Summary

`verifyStarknetNetwork` doesn't handle nicely case of it being called on non Starknet connector, but it is possible on master:
1. when deploying dependency on Starknet sometimes we do it through EVM wallet (L1 EthRelayer) - in this case we should limit it to only be called if Starknet connector is used
2. `executeTransactions` - not required - can be called with any wallet or without it as it's done through mana.
3. `executeQueuedProposal` - not required - can be called with any wallet or without it as it's done through mana.
