### PR TITLE
fix: testnet space creation button

### DIFF
--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -2,6 +2,7 @@
 import { SPACE_CATEGORIES } from '@/helpers/constants';
 import { getUrl } from '@/helpers/utils';
 import { explorePageProtocols, getNetwork, metadataNetwork } from '@/networks';
+import { SNAPSHOT_URLS } from '@/networks/offchain';
 import { ExplorePageProtocol, ProtocolConfig } from '@/networks/types';
 import { SelectItem } from '@/types';
 
@@ -181,7 +182,7 @@ onMounted(() => {
         <UiButton
           :to="
             protocol === 'snapshot'
-              ? 'https://v1.snapshot.box/#/setup'
+              ? `${SNAPSHOT_URLS[metadataNetwork]}/#/setup`
               : 'create'
           "
           class="!px-0 w-[46px]"


### PR DESCRIPTION
### Summary

space creation button on https://testnet.snapshot.box/#/explore doesn't redirect to v1's testnet

### How to test

1. Update .env with `VITE_METADATA_NETWORK=s-tn`
2. Go to http://localhost:8080/#/explore
3. Click on "+" icon
4. It should redirect to v1's testnet
