### PR TITLE
feat: add getDataByMessageHash data endpoint

### DIFF
--- a/apps/mana/src/db.ts
+++ b/apps/mana/src/db.ts
@@ -113,3 +113,7 @@ export async function markProposalProcessed(id: string) {
 export async function getProposal(id: string) {
   return knex(REGISTERED_PROPOSALS).select('*').where({ id }).first();
 }
+
+export async function getDataByMessageHash(hash: string) {
+  return knex(REGISTERED_TRANSACTIONS).select('data').where({ hash }).first();
+}

--- a/apps/mana/src/db.ts
+++ b/apps/mana/src/db.ts
@@ -115,5 +115,5 @@ export async function getProposal(id: string) {
 }
 
 export async function getDataByMessageHash(hash: string) {
-  return knex(REGISTERED_TRANSACTIONS).select('data').where({ hash }).first();
+  return knex(REGISTERED_TRANSACTIONS).select(['type', 'data', 'hash', 'network']).where({ hash }).first();
 }

--- a/apps/mana/src/db.ts
+++ b/apps/mana/src/db.ts
@@ -115,5 +115,8 @@ export async function getProposal(id: string) {
 }
 
 export async function getDataByMessageHash(hash: string) {
-  return knex(REGISTERED_TRANSACTIONS).select(['type', 'data', 'hash', 'network']).where({ hash }).first();
+  return knex(REGISTERED_TRANSACTIONS)
+    .select(['type', 'data', 'hash', 'network'])
+    .where({ hash })
+    .first();
 }

--- a/apps/mana/src/stark/index.ts
+++ b/apps/mana/src/stark/index.ts
@@ -15,7 +15,8 @@ const jsonRpcRequestSchema = z.object({
     'send',
     'execute',
     'registerTransaction',
-    'registerProposal'
+    'registerProposal',
+    'getDataByMessageHash',
   ]),
   params: z.any()
 });

--- a/apps/mana/src/stark/index.ts
+++ b/apps/mana/src/stark/index.ts
@@ -16,7 +16,7 @@ const jsonRpcRequestSchema = z.object({
     'execute',
     'registerTransaction',
     'registerProposal',
-    'getDataByMessageHash',
+    'getDataByMessageHash'
   ]),
   params: z.any()
 });

--- a/apps/mana/src/stark/rpc.ts
+++ b/apps/mana/src/stark/rpc.ts
@@ -156,6 +156,6 @@ export const createNetworkHandler = (chainId: string) => {
     registerTransaction,
     registerProposal,
     getAccount,
-    getDataByMessageHash,
+    getDataByMessageHash
   };
 };

--- a/apps/mana/src/stark/rpc.ts
+++ b/apps/mana/src/stark/rpc.ts
@@ -137,11 +137,25 @@ export const createNetworkHandler = (chainId: string) => {
     }
   }
 
+  async function getDataByMessageHash(id: number, params: any, res: Response) {
+    try {
+      const { hash } = params;
+
+      const transaction = await db.getDataByMessageHash(hash);
+
+      return rpcSuccess(res, transaction, id);
+    } catch (e) {
+      console.log('Failed', e);
+      return rpcError(res, 500, e, id);
+    }
+  }
+
   return {
     send,
     execute,
     registerTransaction,
     registerProposal,
-    getAccount
+    getAccount,
+    getDataByMessageHash,
   };
 };


### PR DESCRIPTION
### Summary

- Adds a `getDataByMessageHash` method that accepts a `hash` as params and returns all the information required for the user to re-compute his hash independently.
- Modifies `sx.js` in order for the `getProposeHash / getVoteHash / getUpdateProposalHash` methods to accept an `address` instead of a `Signer` (required for the `hash-verifier` to work). Also upgrades the corresponding tests.

Closes: #949 

## How to test

1. Build locally and use `yarn link` to link with the [hash-verifier](https://github.com/snapshot-labs/hash-verifier) script.

Question: is `getDataByMessageHash` a proper name? Should we find a better name?