### PR TITLE
fix: completed field on sx proposals

### DIFF
--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -266,7 +266,7 @@ function formatProposal(
     proposal.execution_strategy_type === 'EthRelayer' && baseNetworkId
       ? baseNetworkId
       : networkId;
-
+  const state = getProposalState(networkId, proposal, current);
   return {
     ...proposal,
     space: {
@@ -299,11 +299,12 @@ function formatProposal(
     )
       ? proposal.max_end <= current
       : proposal.min_end <= current,
-    state: getProposalState(networkId, proposal, current),
+    state,
     network: networkId,
     privacy: null,
     quorum: +proposal.quorum,
-    flagged: false
+    flagged: false,
+    completed: ['passed', 'executed', 'rejected'].includes(state)
   };
 }
 

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -400,6 +400,7 @@ watchEffect(() => {
             <button
               v-if="
                 proposal.network === 's' &&
+                proposal.completed &&
                 ['passed', 'rejected', 'executed'].includes(proposal.state)
               "
               class="mt-2.5 inline-flex items-center gap-2 hover:text-skin-link"


### PR DESCRIPTION
### Summary

Issue 1:
- All SX proposals have `completed` field as `undefined` so we display this message on all proposals
- Example space: https://snapshot.box/#/sn:0x07bd3419669f9f0cc8f19e9e2457089cdd4804a4c41a5729ee9c7fd02ab8ab62/proposals
- <img width="1151" alt="image" src="https://github.com/user-attachments/assets/b351a0bd-bd20-4602-b84d-0aadb98680b2" />

Issue 2:
- Also if a proposal is not completed we should not show the download button 
- Example proposal: https://snapshot.box/#/s:thanku.eth/proposal/0x9201a8459b93a29e1e0cf76fb73d5c0364f963a659cdbeed8827cbb50fb5e5f6
- <img width="350" alt="image" src="https://github.com/user-attachments/assets/8bf1472d-bb34-424f-bd4e-abd0af15def6" />



### How to test

1. Go to [SX space](http://localhost:8080/#/sn:0x07bd3419669f9f0cc8f19e9e2457089cdd4804a4c41a5729ee9c7fd02ab8ab62/proposals)
2. Should not show "finalizing results" message

1. Go to [proposal that is finalizing ](http://127.0.0.1:8080/#/s:thanku.eth/proposal/0x9201a8459b93a29e1e0cf76fb73d5c0364f963a659cdbeed8827cbb50fb5e5f6)
2. Should not show download button now
