### PR TITLE
feat: EthRelayer execution fixes

### DIFF
--- a/apps/api/src/utils.ts
+++ b/apps/api/src/utils.ts
@@ -168,10 +168,10 @@ export async function handleExecutionStrategy(
       const [l1Destination] = payload;
       if (!l1Destination)
         throw new Error('Invalid payload for EthRelayer execution strategy');
-      destinationAddress = l1Destination;
+      destinationAddress = formatAddress('Ethereum', l1Destination);
 
       const SimpleQuorumExecutionStrategyContract = new EthContract(
-        l1Destination,
+        destinationAddress,
         SimpleQuorumExecutionStrategyAbi,
         ethProvider
       );

--- a/apps/ui/src/composables/useExecutionActions.ts
+++ b/apps/ui/src/composables/useExecutionActions.ts
@@ -75,6 +75,11 @@ export function useExecutionActions(
   });
 
   async function fetchEthRelayerExecutionDetails() {
+    if (currentTimestamp.value < proposal.max_end * 1000) {
+      message.value =
+        'This execution strategy requires max end time to be reached.';
+    }
+
     if (!proposal.execution_tx) return;
 
     const tx = await network.value.helpers.getTransaction(


### PR DESCRIPTION
### Summary

Fixes issues discovered when working on debugging this issue: https://github.com/snapshot-labs/workflow/issues/267

Looks like there is no issue with execution itself as this task suggests - those are old proposals that were using old contract that didn't include `proposalId` in the message sent to L1 so those won't work.

This PR itself changes two things:
1. You can only try execute once max end has been reached (this is requirement for EthRelayer).
2. `l1DestinationAddress` is now reformatted (because it's stored as string on Starknet it can lose leading zeroes making it incorrect length and it will fail to be stored on Checkpoint.

Closes: https://github.com/snapshot-labs/workflow/issues/267

### How to test

#### Long way
1. Create new space with EthRelayer (use Safe for avatar, make sure to add matching treasury, once deployed add your L1 execution strategy as custom module to your Safe).
2. Run local Starknet API.
3. Create proposal with execution.
4. Vote on it.
5. Wait once received on L1.
6. You can execute it.

#### Short way
1. Go to https://testnet.snapshot.box/#/sn-sep:0x058b2936c07383c9ced7d99c3758b50e3675aa97633e2e1e19a90f020c088004/proposal/4
2. It has been executed and has link to L1 execution.

### Screenshots

<img width="1182" alt="image" src="https://github.com/user-attachments/assets/79ba1c53-c5fc-4f3f-862d-bd2ab4cc87ea">
