### PR TITLE
fix: show Verify signature message for offchain votes

### DIFF
--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -277,7 +277,11 @@ watch([sortBy, choiceFilter], () => {
                       :class="{ 'opacity-80': active }"
                     >
                       <IH-arrow-sm-right class="-rotate-45" :width="16" />
-                      View on block explorer
+                      {{
+                        offchainNetworks.includes(proposal.network)
+                          ? 'Verify signature'
+                          : 'View on block explorer'
+                      }}
                     </a>
                   </UiDropdownItem>
                   <UiDropdownItem v-slot="{ active }">


### PR DESCRIPTION
### Summary

Offchain votes are not on explorers so we update the message to better reflect this link's purpose.

Closes: https://github.com/snapshot-labs/workflow/issues/295

### How to test

1. Go to http://localhost:8080/#/s:kuikuailian.eth/proposal/0xcbc595f8569a6378f899784f7c2c5ff42e56d3183fde27d31002f1f96f86b56c/votes
2. Click on three dots, you see Verify signature link.

### Screenshots

<img width="284" alt="image" src="https://github.com/user-attachments/assets/fcbed38f-3cde-4df2-b77e-bcfa41970c73" />
