### PR TITLE
feat: take into account `hideAbstain` when computing results

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -61,10 +61,6 @@ const results = computed(() => {
 
       const progress = parsedTotal !== 0 ? (score / parsedTotal) * 100 : 0;
 
-      if (hideAbstain.value && i === 2) {
-        return;
-      }
-
       return {
         choice: i + 1,
         progress,

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -31,6 +31,8 @@ const proposalsStore = useProposalsStore();
 
 const displayAllChoices = ref(false);
 
+const hideAbstain = computed(() => props.proposal.hide_abstain ?? false);
+
 const totalProgress = computed(() => quorumProgress(props.proposal));
 
 const placeholderResults = computed(() =>
@@ -45,12 +47,18 @@ const results = computed(() => {
   if (!props.proposal.scores.length) return placeholderResults.value;
 
   // TODO: sx-api returns number, sx-subgraph returns string
-  const parsedTotal = parseFloat(
+  let parsedTotal = parseFloat(
     props.proposal.scores_total as unknown as string
   );
 
+  if (hideAbstain.value && props.proposal.type === 'basic') {
+    parsedTotal = props.proposal.scores[0] + props.proposal.scores[1];
+  }
+
   return props.proposal.scores
     .map((score, i) => {
+      if (hideAbstain.value && i === 2) return;
+
       const progress = parsedTotal !== 0 ? (score / parsedTotal) * 100 : 0;
 
       return {
@@ -59,6 +67,7 @@ const results = computed(() => {
         score
       };
     })
+    .filter(r => !!r)
     .sort((a, b) => b.progress - a.progress);
 });
 

--- a/apps/ui/src/helpers/quorum.test.ts
+++ b/apps/ui/src/helpers/quorum.test.ts
@@ -5,7 +5,8 @@ describe('getProposalCurrentQuorum', () => {
   it('should only use for and abstain votes for onchain spaces', () => {
     const currentQuorum = getProposalCurrentQuorum('eth', {
       scores: [11, 20, 100],
-      scores_total: 131
+      scores_total: 131,
+      type: 'basic'
     });
 
     expect(currentQuorum).toBe(111);
@@ -14,7 +15,8 @@ describe('getProposalCurrentQuorum', () => {
   it('should use total score for offchain spaces', () => {
     const currentQuorum = getProposalCurrentQuorum('s', {
       scores: [11, 20, 100],
-      scores_total: 131
+      scores_total: 131,
+      type: 'basic'
     });
 
     expect(currentQuorum).toBe(131);
@@ -24,7 +26,8 @@ describe('getProposalCurrentQuorum', () => {
     const currentQuorum = getProposalCurrentQuorum('s', {
       scores: [11, 20, 100],
       scores_total: 131,
-      quorum_type: 'rejection'
+      quorum_type: 'rejection',
+      type: 'basic'
     });
 
     expect(currentQuorum).toBe(20);

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -26,7 +26,8 @@ import {
   Transaction,
   User,
   UserActivity,
-  Vote
+  Vote,
+  VoteType
 } from '@/types';
 import {
   PROPOSAL_QUERY as HIGHLIGHT_PROPOSAL_QUERY,
@@ -68,7 +69,9 @@ function getProposalState(
   const quorum = BigInt(proposal.quorum);
   const currentQuorum = getProposalCurrentQuorum(networkId, {
     scores: [proposal.scores_1, proposal.scores_2, proposal.scores_3],
-    scores_total: proposal.scores_total
+    scores_total: proposal.scores_total,
+    type: 'basic' as VoteType,
+    hide_abstain: false
   });
   const scoresFor = BigInt(proposal.scores_1);
   const scoresAgainst = BigInt(proposal.scores_2);

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -78,7 +78,9 @@ function getProposalState(
   if (proposal.state === 'closed') {
     const currentQuorum = getProposalCurrentQuorum(networkId, {
       scores: proposal.scores,
-      scores_total: proposal.scores_total
+      scores_total: proposal.scores_total,
+      type: proposal.type,
+      hide_abstain: proposal.space.voting.hideAbstain
     });
 
     if (currentQuorum < proposal.quorum) return 'rejected';
@@ -296,6 +298,7 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     snapshot: proposal.snapshot,
     quorum: proposal.quorum,
     quorum_type: proposal.quorumType,
+    hide_abstain: proposal.space.voting.hideAbstain,
     choices: proposal.choices,
     labels: proposal.labels,
     scores: proposal.scores,

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -120,6 +120,9 @@ const PROPOSAL_FRAGMENT = gql`
       moderators
       symbol
       terms
+      voting {
+        hideAbstain
+      }
     }
     type
     title

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -104,6 +104,9 @@ export type ApiProposal = {
     moderators: string[];
     symbol: string;
     terms: string;
+    voting: {
+      hideAbstain: boolean;
+    };
   };
   type: VoteType;
   title: string;

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -234,6 +234,7 @@ export type Proposal = {
   type: VoteType;
   quorum: number;
   quorum_type?: 'default' | 'rejection';
+  hide_abstain?: boolean;
   space: {
     id: string;
     name: string;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/380

This PR uses the `hideAbstain` property in the space settings, when computing results.

When `hideAbstain` is enabled, `abstain` in basic voting is ignored from the quorum and results

```
// when hide_abstain = false
total_score = for_score + against_score + abstain_score

// when hide_abstain = true
total_score = for_score + against_score 
```

### How to test

1. Go to a space with `hideAbstain` enabled: http://localhost:8080/#/s:safe.eth/proposal/0x5cf64434792565591b005460db0460e9314753178d4aa5475dfc0ce4d45638a2
2. The results should exclude `abstain` choice from the results list, and quorum should not take abstain scores into account. Results should be same as v1 https://v1.snapshot.box/#/safe.eth/proposal/0x5cf64434792565591b005460db0460e9314753178d4aa5475dfc0ce4d45638a2

## Notes

Excluding ABSTAIN from all scores results in lower quorum, and is marking a proposal that have passed before this PR as rejected (see the example proposal above)

Since the `hide_abstain` option can change proposal outcome depending on its setting, it should not be a global option, and each proposal should have its own local copy (like `privacy`)