### PR TITLE
fix: Add minimum value for proposal threshold

### DIFF
--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -154,6 +154,7 @@ export function createConstants(networkId: NetworkID) {
           threshold: {
             type: 'integer',
             title: 'Proposal threshold',
+            minimum: 1,
             examples: ['1']
           }
         }

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -253,6 +253,7 @@ export function createConstants(
           threshold: {
             type: 'integer',
             title: 'Proposal threshold',
+            minimum: 1,
             examples: ['1']
           }
         }


### PR DESCRIPTION
### Summary
- Add min value of `1` for proposal threshold

Closes: #952 

### How to test

1. Go to your SX space
2. Edit proposal validation
3. Try passing values less than `1`
![image](https://github.com/user-attachments/assets/401957da-5b9c-4a79-8507-77a96845194c)

