### PR TITLE
fix: hide testnet network on mainnet

### DIFF
--- a/apps/ui/src/components/Ui/SelectorNetwork.vue
+++ b/apps/ui/src/components/Ui/SelectorNetwork.vue
@@ -42,15 +42,26 @@ const options = computed(() => {
 
     return [
       ...baseNetworks,
-      ...Object.values(STARKNET_NETWORK_METADATA).map(metadata => ({
-        id: metadata.chainId,
-        name: metadata.name,
-        icon: h('img', {
-          src: getUrl(metadata.avatar),
-          alt: metadata.name,
-          class: 'rounded-full'
+      ...Object.values(STARKNET_NETWORK_METADATA)
+        .filter(metadata => {
+          if (
+            props.definition.networkId === 's' &&
+            metadata.name.includes('Sepolia')
+          ) {
+            return false;
+          }
+
+          return true;
         })
-      }))
+        .map(metadata => ({
+          id: metadata.chainId,
+          name: metadata.name,
+          icon: h('img', {
+            src: getUrl(metadata.avatar),
+            alt: metadata.name,
+            class: 'rounded-full'
+          })
+        }))
     ];
   }
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Depend on and following https://github.com/snapshot-labs/sx-monorepo/pull/946

This PR will hide the "Starknet Sepolia" network in network selector, when using the `s` network, to follow existing pattern of hiding all testnet networks when not relevant

### How to test

1. Go to an offchain space settings
2. Open the delegation modal
3. The network combolist should contain `Starknet`, but not `Starknet Sepolia`
