### PR TITLE
fix: always allow admins and moderators to propose

### DIFF
--- a/apps/ui/src/stores/votingPowers.ts
+++ b/apps/ui/src/stores/votingPowers.ts
@@ -37,7 +37,6 @@ function isSpace(item: SpaceDetails | Proposal): item is Space {
 
 function isSpaceTeamMember(space: Space, account: string): boolean {
   return [
-    space.controller,
     ...(space.additionalRawData?.admins || []),
     ...(space.additionalRawData?.moderators || [])
   ]

--- a/apps/ui/src/stores/votingPowers.ts
+++ b/apps/ui/src/stores/votingPowers.ts
@@ -35,10 +35,11 @@ function isSpace(item: SpaceDetails | Proposal): item is Space {
   return 'proposal_threshold' in item;
 }
 
-function isSpaceTeamMember(space: Space, account: string): boolean {
+function isSpaceMember(space: Space, account: string): boolean {
   return [
     ...(space.additionalRawData?.admins || []),
-    ...(space.additionalRawData?.moderators || [])
+    ...(space.additionalRawData?.moderators || []),
+    ...(space.additionalRawData?.members || [])
   ]
     .filter(Boolean)
     .some(member => compareAddresses(member, account));
@@ -115,7 +116,7 @@ export const useVotingPowersStore = defineStore('votingPowers', () => {
 
         vpItem.canPropose =
           totalProposeVp >= BigInt(item.proposal_threshold) ||
-          isSpaceTeamMember(space as Space, account);
+          isSpaceMember(space as Space, account);
       } else {
         vpItem.canVote = vpItem.totalVotingPower > 0n;
       }

--- a/apps/ui/src/stores/votingPowers.ts
+++ b/apps/ui/src/stores/votingPowers.ts
@@ -35,11 +35,14 @@ function isSpace(item: SpaceDetails | Proposal): item is Space {
   return 'proposal_threshold' in item;
 }
 
-function isSpaceMember(space: Space, account: string): boolean {
+function isSpaceTeamMember(space: Space, account: string): boolean {
   return [
+    space.controller,
     ...(space.additionalRawData?.admins || []),
     ...(space.additionalRawData?.moderators || [])
-  ].some(member => compareAddresses(member, account));
+  ]
+    .filter(Boolean)
+    .some(member => compareAddresses(member, account));
 }
 
 export const useVotingPowersStore = defineStore('votingPowers', () => {
@@ -113,7 +116,7 @@ export const useVotingPowersStore = defineStore('votingPowers', () => {
 
         vpItem.canPropose =
           totalProposeVp >= BigInt(item.proposal_threshold) ||
-          isSpaceMember(space as Space, account);
+          isSpaceTeamMember(space as Space, account);
       } else {
         vpItem.canVote = vpItem.totalVotingPower > 0n;
       }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an issue where admins and moderators couldn't create proposal by default.

Before: admins and moderators are considered like any other proposer, and have to pass the proposal validation (and hold some VP)

after: admins and moderators can always create proposals, regardless of any space settings

### How to test

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth/create
2. Connect as regular member `0xab54624a67e8c018a06b176baae76a40a385a464` account using https://impersonator.xyz/
3. You should see a message about insufficient voting power to create a proposal
4. Connect as a moderator `0x757a20e145435b5bdaf0e274987653aecd47cf37`
5. You should not see any warning message, and the publish button should be enabled
