### PR TITLE
fix: update privacy checks to match new type

### DIFF
--- a/apps/ui/src/components/Modal/Vote.vue
+++ b/apps/ui/src/components/Modal/Vote.vue
@@ -202,7 +202,7 @@ watchEffect(async () => {
           v-text="formattedVotingPower"
         />
       </dl>
-      <div v-if="!proposal.privacy" class="s-box">
+      <div v-if="proposal.privacy === 'none'" class="s-box">
         <UiForm
           v-model="form"
           :error="formErrors"

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -135,7 +135,7 @@ onMounted(() => {
   </div>
   <div
     v-else-if="
-      !!props.proposal.privacy &&
+      props.proposal.privacy !== 'none' &&
       props.proposal.state === 'active' &&
       withDetails
     "
@@ -193,7 +193,7 @@ onMounted(() => {
           v-text="proposal.choices[result.choice - 1]"
         />
         <IH-lock-closed
-          v-if="!!proposal.privacy && !proposal.completed"
+          v-if="proposal.privacy !== 'none' && !proposal.completed"
           class="size-[16px] shrink-0"
         />
         <template v-else>
@@ -236,7 +236,7 @@ onMounted(() => {
       </div>
     </div>
     <div
-      v-else-if="!props.proposal.privacy || props.proposal.completed"
+      v-else-if="props.proposal.privacy === 'none' || props.proposal.completed"
       class="h-full flex items-center"
     >
       <div

--- a/apps/ui/src/components/ProposalVote.vue
+++ b/apps/ui/src/components/ProposalVote.vue
@@ -65,7 +65,7 @@ const isEditable = computed(() => {
       @click="$emit('enterEditMode')"
     >
       <div
-        v-if="proposal.privacy"
+        v-if="proposal.privacy !== 'none'"
         class="flex space-x-2 items-center grow truncate text-skin-link"
       >
         <IH-lock-closed class="size-[16px] shrink-0" />

--- a/apps/ui/src/components/ProposalVoteApproval.vue
+++ b/apps/ui/src/components/ProposalVoteApproval.vue
@@ -13,7 +13,9 @@ const emit = defineEmits<{
 }>();
 
 const selectedChoices = ref<ApprovalChoice>(
-  (!props.proposal.privacy && (props.defaultChoice as ApprovalChoice)) || []
+  (props.proposal.privacy === 'none' &&
+    (props.defaultChoice as ApprovalChoice)) ||
+    []
 );
 
 function toggleSelectedChoice(choice: number) {

--- a/apps/ui/src/components/ProposalVoteChoice.vue
+++ b/apps/ui/src/components/ProposalVoteChoice.vue
@@ -16,7 +16,7 @@ withDefaults(
 
 <template>
   <div
-    v-if="!!proposal.privacy && !proposal.completed"
+    v-if="proposal.privacy !== 'none' && !proposal.completed"
     class="flex gap-1 items-center"
   >
     <span class="text-skin-heading leading-[22px]">Encrypted choice</span>

--- a/apps/ui/src/components/ProposalVoteRankedChoice.vue
+++ b/apps/ui/src/components/ProposalVoteRankedChoice.vue
@@ -14,7 +14,8 @@ const emit = defineEmits<{
 }>();
 
 const selectedChoices = ref<RankedChoice>(
-  (!props.proposal.privacy && (props.defaultChoice as RankedChoice)) ||
+  (props.proposal.privacy === 'none' &&
+    (props.defaultChoice as RankedChoice)) ||
     props.proposal.choices.map((_, i) => i + 1)
 );
 </script>

--- a/apps/ui/src/components/ProposalVoteSingleChoice.vue
+++ b/apps/ui/src/components/ProposalVoteSingleChoice.vue
@@ -11,7 +11,7 @@ const emit = defineEmits<{
 }>();
 
 const selectedChoice = ref<number | null>(
-  (!props.proposal.privacy && (props.defaultChoice as number)) || null
+  (props.proposal.privacy === 'none' && (props.defaultChoice as number)) || null
 );
 </script>
 

--- a/apps/ui/src/components/ProposalVoteWeighted.vue
+++ b/apps/ui/src/components/ProposalVoteWeighted.vue
@@ -14,7 +14,9 @@ defineEmits<{
 }>();
 
 const selectedChoices = ref<WeightedChoice>(
-  (!props.proposal.privacy && (props.defaultChoice as WeightedChoice)) || {}
+  (props.proposal.privacy === 'none' &&
+    (props.defaultChoice as WeightedChoice)) ||
+    {}
 );
 
 function increaseChoice(index: number) {

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -336,7 +336,7 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     tx: '',
     execution_tx: null,
     veto_tx: null,
-    privacy: proposal.privacy,
+    privacy: proposal.privacy || 'none',
     flagged: proposal.flagged
   };
 }

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -1,7 +1,6 @@
 import {
   DelegationType,
   NetworkID,
-  Privacy,
   SpaceMetadataLabel,
   VoteType
 } from '@/types';
@@ -126,7 +125,7 @@ export type ApiProposal = {
   created: number;
   updated: number | null;
   votes: number;
-  privacy: Privacy;
+  privacy: 'shutter' | '';
   plugins: Record<string, any>;
   flagged: boolean;
 };


### PR DESCRIPTION
### Summary

Old checks expected no-privacy proposals to use null, but now it's string 'none'.

We have to update checks to match.

Regression form https://github.com/snapshot-labs/sx-monorepo/pull/954

### How to test

1. Go there: http://localhost:8080/#/base:0x282d013BF31374D0046F04D6a7644d97751ed339/proposal/6
2. It works as expected (results are visible, votes have choice visible, you can use Reason in vote modal).
