### PR TITLE
fix: skip premium networks message for guest user

### DIFF
--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -470,6 +470,7 @@ watchEffect(() => {
         <UiContainer class="pt-5 !max-w-[710px] mx-0 md:mx-auto s-box">
           <UiAlert
             v-if="
+              web3.account &&
               !space.turbo &&
               unsupportedProposalNetworks.length &&
               !proposal?.proposalId


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR will not show the premium networks message for guest user (they will see the "Not enough voting power" message instead)
