### PR TITLE
fix: voting power for offchain pending proposals should use the proposal snapshot

### DIFF
--- a/apps/ui/src/composables/useVotingPower.ts
+++ b/apps/ui/src/composables/useVotingPower.ts
@@ -1,4 +1,4 @@
-import { supportsNullCurrent } from '@/networks';
+import { offchainNetworks, supportsNullCurrent } from '@/networks';
 import { getIndex } from '@/stores/votingPowers';
 import { NetworkID, Proposal, Space } from '@/types';
 
@@ -13,8 +13,10 @@ export function useVotingPower() {
 
   function getProposalSnapshot(proposal: Proposal): number | null {
     return (
-      (proposal.state === 'pending' ? null : proposal.snapshot) ||
-      getLatestBlock(proposal.network)
+      (proposal.state === 'pending' &&
+      !offchainNetworks.includes(proposal.network)
+        ? null
+        : proposal.snapshot) || getLatestBlock(proposal.network)
     );
   }
 

--- a/apps/ui/src/composables/useVotingPower.ts
+++ b/apps/ui/src/composables/useVotingPower.ts
@@ -12,12 +12,13 @@ export function useVotingPower() {
   }
 
   function getProposalSnapshot(proposal: Proposal): number | null {
-    return (
-      (proposal.state === 'pending' &&
+    const snapshot =
+      proposal.state === 'pending' &&
       !offchainNetworks.includes(proposal.network)
         ? null
-        : proposal.snapshot) || getLatestBlock(proposal.network)
-    );
+        : proposal.snapshot;
+
+    return snapshot || getLatestBlock(proposal.network);
   }
 
   function getSnapshot(


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #940

This PR fix the voting power for offchain pending proposal, which were based on `latest` block, instead of the proposal own snapshot

### How to test

1. Open the network in the dev console
2. Go to an offchain pending proposal
3. Inspect the payload for `https://score.snapshot.org/`
4. It should use a number as `snapshot`, instead of `latest`
