### PR TITLE
fix: home page - show loading when followed spaces are still loading

### DIFF
--- a/apps/ui/src/views/My/Home.vue
+++ b/apps/ui/src/views/My/Home.vue
@@ -163,7 +163,7 @@ onUnmounted(() => {
   <ProposalsList
     title="Proposals"
     limit="off"
-    :loading="!loaded"
+    :loading="!followedSpacesStore.followedSpacesLoaded || !loaded"
     :loading-more="loadingMore"
     :proposals="proposals"
     show-space


### PR DESCRIPTION
### Summary
Closes: https://github.com/snapshot-labs/workflow/issues/285

- Show loading when followedSpaces are still loading

### How to test

1. Disconnect your wallet if you are already connected
2. Go to home page
3. Change network settings to "3G"
4. Connect your wallet
5. You should see "There are no proposal here" before the fix
6. You should see loading icon after the fix
