### PR TITLE
chore: bring back API reset

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -65,7 +65,7 @@ async function run() {
     await sleep(PRODUCTION_INDEXER_DELAY);
   }
 
-  // await checkpoint.reset();
+  await checkpoint.reset();
   checkpoint.start();
 }
 


### PR DESCRIPTION
### Summary

Newer version adds reorg support so also a new database schema so reset is needed to call createStore.
