### PR TITLE
fix: pick any available evm network for delegation

### DIFF
--- a/apps/ui/src/helpers/delegation.ts
+++ b/apps/ui/src/helpers/delegation.ts
@@ -1,13 +1,17 @@
+import { enabledNetworks, evmNetworks } from '@/networks';
 import { METADATA } from '@/networks/starknet';
 import { ChainId, NetworkID } from '@/types';
 
 export function getDelegationNetwork(chainId: ChainId) {
-  // TODO: check if eth is actually what we want here, probably should be matching chainId is isEvmNetwork
-  // https://github.com/snapshot-labs/sx-monorepo/pull/946
+  // NOTE: any EVM network can be used for delegation on EVMs (it will switch chainId as needed).
+  // This will also support networks that are not supported natively.
+  const evmNetwork = enabledNetworks.find(networkId =>
+    evmNetworks.includes(networkId)
+  );
 
-  const isEvmNetwork = typeof chainId === 'number';
-  const actionNetwork = isEvmNetwork
-    ? 'eth'
+  const isEvm = typeof chainId === 'number';
+  const actionNetwork = isEvm
+    ? evmNetwork
     : (Object.entries(METADATA).find(
         ([, metadata]) => metadata.chainId === chainId
       )?.[0] as NetworkID);


### PR DESCRIPTION
### Summary

We used eth before, but in case it's not enabled we should use any of enabled EVM network.

Closes: https://github.com/snapshot-labs/workflow/issues/422

### How to test

1. Run UI with `VITE_METADATA_NETWORK=s-tn VITE_ENABLED_NETWORKS=s-tn,sep,sn-sep yarn dev`.
2. Go to http://localhost:8080/#/s-tn:thanku.eth/delegates
3. Delegate to some address (list will be empty https://github.com/snapshot-labs/workflow/issues/423)
4. It works.
