### PR TITLE
fix: force user to login only on account dependent page

### DIFF
--- a/apps/ui/src/stores/notifications.ts
+++ b/apps/ui/src/stores/notifications.ts
@@ -135,6 +135,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
       } else if (!followedSpacesIds.length && refreshNotificationInterval) {
         clearInterval(refreshNotificationInterval);
         refreshNotificationInterval = 0;
+        notifications.value = [];
       }
     },
     { immediate: true }

--- a/apps/ui/src/views/My/Home.vue
+++ b/apps/ui/src/views/My/Home.vue
@@ -10,7 +10,7 @@ const PROPOSALS_LIMIT = 20;
 useTitle('Home');
 
 const metaStore = useMetaStore();
-const { modalAccountWithoutDismissOpen } = useModal();
+const router = useRouter();
 const followedSpacesStore = useFollowedSpacesStore();
 const { web3 } = useWeb3();
 const { loadVotes } = useAccount();
@@ -113,15 +113,11 @@ watch(
   [() => web3.value.account, () => web3.value.authLoading],
   ([account, authLoading]) => {
     if (!account && !authLoading) {
-      modalAccountWithoutDismissOpen.value = true;
+      router.replace({ name: 'my-explore' });
     }
   },
   { immediate: true }
 );
-
-onUnmounted(() => {
-  modalAccountWithoutDismissOpen.value = false;
-});
 </script>
 
 <template>

--- a/apps/ui/src/views/My/Notifications.vue
+++ b/apps/ui/src/views/My/Notifications.vue
@@ -2,6 +2,8 @@
 import { _rt } from '@/helpers/utils';
 
 const notificationsStore = useNotificationsStore();
+const { modalAccountWithoutDismissOpen } = useModal();
+const { web3 } = useWeb3();
 const { setTitle } = useTitle();
 
 watchEffect(async () => {
@@ -11,12 +13,24 @@ watchEffect(async () => {
 });
 
 watch(
-  () => notificationsStore.unreadNotificationsCount,
-  () => {
+  [
+    () => web3.value.account,
+    () => web3.value.authLoading,
+    () => notificationsStore.unreadNotificationsCount
+  ],
+  ([account, authLoading]) => {
+    if (!account && !authLoading) {
+      modalAccountWithoutDismissOpen.value = true;
+    }
+
     notificationsStore.refreshLastUnreadTs();
   },
   { immediate: true }
 );
+
+onUnmounted(() => {
+  modalAccountWithoutDismissOpen.value = false;
+});
 
 onUnmounted(() => notificationsStore.markAllAsRead());
 </script>

--- a/apps/ui/src/views/Settings.vue
+++ b/apps/ui/src/views/Settings.vue
@@ -1,5 +1,20 @@
 <script setup lang="ts">
-const { web3Account } = useWeb3();
+const { web3, web3Account } = useWeb3();
+const { modalAccountWithoutDismissOpen } = useModal();
+
+watch(
+  [() => web3.value.account, () => web3.value.authLoading],
+  ([account, authLoading]) => {
+    if (!account && !authLoading) {
+      modalAccountWithoutDismissOpen.value = true;
+    }
+  },
+  { immediate: true }
+);
+
+onUnmounted(() => {
+  modalAccountWithoutDismissOpen.value = false;
+});
 </script>
 
 <template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/325

This PR will force prompt users to login only page depending on the current wallet (except /home).

- Remove the force login modal on the /home page, will redirect users to /explore page instead
- Add the force login modal on /notifications and /settings/* page, since these page make sense only if wallet is connected, and accessible only with direct link

Also fix a minor issue where logging out while on the /notifications page was not clearing the existing notifications

### How to test

1. Disconnect your wallet
2. Go to /home
3. You should be redirected to /explore
4. Go to /notifications or /settings
5. You should see the login modal
6. Login
7. Go to /home
8. You should see the /home
