### PR TITLE
fix: explore page pagination with category filter

### DIFF
--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -200,7 +200,11 @@ onMounted(() => {
           :loading-more="spacesStore.loadingMore"
           class="justify-center max-w-screen-md 2xl:max-w-screen-xl 3xl:max-w-screen-2xl mx-auto p-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-explore-3 2xl:grid-cols-explore-4 3xl:grid-cols-explore-5 gap-3"
           @end-reached="
-            spacesStore.fetchMore({ searchQuery: route.query.q as string })
+            spacesStore.fetchMore({
+              searchQuery: route.query.q as string,
+              category: category,
+              network: network
+            })
           "
         >
           <SpacesListItem


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/408

### How to test

1. Go to explore page http://localhost:8080/#/explore?p=snapshot&c=media&n=all
2. Scroll down to see more spaces
3. [Before Fix] You will see verified spaces after non-verified spaces
4. [After Fix] You should see the correct spaces in order
