### PR TITLE
fix: match quorum formula based on contracts

### DIFF
--- a/apps/ui/src/components/ProposalExecutionsList.vue
+++ b/apps/ui/src/components/ProposalExecutionsList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { getGenericExplorerUrl } from '@/helpers/explorer';
+import { getProposalCurrentQuorum } from '@/helpers/quorum';
 import { buildBatchFile } from '@/helpers/safe/ build';
 import { getExecutionName } from '@/helpers/ui';
 import { shorten, toBigIntOrNumber } from '@/helpers/utils';
@@ -101,8 +102,8 @@ function downloadExecution(execution: ProposalExecution) {
         proposal.executions &&
         proposal.executions.length > 0 &&
         proposal.scores.length > 0 &&
-        toBigIntOrNumber(proposal.scores_total) >=
-          toBigIntOrNumber(proposal.quorum) &&
+        getProposalCurrentQuorum(proposal.network, proposal) >
+          proposal.quorum &&
         toBigIntOrNumber(proposal.scores[0]) >
           toBigIntOrNumber(proposal.scores[1]) &&
         proposal.has_execution_window_opened

--- a/apps/ui/src/helpers/quorum.test.ts
+++ b/apps/ui/src/helpers/quorum.test.ts
@@ -1,5 +1,35 @@
 import { describe, expect, it } from 'vitest';
-import { formatQuorum } from './quorum';
+import { formatQuorum, getProposalCurrentQuorum } from './quorum';
+
+describe('getProposalCurrentQuorum', () => {
+  it('should only use for and abstain votes for onchain spaces', () => {
+    const currentQuorum = getProposalCurrentQuorum('eth', {
+      scores: [11, 20, 100],
+      scores_total: 131
+    });
+
+    expect(currentQuorum).toBe(111);
+  });
+
+  it('should use total score for offchain spaces', () => {
+    const currentQuorum = getProposalCurrentQuorum('s', {
+      scores: [11, 20, 100],
+      scores_total: 131
+    });
+
+    expect(currentQuorum).toBe(131);
+  });
+
+  it('should only use against votes for rejection quorum', () => {
+    const currentQuorum = getProposalCurrentQuorum('s', {
+      scores: [11, 20, 100],
+      scores_total: 131,
+      quorum_type: 'rejection'
+    });
+
+    expect(currentQuorum).toBe(20);
+  });
+});
 
 describe('formatQuorum', () => {
   it('should format using 3 significant digits', () => {

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -4,6 +4,7 @@ import {
   InMemoryCache
 } from '@apollo/client/core';
 import { CHAIN_IDS } from '@/helpers/constants';
+import { getProposalCurrentQuorum } from '@/helpers/quorum';
 import { getNames } from '@/helpers/stamp';
 import { clone, compareAddresses } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
@@ -57,6 +58,7 @@ type ApiOptions = {
 };
 
 function getProposalState(
+  networkId: NetworkID,
   proposal: ApiProposal,
   current: number
 ): ProposalState {
@@ -64,13 +66,16 @@ function getProposalState(
   // those values are actually strings
   // https://github.com/snapshot-labs/sx-monorepo/pull/529/files#r1691071502
   const quorum = BigInt(proposal.quorum);
-  const scoresTotal = BigInt(proposal.scores_total);
+  const currentQuorum = getProposalCurrentQuorum(networkId, {
+    scores: [proposal.scores_1, proposal.scores_2, proposal.scores_3],
+    scores_total: proposal.scores_total
+  });
   const scoresFor = BigInt(proposal.scores_1);
   const scoresAgainst = BigInt(proposal.scores_2);
 
   if (proposal.executed) return 'executed';
   if (proposal.max_end <= current) {
-    if (scoresTotal < quorum) return 'rejected';
+    if (currentQuorum < quorum) return 'rejected';
     return scoresFor > scoresAgainst ? 'passed' : 'rejected';
   }
   if (proposal.start > current) return 'pending';
@@ -294,7 +299,7 @@ function formatProposal(
     )
       ? proposal.max_end <= current
       : proposal.min_end <= current,
-    state: getProposalState(proposal, current),
+    state: getProposalState(networkId, proposal, current),
     network: networkId,
     privacy: null,
     quorum: +proposal.quorum,

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -5,6 +5,7 @@ import {
 } from '@apollo/client/core';
 import { CHAIN_IDS } from '@/helpers/constants';
 import { parseOSnapTransaction } from '@/helpers/osnap';
+import { getProposalCurrentQuorum } from '@/helpers/quorum';
 import { getNames } from '@/helpers/stamp';
 import { clone } from '@/helpers/utils';
 import {
@@ -70,9 +71,17 @@ const DELEGATION_STRATEGIES = [
 
 const DELEGATE_REGISTRY_URL = 'https://delegate-registry-api.snapshot.box';
 
-function getProposalState(proposal: ApiProposal): ProposalState {
+function getProposalState(
+  networkId: NetworkID,
+  proposal: ApiProposal
+): ProposalState {
   if (proposal.state === 'closed') {
-    if (proposal.scores_total < proposal.quorum) return 'rejected';
+    const currentQuorum = getProposalCurrentQuorum(networkId, {
+      scores: proposal.scores,
+      scores_total: proposal.scores_total
+    });
+
+    if (currentQuorum < proposal.quorum) return 'rejected';
     return proposal.type !== 'basic' || proposal.scores[0] > proposal.scores[1]
       ? 'passed'
       : 'rejected';
@@ -256,7 +265,7 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     ];
   }
 
-  const state = getProposalState(proposal);
+  const state = getProposalState(networkId, proposal);
 
   return {
     id: proposal.id,


### PR DESCRIPTION
### Summary

Onchain spaces only take for and abstain votes into quorum progress. Against votes are not counted.

Offchain spaces take all votes into account (for oSnap/SafeSnap).

### How to test

1. Go to onchain space with against votes: http://localhost:8080/#/sep:0x3CB9321Ed733dc336A59199b05b2FC29beA8b66B/proposal/2
2. Against is not counted towards quorum, proposal is rejected, you can't execute proposal.
3. Go to onchain space that passed: http://localhost:8080/#/sep:0x3CB9321Ed733dc336A59199b05b2FC29beA8b66B/proposal/4
4. Quorum counts all votes, proposal is passed, you can execute proposal (at least button shows up, I haven't configured execution on Safe).

### Screenshots

<img width="1194" alt="image" src="https://github.com/user-attachments/assets/bb78f0a4-4a37-42ff-9887-230272e795c9" />

