### PR TITLE
fix: fix truncated delegate statement

### DIFF
--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -442,7 +442,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
                   user: delegate.user
                 }
               }"
-              class="flex w-full space-x-3 truncate"
+              class="flex w-full space-x-3"
             >
               <div
                 class="flex grow sm:grow-0 sm:shrink-0 items-center w-[190px] py-3 gap-x-3 leading-[22px] truncate"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #1119 

This PR fix an UI issue on the delegates page (e.g http://localhost:8080/#/s:gitcoindao.eth/delegates) where the delegates statement column was being cut on one line, instead of being trumcated with ellipsis on 2 lines

### How to test

1. Go to http://localhost:8080/#/s:gitcoindao.eth/delegates
2. The statement should appear on 2 lines, and end with `...` when truncated
