### PR TITLE
fix: patch bump instead of minor bump

### DIFF
--- a/.changeset/odd-apples-explain.md
+++ b/.changeset/odd-apples-explain.md
@@ -1,5 +1,5 @@
 ---
-"@snapshot-labs/sx": minor
+"@snapshot-labs/sx": patch
 ---
 
 Use `address` instead of `signer` for following methods in Starknet EthereumTx client: `estimateProposeFee`, `estimateVoteFee`, `estimateUpdateProposalFee`, `getProposeHash`, `getVoteHash`, `getUpdateProposalHash`.

--- a/.changeset/strange-ducks-shake.md
+++ b/.changeset/strange-ducks-shake.md
@@ -1,5 +1,5 @@
 ---
-"@snapshot-labs/sx": minor
+"@snapshot-labs/sx": patch
 ---
 
 Support labels on proposals


### PR DESCRIPTION
### Summary

We had previously issued `minor` bumps but we should only have `patch`es right now given how early™ we are.