### PR TITLE
feat: redirect v1 URL paths to v2

### DIFF
--- a/apps/ui/src/components/Site/Footer.vue
+++ b/apps/ui/src/components/Site/Footer.vue
@@ -34,7 +34,7 @@ const SOCIALS = [
               <AppLink :to="{ name: 'my-explore' }"> Explore spaces </AppLink>
             </div>
             <div>
-              <a href="https://snapshot.org/#/setup?step=0" target="_blank">
+              <a href="https://v1.snapshot.box/#/setup" target="_blank">
                 Create a space
                 <IH-arrow-sm-right class="inline-block -rotate-45" />
               </a>

--- a/apps/ui/src/networks/offchain/index.ts
+++ b/apps/ui/src/networks/offchain/index.ts
@@ -13,8 +13,8 @@ const HUB_URLS: Partial<Record<NetworkID, string | undefined>> = {
   's-tn': 'https://testnet.hub.snapshot.org/graphql'
 };
 const SNAPSHOT_URLS: Partial<Record<NetworkID, string | undefined>> = {
-  s: 'https://snapshot.org',
-  's-tn': 'https://testnet.snapshot.org'
+  s: 'https://v1.snapshot.box',
+  's-tn': 'https://testnet.v1.snapshot.box'
 };
 const CHAIN_IDS: Partial<Record<NetworkID, 1 | 11155111>> = {
   s: 1,

--- a/apps/ui/src/routes/index.ts
+++ b/apps/ui/src/routes/index.ts
@@ -55,6 +55,13 @@ router.beforeEach((to, _from, next) => {
     redirectPath = `/${metadataNetwork}:${domain}/delegates`;
   }
 
+  // Match and redirect "/strategy/*" or "/playground/*" to v1.snapshot.box
+  if (to.path.startsWith('/strategy/') || to.path.startsWith('/playground/')) {
+    const newPath = to.path.replace(/^\/(strategy|playground)/, '/#$1');
+    window.location.href = `https://v1.snapshot.box${newPath}`;
+    return;
+  }
+
   // Perform the redirection if a match is found
   if (redirectPath) {
     next({ path: redirectPath, replace: true });

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -180,7 +180,9 @@ onMounted(() => {
       <UiTooltip title="Create new space">
         <UiButton
           :to="
-            protocol === 'snapshot' ? 'https://snapshot.org/#/setup' : 'create'
+            protocol === 'snapshot'
+              ? 'https://v1.snapshot.box/#/setup'
+              : 'create'
           "
           class="!px-0 w-[46px]"
         >

--- a/apps/ui/src/views/Settings/Spaces.vue
+++ b/apps/ui/src/views/Settings/Spaces.vue
@@ -71,7 +71,7 @@ watch(
         <UiButton
           :to="
             spacesStore.protocol === 'snapshot'
-              ? 'https://snapshot.org/#/setup'
+              ? 'https://v1.snapshot.box/#/setup'
               : 'create'
           "
           class="!px-0 w-[46px]"


### PR DESCRIPTION
Add redirections from v1 URL paths like:

- `/#/safe.eth` to v2 path `/#/s:safe.eth`
- `/#/delegate/safe.eth` to v2 path `/#/s:safe.eth/delegates`
- `/#/safe.eth/proposals` to v2 path `/#/s:safe.eth/proposals`
- `/#/safe.eth/about` to v2 path `/#/s:safe.eth`

Also update snapshot.org URLs to point to v1.snapshot.box and testnet.v1.snapshot.org