### PR TITLE
feat: reorganize Settings tabs

### DIFF
--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -58,19 +58,17 @@ const saving = ref(false);
 type Tab = {
   id:
     | 'profile'
-    | 'delegations'
-    | 'treasuries'
-    | 'strategies'
-    | 'authenticators'
-    | 'proposal-validation'
-    | 'voting-strategies'
     | 'proposal'
+    | 'voting-strategies'
     | 'voting'
     | 'members'
-    | 'labels'
     | 'execution'
-    | 'controller'
-    | 'advanced';
+    | 'authenticators'
+    | 'treasuries'
+    | 'delegations'
+    | 'labels'
+    | 'advanced'
+    | 'controller';
   name: string;
   visible: boolean;
 };
@@ -88,39 +86,14 @@ const tabs = computed<Tab[]>(
         visible: true
       },
       {
-        id: 'delegations',
-        name: 'Delegations',
+        id: 'proposal',
+        name: 'Proposal',
         visible: true
-      },
-      {
-        id: 'treasuries',
-        name: 'Treasuries',
-        visible: true
-      },
-      {
-        id: 'authenticators',
-        name: 'Authenticators',
-        visible: !isOffchainNetwork.value
-      },
-      {
-        id: 'strategies',
-        name: 'Strategies',
-        visible: isOffchainNetwork.value
-      },
-      {
-        id: 'proposal-validation',
-        name: 'Proposal validation',
-        visible: !isOffchainNetwork.value
       },
       {
         id: 'voting-strategies',
         name: 'Voting strategies',
-        visible: !isOffchainNetwork.value
-      },
-      {
-        id: 'proposal',
-        name: 'Proposal',
-        visible: isOffchainNetwork.value
+        visible: true
       },
       {
         id: 'voting',
@@ -133,24 +106,39 @@ const tabs = computed<Tab[]>(
         visible: isOffchainNetwork.value
       },
       {
-        id: 'labels',
-        name: 'Labels',
-        visible: true
-      },
-      {
         id: 'execution',
         name: 'Execution',
         visible: !isOffchainNetwork.value
       },
       {
-        id: 'controller',
-        name: 'Controller',
+        id: 'authenticators',
+        name: 'Authenticators',
+        visible: !isOffchainNetwork.value
+      },
+      {
+        id: 'treasuries',
+        name: 'Treasuries',
+        visible: true
+      },
+      {
+        id: 'delegations',
+        name: 'Delegations',
+        visible: true
+      },
+      {
+        id: 'labels',
+        name: 'Labels',
         visible: true
       },
       {
         id: 'advanced',
         name: 'Advanced',
         visible: isOffchainNetwork.value
+      },
+      {
+        id: 'controller',
+        name: 'Controller',
+        visible: true
       }
     ] as const
 );
@@ -323,84 +311,57 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
           @errors="v => (formErrors = v)"
         />
       </div>
-      <UiContainerSettings
-        v-if="activeTab === 'delegations'"
-        title="Delegations"
-        description="Delegations allow users to delegate their voting power to other users."
-      >
-        <FormSpaceDelegations
-          v-model="form.delegations"
+      <template v-if="activeTab === 'proposal'">
+        <UiContainerSettings
+          v-if="isOffchainNetwork"
+          title="Proposal"
+          description="Set proposal validation to define who can create proposals and provide additional resources for proposal authors."
+        >
+          <FormSpaceProposal
+            v-model:proposal-validation="proposalValidation"
+            v-model:guidelines="guidelines"
+            v-model:template="template"
+            :network-id="space.network"
+            :snapshot-chain-id="snapshotChainId"
+            :space="space"
+            @update-validity="v => (hasProposalErrors = !v)"
+          />
+        </UiContainerSettings>
+        <FormValidation
+          v-else
+          v-model="validationStrategy"
           :network-id="space.network"
-          :limit="isOffchainNetwork ? 1 : undefined"
+          :available-strategies="network.constants.EDITOR_PROPOSAL_VALIDATIONS"
+          :available-voting-strategies="
+            network.constants.EDITOR_PROPOSAL_VALIDATION_VOTING_STRATEGIES
+          "
+          title="Proposal"
+          description="Proposal validation strategies are used to determine if a user is allowed to create a proposal."
         />
-      </UiContainerSettings>
-      <UiContainerSettings
-        v-if="activeTab === 'treasuries'"
-        title="Treasuries"
-        description="Treasuries are used to manage the funds of the space."
-      >
-        <FormSpaceTreasuries
-          v-model="form.treasuries"
+      </template>
+      <template v-if="activeTab === 'voting-strategies'">
+        <UiContainerSettings
+          v-if="isOffchainNetwork"
+          title="Voting strategies"
+          description="Voting strategies are sets of conditions used to calculate user's voting power."
+        >
+          <FormSpaceStrategies
+            v-model:snapshot-chain-id="snapshotChainId"
+            v-model:strategies="strategies"
+            :network-id="space.network"
+            :is-ticket-valid="isTicketValid"
+            :space="space"
+          />
+        </UiContainerSettings>
+        <FormStrategies
+          v-else
+          v-model="votingStrategies"
           :network-id="space.network"
-          :limit="isOffchainNetwork ? 10 : undefined"
+          :available-strategies="network.constants.EDITOR_VOTING_STRATEGIES"
+          title="Voting strategies"
+          description="Voting strategies are customizable contracts used to define how much voting power each user has when casting a vote."
         />
-      </UiContainerSettings>
-      <UiContainerSettings
-        v-else-if="activeTab === 'strategies'"
-        title="Strategies"
-        description="Strategies are sets of conditions used to calculate user's voting power."
-      >
-        <FormSpaceStrategies
-          v-model:snapshot-chain-id="snapshotChainId"
-          v-model:strategies="strategies"
-          :network-id="space.network"
-          :is-ticket-valid="isTicketValid"
-          :space="space"
-        />
-      </UiContainerSettings>
-      <FormStrategies
-        v-if="activeTab === 'authenticators'"
-        v-model="authenticators"
-        unique
-        :network-id="space.network"
-        :available-strategies="network.constants.EDITOR_AUTHENTICATORS"
-        title="Authenticators"
-        description="Authenticators are customizable contracts that verify user identity for proposing and voting using different methods."
-      />
-      <FormValidation
-        v-else-if="activeTab === 'proposal-validation'"
-        v-model="validationStrategy"
-        :network-id="space.network"
-        :available-strategies="network.constants.EDITOR_PROPOSAL_VALIDATIONS"
-        :available-voting-strategies="
-          network.constants.EDITOR_PROPOSAL_VALIDATION_VOTING_STRATEGIES
-        "
-        title="Proposal validation"
-        description="Proposal validation strategies are used to determine if a user is allowed to create a proposal."
-      />
-      <FormStrategies
-        v-else-if="activeTab === 'voting-strategies'"
-        v-model="votingStrategies"
-        :network-id="space.network"
-        :available-strategies="network.constants.EDITOR_VOTING_STRATEGIES"
-        title="Voting strategies"
-        description="Voting strategies are customizable contracts used to define how much voting power each user has when casting a vote."
-      />
-      <UiContainerSettings
-        v-else-if="activeTab === 'proposal'"
-        title="Proposal"
-        description="Set proposal validation to define who can create proposals and provide additional resources for proposal authors."
-      >
-        <FormSpaceProposal
-          v-model:proposal-validation="proposalValidation"
-          v-model:guidelines="guidelines"
-          v-model:template="template"
-          :network-id="space.network"
-          :snapshot-chain-id="snapshotChainId"
-          :space="space"
-          @update-validity="v => (hasProposalErrors = !v)"
-        />
-      </UiContainerSettings>
+      </template>
       <UiContainerSettings
         v-else-if="activeTab === 'voting'"
         title="Voting"
@@ -434,13 +395,6 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
         />
       </UiContainerSettings>
       <UiContainerSettings
-        v-else-if="activeTab === 'labels'"
-        title="Labels"
-        description="Labels are used to categorize proposals."
-      >
-        <FormSpaceLabels v-model="form.labels" />
-      </UiContainerSettings>
-      <UiContainerSettings
         v-else-if="activeTab === 'execution'"
         title="Execution(s)"
         description="Execution strategies determine if a proposal passes and how it is executed. This section is currently read-only."
@@ -455,25 +409,43 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
           />
         </div>
       </UiContainerSettings>
+      <FormStrategies
+        v-if="activeTab === 'authenticators'"
+        v-model="authenticators"
+        unique
+        :network-id="space.network"
+        :available-strategies="network.constants.EDITOR_AUTHENTICATORS"
+        title="Authenticators"
+        description="Authenticators are customizable contracts that verify user identity for proposing and voting using different methods."
+      />
       <UiContainerSettings
-        v-else-if="activeTab === 'controller'"
-        title="Controller"
-        description="The controller is the account able to change the space settings and cancel pending proposals."
+        v-if="activeTab === 'treasuries'"
+        title="Treasuries"
+        description="Treasuries are used to manage the funds of the space."
       >
-        <UiMessage
-          v-if="isOffchainNetwork && isOwner"
-          type="danger"
-          class="mb-3"
-        >
-          The controller is the owner of the ENS name. To change the controller,
-          you need to change the owner of the ENS name.
-        </UiMessage>
-        <FormSpaceController
-          :controller="controller"
-          :network="network"
-          :disabled="!isController || isOffchainNetwork"
-          @save="handleControllerSave"
+        <FormSpaceTreasuries
+          v-model="form.treasuries"
+          :network-id="space.network"
+          :limit="isOffchainNetwork ? 10 : undefined"
         />
+      </UiContainerSettings>
+      <UiContainerSettings
+        v-else-if="activeTab === 'delegations'"
+        title="Delegations"
+        description="Delegations allow users to delegate their voting power to other users."
+      >
+        <FormSpaceDelegations
+          v-model="form.delegations"
+          :network-id="space.network"
+          :limit="isOffchainNetwork ? 1 : undefined"
+        />
+      </UiContainerSettings>
+      <UiContainerSettings
+        v-else-if="activeTab === 'labels'"
+        title="Labels"
+        description="Labels are used to categorize proposals."
+      >
+        <FormSpaceLabels v-model="form.labels" />
       </UiContainerSettings>
       <UiContainerSettings v-show="activeTab === 'advanced'" title="Advanced">
         <FormSpaceAdvanced
@@ -492,6 +464,26 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
               isAdvancedFormResolved = resolved;
             }
           "
+        />
+      </UiContainerSettings>
+      <UiContainerSettings
+        v-if="activeTab === 'controller'"
+        title="Controller"
+        description="The controller is the account able to change the space settings and cancel pending proposals."
+      >
+        <UiMessage
+          v-if="isOffchainNetwork && isOwner"
+          type="danger"
+          class="mb-3"
+        >
+          The controller is the owner of the ENS name. To change the controller,
+          you need to change the owner of the ENS name.
+        </UiMessage>
+        <FormSpaceController
+          :controller="controller"
+          :network="network"
+          :disabled="!isController || isOffchainNetwork"
+          @save="handleControllerSave"
         />
       </UiContainerSettings>
       <UiToolbarBottom


### PR DESCRIPTION
### Summary

This commit updates settings tabs with new order, but also merges previously separate tabs into single entry. In case of previously separate tabs that ended up as single entry title of the tab has been updated to be the same, but we use old description for each.

 - Profile - leave as-is (shared)
 - Proposal - merge proposal (offchain) and proposal-validation (SX)
 - Voting strategies - merge strategies (offchain) and voting-strategies (SX)
 - Voting - leave as-is (shared)
 - Members - leave as-is (offchain)
 - Execution - leave as-is (SX)
 - Authenticators - leave as-is (SX)
 - Treasuries - leave as-is (shared)
 - Delegations - leave as-is (shared)
 - Labels - leave as-is (shared)
 - Advanced - leave as-is (offchain)
 - Controller - leave as-is (shared)

New tab order is:
**Snapshot**: Profile, Proposal, Voting strategies, Voting, Members, Treasuries, Delegations, Labels, Advanced, Controller
**SX**: Profile, Proposal, Voting strategies, Voting, Execution, Authenticators, Treasuries, Delegations, Labels, Controller

Closes: https://github.com/snapshot-labs/workflow/issues/395

### How to test

1. Go to offchain space settings.
2. Go to onchain space settings.
3. Order and tabs are as epxected.
