### PR TITLE
fix: fix watcher not being triggered on proposal change

### DIFF
--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -132,10 +132,15 @@ watch(
 );
 
 watch(
-  id,
-  async id => {
+  [id, proposal],
+  async ([id, proposal]) => {
     modalOpenVote.value = false;
     editMode.value = false;
+    discourseTopic.value = null;
+    boostCount.value = 0;
+
+    if (!proposal) return;
+
     if (discussion.value) {
       loadSingleTopic(discussion.value).then(result => {
         discourseTopic.value = result;
@@ -145,7 +150,7 @@ watch(
     if (props.space.additionalRawData?.boost?.enabled) {
       const bribeEnabled =
         props.space.additionalRawData.boost.bribeEnabled || false;
-      const proposalEnd = proposal.value?.max_end || 0;
+      const proposalEnd = proposal.max_end || 0;
       getBoostsCount(id, bribeEnabled, proposalEnd).then(result => {
         boostCount.value = result;
       });


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an issue where a watcher inside the proposal page is not being triggered, since the proposal is now fetched async out of the watcher with vue query

### How to test

1. Go to a proposal with some discussion, like http://localhost:8080/#/s:apecoin.eth/proposal/0xb732d60fcf82a2cd739f94fb76e950734475f08ce7b588e801fae9736f46f636
2. On page load, it should show the discussions count number
3. Navigating internally between some proposals page should refresh the counter
