### PR TITLE
feat: add flash message introducing v2

### DIFF
--- a/apps/ui/src/components/FlashMessageWelcome.vue
+++ b/apps/ui/src/components/FlashMessageWelcome.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { lsGet, lsSet } from '@/helpers/utils';
+
+const KEY = 'showV2Welcome';
+
+const open = ref(false);
+
+function handleClose() {
+  open.value = false;
+  lsSet(KEY, false);
+}
+
+onMounted(async () => {
+  open.value = lsGet(KEY) ?? true;
+});
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="fixed bottom-0 right-0 sm:mx-4 sm:mb-4 sm:rounded-lg bg-skin-link text-skin-bg z-[99] blocks-x !bg-left-top sm:max-w-[320px]"
+  >
+    <UiButton
+      class="!text-skin-bg !bg-transparent !border-none absolute top-1 right-1 !px-0 w-[40px] !h-[40px]"
+      @click="handleClose"
+    >
+      <IH-x class="inline-block" />
+    </UiButton>
+    <div class="bg-skin-link/90 sm:rounded-lg p-4">
+      <div class="flex space-x-3">
+        <div class="text-end">
+          <img src="@/assets/snapshot.svg" alt="Snapshot" class="w-[36px]" />
+        </div>
+        <div class="font-bold text-md leading-5">
+          Welcome to the new
+          <div class="font-display text-xl">Snapshot</div>
+        </div>
+      </div>
+      <div class="mt-3 mb-4">
+        Introducing the next evolution of Snapshot, with a brand new interface,
+        support for onchain voting, proposal executions, and many more
+        governance enhancements.
+      </div>
+      <UiButton
+        class="w-full"
+        to="https://snapshot.mirror.xyz/0qnfjmE0SFeUykArdi664oO4qFcZUoZTTOd8m7es_Eo"
+        >Learn more</UiButton
+      >
+    </div>
+  </div>
+</template>

--- a/apps/ui/src/components/FlashMessageWelcome.vue
+++ b/apps/ui/src/components/FlashMessageWelcome.vue
@@ -41,17 +41,18 @@ onMounted(async () => {
         support for onchain voting, proposal executions, and many more
         governance enhancements.
       </div>
-      <div class="space-y-2">
+      <div class="space-y-2 text-center">
         <UiButton
           class="w-full"
           to="https://snapshot.mirror.xyz/0qnfjmE0SFeUykArdi664oO4qFcZUoZTTOd8m7es_Eo"
           >Learn more</UiButton
         >
-        <UiButton
-          to="https://v1.snapshot.box"
-          class="!bg-transparent !border-skin-border w-full !text-skin-border"
-          >Go back to the old interface</UiButton
-        >
+        <div class="block text-sm">
+          <span class="text-skin-bg/70">Or, go back to the </span>
+          <a to="https://v1.snapshot.box" target="_blank" class="text-skin-bg"
+            >previous interface</a
+          >
+        </div>
       </div>
     </div>
   </div>

--- a/apps/ui/src/components/FlashMessageWelcome.vue
+++ b/apps/ui/src/components/FlashMessageWelcome.vue
@@ -41,11 +41,18 @@ onMounted(async () => {
         support for onchain voting, proposal executions, and many more
         governance enhancements.
       </div>
-      <UiButton
-        class="w-full"
-        to="https://snapshot.mirror.xyz/0qnfjmE0SFeUykArdi664oO4qFcZUoZTTOd8m7es_Eo"
-        >Learn more</UiButton
-      >
+      <div class="space-y-2">
+        <UiButton
+          class="w-full"
+          to="https://snapshot.mirror.xyz/0qnfjmE0SFeUykArdi664oO4qFcZUoZTTOd8m7es_Eo"
+          >Learn more</UiButton
+        >
+        <UiButton
+          to="https://v1.snapshot.box"
+          class="!bg-transparent !border-skin-border w-full !text-skin-border"
+          >Go back to the old interface</UiButton
+        >
+      </div>
     </div>
   </div>
 </template>

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -222,6 +222,7 @@ router.afterEach(() => {
       @add="handleTransactionAccept"
       @close="handleTransactionReject"
     />
+    <FlashMessageWelcome />
   </div>
 </template>
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/318

This PR adds a new flash message on the bottom right corner, introducing the v2, as well as show link to go back to v1

Once closed, flash message will not appear again (state saved in localStorage)

![Screenshot 2024-12-10 at 00 12 23](https://github.com/user-attachments/assets/d6b33be0-3c08-46c0-8fc4-d6121c5a4c7d)


### How to test

1. Open the app (not available on landing page)
2. Close the message
3. Message will not appear again on page refresh
