### PR TITLE
fix: Use etherscan API v2 to use it for multichain

### DIFF
--- a/apps/ui/src/helpers/etherscan.ts
+++ b/apps/ui/src/helpers/etherscan.ts
@@ -2,23 +2,17 @@ import { call } from './call';
 import { getProvider } from './provider';
 
 export async function getABI(chainId: number, address: string) {
-  let apiHost: string;
-  if (chainId === 1) apiHost = 'https://api.etherscan.io';
-  else if (chainId === 10) apiHost = 'https://api-optimistic.etherscan.io';
-  else if (chainId === 137) apiHost = 'https://api.polygonscan.com';
-  else if (chainId === 8453) apiHost = 'https://api.basescan.org';
-  else if (chainId === 42161) apiHost = 'https://api.arbiscan.io';
-  else if (chainId === 11155111) apiHost = 'https://api-sepolia.etherscan.io';
-  else throw new Error('Unsupported chainId');
+  const apiHost = `https://api.etherscan.io/v2/api`;
 
   const params = new URLSearchParams({
+    chainid: chainId.toString(),
     module: 'contract',
     action: 'getAbi',
     address,
     apikey: import.meta.env.VITE_ETHERSCAN_API_KEY || ''
   });
 
-  const res = await fetch(`${apiHost}/api?${params}`);
+  const res = await fetch(`${apiHost}?${params}`);
   const { result } = await res.json();
   const abi = JSON.parse(result);
 


### PR DESCRIPTION
### Summary
- Current API works only with Ethereum (if you try to use contract call execution on base, it will ask for ABI instead of fetching it)
- Update etherscan API url to use v2 so it works for multichain with single API key

### How to test

1. Go to http://127.0.0.1:8080/#/s:nation3.eth/create
2. Use contract call execution on Ethereum using contract `0x524cab2ec69124574082676e6f654a18df49a048`
3. It should get ABI and show methods 
<img width="423" alt="Untitled 6" src="https://github.com/user-attachments/assets/cbfcd501-8943-4fa0-96a3-98b6e50682f2" />

4. Go to http://127.0.0.1:8080/#/base:0xED3b9f4B7AbFd08c0C73b665D732083e63316DfD/create
5. Use contract call execution on base using contract `0x14a03056324c4102b85d175be2fa299f85e18581`
6. It should get ABI and show methods
7. <img width="445" alt="Untitled 7" src="https://github.com/user-attachments/assets/7824f4c2-4cb5-4360-80a3-17d4cb91663c" />


