### PR TITLE
fix: Default quorum to zero

### DIFF
--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -151,7 +151,7 @@ export function useSpaceSettings(space: Ref<Space>) {
   const quorumType = ref(
     'default' as NonNullable<OffchainApiSpace['voting']['quorumType']>
   );
-  const quorum = ref(1 as string | number);
+  const quorum = ref(0 as string | number);
   const voteType = ref(
     'any' as
       | 'any'
@@ -425,7 +425,7 @@ export function useSpaceSettings(space: Ref<Space>) {
 
     return {
       quorumType: space.additionalRawData?.voting.quorumType ?? 'default',
-      quorum: space.additionalRawData?.voting.quorum ?? 1,
+      quorum: space.additionalRawData?.voting.quorum ?? 0,
       votingType:
         !spaceVoteType || spaceVoteType === 'custom' ? 'any' : spaceVoteType,
       privacy: validPrivacyTypes.includes(privacyValue as string)


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1095

### How to test

1. Go to your space settings
2. Update quorum to `0`
3. Save settings
4. Reload
5. You should see `0` after fix instead `1`
