### PR TITLE
feat: add closed proposal status for non-basic proposals

### DIFF
--- a/apps/ui/src/components/ProposalIconStatus.vue
+++ b/apps/ui/src/components/ProposalIconStatus.vue
@@ -39,7 +39,7 @@ const style = computed(() => ({
       class="text-skin-link"
       :style="style"
     />
-    <IH-minus-circle
+    <IS-minus-circle
       v-else-if="state === 'closed'"
       class="text-skin-link"
       :style="style"

--- a/apps/ui/src/components/ProposalIconStatus.vue
+++ b/apps/ui/src/components/ProposalIconStatus.vue
@@ -5,6 +5,7 @@ const titles: Record<ProposalState, string> = {
   pending: 'Pending',
   active: 'Active',
   passed: 'Passed',
+  closed: 'Closed',
   rejected: 'Rejected',
   executed: 'Executed'
 };
@@ -35,6 +36,11 @@ const style = computed(() => ({
     />
     <IS-check-circle
       v-else-if="state === 'passed'"
+      class="text-skin-link"
+      :style="style"
+    />
+    <IH-minus-circle
+      v-else-if="state === 'closed'"
       class="text-skin-link"
       :style="style"
     />

--- a/apps/ui/src/components/ProposalStatus.vue
+++ b/apps/ui/src/components/ProposalStatus.vue
@@ -5,6 +5,7 @@ const titles: Record<ProposalState, string> = {
   pending: 'Pending',
   active: 'Active',
   passed: 'Passed',
+  closed: 'Closed',
   rejected: 'Rejected',
   executed: 'Executed'
 };
@@ -17,10 +18,10 @@ defineProps<{ state: ProposalState }>();
     :class="{
       'bg-gray-400': state === 'pending',
       'bg-skin-success': state === 'active',
-      'bg-skin-link': state === 'passed',
+      'bg-skin-link': ['passed', 'closed'].includes(state),
       'bg-purple-500': state === 'executed',
       'bg-skin-danger': state === 'rejected',
-      '!text-skin-bg': state === 'passed'
+      '!text-skin-bg': ['passed', 'closed'].includes(state)
     }"
     class="inline-block rounded-full pl-2 pr-[10px] pb-0.5 text-white mb-2"
   >
@@ -34,6 +35,10 @@ defineProps<{ state: ProposalState }>();
     />
     <IS-check-circle
       v-else-if="state === 'passed'"
+      class="text-skin-bg inline-block size-[17px] mb-[1px]"
+    />
+    <IH-minus-circle
+      v-else-if="state === 'closed'"
       class="text-skin-bg inline-block size-[17px] mb-[1px]"
     />
     <IS-play

--- a/apps/ui/src/components/ProposalStatus.vue
+++ b/apps/ui/src/components/ProposalStatus.vue
@@ -37,7 +37,7 @@ defineProps<{ state: ProposalState }>();
       v-else-if="state === 'passed'"
       class="text-skin-bg inline-block size-[17px] mb-[1px]"
     />
-    <IH-minus-circle
+    <IS-minus-circle
       v-else-if="state === 'closed'"
       class="text-skin-bg inline-block size-[17px] mb-[1px]"
     />

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -82,9 +82,12 @@ function getProposalState(
     });
 
     if (currentQuorum < proposal.quorum) return 'rejected';
-    return proposal.type !== 'basic' || proposal.scores[0] > proposal.scores[1]
-      ? 'passed'
-      : 'rejected';
+
+    if (proposal.type !== 'basic') {
+      return 'closed';
+    }
+
+    return proposal.scores[0] > proposal.scores[1] ? 'passed' : 'rejected';
   }
 
   return proposal.state;

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -9,6 +9,7 @@ export type ProposalState =
   | 'active'
   | 'passed'
   | 'rejected'
+  | 'closed'
   | 'executed';
 
 export type NetworkID =

--- a/apps/ui/src/views/My/Home.vue
+++ b/apps/ui/src/views/My/Home.vue
@@ -151,7 +151,7 @@ watch(
               key: 'closed',
               label: 'Closed',
               component: ProposalIconStatus,
-              componentProps: { ...selectIconBaseProps, state: 'passed' }
+              componentProps: { ...selectIconBaseProps, state: 'closed' }
             }
           ]"
         />

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -145,7 +145,7 @@ watchEffect(() => setTitle(`Proposals - ${props.space.name}`));
               key: 'closed',
               label: 'Closed',
               component: ProposalIconStatus,
-              componentProps: { ...selectIconBaseProps, state: 'passed' }
+              componentProps: { ...selectIconBaseProps, state: 'closed' }
             }
           ]"
         />


### PR DESCRIPTION
### Summary

Non basic proposals will now use Closed status instead of Passed.

Closes: https://github.com/snapshot-labs/workflow/issues/342

Wasn't sure about icons/colors to be used. Let me know what should be used @bonustrack

### How to test

1. Go to http://localhost:8080/#/s:veyfi.eth/proposals
2. Go to http://localhost:8080/#/s:veyfi.eth/proposal/0xdfdf20a60f67ee7d55125699121924070e18dd1df65ca7c27b88d1bce52d4f1d
3. Non-basic proposals have Closed status.

### Screenshots

<img width="784" alt="image" src="https://github.com/user-attachments/assets/58d15883-4bde-4477-9337-e1a40f83ccd9" />
<img width="562" alt="image" src="https://github.com/user-attachments/assets/b415c158-8928-43dc-bb6c-44e78db4de47" />
