### PR TITLE
fix: Restore back missing feature where choices for pending shutter proposals are visible

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -91,7 +91,11 @@ const otherResultsSummary = computed(() => {
 
 <template>
   <div
-    v-if="!!props.proposal.privacy && !props.proposal.completed && withDetails"
+    v-if="
+      !!props.proposal.privacy &&
+      props.proposal.state === 'active' &&
+      withDetails
+    "
   >
     <div class="mb-1">
       All votes are encrypted and will be decrypted only after the voting period
@@ -154,10 +158,16 @@ const otherResultsSummary = computed(() => {
           class="truncate grow"
           v-text="proposal.choices[result.choice - 1]"
         />
-        <div>
-          {{ _vp(result.score / 10 ** decimals) }}
-        </div>
-        <div v-text="_p(result.progress / 100)" />
+        <IH-lock-closed
+          v-if="!!proposal.privacy && !proposal.completed"
+          class="size-[16px] shrink-0"
+        />
+        <template v-else>
+          <div>
+            {{ _vp(result.score / 10 ** decimals) }}
+          </div>
+          <div v-text="_p(result.progress / 100)" />
+        </template>
       </div>
       <button
         v-if="!displayAllChoices && otherResultsSummary.count > 0"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR restore the missing (may be due to some botched merge conflict) feature introduced with #1044

Also show a lock icon instead of votes count for progress

![Screenshot 2024-12-17 at 15 34 02](https://github.com/user-attachments/assets/ba6c4241-334c-419a-9d72-9cf9c6ee31e0)


### How to test

1. PENDING: Go to http://localhost:8080/#/s:test.wa0x6e.eth/proposal/0xf68984180a080d0331c873ea7c48e04c9ef00ca12c95da004fc586e1bcec3b0b
2. It should show results, with LOCK icon instead of results count
3. CLOSED: http://localhost:8080/#/s:test.wa0x6e.eth/proposal/0xfe22dfb4473476dc73ea54cadff7cf1faf30540c4afe97e3292d6e51d38cbfbc
4. It should show the results, with the final votes count
5. ACTIVE: http://localhost:8080/#/s:test.wa0x6e.eth/proposal/0x605c475a7aac97c53272ca02e973e5cd5676f0c5abcdc8fdbb2a182f3fe22313
6. It should just show a message instead of results
