### PR TITLE
feat: add network icon to UiInputAddress

### DIFF
--- a/apps/ui/src/components/FormController.vue
+++ b/apps/ui/src/components/FormController.vue
@@ -1,23 +1,26 @@
 <script setup lang="ts">
 import { validateForm } from '@/helpers/validation';
+import { ChainId } from '@/types';
 
 const model = defineModel<string>({ required: true });
 
-defineProps<{
+const props = defineProps<{
   title: string;
   description?: string;
+  chainId: ChainId;
 }>();
 
 const emit = defineEmits<{
   (e: 'errors', value: any);
 }>();
 
-const definition = {
+const definition = computed(() => ({
   type: 'string',
   format: 'address',
+  chainId: props.chainId,
   title: 'Space controller',
   examples: ['0x0000…']
-};
+}));
 
 const formErrors = computed(() =>
   validateForm(
@@ -27,7 +30,7 @@ const formErrors = computed(() =>
       additionalProperties: false,
       required: ['controller'],
       properties: {
-        controller: definition
+        controller: definition.value
       }
     },
     {
@@ -42,7 +45,8 @@ watch(formErrors, value => emit('errors', value));
 <template>
   <UiContainerSettings :title="title" :description="description">
     <div class="s-box">
-      <UiInputString
+      <UiInputAddress
+        :show-picker="false"
         :model-value="model"
         :error="formErrors.controller"
         :definition="definition"

--- a/apps/ui/src/components/FormSpaceController.vue
+++ b/apps/ui/src/components/FormSpaceController.vue
@@ -54,6 +54,7 @@ function handleSave(value: string) {
     <teleport to="#modal">
       <ModalChangeController
         :open="changeControllerModalOpen"
+        :chain-id="network.chainId"
         :initial-state="{ controller }"
         @close="changeControllerModalOpen = false"
         @save="handleSave"

--- a/apps/ui/src/components/Modal/Delegate.vue
+++ b/apps/ui/src/components/Modal/Delegate.vue
@@ -22,23 +22,6 @@ const emit = defineEmits<{
   (e: 'close');
 }>();
 
-const DELEGATEE_DEFINITION = {
-  type: 'string',
-  format: 'ens-or-address',
-  title: 'Delegatee',
-  examples: ['Address or ENS']
-};
-
-const formValidator = getValidator({
-  $async: true,
-  type: 'object',
-  additionalProperties: false,
-  required: ['delegatee'],
-  properties: {
-    delegatee: DELEGATEE_DEFINITION
-  }
-});
-
 const { delegate } = useActions();
 
 const form: {
@@ -50,6 +33,26 @@ const showPicker = ref(false);
 const searchValue = ref('');
 const sending = ref(false);
 const formErrors = ref({} as Record<string, any>);
+
+const delegateDefinition = computed(() => ({
+  type: 'string',
+  format: 'ens-or-address',
+  chainId: props.delegation?.chainId ?? undefined,
+  title: 'Delegatee',
+  examples: ['Address or ENS']
+}));
+
+const formValidator = computed(() =>
+  getValidator({
+    $async: true,
+    type: 'object',
+    additionalProperties: false,
+    required: ['delegatee'],
+    properties: {
+      delegatee: delegateDefinition.value
+    }
+  })
+);
 
 const selectedDelegation = computed<SpaceMetadataDelegation>(() => {
   return props.delegation || props.space.delegations[form.selectedIndex];
@@ -138,7 +141,7 @@ watch(
 watchEffect(async () => {
   formValidated.value = false;
 
-  formErrors.value = await formValidator.validateAsync(form);
+  formErrors.value = await formValidator.value.validateAsync(form);
   formValidated.value = true;
 });
 </script>
@@ -191,7 +194,7 @@ watchEffect(async () => {
       />
       <UiInputAddress
         v-model="form.delegatee"
-        :definition="DELEGATEE_DEFINITION"
+        :definition="delegateDefinition"
         :error="formErrors.delegatee"
         @pick="showPicker = true"
       />

--- a/apps/ui/src/components/Modal/DelegationConfig.vue
+++ b/apps/ui/src/components/Modal/DelegationConfig.vue
@@ -79,6 +79,7 @@ const definition = computed(() => {
                     title: 'Delegation contract address',
                     examples: ['0x0000…'],
                     format: 'address',
+                    chainId: form.value.chainId,
                     minLength: 1
                   }
                 }

--- a/apps/ui/src/components/Modal/SendNft.vue
+++ b/apps/ui/src/components/Modal/SendNft.vue
@@ -10,13 +10,6 @@ const DEFAULT_FORM_STATE = {
   amount: ''
 };
 
-const RECIPIENT_DEFINITION = {
-  type: 'string',
-  format: 'ens-or-address',
-  title: 'Recipient',
-  examples: ['Address or ENS']
-};
-
 const props = defineProps<{
   open: boolean;
   address: string;
@@ -25,16 +18,26 @@ const props = defineProps<{
   initialState?: any;
 }>();
 
-const formValidator = getValidator({
-  $async: true,
-  type: 'object',
-  title: 'TokenTransfer',
-  additionalProperties: false,
-  required: ['to'],
-  properties: {
-    to: RECIPIENT_DEFINITION
-  }
-});
+const recipientDefinition = computed(() => ({
+  type: 'string',
+  format: 'ens-or-address',
+  chainId: props.network,
+  title: 'Recipient',
+  examples: ['Address or ENS']
+}));
+
+const formValidator = computed(() =>
+  getValidator({
+    $async: true,
+    type: 'object',
+    title: 'TokenTransfer',
+    additionalProperties: false,
+    required: ['to'],
+    properties: {
+      to: recipientDefinition.value
+    }
+  })
+);
 
 const emit = defineEmits(['add', 'close']);
 
@@ -111,7 +114,7 @@ watch(
 watchEffect(async () => {
   formValidated.value = false;
 
-  formErrors.value = await formValidator.validateAsync({
+  formErrors.value = await formValidator.value.validateAsync({
     to: form.to
   });
   formValidated.value = true;
@@ -167,7 +170,7 @@ watchEffect(async () => {
     <div v-if="!showPicker" class="s-box p-4">
       <UiInputAddress
         v-model="form.to"
-        :definition="RECIPIENT_DEFINITION"
+        :definition="recipientDefinition"
         :error="formErrors.to"
         @pick="handlePickerClick('contact')"
       />

--- a/apps/ui/src/components/Modal/SendToken.vue
+++ b/apps/ui/src/components/Modal/SendToken.vue
@@ -15,13 +15,6 @@ const DEFAULT_FORM_STATE = {
   value: ''
 };
 
-const RECIPIENT_DEFINITION = {
-  type: 'string',
-  format: 'ens-or-address',
-  title: 'Recipient',
-  examples: ['Address or ENS']
-};
-
 const props = defineProps<{
   open: boolean;
   address: string;
@@ -79,6 +72,14 @@ const currentToken = computed(() => {
   return token;
 });
 
+const recipientDefinition = computed(() => ({
+  type: 'string',
+  format: 'ens-or-address',
+  chainId: props.network,
+  title: 'Recipient',
+  examples: ['Address or ENS']
+}));
+
 const amountDefinition = computed(() => ({
   type: 'string',
   decimals: currentToken.value?.decimals ?? 0,
@@ -94,7 +95,7 @@ const formValidator = computed(() =>
     additionalProperties: false,
     required: ['to', 'amount'],
     properties: {
-      to: RECIPIENT_DEFINITION,
+      to: recipientDefinition.value,
       amount: amountDefinition.value
     }
   })
@@ -278,7 +279,7 @@ watchEffect(async () => {
     <div v-if="!showPicker" class="s-box p-4">
       <UiInputAddress
         v-model="form.to"
-        :definition="RECIPIENT_DEFINITION"
+        :definition="recipientDefinition"
         :error="formErrors.to"
         @pick="handlePickerClick('contact')"
       />

--- a/apps/ui/src/components/Modal/Transaction.vue
+++ b/apps/ui/src/components/Modal/Transaction.vue
@@ -7,7 +7,7 @@ import { resolver } from '@/helpers/resolver';
 import { createContractCallTransaction } from '@/helpers/transactions';
 import { abiToDefinition, clone } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
-import { Contact } from '@/types';
+import { ChainId, Contact } from '@/types';
 
 const DEFAULT_FORM_STATE = {
   to: '',
@@ -19,7 +19,7 @@ const DEFAULT_FORM_STATE = {
 
 const props = defineProps<{
   open: boolean;
-  network: number | string;
+  network: ChainId;
   extraContacts?: Contact[];
   initialState?: any;
 }>();
@@ -66,7 +66,7 @@ const definition = computed(() => {
     currentMethod.value.name &&
     currentMethod.value.inputs.length > 0
   ) {
-    return abiToDefinition(currentMethod.value);
+    return abiToDefinition(currentMethod.value, props.network);
   }
 
   return {};
@@ -79,7 +79,8 @@ const formValidator = computed(() =>
     properties: {
       to: {
         type: 'string',
-        format: 'ens-or-address'
+        format: 'ens-or-address',
+        chainId: props.network
       },
       abi: {
         type: 'string',
@@ -309,7 +310,8 @@ watchEffect(async () => {
           :definition="{
             type: 'string',
             title: 'Contract address',
-            examples: ['Address or ENS']
+            examples: ['Address or ENS'],
+            chainId: props.network
           }"
           @pick="handlePickerClick('to')"
         />

--- a/apps/ui/src/components/Modal/TreasuryConfig.vue
+++ b/apps/ui/src/components/Modal/TreasuryConfig.vue
@@ -52,6 +52,7 @@ const definition = computed(() => {
               title: 'Treasury address',
               examples: ['0x0000…'],
               format: 'address',
+              chainId: form.value.chainId,
               minLength: 1
             }
           }

--- a/apps/ui/src/components/Ui/InputAddress.vue
+++ b/apps/ui/src/components/Ui/InputAddress.vue
@@ -1,14 +1,32 @@
-<script lang="ts">
-export default {
-  inheritAttrs: false
-};
-</script>
-
 <script setup lang="ts">
-withDefaults(
+import snapshotJsNetworks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { getUrl } from '@/helpers/utils';
+import { METADATA as STARKNET_NETWORK_METADATA } from '@/networks/starknet';
+
+const STARKNET_NETWORKS = Object.fromEntries(
+  Object.values(STARKNET_NETWORK_METADATA).map(metadata => [
+    metadata.chainId,
+    {
+      name: metadata.name,
+      logoUrl: getUrl(metadata.avatar)
+    }
+  ])
+);
+
+type NetworkDetails = {
+  name: string;
+  logoUrl: string | null;
+};
+
+defineOptions({ inheritAttrs: false });
+
+const props = withDefaults(
   defineProps<{
     showPicker?: boolean;
     path?: string;
+    definition?: {
+      chainId?: number | string;
+    };
   }>(),
   {
     showPicker: true
@@ -18,6 +36,24 @@ withDefaults(
 const emit = defineEmits<{
   (e: 'pick', path: string);
 }>();
+
+const networkDetails = computed<NetworkDetails | null>(() => {
+  const chainId = props.definition?.chainId;
+
+  if (!chainId) return null;
+
+  if (typeof chainId === 'string' && chainId in STARKNET_NETWORKS) {
+    return STARKNET_NETWORKS[chainId];
+  } else if (chainId in snapshotJsNetworks) {
+    const network = snapshotJsNetworks[chainId];
+    return {
+      name: network.name,
+      logoUrl: getUrl(network.logo)
+    };
+  }
+
+  return null;
+});
 </script>
 
 <template>
@@ -27,6 +63,23 @@ const emit = defineEmits<{
         <IH-identification />
       </button>
     </div>
-    <UiInputString v-bind="$attrs as any" class="!pr-7" />
+    <UiTooltip
+      v-if="networkDetails"
+      :title="networkDetails.name"
+      class="!absolute z-10 left-3 top-[29px]"
+    >
+      <img
+        :src="networkDetails.logoUrl ?? undefined"
+        class="size-3.5 rounded-full"
+      />
+    </UiTooltip>
+    <UiInputString
+      :definition="props.definition"
+      v-bind="$attrs as any"
+      class="!pr-7"
+      :class="{
+        '!pl-[42px]': !!networkDetails
+      }"
+    />
   </div>
 </template>

--- a/apps/ui/src/components/Ui/InputAddress.vue
+++ b/apps/ui/src/components/Ui/InputAddress.vue
@@ -2,6 +2,7 @@
 import snapshotJsNetworks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { getUrl } from '@/helpers/utils';
 import { METADATA as STARKNET_NETWORK_METADATA } from '@/networks/starknet';
+import { BaseDefinition } from '@/types';
 
 const STARKNET_NETWORKS = Object.fromEntries(
   Object.values(STARKNET_NETWORK_METADATA).map(metadata => [
@@ -24,7 +25,7 @@ const props = withDefaults(
   defineProps<{
     showPicker?: boolean;
     path?: string;
-    definition?: {
+    definition?: BaseDefinition<string> & {
       chainId?: number | string;
     };
   }>(),

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -14,7 +14,7 @@ import {
 } from 'starknet';
 import { RouteParamsRaw } from 'vue-router';
 import { VotingPowerItem } from '@/stores/votingPowers';
-import { Choice, Proposal, SpaceMetadata } from '@/types';
+import { ChainId, Choice, Proposal, SpaceMetadata } from '@/types';
 import { MAX_SYMBOL_LENGTH } from './constants';
 import pkg from '@/../package.json';
 import ICCoingecko from '~icons/c/coingecko';
@@ -258,7 +258,7 @@ export function _rt(number) {
   }
 }
 
-export function abiToDefinition(abi) {
+export function abiToDefinition(abi, chainId?: ChainId) {
   const definition = {
     $async: true,
     title: abi.name,
@@ -287,6 +287,9 @@ export function abiToDefinition(abi) {
     if (input.type === 'address') {
       definition.properties[input.name].format = 'ens-or-address';
       definition.properties[input.name].examples = ['0x0000…'];
+      if (chainId) {
+        definition.properties[input.name].chainId = chainId;
+      }
     }
     if (input.type.endsWith('[]')) {
       definition.properties[input.name].format = input.type;

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -255,6 +255,7 @@ ajv.addFormat('network', {
 });
 ajv.addKeyword('networkId');
 ajv.addKeyword('networksListKind');
+ajv.addKeyword('chainId');
 
 function getErrorMessage(errorObject: Partial<ErrorObject>): string {
   if (!errorObject.message) return 'Invalid field.';

--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -343,6 +343,7 @@ export function createConstants(networkId: NetworkID) {
           contractAddress: {
             type: 'string',
             format: 'address',
+            chainId: config.Meta.eip712ChainId,
             title: 'Token address',
             examples: ['0x0000…']
           },
@@ -398,6 +399,7 @@ export function createConstants(networkId: NetworkID) {
           contractAddress: {
             type: 'string',
             format: 'address',
+            chainId: config.Meta.eip712ChainId,
             title: 'Token address',
             examples: ['0x0000…']
           },
@@ -455,6 +457,7 @@ export function createConstants(networkId: NetworkID) {
           controller: {
             type: 'string',
             format: 'address',
+            chainId: config.Meta.eip712ChainId,
             title: 'Controller address',
             examples: ['0x0000…']
           },
@@ -466,6 +469,7 @@ export function createConstants(networkId: NetworkID) {
           contractAddress: {
             type: 'string',
             format: 'address',
+            chainId: config.Meta.eip712ChainId,
             title: 'Safe address',
             examples: ['0x0000…']
           }
@@ -510,6 +514,7 @@ export function createConstants(networkId: NetworkID) {
           controller: {
             type: 'string',
             format: 'address',
+            chainId: config.Meta.eip712ChainId,
             title: 'Controller address',
             examples: ['0x0000…']
           },
@@ -521,6 +526,7 @@ export function createConstants(networkId: NetworkID) {
           vetoGuardian: {
             type: 'string',
             format: 'address',
+            chainId: config.Meta.eip712ChainId,
             title: 'Veto guardian address',
             examples: ['0x0000…']
           },
@@ -573,6 +579,7 @@ export function createConstants(networkId: NetworkID) {
           controller: {
             type: 'string',
             format: 'address',
+            chainId: config.Meta.eip712ChainId,
             title: 'Controller address',
             examples: ['0x0000…']
           },
@@ -584,6 +591,7 @@ export function createConstants(networkId: NetworkID) {
           contractAddress: {
             type: 'string',
             format: 'address',
+            chainId: config.Meta.eip712ChainId,
             title: 'Contract address',
             examples: ['0x0000…']
           },
@@ -651,12 +659,14 @@ export function createConstants(networkId: NetworkID) {
           queryAddress: {
             type: 'string',
             format: 'address',
+            chainId: config.Meta.eip712ChainId,
             title: 'Query address',
             examples: ['0x0000…']
           },
           contractAddress: {
             type: 'string',
             format: 'address',
+            chainId: config.Meta.eip712ChainId,
             title: 'Contract address',
             examples: ['0x0000…']
           },

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -138,6 +138,7 @@ export function createConstants(
         contractAddress: {
           type: 'string',
           format: 'address',
+          chainId: baseChainId,
           title: 'Contract address',
           examples: ['0x0000…']
         },
@@ -410,6 +411,7 @@ export function createConstants(
           contractAddress: {
             type: 'string',
             format: 'address',
+            chainId: config.Meta.eip712ChainId,
             title: 'Token address',
             examples: ['0x0000…']
           },
@@ -517,6 +519,7 @@ export function createConstants(
           l1Controller: {
             type: 'string',
             format: 'address',
+            chainId: baseChainId,
             title: 'Controller address',
             examples: ['0x0000…']
           },
@@ -528,6 +531,7 @@ export function createConstants(
           contractAddress: {
             type: 'string',
             format: 'address',
+            chainId: baseChainId,
             title: 'Avatar address',
             examples: ['0x0000…']
           }

--- a/apps/ui/src/views/Create.vue
+++ b/apps/ui/src/views/Create.vue
@@ -286,6 +286,7 @@ watchEffect(() => setTitle('Create space'));
             v-else-if="currentPage === 'controller'"
             v-model="controller"
             title="Controller"
+            :chain-id="selectedNetwork.chainId"
             @errors="v => handleErrors('controller', v)"
           />
         </div>


### PR DESCRIPTION
### Summary

This PR adds network icon with network name in tooltip in UiInputAddress.

Closes: https://github.com/snapshot-labs/workflow/issues/290

### How to test

1. Go to different inputs/modals in space creation form or settings forms.
2. Go to send token/send NFT/contract call modals.
3. Go to delegate voting power modal on delegation page.
4. Inputs have network annotation.

### Screenshots

<img width="657" alt="image" src="https://github.com/user-attachments/assets/c72cfae6-24a9-4a9a-a2ca-da4a23f2e810" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/5bedf0aa-574d-4a22-a587-8045fecf60a2" />
<img width="521" alt="image" src="https://github.com/user-attachments/assets/e4f92eaf-29e2-4b2a-81a7-4db7a26e31f2" />
