### PR TITLE
fix: fix wrong voting power max/min length limit

### DIFF
--- a/apps/ui/src/components/FormSpaceProfile.vue
+++ b/apps/ui/src/components/FormSpaceProfile.vue
@@ -74,8 +74,8 @@ const votingPowerDefinition = computed(() => ({
       type: 'string',
       title: 'Voting power symbol',
       examples: ['e.g. VP'],
-      maxLength: isOffchainNetwork ? 16 : MAX_SYMBOL_LENGTH,
-      minLength: isOffchainNetwork ? 1 : undefined
+      maxLength: isOffchainNetwork.value ? 16 : MAX_SYMBOL_LENGTH,
+      minLength: isOffchainNetwork.value ? 1 : undefined
     }
   }
 }));


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix the incorrect max and min length for the space profile voting power symbol field, which was always returning the limit for offchain

### How to test

1. Go to an offchain/onchain space settings > Profile
2. Focus on the Voting power input
3. The chars counter should show the max limit as 16 for offchain, and 12 for onchain
