### PR TITLE
feat: link SafeSnap executions to old interface

### DIFF
--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -238,6 +238,9 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     } catch (e) {
       console.warn('failed to parse oSnap execution', e);
     }
+  } else if (proposal.plugins.safeSnap) {
+    executions = [];
+    executionType = 'safeSnap';
   }
 
   if (proposal.plugins.readOnlyExecution) {

--- a/apps/ui/src/networks/offchain/index.ts
+++ b/apps/ui/src/networks/offchain/index.ts
@@ -12,7 +12,7 @@ const HUB_URLS: Partial<Record<NetworkID, string | undefined>> = {
   s: 'https://hub.snapshot.org/graphql',
   's-tn': 'https://testnet.hub.snapshot.org/graphql'
 };
-const SNAPSHOT_URLS: Partial<Record<NetworkID, string | undefined>> = {
+export const SNAPSHOT_URLS: Partial<Record<NetworkID, string | undefined>> = {
   s: 'https://v1.snapshot.box',
   's-tn': 'https://testnet.v1.snapshot.box'
 };

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -9,6 +9,7 @@ import {
   shortenAddress
 } from '@/helpers/utils';
 import { offchainNetworks } from '@/networks';
+import { SNAPSHOT_URLS } from '@/networks/offchain';
 import { Proposal } from '@/types';
 
 const props = defineProps<{
@@ -409,12 +410,36 @@ onBeforeUnmount(() => destroyAudio());
           <UiLinkPreview :url="discussion" :show-default="true" />
         </a>
       </div>
-      <div v-if="proposal.executions && proposal.executions.length > 0">
+      <div
+        v-if="
+          (proposal.executions && proposal.executions.length > 0) ||
+          proposal.execution_strategy_type === 'safeSnap'
+        "
+      >
         <h4 class="mb-3 eyebrow flex items-center gap-2">
           <IH-play />
           <span>Execution</span>
         </h4>
         <div class="mb-4">
+          <UiAlert
+            v-if="proposal.execution_strategy_type === 'safeSnap'"
+            type="warning"
+          >
+            <div>
+              This proposal uses SafeSnap execution which is currently not
+              supported on the new interface. You can view execution details on
+              the
+              <a
+                :href="`${SNAPSHOT_URLS[proposal.network]}/#/${proposal.space.id}/proposal/${proposal.id}`"
+                target="_blank"
+                class="inline-flex items-center font-bold"
+              >
+                previous interface
+                <IH-arrow-sm-right class="inline-block -rotate-45" />
+              </a>
+              .
+            </div>
+          </UiAlert>
           <ProposalExecutionsList
             :proposal="proposal"
             :executions="proposal.executions"


### PR DESCRIPTION
### Summary

We currently do not support SafeSnap executions, so when detected we link to v1 UI.

Closes: https://github.com/snapshot-labs/workflow/issues/324

### How to test

1. Go to http://localhost:8080/#/s:launchdao.eth/proposal/0x2440b546cecc6292c56f55539942f10108831a1d6eff3b90a3603a9a157dbeae
2. You have execution section and link to v1 UI.

### Screenshots

<img width="682" alt="image" src="https://github.com/user-attachments/assets/9bd29936-8597-4a59-947b-ff4515b7c0f2" />
