### PR TITLE
fix: add gnosis & walletlink as managerConnectors for offchain

### DIFF
--- a/apps/ui/src/networks/offchain/constants.ts
+++ b/apps/ui/src/networks/offchain/constants.ts
@@ -12,7 +12,12 @@ export const PROPOSAL_VALIDATIONS = {
 };
 export const STRATEGIES = {};
 export const EXECUTORS = {};
-export const CONNECTORS: Connector[] = ['injected', 'walletconnect'];
+export const CONNECTORS: Connector[] = [
+  'injected',
+  'walletconnect',
+  'walletlink',
+  'gnosis'
+];
 export const EDITOR_AUTHENTICATORS = [];
 export const EDITOR_PROPOSAL_VALIDATIONS = [];
 export const EDITOR_VOTING_STRATEGIES = [];


### PR DESCRIPTION
### Summary

With this change gnosis & walletlink should be supported manager connectors for offchain spaces (editing space settings etc.)

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/986

### How to test

1. Add your Safe as space admin.
2. Add this PR's preview as Safe app.
3. Navigate to your space through Safe app.
4. You can edit settings.

