### PR TITLE
fix: close account modal on topnav unmount

### DIFF
--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -85,6 +85,10 @@ watch(
   searchQuery => (searchValue.value = searchQuery),
   { immediate: true }
 );
+
+onUnmounted(() => {
+  resetAccountModal();
+});
 </script>
 
 <template>


### PR DESCRIPTION
### Summary
Closes: https://github.com/snapshot-labs/workflow/issues/286

- Close account modal when we go to landing page

### How to test

1. Go to http://127.0.0.1:8080/#/home
2. Connect your wallet
3. Click on Account button
![image](https://github.com/user-attachments/assets/296b782c-c09f-479c-89d7-fd1fe0bbc5fe)
4. Go to landing page http://127.0.0.1:8080/#/
5. Come back to http://127.0.0.1:8080/#/home
6. You should see modal before the fix, but not after 

