### PR TITLE
fix: match messenger z-index to resizable siderbar

### DIFF
--- a/apps/ui/src/components/Messenger.vue
+++ b/apps/ui/src/components/Messenger.vue
@@ -6,7 +6,7 @@ import { HELPDESK_URL } from '@/helpers/constants';
   <a
     :href="HELPDESK_URL"
     target="_blank"
-    class="hidden md:block fixed bottom-4 right-4 rounded-full bg-skin-link text-skin-bg p-2"
+    class="hidden md:block fixed bottom-4 right-4 rounded-full bg-skin-link text-skin-bg p-2 z-40"
   >
     <IS-chat class="inline-block size-[32px]" />
   </a>


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/394

Regression from: https://github.com/snapshot-labs/sx-monorepo/pull/1050

### How to test

1. Go to http://localhost:8080/#/s:ethpoll.eth/proposal/0x2e185a920cdfb7739a76f31c4fbc75bbb4026c5223a32d79932aaae2c3859bd4
2. Messenger icon is visible above sidebar.

### Screenshots

<img width="369" alt="image" src="https://github.com/user-attachments/assets/aaba2823-eb2f-4e81-a7f6-1df3c496e9ad" />
