### PR TITLE
fix: use decimals of each strategy to calculate voting power

### DIFF
--- a/apps/ui/src/components/Modal/VotingPower.vue
+++ b/apps/ui/src/components/Modal/VotingPower.vue
@@ -58,10 +58,14 @@ const loading = computed(
           />
           <div class="text-skin-link shrink-0">
             {{
-              _n(Number(strategy.value) / 10 ** strategy.decimals, 'compact', {
-                maximumFractionDigits: 2,
-                formatDust: true
-              })
+              _n(
+                Number(strategy.value) / 10 ** strategy.cumulativeDecimals,
+                'compact',
+                {
+                  maximumFractionDigits: 2,
+                  formatDust: true
+                }
+              )
             }}
             {{ votingPower.symbol }}
           </div>
@@ -105,7 +109,7 @@ const loading = computed(
           </div>
           <div v-else />
           <div>
-            {{ _n(Number(strategy.value) / 10 ** strategy.decimals) }}
+            {{ _n(Number(strategy.value) / 10 ** strategy.displayDecimals) }}
             {{ strategy.symbol || 'units' }}
           </div>
         </div>

--- a/apps/ui/src/components/Modal/VotingPower.vue
+++ b/apps/ui/src/components/Modal/VotingPower.vue
@@ -58,14 +58,10 @@ const loading = computed(
           />
           <div class="text-skin-link shrink-0">
             {{
-              _n(
-                Number(strategy.value) / 10 ** votingPower.decimals,
-                'compact',
-                {
-                  maximumFractionDigits: 2,
-                  formatDust: true
-                }
-              )
+              _n(Number(strategy.value) / 10 ** strategy.decimals, 'compact', {
+                maximumFractionDigits: 2,
+                formatDust: true
+              })
             }}
             {{ votingPower.symbol }}
           </div>

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -611,9 +611,11 @@ export function getFormattedVotingPower(votingPower?: VotingPowerItem) {
   if (!votingPower) return;
 
   const { votingPowers, symbol } = votingPower;
-
   const value = _vp(
-    votingPowers.reduce((acc, b) => acc + Number(b.value) / 10 ** b.decimals, 0)
+    votingPowers.reduce(
+      (acc, b) => acc + Number(b.value) / 10 ** b.cumulativeDecimals,
+      0
+    )
   );
 
   return symbol ? `${value} ${symbol}` : value;

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -610,8 +610,11 @@ export function getSocialNetworksLink(data: any) {
 export function getFormattedVotingPower(votingPower?: VotingPowerItem) {
   if (!votingPower) return;
 
-  const { totalVotingPower, decimals, symbol } = votingPower;
-  const value = _vp(Number(totalVotingPower) / 10 ** decimals);
+  const { votingPowers, symbol } = votingPower;
+
+  const value = _vp(
+    votingPowers.reduce((acc, b) => acc + Number(b.value) / 10 ** b.decimals, 0)
+  );
 
   return symbol ? `${value} ${symbol}` : value;
 }

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -736,11 +736,22 @@ export function createActions(
       if (snapshotInfo.at === null)
         throw new Error('EVM requires block number to be defined');
 
+      const cumulativeDecimals = Math.max(
+        ...strategiesMetadata.map(metadata => metadata.decimals ?? 0)
+      );
+
       return Promise.all(
         strategiesAddresses.map(async (address, i) => {
           const strategy = getEvmStrategy(address, networkConfig);
           if (!strategy)
-            return { address, value: 0n, decimals: 0, token: null, symbol: '' };
+            return {
+              address,
+              value: 0n,
+              displayDecimals: 0,
+              cumulativeDecimals: 0,
+              token: null,
+              symbol: ''
+            };
 
           const strategyMetadata = await parseStrategyMetadata(
             strategiesMetadata[i].payload
@@ -761,7 +772,8 @@ export function createActions(
           return {
             address,
             value,
-            decimals: strategiesMetadata[i]?.decimals ?? 0,
+            cumulativeDecimals,
+            displayDecimals: strategiesMetadata[i]?.decimals ?? 0,
             symbol: strategiesMetadata[i]?.symbol ?? '',
             token,
             swapLink: getSwapLink(strategy.type, address, chainId)

--- a/apps/ui/src/networks/offchain/actions.ts
+++ b/apps/ui/src/networks/offchain/actions.ts
@@ -242,7 +242,14 @@ export function createActions(
 
       if (!strategy || !isAddress(voterAddress)) {
         return [
-          { address: name, value: 0n, decimals: 0, token: null, symbol: '' }
+          {
+            address: name,
+            value: 0n,
+            cumulativeDecimals: 0,
+            displayDecimals: 0,
+            token: null,
+            symbol: ''
+          }
         ];
       }
 
@@ -257,7 +264,8 @@ export function createActions(
         return [
           {
             address: strategiesNames[0],
-            decimals: 0,
+            cumulativeDecimals: 0,
+            displayDecimals: 0,
             symbol: '',
             token: '',
             chainId: snapshotInfo.chainId,
@@ -273,7 +281,8 @@ export function createActions(
         return {
           address: strategy.name,
           value,
-          decimals,
+          cumulativeDecimals: decimals,
+          displayDecimals: decimals,
           symbol: strategy.params.symbol,
           token: strategy.params.address,
           chainId: strategy.network ? parseInt(strategy.network) : undefined,

--- a/apps/ui/src/networks/offchain/index.test.ts
+++ b/apps/ui/src/networks/offchain/index.test.ts
@@ -34,7 +34,8 @@ describe('offchain network', () => {
           ).resolves.toEqual([
             {
               address: 'ticket',
-              decimals: 0,
+              cumulativeDecimals: 0,
+              displayDecimals: 0,
               symbol: '',
               token: null,
               value: 0n
@@ -88,7 +89,8 @@ describe('offchain network', () => {
       ).resolves.toEqual([
         {
           address: 'ticket',
-          decimals: 9,
+          cumulativeDecimals: 9,
+          displayDecimals: 9,
           symbol: 'SYM',
           token: 'TOKEN',
           value: result[0],
@@ -97,7 +99,8 @@ describe('offchain network', () => {
         },
         {
           address: 'math',
-          decimals: 18,
+          cumulativeDecimals: 18,
+          displayDecimals: 18,
           symbol: undefined,
           token: undefined,
           value: result[1],
@@ -106,7 +109,8 @@ describe('offchain network', () => {
         },
         {
           address: 'api',
-          decimals: 18,
+          cumulativeDecimals: 18,
+          displayDecimals: 18,
           symbol: undefined,
           token: undefined,
           value: result[2],
@@ -141,7 +145,8 @@ describe('offchain network', () => {
           ).resolves.toEqual([
             {
               address: 'basic',
-              decimals: 0,
+              cumulativeDecimals: 0,
+              displayDecimals: 0,
               symbol: '',
               token: null,
               value: 0n
@@ -167,7 +172,8 @@ describe('offchain network', () => {
             {
               address: 'only-members',
               value: 1n,
-              decimals: 0,
+              cumulativeDecimals: 0,
+              displayDecimals: 0,
               symbol: '',
               token: '',
               chainId: undefined
@@ -191,7 +197,8 @@ describe('offchain network', () => {
             {
               address: 'only-members',
               value: 0n,
-              decimals: 0,
+              cumulativeDecimals: 0,
+              displayDecimals: 0,
               symbol: '',
               token: '',
               chainId: undefined

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -731,11 +731,22 @@ export function createActions(
       voterAddress: string,
       snapshotInfo: SnapshotInfo
     ): Promise<VotingPower[]> => {
+      const cumulativeDecimals = Math.max(
+        ...strategiesMetadata.map(metadata => metadata.decimals ?? 0)
+      );
+
       return Promise.all(
         strategiesAddresses.map(async (address, i) => {
           const strategy = getStarknetStrategy(address, networkConfig);
           if (!strategy)
-            return { address, value: 0n, decimals: 0, token: null, symbol: '' };
+            return {
+              address,
+              value: 0n,
+              cumulativeDecimals: 0,
+              displayDecimals: 0,
+              token: null,
+              symbol: ''
+            };
 
           const strategyMetadata = await parseStrategyMetadata(
             strategiesMetadata[i].payload
@@ -756,7 +767,8 @@ export function createActions(
           return {
             address,
             value,
-            decimals: strategiesMetadata[i]?.decimals ?? 0,
+            cumulativeDecimals,
+            displayDecimals: strategiesMetadata[i]?.decimals ?? 0,
             symbol: strategiesMetadata[i]?.symbol ?? '',
             token: strategiesMetadata[i]?.token ?? null
           };

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -110,7 +110,14 @@ export type SnapshotInfo = {
 export type VotingPower = {
   address: string;
   value: bigint;
-  decimals: number;
+  /**
+   * Decimals used to interpret value in context of final (total) VP.
+   */
+  cumulativeDecimals: number;
+  /**
+   * Decimals used to display this strategy value.
+   */
+  displayDecimals: number;
   token: string | null;
   symbol: string;
   chainId?: number;

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -310,7 +310,7 @@ watchEffect(() => {
                   <a
                     v-if="
                       votingPower?.status === 'success' &&
-                      votingPower.totalVotingPower === BigInt(0)
+                      votingPower.votingPowers.some(v => v.value > 0n)
                     "
                     :href="`${HELPDESK_URL}/en/articles/9566904-why-do-i-have-0-voting-power`"
                     target="_blank"

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -310,7 +310,7 @@ watchEffect(() => {
                   <a
                     v-if="
                       votingPower?.status === 'success' &&
-                      votingPower.votingPowers.some(v => v.value > 0n)
+                      votingPower.votingPowers.every(v => v.value === 0n)
                     "
                     :href="`${HELPDESK_URL}/en/articles/9566904-why-do-i-have-0-voting-power`"
                     target="_blank"

--- a/apps/ui/src/views/SpaceUser.vue
+++ b/apps/ui/src/views/SpaceUser.vue
@@ -38,19 +38,18 @@ const socials = computed(() => getSocialNetworksLink(user.value));
 const cb = computed(() => getCacheHash(user.value?.avatar));
 
 const formattedVotingPower = computed(() => {
-  const votingPower = votingPowers.value.reduce((acc, b) => acc + b.value, 0n);
-  const decimals = Math.max(
-    ...votingPowers.value.map(votingPower => votingPower.decimals),
-    0
+  const votingPower = _vp(
+    votingPowers.value.reduce(
+      (acc, b) => acc + Number(b.value) / 10 ** b.decimals,
+      0
+    )
   );
 
-  const value = _vp(Number(votingPower) / 10 ** decimals);
-
   if (props.space.voting_power_symbol) {
-    return `${value} ${props.space.voting_power_symbol}`;
+    return `${votingPower} ${props.space.voting_power_symbol}`;
   }
 
-  return value;
+  return votingPower;
 });
 
 const navigation = computed(() => [

--- a/apps/ui/src/views/SpaceUser.vue
+++ b/apps/ui/src/views/SpaceUser.vue
@@ -40,7 +40,7 @@ const cb = computed(() => getCacheHash(user.value?.avatar));
 const formattedVotingPower = computed(() => {
   const votingPower = _vp(
     votingPowers.value.reduce(
-      (acc, b) => acc + Number(b.value) / 10 ** b.decimals,
+      (acc, b) => acc + Number(b.value) / 10 ** b.cumulativeDecimals,
       0
     )
   );


### PR DESCRIPTION
### Summary

In case of onchain strategies decimals are only there to specify how
strategy value should be formatted, but it doesn't have effect on how
this value is interpreted (strategy with VP value of 1 and 18 decimals and
strategy with VP value of 1 and 0 decimals are actually the same and give sum
of 2 VP).

We need to separate cumulativeDecimals (used to calculate cumulative VP) and
displayDecimals (used to display specific strategy's value).

Depending on the context one or another needs to be used.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1036

### How to test

**Onchain**
1. Go to http://127.0.0.1:8080/#/sep:0xa6380C7eC883CC0BcdAaf9f46d6F83Fa872BF700/profile/0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70
2. User has 8 AXMVP
3. Impersonate as `0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70`
4. Go to http://127.0.0.1:8080/#/sep:0xa6380C7eC883CC0BcdAaf9f46d6F83Fa872BF700/proposals
5. You have following results (total VP is 8 AXMVP, you have 8 TEST and 1 WHITE):
<img width="466" alt="image" src="https://github.com/user-attachments/assets/1af59a39-459e-47ca-8be0-231b529e3056" />

**Offchain**
1. Go to http://127.0.0.1:8080/#/s:black-flag.eth/profile/0x74fa01a5D0ef8039f1E14F4d4C8f90e8602e07B4
2. User has 351.117 🏴
3. Impersonate as `0x74fa01a5D0ef8039f1E14F4d4C8f90e8602e07B4`
4. Go to http://127.0.0.1:8080/#/s:black-flag.eth/proposals
6. You have following resutls (total VP is 351.117 🏴):
<img width="507" alt="image" src="https://github.com/user-attachments/assets/0953de04-1f4d-4184-a4ed-fa270c6da622" />
