### PR TITLE
fix: use networks list only once ready

### DIFF
--- a/apps/ui/src/composables/useOffchainNetworksList.ts
+++ b/apps/ui/src/composables/useOffchainNetworksList.ts
@@ -59,6 +59,7 @@ export function useOffchainNetworksList(
 
   return {
     networks,
+    loaded,
     premiumChainIds
   };
 }

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -50,9 +50,11 @@ const { get: getPropositionPower, fetch: fetchPropositionPower } =
 const { strategiesWithTreasuries } = useTreasuries(props.space);
 const termsStore = useTermsStore();
 const timestamp = useTimestamp({ interval: 1000 });
-const { networks, premiumChainIds } = useOffchainNetworksList(
-  props.space.network
-);
+const {
+  networks,
+  premiumChainIds,
+  loaded: networksLoaded
+} = useOffchainNetworksList(props.space.network);
 const { limits, lists } = useSettings();
 
 const modalOpen = ref(false);
@@ -231,7 +233,7 @@ const proposalMaxEnd = computed(() => {
 });
 
 const unsupportedProposalNetworks = computed(() => {
-  if (!props.space.snapshot_chain_id) return [];
+  if (!props.space.snapshot_chain_id || !networksLoaded.value) return [];
 
   const ids = new Set<number>([
     props.space.snapshot_chain_id,


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes https://github.com/snapshot-labs/workflow/issues/427

This PR will wait until the list of premium networks are loaded before showing the warning, else all networks will be considered as non-premium

### How to test

1. Go to http://localhost:8080/#/s:stgdao.eth/create/hvwau
2. It should show only Avalanche as non-premium network, and not all strategies networks for a moment
