### PR TITLE
fix: show download votes button for closed proposals

### DIFF
--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -396,7 +396,9 @@ watchEffect(() => {
                 v-if="
                   proposal.network === 's' &&
                   proposal.completed &&
-                  ['passed', 'rejected', 'executed'].includes(proposal.state)
+                  ['passed', 'rejected', 'executed', 'closed'].includes(
+                    proposal.state
+                  )
                 "
                 class="mt-2.5 inline-flex items-center gap-2 hover:text-skin-link"
                 @click="handleDownloadVotes"


### PR DESCRIPTION
### Summary

When proposal is closed (not using basic voting so can't tell if it passed or rejected) we should show download votes button if it's completed.

Closes: https://github.com/snapshot-labs/workflow/issues/390

### How to test

1. Go to http://localhost:8080/#/s:breadnbutterfun.eth/proposal/0x9739f7de9d32836f0f043978c3befdf963982ade9ca5af04060984e1e4959717
2. Can download votes.