### PR TITLE
fix: proposal timeline types

### DIFF
--- a/apps/ui/src/components/EditorTimeline.vue
+++ b/apps/ui/src/components/EditorTimeline.vue
@@ -86,7 +86,7 @@ function formatVotingDuration(
       :data="
         isOffchainSpace || !editable
           ? {
-              ...space,
+              network: space.network,
               created,
               start,
               min_end,

--- a/apps/ui/src/components/ProposalTimeline.vue
+++ b/apps/ui/src/components/ProposalTimeline.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { _t } from '@/helpers/utils';
-import { Proposal, Space } from '@/types';
+import { NetworkID, Proposal, Space } from '@/types';
 
 type ProposalTimelineValues = {
   created?: number;
@@ -9,12 +9,18 @@ type ProposalTimelineValues = {
   max_end: number;
 };
 
+type ProposalTimelineInput = {
+  network: NetworkID;
+} & ProposalTimelineValues;
+
 type State = {
   id: keyof typeof LABELS;
   value: number;
 };
 
-const props = defineProps<{ data: Proposal | Space }>();
+const props = defineProps<{
+  data: Proposal | Space | ProposalTimelineInput;
+}>();
 
 const LABELS = {
   created: 'Created',


### PR DESCRIPTION
### Summary

`yarn typecheck doesn't work on https://github.com/snapshot-labs/sx-monorepo/pull/954#issuecomment-2571711076

Throws this error:
```bash
ui:typecheck: src/components/EditorTimeline.vue:91:15 - error TS2322: Type 'Space | { created: number; start: number; min_end: number; max_end: number; id: string; network: NetworkID; verified: boolean; turbo: boolean; snapshot_chain_id?: number | undefined; ... 43 more ...; additionalRawData?: OffchainAdditionalRawData | undefined; }' is not assignable to type 'Space | Proposal'.
ui:typecheck:   Object literal may only specify known properties, and 'start' does not exist in type 'Space'.
ui:typecheck: 
ui:typecheck: 91               start,
ui:typecheck:                  ~~~~~
ui:typecheck: 
ui:typecheck:   src/components/ProposalTimeline.vue:17:29
ui:typecheck:     17 const props = defineProps<{ data: Proposal | Space }>();
ui:typecheck:                                    ~~~~
ui:typecheck:     The expected type comes from property 'data' which is declared here on type 'Partial<{}> & Omit<{ readonly data: Space | Proposal; } & VNodeProps & AllowedComponentProps & ComponentCustomProps & Readonly<...>, never> & Record<...>'
ui:typecheck: 
ui:typecheck: 
ui:typecheck: Found 1 error in src/components/EditorTimeline.vue:91
ui:typecheck: 
```

### How to test

1. Run `yarn typecheck`
2. Should run without errors

