### PR TITLE
feat: pull constant from hub

### DIFF
--- a/apps/ui/src/components/ButtonFollow.vue
+++ b/apps/ui/src/components/ButtonFollow.vue
@@ -13,6 +13,7 @@ const { isSafeWallet } = useSafeWallet(
 );
 const followedSpacesStore = useFollowedSpacesStore();
 const { isWhiteLabel } = useWhiteLabel();
+const uiStore = useUiStore();
 
 const spaceFollowed = computed(() =>
   followedSpacesStore.isFollowed(spaceIdComposite)
@@ -23,21 +24,53 @@ const loading = computed(
     !followedSpacesStore.followedSpacesLoaded ||
     followedSpacesStore.followedSpaceLoading.has(spaceIdComposite)
 );
+
+const maxFollowLimitReached = computed(
+  () =>
+    followedSpacesStore.followedSpaces.length >=
+    followedSpacesStore.maxFollowLimit
+);
+
+const preventFollowingMore = computed(
+  () => maxFollowLimitReached.value && !spaceFollowed.value
+);
+
+const tooltipMessage = computed(() => {
+  if (preventFollowingMore.value) {
+    return `You can follow up to ${followedSpacesStore.maxFollowLimit} spaces.`;
+  }
+
+  if (isSafeWallet.value) {
+    return 'Safe wallets cannot follow spaces.';
+  }
+
+  return '';
+});
+
+async function handleClick() {
+  try {
+    await followedSpacesStore.toggleSpaceFollow(spaceIdComposite);
+  } catch (error) {
+    uiStore.addNotification('error', error.message);
+  }
+}
 </script>
 
 <template>
-  <UiButton
-    v-if="!isWhiteLabel"
-    :disabled="loading || isSafeWallet"
-    class="group"
-    :class="{ 'hover:border-skin-danger': spaceFollowed }"
-    :loading="loading"
-    @click.prevent="followedSpacesStore.toggleSpaceFollow(spaceIdComposite)"
-  >
-    <span v-if="spaceFollowed" class="inline-block">
-      <span class="group-hover:inline hidden text-skin-danger">Unfollow</span>
-      <span class="group-hover:hidden">Following</span>
-    </span>
-    <span v-else class="inline-block">Follow</span>
-  </UiButton>
+  <UiTooltip :title="tooltipMessage">
+    <UiButton
+      v-if="!isWhiteLabel"
+      :disabled="loading || isSafeWallet || preventFollowingMore"
+      class="group"
+      :class="{ 'hover:border-skin-danger': spaceFollowed }"
+      :loading="loading"
+      @click.prevent="handleClick"
+    >
+      <span v-if="spaceFollowed" class="inline-block">
+        <span class="group-hover:inline hidden text-skin-danger">Unfollow</span>
+        <span class="group-hover:hidden">Following</span>
+      </span>
+      <span v-else class="inline-block">Follow</span>
+    </UiButton>
+  </UiTooltip>
 </template>

--- a/apps/ui/src/components/SpacesListItem.vue
+++ b/apps/ui/src/components/SpacesListItem.vue
@@ -38,7 +38,7 @@ const compositeSpaceId = `${props.space.network}:${props.space.id}`;
     </div>
     <ButtonFollow
       :space="space"
-      class="absolute top-2.5 right-2.5 hidden group-hover:block"
+      class="!absolute top-2.5 right-2.5 hidden group-hover:block"
     />
     <div class="px-4">
       <div class="flex items-center">

--- a/apps/ui/src/composables/useSettings.ts
+++ b/apps/ui/src/composables/useSettings.ts
@@ -11,6 +11,7 @@ export function useSettings() {
 
     try {
       const result = await network.api.loadSettings();
+
       result.forEach(setting => {
         settings.value.set(setting.name, setting.value);
       });

--- a/apps/ui/src/composables/useSettings.ts
+++ b/apps/ui/src/composables/useSettings.ts
@@ -1,0 +1,29 @@
+import { getNetwork, metadataNetwork } from '@/networks';
+
+const settings = ref<Map<string, any>>(new Map());
+const initialized = ref(false);
+
+const network = getNetwork(metadataNetwork);
+
+export function useSettings() {
+  async function load() {
+    if (initialized.value) return;
+
+    try {
+      const result = await network.api.loadSettings();
+      result.forEach(setting => {
+        settings.value.set(setting.name, setting.value);
+      });
+
+      initialized.value = true;
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  onMounted(() => {
+    load();
+  });
+
+  return { settings };
+}

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -713,6 +713,9 @@ export function createApi(
     },
     getNetworksUsage: async () => {
       return {};
+    },
+    loadSettings: async () => {
+      return [];
     }
   };
 }

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -25,6 +25,7 @@ import {
   ProposalExecution,
   ProposalState,
   RelatedSpace,
+  Setting,
   Space,
   SpaceMetadataDelegation,
   SpaceMetadataTreasury,
@@ -40,6 +41,7 @@ import {
   PROPOSAL_QUERY,
   PROPOSALS_QUERY,
   RANKING_QUERY,
+  SETTINGS_QUERY,
   SPACE_QUERY,
   SPACES_QUERY,
   STATEMENTS_QUERY,
@@ -825,6 +827,15 @@ export function createApi(
           network.spacesCount
         ])
       );
+    },
+    loadSettings: async (): Promise<Setting[]> => {
+      const {
+        data: { options }
+      }: { data: { options: Setting[] } } = await apollo.query({
+        query: SETTINGS_QUERY
+      });
+
+      return options;
     }
   };
 }

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -375,3 +375,12 @@ export const NETWORKS_USAGE_QUERY = gql`
     }
   }
 `;
+
+export const SETTINGS_QUERY = gql`
+  query Settings {
+    options {
+      name
+      value
+    }
+  }
+`;

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -10,6 +10,7 @@ import {
   NetworkID,
   Privacy,
   Proposal,
+  Setting,
   Space,
   SpaceMetadata,
   Statement,
@@ -327,6 +328,7 @@ export type NetworkApi = {
   loadStrategies(): Promise<StrategyTemplate[]>;
   loadStrategy(address: string): Promise<StrategyTemplate | null>;
   getNetworksUsage(): Promise<Record<ChainId, number | undefined>>;
+  loadSettings(): Promise<Setting[]>;
 };
 
 export type NetworkConstants = {

--- a/apps/ui/src/stores/followedSpaces.ts
+++ b/apps/ui/src/stores/followedSpaces.ts
@@ -14,6 +14,7 @@ export const useFollowedSpacesStore = defineStore('followedSpaces', () => {
   const actions = useActions();
   const { web3, authInitiated } = useWeb3();
   const { isWhiteLabel } = useWhiteLabel();
+  const { settings } = useSettings();
 
   const followedSpacesIds = ref<string[]>([]);
   const followedSpacesLoaded = ref(false);
@@ -22,6 +23,10 @@ export const useFollowedSpacesStore = defineStore('followedSpaces', () => {
     `${pkg.name}.spaces-followed`,
     {} as Record<string, string[]>
   );
+
+  const maxFollowLimit = computed(() => {
+    return Number(settings.value.get('user.default.follow_limit'));
+  });
 
   const followedSpacesMap = computed(
     () =>
@@ -109,6 +114,12 @@ export const useFollowedSpacesStore = defineStore('followedSpaces', () => {
             (spaceId: string) => spaceId !== id
           );
       } else {
+        if (followedSpaces.value.length >= maxFollowLimit.value) {
+          throw new Error(
+            `You can follow up to ${maxFollowLimit.value} spaces.`
+          );
+        }
+
         const result = await actions.followSpace(spaceNetwork, spaceId);
         if (!result) return;
 
@@ -152,6 +163,7 @@ export const useFollowedSpacesStore = defineStore('followedSpaces', () => {
   );
 
   return {
+    maxFollowLimit,
     followedSpaces,
     followedSpacesIds,
     followedSpaceIdsByNetwork,

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -497,3 +497,8 @@ export type SelectItem<T> = {
   name?: string;
   icon?: VNode;
 };
+
+export type Setting = {
+  name: string;
+  value: string;
+};


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward https://github.com/snapshot-labs/workflow/issues/315

Some constants, like the limits are currently hard coded.

Those limits are re-used on multiple services, and a new `options` endpoint has been added to the hub, to serve as the only source of truth. (see https://hub.snapshot.org/graphql?query=query%20%7B%0A%20%20options%20%7B%20%0A%20%20name%20%0A%20%20value%7D%0A%7D)

This PR will add a new API to fetch those settings from the hub, and expose them via a new composable.

As demonstration, the follow space module has been refactored to take the new limit into consideration. Implementation of the others settings will come in a later PR.

### How to test

1. Follow some spaces
2. When reaching the 25 spaces limit, all FOLLOW buttons should be disabled, and show a tooltip with the explanation.
