### PR TITLE
fix: remove title in space profile step

### DIFF
--- a/apps/ui/src/components/SpaceCreateSnapshot.vue
+++ b/apps/ui/src/components/SpaceCreateSnapshot.vue
@@ -33,10 +33,11 @@ const DEFAULT_STEP_ERRORS = {
 
 type extendedStepRecords = Record<
   keyof StepRecords,
-  StepRecords[keyof StepRecords] & {
-    contentTitle: string;
-    contentDescription?: string;
-  }
+  StepRecords[keyof StepRecords] &
+    Partial<{
+      contentTitle: string;
+      contentDescription: string;
+    }>
 >;
 
 const STEPS: extendedStepRecords = {
@@ -60,9 +61,7 @@ const STEPS: extendedStepRecords = {
   },
   profile: {
     title: 'Profile',
-    isValid: () => !stepsErrors.value['profile'],
-    contentTitle: '',
-    contentDescription: ''
+    isValid: () => !stepsErrors.value['profile']
   },
   network: {
     title: 'Network',

--- a/apps/ui/src/components/SpaceCreateSnapshot.vue
+++ b/apps/ui/src/components/SpaceCreateSnapshot.vue
@@ -61,8 +61,8 @@ const STEPS: extendedStepRecords = {
   profile: {
     title: 'Profile',
     isValid: () => !stepsErrors.value['profile'],
-    contentTitle: 'Space profile',
-    contentDescription: 'Tell us more about your space.'
+    contentTitle: '',
+    contentDescription: ''
   },
   network: {
     title: 'Network',

--- a/apps/ui/src/components/SpaceCreateSnapshotX.vue
+++ b/apps/ui/src/components/SpaceCreateSnapshotX.vue
@@ -138,7 +138,6 @@ watch(selectedNetworkId, () => {
   <UiStepper v-else :steps="STEPS" @submit="handleSubmit">
     <template #content="{ currentStep }">
       <template v-if="currentStep === 'profile'">
-        <h3 class="mb-4">Space profile</h3>
         <FormSpaceProfile
           :form="metadataForm"
           @errors="v => handleErrors('profile', v)"

--- a/apps/ui/src/components/Ui/ContainerSettings.vue
+++ b/apps/ui/src/components/Ui/ContainerSettings.vue
@@ -9,7 +9,6 @@ defineProps<{
   <div class="mb-4">
     <h3
       v-if="title"
-      class="text-md leading-6"
       :class="{
         'mb-4': !description
       }"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward https://github.com/snapshot-labs/workflow/issues/437 

This PR removes the title and description in the PROFILE section, while creating a space, and removes the `text-md leading-6` from the step title