### PR TITLE
feat: add trace208 oz votes strategy to mainnet

### DIFF
--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -452,7 +452,8 @@ export function createConstants(
           createSlotValueStrategyConfig(
             config.Strategies.OZVotesTrace208StorageProof,
             'OZ Votes storage proof (trace 208)',
-            'A strategy that allows to use the value of an slot on EVM chain (for example ERC-20 balance on L1) as voting power including delegated balances (trace 208 format).'
+            'A strategy that allows to use the value of an slot on EVM chain (for example ERC-20 balance on L1) as voting power including delegated balances (trace 208 format).',
+            `${HELPDESK_URL}/en/articles/9839152-oz-votes-storage-proof-voting-strategy`
           )
         ]
       : [])

--- a/packages/sx.js/src/starknetNetworks.ts
+++ b/packages/sx.js/src/starknetNetworks.ts
@@ -118,7 +118,8 @@ export const starknetNetworks = {
         '0x699e53f4b40e19d96b8020386dbeeb156f40172d7bbb78b2a4204cf64ae75f',
       OZVotesStorageProof:
         '0x7ee3cf64f1072fe21570356eb57d4e9f78169ea9235ba610f60a8b33c36cc6e',
-      OZVotesTrace208StorageProof: ''
+      OZVotesTrace208StorageProof:
+        '0x06e7bf6fc2ac80d216076b3340625d3d054d2f4a1d7dc4a22853c06e015907b3'
     },
     ProposalValidations: {
       VotingPower:


### PR DESCRIPTION
### Summary

Adds previously not deployed trace 208 oz votes strategy on mainnet Starknet.

### How to test

1. It's available in Starknet mainnet editor.
2. It works (not tested).