### PR TITLE
feat: allow to go back on space creation

### DIFF
--- a/apps/ui/src/components/CreateDeploymentProgress.vue
+++ b/apps/ui/src/components/CreateDeploymentProgress.vue
@@ -44,6 +44,10 @@ const props = defineProps<{
   controller: string;
 }>();
 
+const emit = defineEmits<{
+  (e: 'back');
+}>();
+
 const { deployDependency, createSpace } = useActions();
 const { web3, login } = useWeb3();
 
@@ -248,14 +252,19 @@ onMounted(() => deploy());
         </div>
         <div>
           <h4 v-text="step.title" />
-          <button
-            v-if="failed && i === currentStep"
-            type="button"
-            class="text-skin-text"
-            @click="deploy(currentStep)"
-          >
-            Retry
-          </button>
+          <div v-if="failed && i === currentStep" class="flex gap-2">
+            <button
+              type="button"
+              class="text-skin-text"
+              @click="deploy(currentStep)"
+            >
+              Retry
+            </button>
+            <span>&middot;</span>
+            <button type="button" class="text-skin-text" @click="emit('back')">
+              Modify space details
+            </button>
+          </div>
           <a
             v-if="txIds[step.id]"
             class="inline-flex items-center"

--- a/apps/ui/src/views/Create.vue
+++ b/apps/ui/src/views/Create.vue
@@ -180,6 +180,7 @@ watchEffect(() => setTitle('Create space'));
       :voting-strategies="votingStrategies"
       :execution-strategies="executionStrategies"
       :controller="controller"
+      @back="confirming = false"
     />
     <div v-else class="pt-5 flex max-w-[50rem] mx-auto px-4">
       <div


### PR DESCRIPTION
### Summary

With this change now it's possible to go back to space creation form to make adjustments.

Closes: https://github.com/snapshot-labs/workflow/issues/309

### How to test

1. Go to http://localhost:8080/#/create
2. Try to create space.
3. Once on deployment page and you get prompted to confirm transaction in the wallet  **reject it**.
4. You will now see now option to `Modify space details`.
5. If you click it you can modify space before trying to deploy it again.

### Screenshots

<img width="583" alt="image" src="https://github.com/user-attachments/assets/0681eb3a-016b-48a2-b981-33b42c481a79" />
