### PR TITLE
feat: add create space link on explore page

### DIFF
--- a/apps/ui/src/components/AppLink.vue
+++ b/apps/ui/src/components/AppLink.vue
@@ -7,6 +7,10 @@ const props = defineProps<
 
 const { isWhiteLabel } = useWhiteLabel();
 
+function isExternalLink(to: RouteLocationRaw) {
+  return typeof to === 'string' && to.startsWith('http');
+}
+
 function normalize(to: RouteLocationRaw) {
   if (
     !isWhiteLabel.value ||
@@ -34,7 +38,10 @@ function normalize(to: RouteLocationRaw) {
 </script>
 
 <template>
-  <router-link v-if="props.to" :to="normalize(props.to)">
+  <a v-if="isExternalLink(props.to)" :href="props.to" target="_blank">
+    <slot />
+  </a>
+  <router-link v-else-if="props.to" :to="normalize(props.to)">
     <slot />
   </router-link>
   <div v-else>

--- a/apps/ui/src/components/AppLink.vue
+++ b/apps/ui/src/components/AppLink.vue
@@ -7,7 +7,7 @@ const props = defineProps<
 
 const { isWhiteLabel } = useWhiteLabel();
 
-function isExternalLink(to: RouteLocationRaw) {
+function isExternalLink(to: RouteLocationRaw | undefined): to is string {
   return typeof to === 'string' && to.startsWith('http');
 }
 

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -144,8 +144,8 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="flex justify-between">
-    <div class="flex flex-row flex-wrap p-4 gap-2">
+  <div class="flex justify-between p-4 gap-2 gap-y-3 flex-row">
+    <div class="flex flex-row flex-wrap gap-2">
       <UiSelectDropdown
         v-model="protocol"
         class="min-h-[46px]"
@@ -176,6 +176,16 @@ onMounted(() => {
         :items="categories"
       />
     </div>
+    <UiTooltip title="Create new space">
+      <UiButton
+        :to="
+          protocol === 'snapshot' ? 'https://snapshot.org/#/setup' : 'create'
+        "
+        class="!px-0 w-[46px]"
+      >
+        <IH-plus-sm />
+      </UiButton>
+    </UiTooltip>
   </div>
   <div>
     <UiLabel label="Spaces" sticky />

--- a/apps/ui/src/views/Settings/Spaces.vue
+++ b/apps/ui/src/views/Settings/Spaces.vue
@@ -56,8 +56,8 @@ watch(
 </script>
 
 <template>
-  <div class="flex justify-between">
-    <div class="flex flex-row p-4 space-x-2">
+  <div class="flex justify-between p-4 gap-2 gap-y-3 flex-row">
+    <div class="flex flex-row space-x-2">
       <UiSelectDropdown
         v-model="spacesStore.protocol"
         title="Protocol"
@@ -66,6 +66,18 @@ watch(
         :items="protocols"
       />
     </div>
+    <UiTooltip title="Create new space">
+      <UiButton
+        :to="
+          spacesStore.protocol === 'snapshot'
+            ? 'https://snapshot.org/#/setup'
+            : 'create'
+        "
+        class="!px-0 w-[46px]"
+      >
+        <IH-plus-sm />
+      </UiButton>
+    </UiTooltip>
   </div>
   <UiLabel label="My spaces" sticky />
   <UiLoading v-if="loading" class="block m-4" />


### PR DESCRIPTION
### Summary

This PR adds link to create route or https://snapshot.org/#/setup?step=0 for offchain in explore page and settings.

Closes: https://github.com/snapshot-labs/workflow/issues/308

### How to test

1. Go to Explore page.
2. You can see button for creating new space (works for offchain and onchain).
3. Same in Settings.