### PR TITLE
refactor: extract controller settings form into its own component

### DIFF
--- a/apps/ui/src/components/FormSpaceController.vue
+++ b/apps/ui/src/components/FormSpaceController.vue
@@ -3,7 +3,7 @@ import { shorten } from '@/helpers/utils';
 import { Network } from '@/networks/types';
 
 defineProps<{
-  isController: boolean;
+  disabled: boolean;
   controller: string;
   network: Network;
 }>();
@@ -35,9 +35,9 @@ const changeControllerModalOpen = ref(false);
       </div>
       <button
         type="button"
-        :disabled="!isController"
+        :disabled="disabled"
         :class="{
-          'opacity-40 cursor-not-allowed text-skin-text': !isController
+          'opacity-40 cursor-not-allowed text-skin-text': disabled
         }"
         @click="changeControllerModalOpen = true"
       >

--- a/apps/ui/src/components/FormSpaceController.vue
+++ b/apps/ui/src/components/FormSpaceController.vue
@@ -8,7 +8,9 @@ defineProps<{
   network: Network;
 }>();
 
-const emit = defineEmits<{ (e: 'save', value: string) }>();
+const emit = defineEmits<{
+  (e: 'save', value: string);
+}>();
 
 const changeControllerModalOpen = ref(false);
 </script>

--- a/apps/ui/src/components/FormSpaceController.vue
+++ b/apps/ui/src/components/FormSpaceController.vue
@@ -1,0 +1,56 @@
+<script lang="ts" setup>
+import { shorten } from '@/helpers/utils';
+import { Network } from '@/networks/types';
+
+defineProps<{
+  isController: boolean;
+  controller: string;
+  network: Network;
+}>();
+
+const emit = defineEmits<{ (e: 'save', value: string) }>();
+
+const changeControllerModalOpen = ref(false);
+</script>
+<template>
+  <div>
+    <div
+      class="flex justify-between items-center rounded-lg border px-4 py-3 text-skin-link"
+    >
+      <div class="flex flex-col">
+        <a
+          :href="network.helpers.getExplorerUrl(controller, 'contract')"
+          target="_blank"
+          class="flex items-center text-skin-text leading-5"
+        >
+          <UiStamp
+            :id="controller"
+            type="avatar"
+            :size="18"
+            class="mr-2 !rounded"
+          />
+          {{ shorten(controller) }}
+          <IH-arrow-sm-right class="-rotate-45" />
+        </a>
+      </div>
+      <button
+        type="button"
+        :disabled="!isController"
+        :class="{
+          'opacity-40 cursor-not-allowed text-skin-text': !isController
+        }"
+        @click="changeControllerModalOpen = true"
+      >
+        <IH-pencil />
+      </button>
+    </div>
+    <teleport to="#modal">
+      <ModalChangeController
+        :open="changeControllerModalOpen"
+        :initial-state="{ controller }"
+        @close="changeControllerModalOpen = false"
+        @save="value => emit('save', value)"
+      />
+    </teleport>
+  </div>
+</template>

--- a/apps/ui/src/components/FormSpaceController.vue
+++ b/apps/ui/src/components/FormSpaceController.vue
@@ -13,6 +13,11 @@ const emit = defineEmits<{
 }>();
 
 const changeControllerModalOpen = ref(false);
+
+function handleSave(value: string) {
+  changeControllerModalOpen.value = false;
+  emit('save', value);
+}
 </script>
 <template>
   <div>
@@ -51,7 +56,7 @@ const changeControllerModalOpen = ref(false);
         :open="changeControllerModalOpen"
         :initial-state="{ controller }"
         @close="changeControllerModalOpen = false"
-        @save="value => emit('save', value)"
+        @save="handleSave"
       />
     </teleport>
   </div>

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { shorten } from '@/helpers/utils';
 import { getNetwork, offchainNetworks } from '@/networks';
 import { Space } from '@/types';
 
@@ -52,7 +51,7 @@ const isAdvancedFormResolved = ref(false);
 const hasVotingErrors = ref(false);
 const hasProposalErrors = ref(false);
 const hasAdvancedErrors = ref(false);
-const changeControllerModalOpen = ref(false);
+
 const executeFn = ref(save);
 const saving = ref(false);
 
@@ -240,8 +239,6 @@ function handleSettingsSave() {
 }
 
 function handleControllerSave(value: string) {
-  changeControllerModalOpen.value = false;
-
   if (!isOwner.value) return;
   controller.value = value;
 
@@ -463,44 +460,12 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
         title="Controller"
         description="The controller is the account able to change the space settings and cancel pending proposals."
       >
-        <div
-          class="flex justify-between items-center rounded-lg border px-4 py-3 text-skin-link"
-        >
-          <div class="flex flex-col">
-            <a
-              :href="network.helpers.getExplorerUrl(controller, 'contract')"
-              target="_blank"
-              class="flex items-center text-skin-text leading-5"
-            >
-              <UiStamp
-                :id="controller"
-                type="avatar"
-                :size="18"
-                class="mr-2 !rounded"
-              />
-              {{ shorten(controller) }}
-              <IH-arrow-sm-right class="-rotate-45" />
-            </a>
-          </div>
-          <button
-            type="button"
-            :disabled="!isController"
-            :class="{
-              'opacity-40 cursor-not-allowed text-skin-text': !isController
-            }"
-            @click="changeControllerModalOpen = true"
-          >
-            <IH-pencil />
-          </button>
-        </div>
-        <teleport to="#modal">
-          <ModalChangeController
-            :open="changeControllerModalOpen"
-            :initial-state="{ controller }"
-            @close="changeControllerModalOpen = false"
-            @save="handleControllerSave"
-          />
-        </teleport>
+        <FormSpaceController
+          :controller="controller"
+          :network="network"
+          :is-controller="isController"
+          @save="handleControllerSave"
+        />
       </UiContainerSettings>
       <UiContainerSettings v-show="activeTab === 'advanced'" title="Advanced">
         <FormSpaceAdvanced

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -463,7 +463,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
         <FormSpaceController
           :controller="controller"
           :network="network"
-          :is-controller="isController"
+          :disabled="!isController || isOffchainNetwork"
           @save="handleControllerSave"
         />
       </UiContainerSettings>

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -460,6 +460,14 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
         title="Controller"
         description="The controller is the account able to change the space settings and cancel pending proposals."
       >
+        <UiMessage
+          v-if="isOffchainNetwork && isOwner"
+          type="danger"
+          class="mb-3"
+        >
+          The controller is the owner of the ENS name. To change the controller,
+          you need to change the owner of the ENS name.
+        </UiMessage>
         <FormSpaceController
           :controller="controller"
           :network="network"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward https://github.com/snapshot-labs/workflow/issues/151

- [refactor] Extract the space controller settings form into is own component, for easier reuse.
- [fix] Disable the space controller edition on offchain space
- [fix] Add a message for offchain for offchain space owner, explaining why the controller can't be changed 

### How to test

1. Go to an onchain space controller settings
2. Form is disabled if you're not the owner, you can change the controller otherwise
3. Go to an offchain space controller settings
4. Form is always disabled
5. If you are the controller, it will additionally show a message explaining why edition is disabled
