### PR TITLE
fix: Allow snapshot in fantom safe and add fantom networks to WC

### DIFF
--- a/apps/ui/src/helpers/connectors.ts
+++ b/apps/ui/src/helpers/connectors.ts
@@ -22,7 +22,7 @@ export default {
     options: {
       projectId: 'e6454bd61aba40b786e866a69bd4c5c6',
       chains: [],
-      optionalChains: [1, 10, 56, 100, 42161, 137, 1088, 11155111],
+      optionalChains: [1, 10, 56, 100, 250, 4002, 42161, 137, 1088, 11155111],
       optionalMethods: ['eth_sendTransaction', 'eth_signTypedData_v4'],
       showQrModal: true
     }

--- a/apps/ui/src/main.ts
+++ b/apps/ui/src/main.ts
@@ -15,7 +15,8 @@ const knownHosts = [
   'multisig.moonbeam.network',
   'worldassociation.org',
   'safe.mainnet.frax.com',
-  'horizen-eon.safe.onchainden.com'
+  'horizen-eon.safe.onchainden.com',
+  'safe.fantom.network'
 ];
 const parentUrl =
   window.location != window.parent.location


### PR DESCRIPTION
### Summary

- Allow snapshot inside fantom safe https://safe.fantom.network/
- Allow fantom networks using walletconnect

### How to test

1. Go to https://safe.fantom.network/apps/custom?safe=ftm:0xEA3fFa8e61Cc58122593D482a7eCaEf74bc68Da9 
2. Connect walletconnect
3. Before fix you should see an error
4. ![image](https://github.com/user-attachments/assets/6ca4a1e7-c7a7-4e57-a6b2-ae390e05c583)

