### PR TITLE
ci: run integration tests on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,13 @@ jobs:
         with:
           node-version: "18.x"
           cache: "yarn"
+      - name: Setup Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
       - run: yarn --frozen-lockfile
       - run: yarn build
       - run: yarn typecheck
       - run: yarn lint
       - run: yarn test
+      - run: yarn test:integration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push]
 
+env:
+  STARKNET_DEVNET_VERSION: 0.2.3
+
 jobs:
   lint-build-test:
     runs-on: ubuntu-22.04
@@ -15,8 +18,13 @@ jobs:
           cache: "yarn"
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Restore Cargo
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-cargo-${{ env.STARKNET_DEVNET_VERSION }}
       - name: Install Starknet Devnet
-        run: cargo install starknet-devnet
+        run: cargo install starknet-devnet@${{ env.STARKNET_DEVNET_VERSION }}
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - run: yarn --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
           cache: "yarn"
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Install Starknet Devnet
+        run: cargo install starknet-devnet
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - run: yarn --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev:full": "./scripts/dev-full.sh",
     "build": "turbo run build",
     "test": "turbo run test",
+    "test:integration": "turbo run test:integration",
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "release": "yarn build && changeset publish"

--- a/packages/sx.js/package.json
+++ b/packages/sx.js/package.json
@@ -24,6 +24,7 @@
     "node:evm": "anvil",
     "node:starknet": "starknet-devnet --seed 1",
     "test": "SEPOLIA_NODE_URL=https://rpc.snapshot.org/11155111 vitest run test/unit",
+    "test:integration": "./test/run-integration-tests.sh",
     "test:integration:starknet": "vitest run test/integration/starknet",
     "test:integration:evm": "vitest run test/integration/evm",
     "test:integration:offchain": "vitest run test/integration/offchain"

--- a/packages/sx.js/test/integration/starknet/index.test.ts
+++ b/packages/sx.js/test/integration/starknet/index.test.ts
@@ -10,7 +10,6 @@ import {
   increaseTime,
   setTime,
   setup,
-  sleep,
   TestConfig
 } from './utils';
 import {
@@ -510,8 +509,7 @@ describe('sx-starknet', () => {
         }
       };
 
-      // NOTE: to avoid Votes: future lookup
-      await sleep(10000);
+      await increaseTime(1000);
 
       const receipt = await client.vote(account, envelope);
       console.log('Receipt', receipt);
@@ -586,6 +584,7 @@ describe('sx-starknet', () => {
 
     it('should execute', async () => {
       await increaseTime(86400);
+      await provider.send('evm_increaseTime', [86400]);
 
       const { executionParams } = getExecutionData(
         'EthRelayer',

--- a/packages/sx.js/test/integration/starknet/utils.ts
+++ b/packages/sx.js/test/integration/starknet/utils.ts
@@ -539,7 +539,3 @@ export function loadL1MessagingContract(networkUrl: string, address: string) {
 export function flush() {
   return postDevnet('postman/flush', {});
 }
-
-export function sleep(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}

--- a/packages/sx.js/test/run-integration-tests.sh
+++ b/packages/sx.js/test/run-integration-tests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+PIDS=()
+
+function start_node() {
+  yarn node:"$1" > /dev/null 2>&1 &
+  PIDS+=($!)
+  echo "Started $1 with PID $!"
+}
+
+function cleanup() {
+  echo "Cleaning up..."
+  for pid in "${PIDS[@]}"; do
+    echo "Killing process $pid"
+    kill "$pid" 2>/dev/null || echo "Process $pid already terminated"
+  done
+}
+
+trap cleanup EXIT
+
+start_node evm
+start_node starknet
+
+echo "Running evm tests"
+yarn test:integration:evm
+
+echo "Running starknet tests"
+yarn test:integration:starknet

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,9 @@
     "test": {
       "dependsOn": ["^build"]
     },
+    "test:integration": {
+      "dependsOn": ["^build"]
+    },
     "dev": {
       "cache": false,
       "persistent": true,


### PR DESCRIPTION
### Summary

With this change integration tests will run on the CI.

This also includes few changes:
- Fixed issue with integration tests (avoid sleep), forward time on L1 node.
- Added `test:integration` script.