### PR TITLE
sx.js: use address instead of signer for ethereum-tx methods

### DIFF
--- a/.changeset/odd-apples-explain.md
+++ b/.changeset/odd-apples-explain.md
@@ -2,4 +2,4 @@
 "@snapshot-labs/sx": minor
 ---
 
-Use `address` instead of `signer` for methods of the ethereum-tx client
+Use `address` instead of `signer` for following methods in Starknet EthereumTx client: `estimateProposeFee`, `estimateVoteFee`, `estimateUpdateProposalFee`, `getProposeHash`, `getVoteHash`, `getUpdateProposalHash`.

--- a/.changeset/odd-apples-explain.md
+++ b/.changeset/odd-apples-explain.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": minor
+---
+
+Use `address` instead of `signer` for methods of the ethereum-tx client

--- a/packages/sx.js/src/clients/starknet/ethereum-tx/index.ts
+++ b/packages/sx.js/src/clients/starknet/ethereum-tx/index.ts
@@ -221,9 +221,8 @@ export class EthereumTx {
     return fees as any;
   }
 
-  async estimateProposeFee(signer: Signer, data: Propose) {
-    const address = await signer.getAddress();
-    const hash = await this.getProposeHash(signer, data);
+  async estimateProposeFee(address: string, data: Propose) {
+    const hash = await this.getProposeHash(address, data);
 
     return this.getMessageFee(data.authenticator, [
       address.toLocaleLowerCase(),
@@ -231,9 +230,8 @@ export class EthereumTx {
     ]);
   }
 
-  async estimateVoteFee(signer: Signer, data: Vote) {
-    const address = await signer.getAddress();
-    const hash = await this.getVoteHash(signer, data);
+  async estimateVoteFee(address: string, data: Vote) {
+    const hash = await this.getVoteHash(address, data);
 
     return this.getMessageFee(data.authenticator, [
       address.toLocaleLowerCase(),
@@ -241,9 +239,8 @@ export class EthereumTx {
     ]);
   }
 
-  async estimateUpdateProposalFee(signer: Signer, data: UpdateProposal) {
-    const address = await signer.getAddress();
-    const hash = await this.getUpdateProposalHash(signer, data);
+  async estimateUpdateProposalFee(address: string, data: UpdateProposal) {
+    const hash = await this.getUpdateProposalHash(address, data);
 
     return this.getMessageFee(data.authenticator, [
       address.toLocaleLowerCase(),
@@ -251,9 +248,7 @@ export class EthereumTx {
     ]);
   }
 
-  async getProposeHash(signer: Signer, data: Propose) {
-    const address = await signer.getAddress();
-
+  async getProposeHash(address: string, data: Propose) {
     const userStrategies = await getStrategiesWithParams(
       'propose',
       data.strategies,
@@ -280,9 +275,7 @@ export class EthereumTx {
     return `0x${poseidonHashMany(compiled.map(v => BigInt(v))).toString(16)}`;
   }
 
-  async getVoteHash(signer: Signer, data: Vote) {
-    const address = await signer.getAddress();
-
+  async getVoteHash(address: string, data: Vote) {
     const userVotingStrategies = await getStrategiesWithParams(
       'vote',
       data.strategies,
@@ -305,9 +298,7 @@ export class EthereumTx {
     return `0x${poseidonHashMany(compiled.map(v => BigInt(v))).toString(16)}`;
   }
 
-  async getUpdateProposalHash(signer: Signer, data: UpdateProposal) {
-    const address = await signer.getAddress();
-
+  async getUpdateProposalHash(address: string, data: UpdateProposal) {
     const callData = new CallData(ENCODE_ABI);
     const compiled = callData.compile('update_proposal', [
       data.space,
@@ -335,8 +326,9 @@ export class EthereumTx {
       signer
     );
 
-    const hash = await this.getProposeHash(signer, data);
-    const { overall_fee } = await this.estimateProposeFee(signer, data);
+    const address = await signer.getAddress();
+    const hash = await this.getProposeHash(address, data);
+    const { overall_fee } = await this.estimateProposeFee(address, data);
 
     const promise = commitContract.commit(data.authenticator, hash, {
       value: overall_fee,
@@ -366,8 +358,9 @@ export class EthereumTx {
       signer
     );
 
-    const hash = await this.getVoteHash(signer, data);
-    const { overall_fee } = await this.estimateVoteFee(signer, data);
+    const address = await signer.getAddress();
+    const hash = await this.getVoteHash(address, data);
+    const { overall_fee } = await this.estimateVoteFee(address, data);
 
     const promise = commitContract.commit(data.authenticator, hash, {
       value: overall_fee,
@@ -397,8 +390,9 @@ export class EthereumTx {
       signer
     );
 
-    const hash = await this.getUpdateProposalHash(signer, data);
-    const { overall_fee } = await this.estimateUpdateProposalFee(signer, data);
+    const address = await signer.getAddress();
+    const hash = await this.getUpdateProposalHash(address, data);
+    const { overall_fee } = await this.estimateUpdateProposalFee(address, data);
 
     const promise = commitContract.commit(data.authenticator, hash, {
       value: overall_fee,

--- a/packages/sx.js/test/unit/clients/starknet/ethereum-tx/index.test.ts
+++ b/packages/sx.js/test/unit/clients/starknet/ethereum-tx/index.test.ts
@@ -38,7 +38,7 @@ describe('EthereumTx', () => {
       metadataUri: 'ipfs://QmNrm6xKuib1THtWkiN5CKtBEerQCDpUtmgDqiaU2xDmca'
     };
 
-    const result = await ethereumTx.getProposeHash(wallet, data);
+    const result = await ethereumTx.getProposeHash(wallet.address, data);
     expect(result).toEqual(
       '0x6ad6a7880f1ed8213c56ce9fcc0fc50eaca6fffbbd8546ff211825519bc9032'
     );
@@ -60,7 +60,7 @@ describe('EthereumTx', () => {
       metadataUri: 'ipfs://QmNrm6xKuib1THtWkiN5CKtBEerQCDpUtmgDqiaU2xDmca'
     };
 
-    const result = await ethereumTx.getVoteHash(wallet, data);
+    const result = await ethereumTx.getVoteHash(wallet.address, data);
     expect(result).toEqual(
       '0x15c3ec5ebb1e82803db2d695eb12a902d5bb0d52c63e1536015e6d3debe70'
     );
@@ -79,7 +79,7 @@ describe('EthereumTx', () => {
       metadataUri: 'ipfs://QmNrm6xKuib1THtWkiN5CKtBEerQCDpUtmgDqiaU2xDmca'
     };
 
-    const result = await ethereumTx.getUpdateProposalHash(wallet, data);
+    const result = await ethereumTx.getUpdateProposalHash(wallet.address, data);
     expect(result).toEqual(
       '0x612204abe7ec1f8975360b848882b53578bbc03bf2bac834c9566cc828a2ab4'
     );


### PR DESCRIPTION
### Summary

Use `address` instead of signer for the ethereum-tx client's methods

For reference: https://github.com/snapshot-labs/sx-monorepo/pull/950#discussion_r1827827446