### PR TITLE
fix: handle unsupported delegation type

### DIFF
--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -3,6 +3,7 @@ import { sanitizeUrl } from '@braintree/sanitize-url';
 import removeMarkdown from 'remove-markdown';
 import { getGenericExplorerUrl } from '@/helpers/explorer';
 import { _n, _p, _vp, shorten } from '@/helpers/utils';
+import { SNAPSHOT_URLS } from '@/networks/offchain';
 import { DelegationType, Space, SpaceMetadataDelegation } from '@/types';
 
 const props = defineProps<{
@@ -93,12 +94,29 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
 
 <template>
   <div
-    v-if="!delegation.apiUrl || delegation.apiType === 'split-delegation'"
+    v-if="!delegation.apiUrl"
     class="px-4 py-3 flex items-center text-skin-link space-x-2"
   >
     <IH-exclamation-circle class="shrink-0" />
     <span>Invalid delegation settings.</span>
   </div>
+  <UiMessage
+    v-if="delegation.apiType === 'split-delegation'"
+    :type="'info'"
+    class="m-4"
+  >
+    This space uses the split-delegation feature, which is currently not
+    supported on the new interface. You can view the delegates dashboard on the
+    <a
+      :href="`${SNAPSHOT_URLS[props.space.network]}/#/${props.space.id}/delegates`"
+      target="_blank"
+      class="inline-flex items-center font-bold"
+    >
+      previous interface
+      <IH-arrow-sm-right class="inline-block -rotate-45" />
+    </a>
+    .
+  </UiMessage>
   <template v-else>
     <div v-if="delegation.contractAddress" class="p-4 space-x-2 flex">
       <UiButton

--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -113,9 +113,8 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
       class="inline-flex items-center font-bold"
     >
       previous interface
-      <IH-arrow-sm-right class="inline-block -rotate-45" />
-    </a>
-    .
+      <IH-arrow-sm-right class="inline-block -rotate-45" /></a
+    >.
   </UiMessage>
   <template v-else>
     <div v-if="delegation.contractAddress" class="p-4 space-x-2 flex">

--- a/apps/ui/src/views/SpaceUser.vue
+++ b/apps/ui/src/views/SpaceUser.vue
@@ -70,6 +70,15 @@ const navigation = computed(() => [
   // { label: 'Delegators', route: 'space-user-delegators', count: delegatesCount.value },
 ]);
 
+const hasInvalidDelegations = computed(() => {
+  if (!props.space.delegations.length) return true;
+
+  return props.space.delegations.some(
+    delegation =>
+      !delegation.apiUrl || delegation.apiType === 'split-delegation'
+  );
+});
+
 async function loadUserActivity() {
   const spaceNetwork = getNetwork(props.space.network);
 
@@ -186,10 +195,7 @@ watch(
         class="relative bg-skin-bg h-[16px] -top-3 rounded-t-[16px] md:hidden"
       />
       <div class="absolute right-4 top-4 space-x-2 flex">
-        <UiButton
-          v-if="space.delegations.length"
-          @click="handleDelegateClick()"
-        >
+        <UiButton v-if="!hasInvalidDelegations" @click="handleDelegateClick()">
           Delegate
         </UiButton>
         <UiTooltip v-if="!isWhiteLabel" title="View profile">

--- a/apps/ui/src/views/SpaceUser.vue
+++ b/apps/ui/src/views/SpaceUser.vue
@@ -70,10 +70,10 @@ const navigation = computed(() => [
   // { label: 'Delegators', route: 'space-user-delegators', count: delegatesCount.value },
 ]);
 
-const hasInvalidDelegations = computed(() => {
+const hasOnlyInvalidDelegations = computed(() => {
   if (!props.space.delegations.length) return true;
 
-  return props.space.delegations.some(
+  return props.space.delegations.every(
     delegation =>
       !delegation.apiUrl || delegation.apiType === 'split-delegation'
   );
@@ -195,7 +195,10 @@ watch(
         class="relative bg-skin-bg h-[16px] -top-3 rounded-t-[16px] md:hidden"
       />
       <div class="absolute right-4 top-4 space-x-2 flex">
-        <UiButton v-if="!hasInvalidDelegations" @click="handleDelegateClick()">
+        <UiButton
+          v-if="!hasOnlyInvalidDelegations"
+          @click="handleDelegateClick()"
+        >
           Delegate
         </UiButton>
         <UiTooltip v-if="!isWhiteLabel" title="View profile">


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix 2 issues:

- Show a different message for spaces using split-delegation: show a link to v1, instead of showing an "invalid settings" message, which is leading users to believe the space is misconfigured, which is not the case.
- For spaces using split-delegation, we should disable the DELEGATE form.

### How to test

1. Go to a space's user, on a space with supported validation: http://localhost:8080/#/sn:0x07c251045154318a2376a3bb65be47d3c90df1740d8e35c9b9d943aa3f240e50/profile/0x0799262e608528601e7d269e381c9f909025dbabe23897bb395a64a55f19ea2a
2. It should show the DELEGATE button on the top right corner
3. Go to a space's user, on a space with unsupported validation:
4. http://localhost:8080/#/s:paraswap-dao.eth/profile/0x168F87fBfe36B84E44B9d06278B2aA1CC73d7400
5. The DELEGATE button should not appear 
6. Go to the /delegates page on a space with unsupported delegation: http://localhost:8080/#/s:paraswap-dao.eth/delegates
7. It should show a link to the dashboard on v1

### Notes

We're assuming that spaces using split-delegations are only using one delegation, which is the case for all v1 spaces.