### PR TITLE
fix: add testnet delegation registry

### DIFF
--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -73,7 +73,7 @@ const DELEGATION_STRATEGIES = [
 
 const DELEGATE_REGISTRY_URLS: Partial<Record<NetworkID, string>> = {
   s: 'https://delegate-registry-api.snapshot.box',
-  's-tn': 'https://delegate-registry-api-testnet-kn6g3.ondigitalocean.app/'
+  's-tn': 'https://testnet-delegate-registry-api.snapshot.box'
 };
 
 function getProposalState(

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -71,7 +71,10 @@ const DELEGATION_STRATEGIES = [
   'erc20-balance-of-with-delegation'
 ];
 
-const DELEGATE_REGISTRY_URL = 'https://delegate-registry-api.snapshot.box';
+const DELEGATE_REGISTRY_URLS: Partial<Record<NetworkID, string>> = {
+  s: 'https://delegate-registry-api.snapshot.box',
+  's-tn': 'https://delegate-registry-api-testnet-kn6g3.ondigitalocean.app/'
+};
 
 function getProposalState(
   networkId: NetworkID,
@@ -194,7 +197,7 @@ function formatSpace(
     proposal_threshold: '1',
     treasuries,
     labels: space.labels,
-    delegations: formatDelegations(space),
+    delegations: formatDelegations(space, networkId),
     // NOTE: ignored
     created: 0,
     authenticators: [DEFAULT_AUTHENTICATOR],
@@ -362,7 +365,10 @@ function formatVote(vote: ApiVote): Vote {
   };
 }
 
-function formatDelegations(space: ApiSpace): SpaceMetadataDelegation[] {
+function formatDelegations(
+  space: ApiSpace,
+  networkId: NetworkID
+): SpaceMetadataDelegation[] {
   const delegations: SpaceMetadataDelegation[] = [];
 
   const spaceDelegationStrategy = space.strategies.find(strategy =>
@@ -391,13 +397,16 @@ function formatDelegations(space: ApiSpace): SpaceMetadataDelegation[] {
   if (spaceDelegationStrategy) {
     const chainId = parseInt(space.network, 10);
 
-    delegations.push({
-      name: 'Delegate registry',
-      apiType: 'delegate-registry',
-      apiUrl: DELEGATE_REGISTRY_URL,
-      contractAddress: space.id,
-      chainId
-    });
+    const apiUrl = DELEGATE_REGISTRY_URLS[networkId];
+    if (apiUrl) {
+      delegations.push({
+        name: 'Delegate registry',
+        apiType: 'delegate-registry',
+        apiUrl,
+        contractAddress: space.id,
+        chainId
+      });
+    }
   }
 
   return delegations;


### PR DESCRIPTION
### Summary

Before delegation registry only worked for mainnet spaces. Now we have second instance that is used for s-tn spaces.

Closes: https://github.com/snapshot-labs/workflow/issues/423

### How to test

1. Go to http://localhost:8080/#/s:cow.eth/delegates (mainnet) - it works
2. Go to http://localhost:8080/#/s-tn:thanku.eth/delegates - it works
