### PR TITLE
fix: remove unsupported Gitcoin Passport stamps

### DIFF
--- a/apps/ui/src/components/Modal/SelectValidation.vue
+++ b/apps/ui/src/components/Modal/SelectValidation.vue
@@ -196,6 +196,11 @@ function handleSelect(validationDetails: ValidationDetails) {
     form.value.scoreThreshold ??= 0;
     form.value.operator ??= 'NONE';
     form.value.stamps ??= [];
+
+    // Remove unsupported options
+    form.value.stamps = definition.value.properties.stamps.options
+      .filter(option => form.value.stamps.includes(option.id))
+      .map(option => option.id);
   }
 }
 


### PR DESCRIPTION
### Summary

Now if unsupported stamp is in the space settings it will be removed from the list (same behavior as on v1).

Closes: https://github.com/snapshot-labs/workflow/issues/349

### How to test

1. Go to http://localhost:8080/#/s:gitcoindao.eth/settings/proposal
2. You can select some stamps without errors.
3. Apply changes.
4. Open gitcoin passport validation again.
5. What you selected is still there.

