### PR TITLE
fix: state of quorum of rejection

### DIFF
--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -83,11 +83,17 @@ function getProposalState(
   if (proposal.state === 'closed') {
     const currentQuorum = getProposalCurrentQuorum(networkId, {
       scores: proposal.scores,
-      scores_total: proposal.scores_total
+      scores_total: proposal.scores_total,
+      quorum_type: proposal.quorumType
     });
 
-    if (currentQuorum < proposal.quorum) return 'rejected';
-
+    if (
+      (proposal.quorumType === 'rejection' &&
+        currentQuorum > proposal.quorum) ||
+      (proposal.quorumType !== 'rejection' && currentQuorum < proposal.quorum)
+    ) {
+      return 'rejected';
+    }
     if (proposal.type !== 'basic') {
       return 'closed';
     }


### PR DESCRIPTION
### Summary

Issue: https://discord.com/channels/955773041898573854/1031838169282392144/1338513018530562140

We are not handling quorum of rejection while calculating state

### How to test

1. Go to http://localhost:8080/#/s:usualmoney.eth/proposal/0x1b081d3b3dd611094e96b690dc5d981d86bb724cce5ef562d9eecbe580b535c2
2. this with proposal with a quorum of rejection and quorum less than 100%, You should see "passed" instead of "rejected"
3. [Proposal with a quorum of rejection and quorum more than 100%](http://localhost:8080/#/s:metislayer2.eth/proposal/0x3c0a2e5e310f42ea4f762f072beb6b225099122a75ab2f0cea22c716ee7384ce) should show "Rejected"
3. [Active proposals](http://localhost:8080/#/s:pistachiodao.eth/proposal/0xa5077ef17097b1d59304b110337bd1c7ce98d95d3ff81d138c3886a80074b4d9) should show "Active"
4. [Non basic proposal and quorum more than 100%](http://localhost:8080/#/s:gitcoindao.eth/proposal/0xb8dfbefd47373a98ac4684af50f61dad738650830f4f106347cb3c4a8dec79ab) should show "closed"
5. [Non basic proposal and quorum less than 100%](http://localhost:8080/#/s:gitcoindao.eth/proposal/0x8b698644c08b424f87709228caa0ee11af6a3a047d47032b0f45a7f971d15696) should show "rejected"