### PR TITLE
fix: fix space avatar from shrinking

### DIFF
--- a/apps/ui/src/components/Breadcrumb.vue
+++ b/apps/ui/src/components/Breadcrumb.vue
@@ -38,11 +38,13 @@ const space = computed(() => {
     class="flex item-center space-x-2.5 truncate text-[24px]"
     v-bind="$attrs"
   >
-    <SpaceAvatar
-      :space="{ ...space, network: networkId as NetworkID }"
-      :size="36"
-      class="!rounded-[4px] shrink-0"
-    />
+    <div class="shrink-0">
+      <SpaceAvatar
+        :space="{ ...space, network: networkId as NetworkID }"
+        :size="36"
+        class="!rounded-[4px]"
+      />
+    </div>
     <span class="truncate" v-text="space.name" />
   </AppLink>
 </template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/337

Regression from https://github.com/snapshot-labs/sx-monorepo/pull/1048

### How to test

1. Go to a space overview and proposal page
2. The avatar in the topnav breadcrumb should not shrink anymore 