### PR TITLE
fix: show 5 proposals on overview page

### DIFF
--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -3,7 +3,7 @@ import { _n, autoLinkText, getSocialNetworksLink } from '@/helpers/utils';
 import { offchainNetworks } from '@/networks';
 import { Space } from '@/types';
 
-const PROPOSALS_LIMIT = 4;
+const PROPOSALS_LIMIT = 6;
 
 const props = defineProps<{ space: Space }>();
 


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/330

### How to test

1. Go there: http://localhost:8080/#/sep:0xEB8EA538C90D2E009460ED69adD7025560E18481
2. You can see 5 proposals.

<img width="1454" alt="image" src="https://github.com/user-attachments/assets/07a05674-d546-4d08-9660-7cfab4d9e4bc" />
