### PR TITLE
fix: use space favicon on white label domains

### DIFF
--- a/apps/ui/src/views/Space.vue
+++ b/apps/ui/src/views/Space.vue
@@ -36,7 +36,7 @@ watch(
 );
 
 watchEffect(() => {
-  if (!space.value || isWhiteLabel.value) {
+  if (!space.value) {
     setFavicon(null);
     return;
   }


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/361

### How to test

1. Run `VITE_WHITE_LABEL_MAPPING='127.0.0.1;balancer.eth' yarn dev`
2. Go to http://127.0.0.1:8080/#/ on incognito 
3. You should see  balancer space's favicon
4. Go to http://localhost:8080/#/home
5. You should still see favicon according to route


<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
