### PR TITLE
fix: add sender to the returned info of getDataByMessageHash

### DIFF
--- a/apps/mana/src/db.ts
+++ b/apps/mana/src/db.ts
@@ -116,7 +116,7 @@ export async function getProposal(id: string) {
 
 export async function getDataByMessageHash(hash: string) {
   return knex(REGISTERED_TRANSACTIONS)
-    .select(['type', 'data', 'hash', 'network'])
+    .select(['sender', 'type', 'data', 'hash', 'network'])
     .where({ hash })
     .first();
 }


### PR DESCRIPTION
Completing #950  , we forgot to add `sender` to the values returned by `getDataByMessageHash`