### PR TITLE
refactor: move Space `terms` property to main Space type 

### DIFF
--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -722,7 +722,7 @@ export function useSpaceSettings(space: Ref<Space>) {
       members.value = getInitialMembers(space.value);
       parent.value = space.value.parent?.id ?? '';
       children.value = space.value.children.map(child => child.id);
-      termsOfServices.value = space.value.additionalRawData?.terms ?? '';
+      termsOfServices.value = space.value.terms ?? '';
       customDomain.value = space.value.additionalRawData?.domain ?? '';
       isPrivate.value = space.value.additionalRawData?.private ?? false;
     }
@@ -900,9 +900,7 @@ export function useSpaceSettings(space: Ref<Space>) {
         return;
       }
 
-      if (
-        termsOfServicesValue !== (space.value.additionalRawData?.terms ?? '')
-      ) {
+      if (termsOfServicesValue !== (space.value.terms ?? '')) {
         isModified.value = true;
         return;
       }

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -182,6 +182,7 @@ function formatSpace(
     github: space.metadata.github,
     twitter: space.metadata.twitter,
     discord: space.metadata.discord,
+    terms: '',
     voting_power_symbol: space.metadata.voting_power_symbol,
     voting_types: constants.EDITOR_VOTING_TYPES,
     treasuries: space.metadata.treasuries.map(treasury => {

--- a/apps/ui/src/networks/common/graphqlApi/types.ts
+++ b/apps/ui/src/networks/common/graphqlApi/types.ts
@@ -33,7 +33,6 @@ export type ApiSpace = {
     twitter: string;
     github: string;
     discord: string;
-    terms: string;
     voting_power_symbol: string;
     wallet: string;
     executors: string[];

--- a/apps/ui/src/networks/common/graphqlApi/types.ts
+++ b/apps/ui/src/networks/common/graphqlApi/types.ts
@@ -33,6 +33,7 @@ export type ApiSpace = {
     twitter: string;
     github: string;
     discord: string;
+    terms: string;
     voting_power_symbol: string;
     wallet: string;
     executors: string[];

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -137,7 +137,6 @@ function formatSpace(
 
   const additionalRawData: OffchainAdditionalRawData = {
     type: 'offchain',
-    terms: space.terms,
     private: space.private,
     domain: space.domain,
     skin: space.skin,
@@ -209,6 +208,7 @@ function formatSpace(
     voting_power_validation_strategies_parsed_metadata: [],
     children: space.children.map(formatRelatedSpace),
     parent: space.parent ? formatRelatedSpace(space.parent) : null,
+    terms: space.terms,
     additionalRawData
   };
 }

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -71,8 +71,8 @@ export type ApiSpace = {
   followersCount: number;
   children: [ApiRelatedSpace];
   parent: ApiRelatedSpace | null;
-  // properties used for settings
   terms: string;
+  // properties used for settings
   private: boolean;
   domain: string | null;
   skin: string | null;

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -136,7 +136,6 @@ export type OffchainAdditionalRawData = {
   type: 'offchain';
 } & Pick<
   OffchainApiSpace,
-  | 'terms'
   | 'private'
   | 'domain'
   | 'skin'
@@ -174,6 +173,7 @@ export type Space = {
   github: string;
   discord: string;
   coingecko?: string;
+  terms: string;
   voting_power_symbol: string;
   controller: string;
   voting_delay: number;

--- a/apps/ui/src/views/Create.vue
+++ b/apps/ui/src/views/Create.vue
@@ -68,6 +68,7 @@ const metadataForm: SpaceMetadata = reactive(
     twitter: '',
     github: '',
     discord: '',
+    terms: '',
     votingPowerSymbol: '',
     treasuries: [],
     labels: [],


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward https://github.com/snapshot-labs/workflow/issues/274

This PR moves the `terms` property from `OffchainAdditionalRawData` to the main `Space` type, following recommendation by

https://github.com/snapshot-labs/sx-monorepo/blob/fe5d64d546f2d715c7074a0c71e5a57ff932ffa8/apps/ui/src/types.ts#L212-L213

This will prepare the ground for the other PR to:

- use the `terms` property to show a modal
- adds `terms` to onchain space settings

### How to test

1. Go to an offchain space settings
2. In advanced, edit and save the `terms` field
3. It should save