### PR TITLE
refactor: improve Form component consistency

### DIFF
--- a/apps/ui/src/components/FormController.vue
+++ b/apps/ui/src/components/FormController.vue
@@ -3,6 +3,11 @@ import { validateForm } from '@/helpers/validation';
 
 const model = defineModel<string>({ required: true });
 
+defineProps<{
+  title: string;
+  description?: string;
+}>();
+
 const emit = defineEmits<{
   (e: 'errors', value: any);
 }>();
@@ -35,13 +40,14 @@ watch(formErrors, value => emit('errors', value));
 </script>
 
 <template>
-  <h3>Controller</h3>
-  <div class="s-box pt-4">
-    <UiInputString
-      :model-value="model"
-      :error="formErrors.controller"
-      :definition="definition"
-      @update:model-value="v => (model = v)"
-    />
-  </div>
+  <UiContainerSettings :title="title" :description="description">
+    <div class="s-box">
+      <UiInputString
+        :model-value="model"
+        :error="formErrors.controller"
+        :definition="definition"
+        @update:model-value="v => (model = v)"
+      />
+    </div>
+  </UiContainerSettings>
 </template>

--- a/apps/ui/src/components/FormNetwork.vue
+++ b/apps/ui/src/components/FormNetwork.vue
@@ -7,6 +7,11 @@ const model = defineModel<NetworkID>({
   required: true
 });
 
+defineProps<{
+  title: string;
+  description?: string;
+}>();
+
 const availableNetworks = enabledReadWriteNetworks.map(id => {
   const { name, avatar, readOnly } = getNetwork(id);
   return { id, name, avatar, readOnly };
@@ -14,9 +19,8 @@ const availableNetworks = enabledReadWriteNetworks.map(id => {
 </script>
 
 <template>
-  <div class="mb-2">
-    <h3>Space network</h3>
-    <div class="grid grid-cols-auto gap-3 pt-4 mb-3">
+  <UiContainerSettings :title="title" :description="description">
+    <div class="grid grid-cols-auto gap-3 mb-3">
       <button
         v-for="network in availableNetworks"
         :key="network.id"
@@ -32,5 +36,5 @@ const availableNetworks = enabledReadWriteNetworks.map(id => {
         {{ network.name }}
       </button>
     </div>
-  </div>
+  </UiContainerSettings>
 </template>

--- a/apps/ui/src/components/FormVoting.vue
+++ b/apps/ui/src/components/FormVoting.vue
@@ -5,6 +5,8 @@ import { NetworkID } from '@/types';
 const props = defineProps<{
   form: any;
   selectedNetworkId: NetworkID;
+  title: string;
+  description?: string;
 }>();
 
 const emit = defineEmits<{
@@ -52,8 +54,13 @@ const formErrors = computed(() => {
 </script>
 
 <template>
-  <h3>Voting settings</h3>
-  <div class="s-box pt-4">
-    <UiForm :model-value="form" :error="formErrors" :definition="definition" />
-  </div>
+  <UiContainerSettings :title="title" :description="description">
+    <div class="s-box">
+      <UiForm
+        :model-value="form"
+        :error="formErrors"
+        :definition="definition"
+      />
+    </div>
+  </UiContainerSettings>
 </template>

--- a/apps/ui/src/components/Ui/InputDuration.vue
+++ b/apps/ui/src/components/Ui/InputDuration.vue
@@ -32,6 +32,7 @@ watch(
 <template>
   <div>
     <div
+      class="mb-1"
       :class="{ 'text-skin-danger': error && dirty }"
       v-text="definition.title"
     />

--- a/apps/ui/src/views/Create.vue
+++ b/apps/ui/src/views/Create.vue
@@ -206,26 +206,28 @@ watchEffect(() => setTitle('Create space'));
       <div class="flex-1">
         <div class="mt-8 lg:mt-0">
           <template v-if="currentPage === 'profile'">
-            <h3 class="mb-4">Space profile</h3>
-            <FormSpaceProfile
-              :form="metadataForm"
-              @errors="v => handleErrors('profile', v)"
-            />
-            <div class="s-box p-4 -mt-6">
-              <FormSpaceTreasuries
-                v-model="metadataForm.treasuries"
-                :network-id="selectedNetworkId"
+            <UiContainerSettings title="Space profile">
+              <FormSpaceProfile
+                :form="metadataForm"
+                @errors="v => handleErrors('profile', v)"
               />
-              <FormSpaceDelegations
-                v-model="metadataForm.delegations"
-                :network-id="selectedNetworkId"
-                class="mt-2"
-              />
-            </div>
+              <div class="s-box p-4 -mt-6">
+                <FormSpaceTreasuries
+                  v-model="metadataForm.treasuries"
+                  :network-id="selectedNetworkId"
+                />
+                <FormSpaceDelegations
+                  v-model="metadataForm.delegations"
+                  :network-id="selectedNetworkId"
+                  class="mt-2"
+                />
+              </div>
+            </UiContainerSettings>
           </template>
           <FormNetwork
             v-else-if="currentPage === 'network'"
             v-model="selectedNetworkId"
+            title="Space network"
           />
           <FormStrategies
             v-else-if="currentPage === 'strategies'"
@@ -277,11 +279,13 @@ watchEffect(() => setTitle('Create space'));
             v-else-if="currentPage === 'voting'"
             :form="settingsForm"
             :selected-network-id="selectedNetworkId"
+            title="Voting settings"
             @errors="v => handleErrors('voting', v)"
           />
           <FormController
             v-else-if="currentPage === 'controller'"
             v-model="controller"
+            title="Controller"
             @errors="v => handleErrors('controller', v)"
           />
         </div>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward https://github.com/snapshot-labs/workflow/issues/151

This PR improves the consistency for the `FormXXXX` components, used in space creation.

Some components are wrapped using `<UiContainerSettings>`, some other are defining its own `<h3>`.

This PR will migrate the remaining components to use `<UiContainerSettings>`, for consistency, and to prepare the components to be reused in the offchain space creation, where the title and description may be a little different.

Also fix a minor issue where the label is too close to the input duration form

### How to test

1. Go to the space creation page
2. The title H3 for all steps should have the same size and line-height
