### PR TITLE
chore: upgrade node to v22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
-      - name: Setup Node.js 16
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
       - name: Install Dependencies
         run: yarn
       - name: Create Release Pull Request or Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
-      - name: Setup Node.js
+      - name: Setup Node.js 22
         uses: actions/setup-node@v3
         with:
           node-version: 22

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Setup Node.js
+      - name: Setup Node.js 22
         uses: actions/setup-node@v2
         with:
           node-version: 22

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "18.x"
+          node-version: 22
           cache: "yarn"
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "turbo": "^1.12.3"
   },
   "engines": {
-    "node": ">=18.x"
+    "node": ">=22.x"
   },
   "packageManager": "yarn@1.22.19",
   "workspaces": {


### PR DESCRIPTION
### Summary

We currently use v18 which is a bit old (in JS terms). I'm currently working on some feature that use `Intl.NumberFormat` and some options (`roundingMode`) were added in node v19 so tests are failing with v18.