### PR TITLE
fix: make the voting power symbol property mandatory for offchain space settings

### DIFF
--- a/apps/ui/src/components/FormSpaceProfile.vue
+++ b/apps/ui/src/components/FormSpaceProfile.vue
@@ -68,7 +68,7 @@ const votingPowerDefinition = computed(() => ({
   type: 'object',
   title: 'Voting power',
   additionalProperties: true,
-  required: [],
+  required: isOffchainNetwork.value ? ['votingPowerSymbol'] : [],
   properties: {
     votingPowerSymbol: {
       type: 'string',


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #1098

This PR will make the voting power symbol property mandatory for offchain space settings, to be in sync with the schema expected by sequencer.

### How to test

1. Go to an offchain space settings
2. Clear the VP symbol field
3. It should show an error
