### PR TITLE
fix: use system theme if there is no preference

### DIFF
--- a/apps/ui/src/composables/useUserSkin.ts
+++ b/apps/ui/src/composables/useUserSkin.ts
@@ -1,9 +1,10 @@
 type Skin = 'dark' | 'light' | 'none';
 
+const preferredColor = usePreferredColorScheme();
 export function useUserSkin() {
   const store = useStorage<Skin>('skin', 'none');
   const currentMode = computed(() =>
-    ['light', 'none'].includes(store.value) ? 'light' : 'dark'
+    store.value === 'none' ? preferredColor.value : store.value
   );
 
   function toggleSkin() {

--- a/apps/ui/src/composables/useUserSkin.ts
+++ b/apps/ui/src/composables/useUserSkin.ts
@@ -4,7 +4,9 @@ const preferredColor = usePreferredColorScheme();
 export function useUserSkin() {
   const store = useStorage<Skin>('skin', 'none');
   const currentMode = computed(() =>
-    store.value === 'none' ? preferredColor.value : store.value
+    store.value === 'none'
+      ? (preferredColor.value as 'dark' | 'light')
+      : store.value
   );
 
   function toggleSkin() {


### PR DESCRIPTION
### Summary
- Use system theme if there is theme preference (similar to v1)

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1073

### How to test

1. Open app in incognito
2. Switch system settings to use light and dark themes
