### PR TITLE
feat: allow any network to be used in Treasuries

### DIFF
--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -116,7 +116,7 @@ watch(
         class="w-full flex justify-between items-center px-4 py-3"
       >
         <UiBadgeNetwork
-          :id="treasury.networkId"
+          :chain-id="treasury.network"
           class="mr-3 shrink-0 size-fit"
           :class="{
             'opacity-40': disabled
@@ -175,7 +175,7 @@ watch(
           </UiTooltip>
         </div>
       </div>
-      <template v-if="model.length > 0 && treasury && treasury.networkId">
+      <template v-if="model.length > 0 && treasury">
         <UiLabel label="Transactions" class="border-t" />
         <div>
           <Draggable
@@ -184,7 +184,7 @@ watch(
             :item-key="() => undefined"
           >
             <template #item="{ element: tx, index: i }">
-              <TransactionsListItem :tx="tx" :network-id="treasury.networkId">
+              <TransactionsListItem :tx="tx" :chain-id="treasury.network">
                 <template #left>
                   <div
                     v-if="model.length > 1"
@@ -247,18 +247,17 @@ watch(
 
     <teleport to="#modal">
       <ModalSendToken
-        v-if="treasury && treasury.networkId"
+        v-if="treasury"
         :open="modalOpen.sendToken"
         :address="treasury.wallet"
         :network="treasury.network"
-        :network-id="treasury.networkId"
         :extra-contacts="extraContacts"
         :initial-state="modalState.sendToken"
         @close="modalOpen.sendToken = false"
         @add="addTx"
       />
       <ModalSendNft
-        v-if="treasury && treasury.networkId"
+        v-if="treasury"
         :open="modalOpen.sendNft"
         :address="treasury.wallet"
         :network="treasury.network"
@@ -268,17 +267,16 @@ watch(
         @add="addTx"
       />
       <ModalStakeToken
-        v-if="treasury && treasury.networkId"
+        v-if="treasury"
         :open="modalOpen.stakeToken"
         :address="treasury.wallet"
         :network="treasury.network"
-        :network-id="treasury.networkId"
         :initial-state="modalState.stakeToken"
         @close="modalOpen.stakeToken = false"
         @add="addTx"
       />
       <ModalTransaction
-        v-if="treasury && treasury.networkId"
+        v-if="treasury"
         :open="modalOpen.contractCall"
         :network="treasury.network"
         :extra-contacts="extraContacts"

--- a/apps/ui/src/components/FormSpaceTreasuries.vue
+++ b/apps/ui/src/components/FormSpaceTreasuries.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import Draggable from 'vuedraggable';
-import { offchainNetworks } from '@/networks';
 import { NetworkID, SpaceMetadataTreasury } from '@/types';
 
 const model = defineModel<SpaceMetadataTreasury[]>({
   required: true
 });
 
-const props = defineProps<{
+defineProps<{
   networkId: NetworkID;
   limit?: number;
 }>();
@@ -28,11 +27,7 @@ function addTreasuryConfig(config: SpaceMetadataTreasury) {
       : model.value;
 
   const getId = (t: SpaceMetadataTreasury) => {
-    const networkIdentifeir = offchainNetworks.includes(props.networkId)
-      ? t.chainId
-      : t.network;
-
-    return `${t.name}-${networkIdentifeir}-${t.address}`;
+    return `${t.name}-${t.chainId}-${t.address}`;
   };
 
   const existingTreasuries = new Map(

--- a/apps/ui/src/components/Modal/SendToken.vue
+++ b/apps/ui/src/components/Modal/SendToken.vue
@@ -6,7 +6,7 @@ import { ETH_CONTRACT } from '@/helpers/constants';
 import { createSendTokenTransaction } from '@/helpers/transactions';
 import { clone } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
-import { ChainId, Contact, NetworkID, Transaction } from '@/types';
+import { ChainId, Contact, Transaction } from '@/types';
 
 const DEFAULT_FORM_STATE = {
   to: '',
@@ -26,7 +26,6 @@ const props = defineProps<{
   open: boolean;
   address: string;
   network: ChainId;
-  networkId: NetworkID;
   extraContacts?: Contact[];
   initialState?: any;
 }>();
@@ -257,7 +256,6 @@ watchEffect(async () => {
         :assets="allAssets"
         :address="address"
         :network="network"
-        :network-id="networkId"
         :loading="loading"
         :search-value="searchValue"
         @pick="
@@ -294,7 +292,7 @@ watchEffect(async () => {
           <div class="flex items-center">
             <UiStamp
               v-if="currentToken"
-              :id="`${networkId}:${currentToken.contractAddress}`"
+              :id="`eip155:${network}:${currentToken.contractAddress}`"
               type="token"
               class="mr-2"
               :size="20"

--- a/apps/ui/src/components/Modal/StakeToken.vue
+++ b/apps/ui/src/components/Modal/StakeToken.vue
@@ -4,14 +4,14 @@ import { ETH_CONTRACT } from '@/helpers/constants';
 import { createStakeTokenTransaction } from '@/helpers/transactions';
 import { clone } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
-import { ChainId, NetworkID, Transaction } from '@/types';
+import { ChainId, Transaction } from '@/types';
 
 const STAKING_CONTRACTS = {
-  eth: {
+  1: {
     address: '0xae7ab96520de3a18e5e111b5eaab095312d7fe84',
     referral: '0x01e8CEC73B020AB9f822fD0dee3Aa4da2fe39e38'
   },
-  sep: {
+  11155111: {
     address: '0x3e3FE7dBc6B4C189E7128855dD526361c49b40Af',
     referral: '0x8C28Cf33d9Fd3D0293f963b1cd27e3FF422B425c'
   }
@@ -43,7 +43,6 @@ const props = defineProps<{
   open: boolean;
   address: string;
   network: ChainId;
-  networkId: NetworkID;
   initialState?: any;
 }>();
 
@@ -88,7 +87,7 @@ const token = computed(() => {
   return token;
 });
 
-const stakingContract = computed(() => STAKING_CONTRACTS[props.networkId]);
+const stakingContract = computed(() => STAKING_CONTRACTS[props.network]);
 
 function handleMaxClick() {
   handleAmountUpdate(
@@ -176,7 +175,7 @@ watch(
           />
           <div class="absolute right-3 top-[28px] flex items-center gap-x-2">
             <UiStamp
-              :id="`${networkId}:${stakingContract.address}`"
+              :id="`eip155:${network}:${stakingContract.address}`"
               type="token"
               :size="20"
             />

--- a/apps/ui/src/components/Modal/TreasuryConfig.vue
+++ b/apps/ui/src/components/Modal/TreasuryConfig.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import { clone } from '@/helpers/utils';
 import { validateForm } from '@/helpers/validation';
-import { offchainNetworks } from '@/networks';
 import { NetworkID, SpaceMetadataTreasury } from '@/types';
 
 const DEFAULT_FORM_STATE = {
   name: '',
   address: '',
-  network: null,
   chainId: null
 };
 
@@ -25,16 +23,12 @@ const showPicker = ref(false);
 const searchValue = ref('');
 const form: Ref<SpaceMetadataTreasury> = ref(clone(DEFAULT_FORM_STATE));
 
-const networkField = computed(() =>
-  offchainNetworks.includes(props.networkId) ? 'chainId' : 'network'
-);
-
 const definition = computed(() => {
   return {
     type: 'object',
     title: 'Space',
     additionalProperties: true,
-    required: ['name', 'network', 'address'],
+    required: ['name', 'chainId', 'address'],
     properties: {
       name: {
         type: 'string',
@@ -43,17 +37,15 @@ const definition = computed(() => {
         maxLength: 32,
         examples: ['Treasury name']
       },
-      [networkField.value]: {
+      chainId: {
         type: ['string', 'number', 'null'],
         format: 'network',
         networkId: props.networkId,
-        networksListKind: offchainNetworks.includes(props.networkId)
-          ? 'full'
-          : 'builtin',
+        networksListKind: 'full',
         title: 'Treasury network',
         nullable: true
       },
-      ...(form.value[networkField.value] !== null
+      ...(form.value.chainId !== null
         ? {
             address: {
               type: 'string',
@@ -75,7 +67,7 @@ const formErrors = computed(() =>
 const formValid = computed(() => {
   return (
     Object.keys(formErrors.value).length === 0 &&
-    form.value[networkField.value] !== null &&
+    form.value.chainId !== null &&
     form.value.address !== ''
   );
 });

--- a/apps/ui/src/components/PickerToken.vue
+++ b/apps/ui/src/components/PickerToken.vue
@@ -7,7 +7,7 @@ import { ETH_CONTRACT } from '@/helpers/constants';
 import Multicaller from '@/helpers/multicaller';
 import { getProvider } from '@/helpers/provider';
 import { _n, shorten } from '@/helpers/utils';
-import { ChainId, NetworkID } from '@/types';
+import { ChainId } from '@/types';
 
 const props = defineProps<{
   searchValue: string;
@@ -15,7 +15,6 @@ const props = defineProps<{
   assets: Token[];
   address: string;
   network: ChainId;
-  networkId: NetworkID;
 }>();
 
 const emit = defineEmits<{
@@ -143,9 +142,9 @@ watch(
       @click="handlePick(asset)"
     >
       <div class="flex items-center min-w-0 pr-2">
-        <UiBadgeNetwork :id="networkId">
+        <UiBadgeNetwork :chain-id="network">
           <UiStamp
-            :id="`${networkId}:${asset.contractAddress}`"
+            :id="`eip155:${network}:${asset.contractAddress}`"
             type="token"
             :size="32"
           />

--- a/apps/ui/src/components/ProposalExecutionActions.vue
+++ b/apps/ui/src/components/ProposalExecutionActions.vue
@@ -16,7 +16,7 @@ const {
   fetchingDetails,
   message,
   executionTx,
-  executionNetwork,
+  executionTxUrl,
   finalizeProposalSending,
   executeProposalSending,
   executeQueuedProposalSending,
@@ -44,9 +44,7 @@ const network = computed(() => getNetwork(props.proposal.network));
       <a
         class="inline-flex items-center"
         target="_blank"
-        :href="
-          executionNetwork.helpers.getExplorerUrl(executionTx, 'transaction')
-        "
+        :href="executionTxUrl || undefined"
       >
         {{ shorten(executionTx) }}
         <IH-arrow-sm-right class="inline-block ml-1 -rotate-45" />

--- a/apps/ui/src/components/TransactionsListItem.vue
+++ b/apps/ui/src/components/TransactionsListItem.vue
@@ -1,17 +1,13 @@
 <script setup lang="ts">
 import { formatUnits } from '@ethersproject/units';
+import { getGenericExplorerUrl } from '@/helpers/explorer';
 import { getNames } from '@/helpers/stamp';
 import { _n, shorten } from '@/helpers/utils';
-import { getNetwork } from '@/networks';
-import { NetworkID, Transaction } from '@/types';
+import { ChainId, Transaction } from '@/types';
 
-const props = defineProps<{ networkId: NetworkID; tx: Transaction }>();
+const props = defineProps<{ chainId: ChainId; tx: Transaction }>();
 
 const expanded = ref(false);
-
-const network = computed(() => {
-  return getNetwork(props.networkId);
-});
 
 const title = computed(() => {
   if (props.tx._type === 'sendToken') {
@@ -183,7 +179,9 @@ const parsedTitle = computedAsync(
         <a
           class="inline-flex items-center"
           target="_blank"
-          :href="network.helpers.getExplorerUrl(call.to, 'address')"
+          :href="
+            getGenericExplorerUrl(chainId, call.to, 'address') || undefined
+          "
         >
           {{ shorten(call.to) }}
           <IH-arrow-sm-right class="inline-block ml-1 -rotate-45" />
@@ -194,7 +192,10 @@ const parsedTitle = computedAsync(
         <a
           class="inline-flex items-center"
           target="_blank"
-          :href="network.helpers.getExplorerUrl(interaction.to, 'address')"
+          :href="
+            getGenericExplorerUrl(chainId, interaction.to, 'address') ||
+            undefined
+          "
         >
           {{ shorten(interaction.to) }}
           <IH-arrow-sm-right class="inline-block ml-1 -rotate-45" />
@@ -208,7 +209,10 @@ const parsedTitle = computedAsync(
             v-if="param.type === 'address'"
             class="inline-flex items-center"
             target="_blank"
-            :href="network.helpers.getExplorerUrl(param.value, 'address')"
+            :href="
+              getGenericExplorerUrl(chainId, param.value, 'address') ||
+              undefined
+            "
           >
             {{ shorten(param.value) }}
             <IH-arrow-sm-right class="inline-block ml-1 -rotate-45" />

--- a/apps/ui/src/composables/useExecutionActions.ts
+++ b/apps/ui/src/composables/useExecutionActions.ts
@@ -4,6 +4,7 @@ import {
   InMemoryCache
 } from '@apollo/client/core';
 import gql from 'graphql-tag';
+import { getGenericExplorerUrl } from '@/helpers/explorer';
 import {
   getModuleAddressForTreasury,
   getOgProposalGql,
@@ -74,6 +75,16 @@ export function useExecutionActions(
     return Math.max(proposal.execution_time * 1000 - currentTimestamp.value, 0);
   });
 
+  const executionTxUrl = computed(() => {
+    if (!executionTx.value) return null;
+
+    return getGenericExplorerUrl(
+      execution.chainId,
+      executionTx.value,
+      'transaction'
+    );
+  });
+
   async function fetchEthRelayerExecutionDetails() {
     if (currentTimestamp.value < proposal.max_end * 1000) {
       message.value =
@@ -121,7 +132,7 @@ export function useExecutionActions(
 
   async function fetchOSnapExecutionDetails() {
     try {
-      if (!execution.chainId) {
+      if (!execution.chainId || typeof execution.chainId !== 'number') {
         throw new Error('Chain ID is required for oSnap execution');
       }
 
@@ -151,7 +162,6 @@ export function useExecutionActions(
           : 'Space is not configured for automatic execution.';
       } else if (data.executionTransactionHash) {
         try {
-          executionNetwork.value = getNetwork(execution.networkId);
           executionTx.value = data.executionTransactionHash;
         } catch (e) {
           message.value =
@@ -230,7 +240,7 @@ export function useExecutionActions(
     fetchingDetails,
     message,
     executionTx,
-    executionNetwork,
+    executionTxUrl,
     finalizeProposalSending,
     executeProposalSending,
     executeQueuedProposalSending,

--- a/apps/ui/src/composables/useOffchainNetworksList.ts
+++ b/apps/ui/src/composables/useOffchainNetworksList.ts
@@ -18,7 +18,10 @@ export function useOffchainNetworksList(
   }
 
   const networks = computed(() => {
-    const rawNetworks = Object.values(snapshotJsNetworks);
+    const rawNetworks = Object.values(snapshotJsNetworks).filter(
+      ({ chainId }) => typeof chainId === 'number'
+    );
+
     const usageValue = usage.value;
     if (!usageValue) return rawNetworks;
 

--- a/apps/ui/src/composables/useTreasury.ts
+++ b/apps/ui/src/composables/useTreasury.ts
@@ -1,48 +1,31 @@
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import { SUPPORTED_CHAIN_IDS as TOKENS_SUPPORTED_CHAIN_IDS } from '@/helpers/alchemy';
-import { CHAIN_IDS } from '@/helpers/constants';
 import { getGenericExplorerUrl } from '@/helpers/explorer';
 import { SUPPORTED_CHAIN_IDS as NFTS_SUPPORTED_CHAIN_IDS } from '@/helpers/opensea';
-import { getNetwork } from '@/networks';
 import { SpaceMetadataTreasury } from '@/types';
 
 export function useTreasury(treasuryData: SpaceMetadataTreasury) {
   const treasury = computed(() => {
     if (!treasuryData) return null;
 
-    const networkId = treasuryData.network;
+    const { chainId, address, name } = treasuryData;
 
-    const chainId =
-      treasuryData.chainId ?? (networkId ? CHAIN_IDS[networkId] : null);
     if (!chainId) return null;
 
     return {
-      networkId,
       network: chainId,
-      wallet: treasuryData.address,
-      name: treasuryData.name,
+      wallet: address,
+      name,
       supportsTokens: TOKENS_SUPPORTED_CHAIN_IDS.includes(chainId as any),
       supportsNfts: NFTS_SUPPORTED_CHAIN_IDS.includes(chainId as any)
     };
-  });
-
-  const currentNetwork = computed(() => {
-    if (!treasury.value?.networkId) return null;
-
-    try {
-      return getNetwork(treasury.value.networkId);
-    } catch (e) {
-      return null;
-    }
   });
 
   function getExplorerUrl(address: string, type: 'address' | 'token') {
     if (!treasury.value) return null;
 
     let url: string | null = null;
-    if (currentNetwork.value) {
-      url = currentNetwork.value.helpers.getExplorerUrl(address, type);
-    } else if (treasury.value.network) {
+    if (treasury.value.network) {
       url = getGenericExplorerUrl(treasury.value.network, address, type);
     }
 

--- a/apps/ui/src/helpers/explorer.ts
+++ b/apps/ui/src/helpers/explorer.ts
@@ -9,10 +9,17 @@ import { ChainId, NetworkID } from '@/types';
 export function getGenericExplorerUrl(
   chainId: ChainId,
   address: string,
-  type: 'address' | 'token'
+  type: 'address' | 'token' | 'transaction'
 ) {
   if (typeof chainId === 'number') {
-    return `${networks[chainId].explorer.url}/${type}/${address}`;
+    let mappedType = 'tx';
+    if (type === 'address') {
+      mappedType = 'address';
+    } else if (type === 'token') {
+      mappedType = 'token';
+    }
+
+    return `${networks[chainId].explorer.url}/${mappedType}/${address}`;
   }
 
   const starknetNetwork = Object.entries(STARKNET_NETWORKS_METADATA).find(

--- a/apps/ui/src/helpers/utils.test.ts
+++ b/apps/ui/src/helpers/utils.test.ts
@@ -68,7 +68,7 @@ describe('utils', () => {
         treasuries: [
           {
             name: 'treasury 1',
-            network: 'sep',
+            chainId: 11155111,
             address: '0x000000000000000000000000000000000000dead'
           }
         ],
@@ -106,7 +106,7 @@ describe('utils', () => {
           treasuries: [
             {
               name: 'treasury 1',
-              network: 'sep',
+              chain_id: 11155111,
               address: '0x000000000000000000000000000000000000dead'
             }
           ],

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -444,7 +444,7 @@ export function createErc1155Metadata(
       discord: metadata.discord,
       treasuries: metadata.treasuries.map(treasury => ({
         name: treasury.name,
-        network: treasury.network,
+        chain_id: treasury.chainId,
         address: treasury.address
       })),
       labels: metadata.labels?.map(label => ({

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -60,13 +60,6 @@ import { DEFAULT_VOTING_DELAY } from '../constants';
 
 const DEFAULT_AUTHENTICATOR = 'OffchainAuthenticator';
 
-const TREASURY_NETWORKS = new Map(
-  Object.entries(CHAIN_IDS).map(([networkId, chainId]) => [
-    chainId,
-    networkId as keyof typeof CHAIN_IDS
-  ])
-);
-
 const DELEGATION_STRATEGIES = [
   'delegation',
   'erc20-balance-of-delegation',
@@ -101,7 +94,6 @@ function formatSpace(
 
     return {
       name: treasury.name,
-      network: TREASURY_NETWORKS.get(chainId) ?? null,
       address: treasury.address,
       chainId
     };

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -61,9 +61,8 @@ export type SelectedStrategy = {
 
 export type SpaceMetadataTreasury = {
   name: string;
-  network: Exclude<NetworkID, 's' | 's-tn'> | null;
   address: string;
-  chainId?: ChainId | null;
+  chainId: ChainId | null;
 };
 
 export type SpaceMetadataLabel = {
@@ -217,9 +216,8 @@ export type ProposalExecution = {
   strategyType: string;
   safeName: string;
   safeAddress: string;
-  networkId: NetworkID;
   transactions: Transaction[];
-  chainId?: number;
+  chainId: ChainId;
 };
 
 export type Proposal = {


### PR DESCRIPTION
### Summary

Now any network should be possible to be used in Treasuries on onchain spaces.

Depends on: https://github.com/snapshot-labs/sx-monorepo/pull/946

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/857

### How to test

1. Go to SX space settings.
2. Create treasuries on some non-SX supported network (Base for example).
3. It shows up in treasuries.

