### PR TITLE
refactor: create dedicated composable for proposing power

### DIFF
--- a/apps/ui/src/composables/usePropositionPower.ts
+++ b/apps/ui/src/composables/usePropositionPower.ts
@@ -1,0 +1,40 @@
+import { supportsNullCurrent } from '@/networks';
+import { getIndex } from '@/stores/votingPowers';
+import { NetworkID, Space } from '@/types';
+
+export function usePropositionPower() {
+  const votingPowersStore = useVotingPowersStore();
+  const { web3 } = useWeb3();
+  const { getCurrent } = useMetaStore();
+
+  function latestBlock(network: NetworkID) {
+    return supportsNullCurrent(network) ? null : getCurrent(network) ?? 0;
+  }
+
+  function fetch(space: Space) {
+    votingPowersStore.fetch(
+      space,
+      web3.value.account,
+      latestBlock(space.network)
+    );
+  }
+
+  function get(space: Space) {
+    return votingPowersStore.votingPowers.get(
+      getIndex(space, latestBlock(space.network))
+    );
+  }
+
+  function reset() {
+    votingPowersStore.reset();
+  }
+
+  watch(
+    () => web3.value.account,
+    account => {
+      if (!account) reset();
+    }
+  );
+
+  return { fetch, get };
+}

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -47,7 +47,7 @@ const {
   reset
 } = useWalletConnectTransaction();
 const proposalsStore = useProposalsStore();
-const { get: getProposingPower, fetch: fetchProposingPower } =
+const { get: getPropositionPower, fetch: fetchPropositionPower } =
   usePropositionPower();
 const { strategiesWithTreasuries } = useTreasuries(props.space);
 
@@ -153,7 +153,7 @@ const canSubmit = computed(() => {
   if (Object.keys(formErrors.value).length > 0) return false;
 
   return web3.value.account
-    ? proposingPower.value?.canPropose
+    ? propositionPower.value?.canPropose
     : !web3.value.authLoading;
 });
 const spaceType = computed(() =>
@@ -166,7 +166,7 @@ const proposalLimitReached = computed(
     (props.space.proposal_count_30d || 0) >= MAX_30D_PROPOSALS[spaceType.value]
 );
 
-const proposingPower = computed(() => getProposingPower(props.space));
+const propositionPower = computed(() => getPropositionPower(props.space));
 
 async function handleProposeClick() {
   if (!proposal.value) return;
@@ -269,8 +269,8 @@ function handleTransactionAccept() {
   reset();
 }
 
-function handleFetchProposingPower() {
-  fetchProposingPower(props.space);
+function handleFetchPropositionPower() {
+  fetchPropositionPower(props.space);
 }
 
 watch(
@@ -278,7 +278,7 @@ watch(
   toAccount => {
     if (!toAccount) return;
 
-    handleFetchProposingPower();
+    handleFetchPropositionPower();
   },
   { immediate: true }
 );
@@ -349,7 +349,9 @@ watchEffect(() => {
         class="primary min-w-[46px] flex gap-2 justify-center items-center !px-0 md:!px-3"
         :loading="
           !!web3.account &&
-          (sending || !proposingPower || proposingPower.status === 'loading')
+          (sending ||
+            !propositionPower ||
+            propositionPower.status === 'loading')
         "
         :disabled="!canSubmit"
         @click="handleProposeClick"
@@ -364,15 +366,15 @@ watchEffect(() => {
     <div class="md:mr-[340px]">
       <UiContainer class="pt-5 !max-w-[710px] mx-0 md:mx-auto s-box">
         <MessageVotingPower
-          v-if="proposingPower"
+          v-if="propositionPower"
           class="mb-4"
-          :voting-power="proposingPower"
+          :voting-power="propositionPower"
           action="propose"
-          @fetch-voting-power="handleFetchProposingPower"
+          @fetch-voting-power="handleFetchPropositionPower"
         />
         <UiAlert
           v-if="
-            proposingPower && spaceType === 'default' && proposalLimitReached
+            propositionPower && spaceType === 'default' && proposalLimitReached
           "
           type="error"
           class="mb-4"
@@ -389,7 +391,7 @@ watchEffect(() => {
         </UiAlert>
         <UiAlert
           v-else-if="
-            proposingPower && spaceType !== 'turbo' && proposalLimitReached
+            propositionPower && spaceType !== 'turbo' && proposalLimitReached
           "
           type="error"
           class="mb-4"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward #939 

This PR extracts the proposition power from the `useVotingPower` into its own composable, and avoid mixing voting and proposing power.

Merging this one first will allow #938 to use the final correct name, without filename collision

### How to test

1. Everything should work as before
2. Create a proposal on a space you have proposition power, you should be able to create a proposal
3. Create a proposal on a space you do not have proposition power, it should show a message about insufficient proposition power.
