### PR TITLE
fix: remove the offchain getting started step in space creation

### DIFF
--- a/apps/ui/src/components/EnsConfiguratorOffchain.vue
+++ b/apps/ui/src/components/EnsConfiguratorOffchain.vue
@@ -22,6 +22,7 @@ const {
   refresh
 } = useWalletEns(props.networkId);
 const { web3 } = useWeb3();
+const { modalAccountOpen } = useModal();
 
 const validNames = computed(() => {
   return Object.values(names.value || {}).filter(d => d.status === 'AVAILABLE');
@@ -75,82 +76,93 @@ function handleSelect(value: string) {
         space or proposals on Snapshot.
       </UiMessage>
     </div>
-    <div class="space-y-3">
-      <div class="flex justify-between items-center">
-        <h4 class="eyebrow">ENS names</h4>
-        <UiButton
-          v-if="names"
-          class="flex items-center gap-1 !text-skin-text !p-0 !border-0 !h-auto !w-auto"
-          :disabled="isLoading"
-          :loading="isRefreshing"
-          @click="refresh"
-        >
-          <IH-refresh class="h-[16px]" />
-          Refresh
-        </UiButton>
-      </div>
-      <UiLoading v-if="(isLoading && !isRefreshing) || !names" class="block" />
-      <div v-else-if="Object.keys(names).length" class="space-y-2">
-        <UiSelector
-          v-for="name in validNames"
-          :key="name.name"
-          :is-active="spaceId === name.name"
-          class="w-full"
-          @click="() => handleSelect(name.name)"
-        >
-          <div class="flex gap-2 items-center text-skin-link">
-            <IH-Globe-alt class="shrink-0" />
-            {{ name.name }}
-          </div>
-        </UiSelector>
-        <UiSelector
-          v-for="name in invalidNames"
-          :key="name.name"
-          :disabled="true"
-          class="w-full"
-        >
-          <div class="flex gap-2 items-top">
-            <IH-Exclamation class="mt-[5px] text-skin-danger shrink-0" />
-            <div class="flex flex-col">
-              <div class="text-skin-danger" v-text="name.name" />
-              <div v-if="name.status === 'TOO_LONG'">
-                ENS name is too long. It must be less than
-                {{ MAX_ENS_NAME_LENGTH }} characters
-              </div>
-              <div v-else-if="name.status === 'DELETED'">
-                ENS name was used by a previously deleted space and can not be
-                reused to create a new space.
-                <AppLink
-                  to="https://docs.snapshot.box/faq/im-a-snapshot-user/space-settings#why-cant-i-create-a-new-space-with-my-previous-deleted-space-ens-name"
-                  class="text-skin-link"
-                >
-                  Learn more
-                  <IH-arrow-sm-right class="-rotate-45 inline" />
-                </AppLink>
+    <div v-if="web3.account" class="space-y-4">
+      <div class="space-y-3">
+        <div class="flex justify-between items-center">
+          <h4 class="eyebrow">ENS names</h4>
+          <UiButton
+            v-if="names"
+            class="flex items-center gap-1 !text-skin-text !p-0 !border-0 !h-auto !w-auto"
+            :disabled="isLoading"
+            :loading="isRefreshing"
+            @click="refresh"
+          >
+            <IH-refresh class="h-[16px]" />
+            Refresh
+          </UiButton>
+        </div>
+        <UiLoading
+          v-if="(isLoading && !isRefreshing) || !names"
+          class="block"
+        />
+        <div v-else-if="Object.keys(names).length" class="space-y-2">
+          <UiSelector
+            v-for="name in validNames"
+            :key="name.name"
+            :is-active="spaceId === name.name"
+            class="w-full"
+            @click="() => handleSelect(name.name)"
+          >
+            <div class="flex gap-2 items-center text-skin-link">
+              <IH-Globe-alt class="shrink-0" />
+              {{ name.name }}
+            </div>
+          </UiSelector>
+          <UiSelector
+            v-for="name in invalidNames"
+            :key="name.name"
+            :disabled="true"
+            class="w-full"
+          >
+            <div class="flex gap-2 items-top">
+              <IH-Exclamation class="mt-[5px] text-skin-danger shrink-0" />
+              <div class="flex flex-col">
+                <div class="text-skin-danger" v-text="name.name" />
+                <div v-if="name.status === 'TOO_LONG'">
+                  ENS name is too long. It must be less than
+                  {{ MAX_ENS_NAME_LENGTH }} characters
+                </div>
+                <div v-else-if="name.status === 'DELETED'">
+                  ENS name was used by a previously deleted space and can not be
+                  reused to create a new space.
+                  <AppLink
+                    to="https://docs.snapshot.box/faq/im-a-snapshot-user/space-settings#why-cant-i-create-a-new-space-with-my-previous-deleted-space-ens-name"
+                    class="text-skin-link"
+                  >
+                    Learn more
+                    <IH-arrow-sm-right class="-rotate-45 inline" />
+                  </AppLink>
+                </div>
               </div>
             </div>
-          </div>
-        </UiSelector>
+          </UiSelector>
+        </div>
+        <UiMessage v-else type="danger">
+          No ENS names found for the current wallet.
+        </UiMessage>
+        <AppLink to="https://app.ens.domains" class="inline-block">
+          Register a new ENS name
+          <IH-arrow-sm-right class="-rotate-45 inline" />
+        </AppLink>
       </div>
-      <UiMessage v-else type="danger">
-        No ENS names found for the current wallet.
-      </UiMessage>
-      <AppLink to="https://app.ens.domains" class="inline-block">
-        Register a new ENS name <IH-arrow-sm-right class="-rotate-45 inline" />
-      </AppLink>
+      <div class="space-y-3">
+        <h4 class="eyebrow">Controller</h4>
+        <UiMessage type="info">
+          Your space controller will be set to the ENS name owner. Any changes
+          to the ENS name ownership will also change the controller.</UiMessage
+        >
+        <FormSpaceController
+          :controller="web3.account"
+          :network="getNetwork(networkId)"
+          :disabled="true"
+        />
+      </div>
     </div>
-
-    <div class="space-y-3">
-      <h4 class="eyebrow">Controller</h4>
-      <UiMessage type="info">
-        Your space controller will be set to the ENS name owner. Any changes to
-        the ENS name ownership will also change the controller.</UiMessage
-      >
-      <FormSpaceController
-        :controller="web3.account"
-        :network="getNetwork(networkId)"
-        :disabled="true"
-      />
-    </div>
+    <UiMessage v-else type="danger">
+      <button class="text-skin-link" @click="modalAccountOpen = true">
+        Connect your wallet
+      </button>
+      in order to see your ENS names
+    </UiMessage>
   </div>
 </template>

--- a/apps/ui/src/components/Ui/Stepper.vue
+++ b/apps/ui/src/components/Ui/Stepper.vue
@@ -3,7 +3,6 @@ export type StepRecords = Record<string, Step>;
 type Step = {
   title: string;
   isValid: () => boolean;
-  onBeforeQuit?: () => boolean;
 };
 
 const props = withDefaults(
@@ -37,8 +36,6 @@ const currentStep = computed(() => {
 });
 
 function goToStep(stepName: string) {
-  if (props.steps[currentStep.value]?.onBeforeQuit?.() === false) return;
-
   stepper.goTo(stepName);
   window.scrollTo({
     top: 0

--- a/apps/ui/src/views/CreateSpaceSnapshot.vue
+++ b/apps/ui/src/views/CreateSpaceSnapshot.vue
@@ -43,18 +43,6 @@ type extendedStepRecords = Record<
 >;
 
 const STEPS: extendedStepRecords = {
-  welcome: {
-    title: 'Getting started',
-    isValid: () => !web3.value.authLoading,
-    contentTitle: 'Getting started',
-    contentDescription: 'Create a snapshot space offchain.',
-    onBeforeQuit: () => {
-      if (web3.value.account) return true;
-
-      modalAccountOpen.value = true;
-      return false;
-    }
-  },
   id: {
     title: 'ENS name',
     isValid: () => !!settingsForm.value.id,
@@ -101,7 +89,6 @@ const STEPS: extendedStepRecords = {
 const { createSpaceRaw } = useActions();
 const { web3, authInitiated } = useWeb3();
 const router = useRouter();
-const { modalAccountOpen } = useModal();
 useTitle('Create space');
 
 const sending = ref(false);
@@ -225,30 +212,6 @@ watch(
           :title="STEPS[currentStep].contentTitle"
           :description="STEPS[currentStep].contentDescription"
         >
-          <div v-if="currentStep === 'welcome'" class="space-y-4">
-            <div>
-              You will be guided through the process of creating a space.
-              <br />
-              Don't worry, all settings can be changed later.
-            </div>
-            <div class="border py-3 px-4 rounded-lg flex gap-3">
-              <IH-Book-open class="shrink-0 size-[30px]" />
-              <div>
-                <b>Not sure how to setup your space?</b>
-                <br />
-                Learn more in the
-                <AppLink
-                  :to="'https://docs.snapshot.box/user-guides/spaces/create'"
-                >
-                  documentation
-                </AppLink>
-                or contact support on
-                <AppLink :to="'https://help.snapshot.box/en'">
-                  Helpdesk </AppLink
-                >.
-              </div>
-            </div>
-          </div>
           <EnsConfiguratorOffchain
             v-if="currentStep === 'id'"
             v-model="settingsForm.id"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward https://github.com/snapshot-labs/workflow/issues/437

This PR removes the "Getting started" step, in offchain space creation.

Since this removed step was also ensuring that only logged in users can move to step 2 before, a message was added in the ENS step for guest users, asking them to login

### How to test

1. Go to http://localhost:8080/#/create/snapshot
2. The "Getting started" step was removed, and the first step is now ENS name
3. In logged in, it should show your ENS names as before, else, it will show a message asking you to log in
