### PR TITLE
fix: show the v2 welcome message also on landing page

### DIFF
--- a/apps/ui/src/components/Layout/Site.vue
+++ b/apps/ui/src/components/Layout/Site.vue
@@ -2,4 +2,5 @@
   <SiteTopnav />
   <router-view />
   <SiteFooter />
+  <FlashMessageWelcome />
 </template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/pull/1028#issuecomment-2532568521

This PR will also show the v2 welcome flash message on landing page

### How to test

1. clear your local storage
2. Go to landing page
3. You should see the v2 welcome message
