### PR TITLE
refactor: move script to html tag

### DIFF
--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -11,8 +11,8 @@
     <div id="app"></div>
     <div id="modal"></div>
     <script type="module" src="/src/main.ts"></script>
+    <script>
+    var global = global || window;
+    </script>
   </body>
 </html>
-<script>
-  var global = global || window;
-</script>


### PR DESCRIPTION

<img width="597" alt="Снимок экрана 2024-11-02 в 15 25 03" src="https://github.com/user-attachments/assets/ef9db18d-c28c-4cc3-917a-e1fc1b54e5e8">

The `<script>` tag with `var global = global || window;` is placed outside of the `<body>`. It’s better to move it inside the `<body>` or put it in the _<head>_ to avoid potential loading issues.

<!--
### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
-->
