### PR TITLE
fix: truncate too long choices

### DIFF
--- a/apps/ui/src/components/ProposalVote.vue
+++ b/apps/ui/src/components/ProposalVote.vue
@@ -58,6 +58,9 @@ const isEditable = computed(() => {
   <slot v-if="currentVote && !editMode" name="voted" :vote="currentVote">
     <UiButton
       class="!h-[48px] text-left w-full flex items-center justify-between rounded-lg space-x-2"
+      :class="{
+        'border-skin-link': isEditable
+      }"
       :disabled="!isEditable"
       @click="$emit('enterEditMode')"
     >

--- a/apps/ui/src/components/ProposalVote.vue
+++ b/apps/ui/src/components/ProposalVote.vue
@@ -69,7 +69,7 @@ const isEditable = computed(() => {
         <IH-lock-closed class="size-[16px] shrink-0" />
         <span class="truncate">Encrypted choice</span>
       </div>
-      <div v-else class="flex items-center gap-2">
+      <div v-else class="flex items-center gap-2 overflow-hidden">
         <div
           v-if="proposal.type === 'basic'"
           class="shrink-0 rounded-full choice-bg inline-block size-[18px]"

--- a/apps/ui/src/components/ProposalVote.vue
+++ b/apps/ui/src/components/ProposalVote.vue
@@ -57,7 +57,7 @@ const isEditable = computed(() => {
 <template>
   <slot v-if="currentVote && !editMode" name="voted" :vote="currentVote">
     <UiButton
-      class="!h-[48px] text-left w-full flex items-center rounded-lg space-x-2"
+      class="!h-[48px] text-left w-full flex items-center justify-between rounded-lg space-x-2"
       :disabled="!isEditable"
       @click="$emit('enterEditMode')"
     >

--- a/apps/ui/src/components/ProposalVote.vue
+++ b/apps/ui/src/components/ProposalVote.vue
@@ -66,8 +66,7 @@ const isEditable = computed(() => {
     >
       <div
         v-if="proposal.privacy"
-        class="flex space-x-2 items-center grow truncate"
-        :class="{ 'text-skin-text': !isEditable }"
+        class="flex space-x-2 items-center grow truncate text-skin-link"
       >
         <IH-lock-closed class="size-[16px] shrink-0" />
         <span class="truncate">Encrypted choice</span>
@@ -92,8 +91,7 @@ const isEditable = computed(() => {
           />
         </div>
         <div
-          class="grow truncate"
-          :class="{ 'text-skin-text': !isEditable }"
+          class="grow truncate text-skin-link"
           v-text="getChoiceText(proposal.choices, currentVote.choice)"
         />
       </div>


### PR DESCRIPTION
### Summary

This PR will truncate long choice text on edit vote message.

Closes: https://github.com/snapshot-labs/workflow/issues/301

### How to test

1. On offchain create proposal with long choice.
2. Vote on this long choice.
3. Edit message should truncate text.

### Screenshots

<img width="422" alt="image" src="https://github.com/user-attachments/assets/54c6aa88-d343-4d71-9688-b0cfcaf70871">
