### PR TITLE
fix: show offchain networks in network selector

### DIFF
--- a/apps/ui/src/components/FormSpaceStrategies.vue
+++ b/apps/ui/src/components/FormSpaceStrategies.vue
@@ -38,7 +38,8 @@ const strategiesLimit = computed(() => {
         tooltip:
           'The default network used for this space. Networks can also be specified in individual strategies',
         examples: ['Select network'],
-        networkId
+        networkId,
+        networksListKind: 'offchain'
       }"
     />
   </div>

--- a/apps/ui/src/components/Modal/EditStrategy.vue
+++ b/apps/ui/src/components/Modal/EditStrategy.vue
@@ -166,7 +166,8 @@ watchEffect(() => {
           type: ['string', 'number'],
           title: 'Network',
           examples: ['Select network'],
-          networkId
+          networkId,
+          networksListKind: 'offchain'
         }"
       />
       <UiForm

--- a/apps/ui/src/components/Ui/SelectorNetwork.vue
+++ b/apps/ui/src/components/Ui/SelectorNetwork.vue
@@ -11,7 +11,7 @@ const network = defineModel<string | number | null>({
 const props = defineProps<{
   definition: BaseDefinition<string | number | null> & {
     networkId: NetworkID;
-    networksListKind?: 'full' | 'builtin';
+    networksListKind?: 'full' | 'builtin' | 'offchain';
   };
 }>();
 
@@ -20,7 +20,8 @@ const { networks, getUsage } = useOffchainNetworksList(
 );
 
 const options = computed(() => {
-  if (props.definition.networksListKind === 'full') {
+  const networksListKind = props.definition.networksListKind;
+  if (networksListKind === 'full' || networksListKind === 'offchain') {
     const baseNetworks = networks.value
       .filter(network => {
         if (
@@ -42,6 +43,7 @@ const options = computed(() => {
           class: 'rounded-full'
         })
       }));
+    if (networksListKind === 'offchain') return baseNetworks;
 
     return [
       ...baseNetworks,


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1029 and https://github.com/snapshot-labs/sx-monorepo/issues/1030

### How to test

1. Go to offchain space settings
2. Strategies tab
3. Network selector should show offchain networks (should not show testnet networks)
5. On testnet offchain space, you should see both testnet and mainnet networks
