### PR TITLE
fix: Update signator URL path

### DIFF
--- a/apps/ui/src/networks/offchain/index.ts
+++ b/apps/ui/src/networks/offchain/index.ts
@@ -63,7 +63,7 @@ export function createOffchainNetwork(networkId: NetworkID): Network {
             return network ? `${network.explorer.url}/tx/${id}` : '';
           }
 
-          return `https://signator.io/view?ipfs=${id}`;
+          return `https://signator.io/ipfs/${id}`;
         case 'strategy':
           return `${SNAPSHOT_URLS[networkId]}/#/strategy/${id}`;
         case 'contract':


### PR DESCRIPTION
### Summary

As requested by signator team,
Signator has updated its IPFS URL path to https://signator.io/ipfs/bafkreibtcg6jbo6dwbai5s5arh74osuf7t522w4lg7fb5nnfb4wgzupfue instead of `?ipfs` query


### How to test

1. Go to the votes page of any off-chain spaces
2. It should redirect to a new URL instead of old 
