### PR TITLE
fix: copy minScore from filters to params

### DIFF
--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -442,6 +442,12 @@ export function useSpaceSettings(space: Ref<Space>) {
     if (space.additionalRawData?.filters.onlyMembers) {
       validation.name = 'only-members';
       validation.params = {};
+    } else if (
+      space.additionalRawData?.filters.minScore &&
+      validation.name === 'basic' &&
+      !validation.params.minScore
+    ) {
+      validation.params.minScore = space.additionalRawData.filters.minScore;
     } else if (validation.name === 'any') {
       validation.name = 'basic';
       validation.params = {


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/307

https://github.com/snapshot-labs/snapshot/blob/9e4c95e0e001f33328d95e4cb18d82464fdbf156/src/components/ModalValidation.vue#L82-L83

### How to test

1. Go to http://localhost:8080/#/s:safe.eth/settings/proposal
2. Open validation.
3. Min score is populated.

