### PR TITLE
fix: show network logo and apply dynamic width to network selector

### DIFF
--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -200,7 +200,7 @@ watch(model, () => {
     content: attr(data-value);
     @apply px-3 border-x col-start-1 row-start-1;
     visibility: hidden;
-    white-space: pre-wrap;
+    white-space: nowrap;
   }
 
   &.sizer-with-icon::after {

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -47,6 +47,12 @@ const inputValue = computed({
 });
 
 const content = computed(() => query.value || getDisplayValue(model.value));
+const icon = computed(() => {
+  const option = props.definition.options.find(
+    option => option.id === model.value
+  );
+  return option ? option.icon : null;
+});
 
 function handleFocus(event: FocusEvent, open: boolean) {
   if (!event.target || open) return;
@@ -97,20 +103,28 @@ watch(model, () => {
               sizer: inline
             }"
           >
-            <ComboboxInput
-              class="s-input !flex items-center justify-between !mb-0"
+            <div
+              class="s-input !flex items-center"
               :class="{
                 '!rounded-b-none': !gap && open,
-                'h-[42px] min-w-11': inline
+                'h-[42px]': inline
               }"
-              :size="'1'"
-              autocomplete="off"
-              :placeholder="definition.examples?.[0]"
-              :display-value="item => getDisplayValue(item as T)"
-              @keydown.enter="() => (query = '')"
-              @change="e => (query = e.target.value)"
-              @focus="event => handleFocus(event, open)"
-            />
+            >
+              <component :is="icon" class="size-[20px] mr-2" />
+              <ComboboxInput
+                class="bg-transparent"
+                :size="content.length"
+                :class="{
+                  'h-[42px] min-w-11': inline
+                }"
+                autocomplete="off"
+                :placeholder="definition.examples?.[0]"
+                :display-value="item => getDisplayValue(item as T)"
+                @keydown.enter="() => (query = '')"
+                @change="e => (query = e.target.value)"
+                @focus="event => handleFocus(event, open)"
+              />
+            </div>
           </ComboboxButton>
           <ComboboxButton v-if="!inline" class="absolute right-3 bottom-[14px]">
             <IH-chevron-up v-if="open" />
@@ -178,7 +192,7 @@ watch(model, () => {
     @apply col-start-1 row-start-1;
   }
 
-  &::after {
+  input::after {
     content: attr(data-value);
     @apply px-3 border-x col-start-1 row-start-1;
     visibility: hidden;

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -107,7 +107,7 @@ watch(model, () => {
             }"
           >
             <div
-              class="s-input !flex items-center"
+              class="s-input !flex items-center !mb-0"
               :class="{
                 '!rounded-b-none': !gap && open,
                 'h-[42px]': inline
@@ -193,13 +193,6 @@ watch(model, () => {
 
   input {
     @apply col-start-1 row-start-1;
-  }
-
-  .s-input::after {
-    content: attr(data-value);
-    @apply px-3 border-x col-start-1 row-start-1;
-    visibility: hidden;
-    white-space: pre-wrap;
   }
 }
 </style>

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -43,6 +43,7 @@ const inputValue = computed({
   },
   set(newValue: T | null) {
     dirty.value = true;
+    query.value = '';
     model.value = newValue;
   }
 });
@@ -105,31 +106,29 @@ watch(model, () => {
             as="div"
             :data-value="content"
             :class="{
-              sizer: inline
+              sizer: inline,
+              'sizer-with-icon': inline && icon
             }"
           >
-            <div
-              class="s-input !flex items-center !mb-0"
+            <component
+              :is="icon"
+              class="absolute size-[20px] left-3 bottom-2.5"
+            />
+            <ComboboxInput
+              class="s-input !flex items-center justify-between !mb-0"
               :class="{
                 '!rounded-b-none': !gap && open,
-                'h-[42px]': inline
+                'h-[42px] min-w-11': inline,
+                '!pl-[42px]': icon
               }"
-            >
-              <component :is="icon" class="size-[20px] mr-2" />
-              <ComboboxInput
-                class="bg-transparent"
-                :size="content.length"
-                :class="{
-                  'h-[42px] min-w-11': inline
-                }"
-                autocomplete="off"
-                :placeholder="definition.examples?.[0]"
-                :display-value="item => getDisplayValue(item as T)"
-                @keydown.enter="() => (query = '')"
-                @change="e => (query = e.target.value)"
-                @focus="event => handleFocus(event, open)"
-              />
-            </div>
+              :size="'1'"
+              autocomplete="off"
+              :placeholder="definition.examples?.[0]"
+              :display-value="item => getDisplayValue(item as T)"
+              @keydown.enter="() => (query = '')"
+              @change="e => (query = e.target.value)"
+              @focus="event => handleFocus(event, open)"
+            />
           </ComboboxButton>
           <ComboboxButton v-if="!inline" class="absolute right-3 bottom-[14px]">
             <IH-chevron-up v-if="open" />
@@ -195,6 +194,17 @@ watch(model, () => {
 
   input {
     @apply col-start-1 row-start-1;
+  }
+
+  &::after {
+    content: attr(data-value);
+    @apply px-3 border-x col-start-1 row-start-1;
+    visibility: hidden;
+    white-space: pre-wrap;
+  }
+
+  &.sizer-with-icon::after {
+    @apply pl-[42px];
   }
 }
 </style>

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -81,7 +81,10 @@ watch(model, () => {
     :definition="inline ? omit(definition, ['title']) : definition"
     :error="error"
     :dirty="dirty"
-    class="relative mb-[14px] w-auto"
+    class="relative w-auto"
+    :class="{
+      'mb-[14px]': !inline
+    }"
   >
     <Combobox v-slot="{ open }" v-model="inputValue" as="div" nullable>
       <Float
@@ -192,7 +195,7 @@ watch(model, () => {
     @apply col-start-1 row-start-1;
   }
 
-  input::after {
+  .s-input::after {
     content: attr(data-value);
     @apply px-3 border-x col-start-1 row-start-1;
     visibility: hidden;

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -102,7 +102,6 @@ watch(model, () => {
           }"
         >
           <ComboboxButton
-            class="w-full"
             as="div"
             :data-value="content"
             :class="{

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -142,7 +142,7 @@ watchEffect(() => setTitle('Explore'));
 <template>
   <div>
     <div class="flex justify-between p-4 gap-2 gap-y-3 flex-row">
-      <div class="flex flex-row flex-wrap gap-2">
+      <div class="flex sm:flex-row flex-col flex-wrap gap-2">
         <UiSelectDropdown
           v-model="protocol"
           class="min-h-[46px]"


### PR DESCRIPTION
### Summary
- Show network logo in network selector everywhere
- Adjust width dynamically on explore page

Closes https://github.com/snapshot-labs/workflow/issues/426
Closes https://github.com/snapshot-labs/workflow/issues/434

### How to test

1. Go to explore page, network selector should use dynamic width
2. ![image](https://github.com/user-attachments/assets/4e087032-3123-428b-8dea-77b0885031b6)
3. Go to strategies settings page, network selector should display network logo
4. <img width="627" alt="image" src="https://github.com/user-attachments/assets/46bdabd8-ea6a-4b65-9aa5-33b688c31ee7" />
5. Edit any strategy
6. <img width="550" alt="image" src="https://github.com/user-attachments/assets/1d774682-1837-4818-b8a5-ceb263c39ee5" />
7. Go to http://localhost:8080/#/sn:0x07c251045154318a2376a3bb65be47d3c90df1740d8e35c9b9d943aa3f240e50/profile/0x24F15402C6Bb870554489b2fd2049A85d75B982f
8. Click Delegate
9. <img width="518" alt="image" src="https://github.com/user-attachments/assets/2a62049c-4f62-454b-ab63-4e8dd3a3dd1b" />

