### PR TITLE
chore: rename avatar input to safe

### DIFF
--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -466,7 +466,7 @@ export function createConstants(networkId: NetworkID) {
           contractAddress: {
             type: 'string',
             format: 'address',
-            title: 'Avatar address',
+            title: 'Safe address',
             examples: ['0x0000…']
           }
         }

--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -425,7 +425,7 @@ export function createConstants(networkId: NetworkID) {
       type: 'SimpleQuorumAvatar',
       name: EXECUTORS.SimpleQuorumAvatar,
       about:
-        'An execution strategy that allows proposals to execute transactions from a specified target Avatar contract, the most popular one being a Safe.',
+        'An execution strategy that allows proposals to execute transactions from a specified target Safe contract.',
       icon: IHUserCircle,
       generateSummary: (params: Record<string, any>) =>
         `(${params.quorum}, ${shorten(params.contractAddress)})`,


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/291

This way it's clearer for users. Not sure if now description matches, because it mentions avatar (Avatar contract, the most popular one being a Safe), might be confusing if someone actually tries to use non-safe avatar. Maybe it should say `Avatar (eg. Safe) address`? @bonustrack 

### How to test

1. When configuring space we show Safe instead of Avatar.

### Screenshots

<img width="514" alt="image" src="https://github.com/user-attachments/assets/530111da-9fbc-4d20-97ba-489277e9450b">
