### PR TITLE
fix: improve time input UI

### DIFF
--- a/apps/ui/src/components/Modal/DateTime.vue
+++ b/apps/ui/src/components/Modal/DateTime.vue
@@ -106,25 +106,28 @@ watch(
     <template #header>
       <h3 v-text="current.title" />
     </template>
-    <div :class="['!m-4 text-center', { 's-error': formError }]">
+    <div :class="['s-box !m-4 text-center', { 's-error': formError }]">
       <UiCalendar
         v-if="isCurrent('date')"
         :min="min"
         :selected="date"
         @pick="handleDateUpdate"
       />
-      <template v-else-if="isCurrent('time')">
-        <input
-          v-model="time"
-          type="time"
-          class="s-input mx-auto max-w-[140px] text-center text-lg"
-        />
+      <div v-else-if="isCurrent('time')" class="s-base">
+        <div class="relative mx-auto max-w-[140px]">
+          <label class="s-label w-full">Time</label>
+          <input
+            v-model="time"
+            type="time"
+            class="s-input text-center text-lg"
+          />
+        </div>
         <span
           v-if="formError"
           class="s-input-error-message"
           v-text="formError"
         />
-      </template>
+      </div>
     </div>
     <template #footer>
       <div class="flex space-x-3">

--- a/apps/ui/src/style.scss
+++ b/apps/ui/src/style.scss
@@ -219,6 +219,10 @@ input[type='number'] {
   appearance: textfield;
 }
 
+input[type="time"]::-webkit-calendar-picker-indicator {
+  display: none;
+}
+
 input:placeholder-shown {
   @apply text-ellipsis;
 }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/pull/1015#issuecomment-2531409401

This PR improve the time input UI:

- hides the webkit default control on time input (not tested on non-webkit browsers)
- uses the `s-box` style for the time input

Before

![Screenshot 2024-12-10 at 22 04 53](https://github.com/user-attachments/assets/bfca5ad0-05e0-4844-97b9-5e74919de092)

After

![Screenshot 2024-12-11 at 11 43 11](https://github.com/user-attachments/assets/04b0fcd9-5e57-470a-a9df-bbce236f0bf0)

### How to test

1. Go to a date edition in the editor
2. The time picker should appear without the browser default control, and with the same style as all other inputs
