### PR TITLE
feat: add button to duplicate proposal

### DIFF
--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -139,6 +139,39 @@ async function handleEditClick() {
   });
 }
 
+async function handleDuplicateClick() {
+  if (!props.proposal) return;
+
+  const spaceId = `${props.proposal.network}:${props.proposal.space.id}`;
+
+  const executions = Object.fromEntries(
+    props.proposal.executions.map(execution => {
+      const address = offchainNetworks.includes(props.proposal.network)
+        ? execution.safeAddress
+        : props.proposal.execution_strategy;
+
+      return [address, execution.transactions];
+    })
+  );
+
+  const draftId = await createDraft(spaceId, {
+    title: props.proposal.title,
+    body: props.proposal.body,
+    discussion: props.proposal.discussion,
+    type: props.proposal.type,
+    choices: props.proposal.choices,
+    labels: props.proposal.labels,
+    executions
+  });
+
+  router.push({
+    name: 'space-editor',
+    params: {
+      key: draftId
+    }
+  });
+}
+
 async function handleCancelClick() {
   cancelling.value = true;
 
@@ -298,6 +331,17 @@ onBeforeUnmount(() => destroyAudio());
               </UiButton>
             </template>
             <template #items>
+              <UiDropdownItem v-slot="{ active }">
+                <button
+                  type="button"
+                  class="flex items-center gap-2"
+                  :class="{ 'opacity-80': active }"
+                  @click="handleDuplicateClick"
+                >
+                  <IH-document-duplicate :width="16" />
+                  Duplicate proposal
+                </button>
+              </UiDropdownItem>
               <UiDropdownItem v-if="editable" v-slot="{ active }">
                 <button
                   type="button"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/322

This PR adds a new button in the proposal overview dropdown menu, to duplicate the current proposal.

![Screenshot 2024-12-10 at 15 14 41](https://github.com/user-attachments/assets/1c77725c-b9bd-4aff-80ec-5f999aa3c2e2)



### How to test

1. Go to any proposal
2. Go to the dropdown menu (next to share, under the title)
3. Click om "Duplicate proposal"
4. It should create a new draft, pre-populated with the proposal content 
