### PR TITLE
fix: stop checking proposal validation for space members

### DIFF
--- a/apps/ui/src/stores/votingPowers.ts
+++ b/apps/ui/src/stores/votingPowers.ts
@@ -58,12 +58,13 @@ export const useVotingPowersStore = defineStore('votingPowers', () => {
 
     const network = getNetwork(item.network);
 
+    const canPropose = isSpaceMember(space as Space, account);
     let vpItem: VotingPowerItem = {
       status: 'loading',
       votingPowers: [],
       symbol: space.voting_power_symbol,
       error: null,
-      canPropose: false,
+      canPropose,
       canVote: false
     };
 
@@ -87,7 +88,7 @@ export const useVotingPowersStore = defineStore('votingPowers', () => {
           account,
           opts
         ),
-        isSpace(item)
+        isSpace(item) && !vpItem.canPropose
           ? network.actions.getVotingPower(
               space.id,
               item.voting_power_validation_strategy_strategies,
@@ -111,9 +112,7 @@ export const useVotingPowersStore = defineStore('votingPowers', () => {
           0
         );
 
-        vpItem.canPropose =
-          totalProposeVp >= BigInt(item.proposal_threshold) ||
-          isSpaceMember(space as Space, account);
+        vpItem.canPropose ||= totalProposeVp >= BigInt(item.proposal_threshold);
       } else {
         vpItem.canVote = vp.some(vp => vp.value > 0n);
       }


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/348

- Check proposal validation only if address is not a space member

### How to test

1. Connect with `0xa53D1eED800BD55d15C01733C2647AC77017aaA8` using impersonator
2. Go to http://127.0.0.1:8080/#/s:gitcoindao.eth/create you should not see proposal validation error (different issue)
