### PR TITLE
fix: fix proposition power to updating on account change

### DIFF
--- a/apps/ui/src/composables/usePropositionPower.ts
+++ b/apps/ui/src/composables/usePropositionPower.ts
@@ -36,5 +36,5 @@ export function usePropositionPower() {
     }
   );
 
-  return { fetch, get };
+  return { fetch, get, reset };
 }

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -47,8 +47,11 @@ const {
   reset
 } = useWalletConnectTransaction();
 const proposalsStore = useProposalsStore();
-const { get: getPropositionPower, fetch: fetchPropositionPower } =
-  usePropositionPower();
+const {
+  get: getPropositionPower,
+  fetch: fetchPropositionPower,
+  reset: resetPropositionPower
+} = usePropositionPower();
 const { strategiesWithTreasuries } = useTreasuries(props.space);
 const termsStore = useTermsStore();
 
@@ -286,9 +289,13 @@ function handleFetchPropositionPower() {
 }
 
 watch(
-  () => web3.value.account,
-  toAccount => {
-    if (!toAccount) return;
+  [() => web3.value.account, () => web3.value.authLoading],
+  ([toAccount, toAuthLoading], [fromAccount]) => {
+    if (fromAccount && toAccount && fromAccount !== toAccount) {
+      resetPropositionPower();
+    }
+
+    if (toAuthLoading || !toAccount) return;
 
     handleFetchPropositionPower();
   },


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1008

This PR fix an issue where the proposition power was not updating on account change

### How to test

1. Go to a space editor where you have some VP
2. There is no warning
3. Without leaving the page, change your metamask to another wallet without VP on the space
4. It should show a warning about insufficient VP
