### PR TITLE
fix: validate resolver address before setting snapshot text record

### DIFF
--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -111,8 +111,17 @@ export async function setEnsTextRecord(
 
   const ensHash = namehash(ensNormalize(ens));
 
+  const resolverAddress = await call(
+    getProvider(chainId),
+    ENS_CONTRACTS.registryAbi,
+    [ENS_CONTRACTS.registry, 'resolver', [ensHash]]
+  );
+
+  if (!resolvers.includes(resolverAddress))
+    throw new Error('Unsupported resolver');
+
   const contract = new Contract(
-    resolvers[0],
+    resolverAddress,
     ENS_CONTRACTS.resolverAbi,
     signer
   );


### PR DESCRIPTION
### Summary
- Gets and validated ENS resolver before settings snapshot text record

### How to test

1. Go to http://127.0.0.1:8080/#/s:odos.eth/settings/controller
2. Login with resolver address `0x47E2D28169738039755586743E2dfCF3bd643f86` using Safe's wallet connect
<img width="497" alt="Untitled 6" src="https://github.com/user-attachments/assets/cd80121b-0c7c-43dc-9d6e-50a8366aba6b" />

3. Change controller to some other address in space settings
4. Transaction on safe should display new resolver address


| Before | After |
| ------- | ----- |
| <img width="432" alt="Untitled 8" src="https://github.com/user-attachments/assets/348502ef-0ee6-440f-9795-3b52d6fee4ac" /> | <img width="460" alt="Untitled 9" src="https://github.com/user-attachments/assets/bcf216c6-8566-46d6-845b-d348c7fb69c7" />  |


<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
