### PR TITLE
feat: show warning message for flagged proposals

### DIFF
--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -296,7 +296,8 @@ function formatProposal(
     state: getProposalState(proposal, current),
     network: networkId,
     privacy: null,
-    quorum: +proposal.quorum
+    quorum: +proposal.quorum,
+    flagged: false
   };
 }
 

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -319,7 +319,8 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     tx: '',
     execution_tx: null,
     veto_tx: null,
-    privacy: proposal.privacy
+    privacy: proposal.privacy,
+    flagged: proposal.flagged
   };
 }
 

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -143,6 +143,7 @@ const PROPOSAL_FRAGMENT = gql`
     votes
     privacy
     plugins
+    flagged
   }
 `;
 

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -125,6 +125,7 @@ export type ApiProposal = {
   votes: number;
   privacy: Privacy;
   plugins: Record<string, any>;
+  flagged: boolean;
 };
 
 export type ApiVote = {

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -283,6 +283,7 @@ export type Proposal = {
   cancelled: boolean;
   state: ProposalState;
   privacy: Privacy;
+  flagged: boolean;
 };
 
 export type UserProfile = {

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -200,6 +200,11 @@ onBeforeUnmount(() => destroyAudio());
 <template>
   <UiContainer class="pt-5 !max-w-[710px] mx-0 md:mx-auto">
     <div>
+      <UiAlert v-if="proposal.flagged" type="error" class="mb-3">
+        This proposal might contain scams, offensive material, or be malicious
+        in nature. Please proceed with caution.
+      </UiAlert>
+
       <h1 class="mb-3 text-[40px] leading-[1.1em] break-words">
         {{ proposal.title || `Proposal #${proposal.proposal_id}` }}
       </h1>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/304

This PR shows a warning message when viewing a flagged proposal

![Screenshot 2024-11-27 at 18 27 21](https://github.com/user-attachments/assets/900b12b9-4148-4a52-91bc-33b9558b20b6)

This warning will appear only when accessing flagged proposals directly (knowing the link), as the space's proposals list is already filtering out all flagged proposals

### How to test

1. Go to http://localhost:8080/#/s:safe.eth/proposal/0x669c3ea414783e16ed98142ba6203a684d6a2e06dbf5e6a6ef372943d75fdf23
2. It should show a warning message above the proposal title
3. Go to any other proposals from the space proposals list
4. It should not show any warnings
