### PR TITLE
fix: delegates table columns width

### DIFF
--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -380,7 +380,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
         </div>
         <button
           type="button"
-          class="hidden md:flex w-[120px] shrink-0 items-center justify-end hover:text-skin-link space-x-1 truncate"
+          class="hidden md:flex w-[80px] shrink-0 items-center justify-end hover:text-skin-link space-x-1 truncate"
           @click="handleSortChange('tokenHoldersRepresentedAmount')"
         >
           <span class="truncate">Delegators</span>
@@ -460,7 +460,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
                 </div>
               </div>
               <div
-                class="hidden sm:flex items-center grow text-[17px] overflow-hidden leading-[22px] text-skin-heading"
+                class="hidden sm:flex items-center grow w-0 text-[17px] leading-[22px] text-skin-heading"
               >
                 <div
                   v-if="delegate.statement"
@@ -471,7 +471,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
                 />
               </div>
               <div
-                class="hidden md:flex shrink-0 w-[120px] flex-col items-end justify-center leading-[22px] truncate"
+                class="hidden md:flex shrink-0 w-[80px] flex-col items-end justify-center leading-[22px] truncate"
               >
                 <h4
                   class="text-skin-link"


### PR DESCRIPTION
### Summary
- Added `w-0` to avoid overflow caused by `grow`
- Reduced `Delegates` column width to `80px` instead of `120px` ( which is way more than required)

Closes https://github.com/snapshot-labs/workflow/issues/415

### How to test

1. Go to http://127.0.0.1:8080/#/s:cow.eth/delegates
2. The table should be responsive like before
3. Overflow of statements should be fixed

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/b253a906-051f-46cd-b818-81ce993afa4f) | ![image](https://github.com/user-attachments/assets/0f40de29-de13-4bae-946e-cf4c884e79e1) |
