### PR TITLE
fix: hide welcome popup on whitelabel domain

### DIFF
--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -222,7 +222,7 @@ router.afterEach(() => {
       @add="handleTransactionAccept"
       @close="handleTransactionReject"
     />
-    <FlashMessageWelcome />
+    <FlashMessageWelcome v-if="!whiteLabelSpace" />
   </div>
 </template>
 


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/360

### How to test
 
1. Run `VITE_WHITE_LABEL_MAPPING='127.0.0.1;balancer.eth' yarn dev`
2. Go to http://127.0.0.1:8080/#/ on incognito 
3. You should not see welcome popup like before
4. Go to http://localhost:8080/#/home
5. You should still see popup
