### PR TITLE
fix: finalize proposal excection button when proposal reaches its quorum

### DIFF
--- a/apps/ui/src/components/ProposalExecutionsList.vue
+++ b/apps/ui/src/components/ProposalExecutionsList.vue
@@ -102,7 +102,7 @@ function downloadExecution(execution: ProposalExecution) {
         proposal.executions &&
         proposal.executions.length > 0 &&
         proposal.scores.length > 0 &&
-        getProposalCurrentQuorum(proposal.network, proposal) >
+        getProposalCurrentQuorum(proposal.network, proposal) >=
           proposal.quorum &&
         toBigIntOrNumber(proposal.scores[0]) >
           toBigIntOrNumber(proposal.scores[1]) &&


### PR DESCRIPTION

### Summary
- previously button was shown when quorum reaches above 100%
- Fix will show the button when it reaches 100%
