### PR TITLE
fix: add wrapper to Delegates page

### DIFF
--- a/apps/ui/src/views/Space/Delegates.vue
+++ b/apps/ui/src/views/Space/Delegates.vue
@@ -14,39 +14,41 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
 </script>
 
 <template>
-  <div
-    v-if="space.delegations.length === 0"
-    class="px-4 py-3 flex items-center text-skin-link space-x-2"
-  >
-    <IH-exclamation-circle class="inline-block" />
-    <span>No delegations configured.</span>
-  </div>
-  <div v-else>
-    <UiScrollerHorizontal
-      v-if="space.delegations.length > 1"
-      class="z-40 sticky top-[71px] lg:top-[72px]"
-      with-buttons
-      gradient="xxl"
+  <div>
+    <div
+      v-if="space.delegations.length === 0"
+      class="px-4 py-3 flex items-center text-skin-link space-x-2"
     >
-      <div class="flex px-4 space-x-3 bg-skin-bg border-b min-w-max">
-        <button
-          v-for="(delegation, i) in space.delegations"
-          :key="i"
-          type="button"
-          @click="activeDelegationId = i"
-        >
-          <UiLink
-            :is-active="activeDelegationId === i"
-            :text="delegation.name || `Delegates ${i + 1}`"
-          />
-        </button>
-      </div>
-    </UiScrollerHorizontal>
-    <SpaceDelegates
-      v-if="delegateData"
-      :key="activeDelegationId"
-      :space="space"
-      :delegation="delegateData"
-    />
+      <IH-exclamation-circle class="inline-block" />
+      <span>No delegations configured.</span>
+    </div>
+    <div v-else>
+      <UiScrollerHorizontal
+        v-if="space.delegations.length > 1"
+        class="z-40 sticky top-[71px] lg:top-[72px]"
+        with-buttons
+        gradient="xxl"
+      >
+        <div class="flex px-4 space-x-3 bg-skin-bg border-b min-w-max">
+          <button
+            v-for="(delegation, i) in space.delegations"
+            :key="i"
+            type="button"
+            @click="activeDelegationId = i"
+          >
+            <UiLink
+              :is-active="activeDelegationId === i"
+              :text="delegation.name || `Delegates ${i + 1}`"
+            />
+          </button>
+        </div>
+      </UiScrollerHorizontal>
+      <SpaceDelegates
+        v-if="delegateData"
+        :key="activeDelegationId"
+        :space="space"
+        :delegation="delegateData"
+      />
+    </div>
   </div>
 </template>


### PR DESCRIPTION
### Summary

After https://github.com/snapshot-labs/sx-monorepo/pull/1038 we apply h-full to all routes. Because Delegates page didn't have wrapper it could end up on delegation not configured error message.

Closes: https://github.com/snapshot-labs/workflow/issues/424

### How to test

1. Go to http://localhost:8080/#/s:walletconnect.eth/delegates
2. Error message is shown at the top of the page.

### Reviewing

Mainly only whitespace changes, so you can use this setting to simplify:
<img width="333" alt="image" src="https://github.com/user-attachments/assets/29d23e1e-9165-4a47-9a94-beae1b177bee" />


### Screenshots
<img width="1917" alt="image" src="https://github.com/user-attachments/assets/badcc143-91c7-4720-8ec4-b75adcf7783f" />
