### PR TITLE
build: install graphql locally to limit peer deps warnings

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,7 +30,8 @@
     "@types/node": "^18.11.6",
     "cross-fetch": "^4.0.0",
     "dotenv": "^16.0.1",
-    "starknet": "6.11.0"
+    "starknet": "6.11.0",
+    "graphql": "^16.8.1"
   },
   "devDependencies": {
     "@snapshot-labs/eslint-config": "0.1.0-beta.18",


### PR DESCRIPTION
### Summary

For now we will only have 3 warnings left:
1. One checkpoint related that needs to be fixed upstream (by replacing outdated package, we don't have good replacement though unless we make Apollo Server the default).
2. One WalletConnect related (needs to be fixed upstream to avoid dependency that requires react as per dep).
3. `starknetkit` related one that can be fixed by bumping it to newer version however it breaks the app.

### Test plan
1. Run `yarn install --force`.