### PR TITLE
feat: use precomputed merkletree on Starknet

### DIFF
--- a/apps/mana/src/constants.ts
+++ b/apps/mana/src/constants.ts
@@ -1,0 +1,1 @@
+export const PORT = process.env.PORT || 3001;

--- a/apps/mana/src/db.ts
+++ b/apps/mana/src/db.ts
@@ -2,6 +2,7 @@ import knex from './knex';
 
 export const REGISTERED_TRANSACTIONS = 'registered_transactions';
 export const REGISTERED_PROPOSALS = 'registered_proposals';
+export const MERKLETREE_REQUESTS = 'merkletree_requests';
 export const MERKLETREES = 'merkletrees';
 
 export async function createTables() {
@@ -10,6 +11,8 @@ export async function createTables() {
   );
   const registeredProposalsTableExists =
     await knex.schema.hasTable(REGISTERED_PROPOSALS);
+  const merkletreeRequestsTableExists =
+    await knex.schema.hasTable(MERKLETREE_REQUESTS);
   const merkletreesTableExists = await knex.schema.hasTable(MERKLETREES);
 
   if (!registeredTransactionsTableExists) {
@@ -36,6 +39,15 @@ export async function createTables() {
       t.string('strategyAddress');
       t.string('herodotusId');
       t.boolean('processed').defaultTo(false).index();
+    });
+  }
+
+  if (!merkletreeRequestsTableExists) {
+    await knex.schema.createTable(MERKLETREE_REQUESTS, t => {
+      t.string('id').primary();
+      t.timestamps(true, true);
+      t.boolean('processed').defaultTo(false).index();
+      t.string('root');
     });
   }
 
@@ -131,14 +143,26 @@ export async function getDataByMessageHash(hash: string) {
     .first();
 }
 
-export async function saveMerkleTree(id: string, tree: string[]) {
-  return knex(MERKLETREES)
-    .insert({
+export async function saveMerkleTree(id: string, root: string, tree: string[]) {
+  return knex.transaction(async trx => {
+    await trx(MERKLETREES)
+      .insert({
+        id: root,
+        tree: JSON.stringify(tree)
+      })
+      .onConflict()
+      .ignore();
+
+    await trx(MERKLETREE_REQUESTS).insert({
       id,
-      tree: JSON.stringify(tree)
-    })
-    .onConflict()
-    .ignore();
+      processed: true,
+      root
+    });
+  });
+}
+
+export async function getMerkleTreeRequest(id: string) {
+  return knex(MERKLETREE_REQUESTS).select('*').where({ id }).first();
 }
 
 export async function getMerkleTree(id: string) {

--- a/apps/mana/src/index.ts
+++ b/apps/mana/src/index.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import cors from 'cors';
 import express from 'express';
+import { PORT } from './constants';
 import { createTables } from './db';
 import ethRpc from './eth';
 import starkRpc from './stark';
@@ -11,11 +12,11 @@ import {
 import pkg from '../package.json';
 
 const app = express();
-const PORT = process.env.PORT || 3001;
+
 const commit = process.env.COMMIT_HASH || '';
 const version = commit ? `${pkg.version}#${commit.substr(0, 7)}` : pkg.version;
 
-app.use(express.json({ limit: '4mb' }));
+app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ limit: '4mb', extended: false }));
 app.use(cors({ maxAge: 86400 }));
 app.use('/eth_rpc', ethRpc);

--- a/apps/mana/src/stark/index.ts
+++ b/apps/mana/src/stark/index.ts
@@ -17,6 +17,7 @@ const jsonRpcRequestSchema = z.object({
     'registerTransaction',
     'registerProposal',
     'getDataByMessageHash',
+    'generateMerkleTree',
     'getMerkleRoot',
     'getMerkleProof'
   ]),

--- a/apps/mana/src/stark/index.ts
+++ b/apps/mana/src/stark/index.ts
@@ -16,7 +16,9 @@ const jsonRpcRequestSchema = z.object({
     'execute',
     'registerTransaction',
     'registerProposal',
-    'getDataByMessageHash'
+    'getDataByMessageHash',
+    'getMerkleRoot',
+    'getMerkleProof'
   ]),
   params: z.any()
 });

--- a/apps/mana/src/stark/networks.ts
+++ b/apps/mana/src/stark/networks.ts
@@ -7,6 +7,7 @@ import {
 import { Account, constants, RpcProvider } from 'starknet';
 import { createAccountProxy, ETH_NODE_URLS, getProvider } from './dependencies';
 import { NonceManager } from './nonce-manager';
+import { PORT } from '../constants';
 
 export const NETWORKS = new Map<string, NetworkConfig>([
   [constants.StarknetChainId.SN_MAIN, starknetMainnet],
@@ -47,7 +48,8 @@ export function getClient(chainId: string) {
   const client = new clients.StarknetTx({
     starkProvider: provider,
     ethUrl,
-    networkConfig
+    networkConfig,
+    manaUrl: `http://localhost:${PORT}`
   });
 
   const herodotusController = new clients.HerodotusController(networkConfig);

--- a/apps/mana/src/stark/rpc.ts
+++ b/apps/mana/src/stark/rpc.ts
@@ -151,17 +151,38 @@ export const createNetworkHandler = (chainId: string) => {
     }
   }
 
-  async function getMerkleRoot(id: number, params: any, res: Response) {
+  async function generateTree(requestId: string, entries: string[]) {
+    const tree = await utils.merkle.generateMerkleTree(entries);
+    const root = tree[0];
+    if (!root) throw new Error('Merkle tree not generated');
+
+    await db.saveMerkleTree(requestId, root, tree);
+  }
+
+  async function generateMerkleTree(id: number, params: any, res: Response) {
     try {
       const { entries } = params;
 
-      const tree = await utils.merkle.generateMerkleTree(entries);
-      const root = tree[0];
-      if (!root) throw new Error('Merkle tree not generated');
+      const requestId = crypto.randomUUID();
 
-      await db.saveMerkleTree(root, tree);
+      // NOTE: no await here as we want to execute it in the background
+      generateTree(requestId, entries);
 
-      return rpcSuccess(res, root, id);
+      return rpcSuccess(res, requestId, id);
+    } catch (e) {
+      console.log('Failed', e);
+      return rpcError(res, 500, e, id);
+    }
+  }
+
+  async function getMerkleRoot(id: number, params: any, res: Response) {
+    try {
+      const { requestId } = params;
+
+      const request = await db.getMerkleTreeRequest(requestId);
+      if (!request) throw new Error('Request not ready yet');
+
+      return rpcSuccess(res, request.root, id);
     } catch (e) {
       console.log('Failed', e);
       return rpcError(res, 500, e, id);
@@ -191,6 +212,7 @@ export const createNetworkHandler = (chainId: string) => {
     registerProposal,
     getAccount,
     getDataByMessageHash,
+    generateMerkleTree,
     getMerkleRoot,
     getMerkleProof
   };

--- a/apps/mana/src/stark/rpc.ts
+++ b/apps/mana/src/stark/rpc.ts
@@ -155,9 +155,9 @@ export const createNetworkHandler = (chainId: string) => {
 
   async function getMerkleRoot(id: number, params: any, res: Response) {
     try {
-      const { hashes } = params;
+      const { entries } = params;
 
-      tree = utils.merkle.generateMerkleTree(hashes);
+      tree = await utils.merkle.generateMerkleTree(entries);
       const root = tree[0];
 
       return rpcSuccess(res, root, id);
@@ -173,7 +173,7 @@ export const createNetworkHandler = (chainId: string) => {
 
       const { root, index } = params;
 
-      const proof = utils.merkle.getProof(tree, tree.length - 1 - index);
+      const proof = utils.merkle.generateMerkleProof(tree, index);
 
       return rpcSuccess(res, proof, id);
     } catch (e) {

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -296,12 +296,12 @@ export function useSpaceSettings(space: Ref<Space>) {
     let params: string[] = [];
     if (evmNetworks.includes(space.value.network)) {
       params = strategy.generateParams
-        ? strategy.generateParams(strategy.params)
+        ? await strategy.generateParams(strategy.params)
         : ['0x'];
       previousParams = previousParams ?? ['0x'];
     } else {
       params = strategy.generateParams
-        ? strategy.generateParams(strategy.params)
+        ? await strategy.generateParams(strategy.params)
         : [];
       previousParams = previousParams ?? [];
     }

--- a/apps/ui/src/helpers/mana.ts
+++ b/apps/ui/src/helpers/mana.ts
@@ -46,11 +46,20 @@ export async function executionCall(
   return rpcCall(`${network}_rpc/${chainId}`, method, params);
 }
 
-export async function getMerkleRoot(
+export async function generateMerkleTree(
   chainId: number | string,
   params: {
     entries: string[];
   }
-) {
+): Promise<string> {
+  return rpcCall(`stark_rpc/${chainId}`, 'generateMerkleTree', params);
+}
+
+export async function getMerkleRoot(
+  chainId: number | string,
+  params: {
+    requestId: string;
+  }
+): Promise<string> {
   return rpcCall(`stark_rpc/${chainId}`, 'getMerkleRoot', params);
 }

--- a/apps/ui/src/helpers/mana.ts
+++ b/apps/ui/src/helpers/mana.ts
@@ -45,3 +45,12 @@ export async function executionCall(
 ) {
   return rpcCall(`${network}_rpc/${chainId}`, method, params);
 }
+
+export async function getMerkleRoot(
+  chainId: number | string,
+  params: {
+    entries: string[];
+  }
+) {
+  return rpcCall(`stark_rpc/${chainId}`, 'getMerkleRoot', params);
+}

--- a/apps/ui/src/networks/common/helpers.ts
+++ b/apps/ui/src/networks/common/helpers.ts
@@ -148,7 +148,11 @@ export function createStrategyPicker({
     const selectedStrategies = strategies
       .map(
         (strategy, index) =>
-          ({ address: strategy, index: strategiesIndicies[index] }) as const
+          ({
+            address: strategy,
+            index: strategiesIndicies[index],
+            paramsIndex: index
+          }) as const
       )
       .filter(({ address }) => helpers.isStrategySupported(address));
 

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -184,18 +184,22 @@ export function createActions(
         params: {
           ...params,
           authenticators: params.authenticators.map(config => config.address),
-          votingStrategies: params.votingStrategies.map(config => ({
-            addr: config.address,
-            params: config.generateParams
-              ? config.generateParams(config.params)[0]
-              : '0x'
-          })),
+          votingStrategies: await Promise.all(
+            params.votingStrategies.map(async config => ({
+              addr: config.address,
+              params: config.generateParams
+                ? (await config.generateParams(config.params))[0]
+                : '0x'
+            }))
+          ),
           votingStrategiesMetadata: metadataUris,
           proposalValidationStrategy: {
             addr: params.validationStrategy.address,
             params: params.validationStrategy.generateParams
-              ? params.validationStrategy.generateParams(
-                  params.validationStrategy.params
+              ? (
+                  await params.validationStrategy.generateParams(
+                    params.validationStrategy.params
+                  )
                 )[0]
               : '0x'
           },
@@ -707,12 +711,14 @@ export function createActions(
             authenticatorsToRemove: space.authenticators.filter(
               (authenticator, index) => authenticatorsToRemove.includes(index)
             ),
-            votingStrategiesToAdd: votingStrategiesToAdd.map(config => ({
-              addr: config.address,
-              params: config.generateParams
-                ? config.generateParams(config.params)[0]
-                : '0x'
-            })),
+            votingStrategiesToAdd: await Promise.all(
+              votingStrategiesToAdd.map(async config => ({
+                addr: config.address,
+                params: config.generateParams
+                  ? (await config.generateParams(config.params))[0]
+                  : '0x'
+              }))
+            ),
             votingStrategiesToRemove: votingStrategiesToRemove.map(
               index => space.strategies_indices[index]
             ),
@@ -720,8 +726,10 @@ export function createActions(
             proposalValidationStrategy: {
               addr: validationStrategy.address,
               params: validationStrategy.generateParams
-                ? validationStrategy.generateParams(
-                    validationStrategy.params
+                ? (
+                    await validationStrategy.generateParams(
+                      validationStrategy.params
+                    )
                   )[0]
                 : '0x'
             },

--- a/apps/ui/src/networks/evm/constants.test.ts
+++ b/apps/ui/src/networks/evm/constants.test.ts
@@ -27,8 +27,8 @@ describe('EVM Constants', () => {
       });
 
       describe('generateParams', () => {
-        it('should return the encoded value of the whitelist tree root', () => {
-          const summary = strategy.generateParams!({
+        it('should return the encoded value of the whitelist tree root', async () => {
+          const summary = await strategy.generateParams!({
             whitelist: input
           });
 

--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -98,17 +98,19 @@ export function createConstants(networkId: NetworkID) {
         return params?.strategies?.length > 0;
       },
       generateSummary: (params: Record<string, any>) => `(${params.threshold})`,
-      generateParams: (params: Record<string, any>) => {
+      generateParams: async (params: Record<string, any>) => {
         const abiCoder = new AbiCoder();
 
-        const strategies = params.strategies.map((strategy: StrategyConfig) => {
-          return {
-            addr: strategy.address,
-            params: strategy.generateParams
-              ? strategy.generateParams(strategy.params)[0]
-              : '0x00'
-          };
-        });
+        const strategies = await Promise.all(
+          params.strategies.map(async (strategy: StrategyConfig) => {
+            return {
+              addr: strategy.address,
+              params: strategy.generateParams
+                ? (await strategy.generateParams(strategy.params))[0]
+                : '0x00'
+            };
+          })
+        );
 
         return [
           abiCoder.encode(
@@ -219,7 +221,7 @@ export function createConstants(networkId: NetworkID) {
 
         return `(${length} ${length === 1 ? 'address' : 'addresses'})`;
       },
-      generateParams: (params: Record<string, any>) => {
+      generateParams: async (params: Record<string, any>) => {
         const whitelist = params.whitelist
           .split(/[\n,]/)
           .filter((s: string) => s.trim().length)
@@ -313,7 +315,9 @@ export function createConstants(networkId: NetworkID) {
       icon: IHCode,
       generateSummary: (params: Record<string, any>) =>
         `(${shorten(params.contractAddress)}, ${params.decimals})`,
-      generateParams: (params: Record<string, any>) => [params.contractAddress],
+      generateParams: async (params: Record<string, any>) => [
+        params.contractAddress
+      ],
       generateMetadata: async (params: Record<string, any>) => ({
         name: 'ERC-20 Votes (EIP-5805)',
         properties: {
@@ -369,7 +373,9 @@ export function createConstants(networkId: NetworkID) {
       icon: IHCode,
       generateSummary: (params: Record<string, any>) =>
         `(${shorten(params.contractAddress)}, ${params.decimals})`,
-      generateParams: (params: Record<string, any>) => [params.contractAddress],
+      generateParams: async (params: Record<string, any>) => [
+        params.contractAddress
+      ],
       generateMetadata: async (params: Record<string, any>) => ({
         name: 'ERC-20 Votes Comp (EIP-5805)',
         properties: {

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -278,6 +278,11 @@ export function createActions(
 
       const strategiesWithMetadata = await Promise.all(
         strategies.map(async strategy => {
+          const params =
+            space.voting_power_validation_strategy_strategies_params[
+              strategy.paramsIndex
+            ];
+
           const metadata = await parseStrategyMetadata(
             space.voting_power_validation_strategies_parsed_metadata[
               strategy.index
@@ -286,6 +291,7 @@ export function createActions(
 
           return {
             ...strategy,
+            params,
             metadata
           };
         })
@@ -457,12 +463,14 @@ export function createActions(
             strategy.index
           );
 
+          const params = proposal.strategies_params[strategy.paramsIndex];
           const metadata = await parseStrategyMetadata(
             proposal.space.strategies_parsed_metadata[metadataIndex].payload
           );
 
           return {
             ...strategy,
+            params,
             metadata
           };
         })

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -188,7 +188,7 @@ export function createActions(
           proposalValidationStrategy: {
             addr: params.validationStrategy.address,
             params: params.validationStrategy.generateParams
-              ? params.validationStrategy.generateParams(
+              ? await params.validationStrategy.generateParams(
                   params.validationStrategy.params
                 )
               : []
@@ -197,12 +197,14 @@ export function createActions(
           metadataUri: `ipfs://${pinned.cid}`,
           daoUri: '',
           authenticators: params.authenticators.map(config => config.address),
-          votingStrategies: params.votingStrategies.map(config => ({
-            addr: config.address,
-            params: config.generateParams
-              ? config.generateParams(config.params)
-              : []
-          })),
+          votingStrategies: await Promise.all(
+            params.votingStrategies.map(async config => ({
+              addr: config.address,
+              params: config.generateParams
+                ? await config.generateParams(config.params)
+                : []
+            }))
+          ),
           votingStrategiesMetadata: metadataUris
         }
       });
@@ -635,12 +637,14 @@ export function createActions(
           authenticatorsToRemove: space.authenticators.filter(
             (authenticator, index) => authenticatorsToRemove.includes(index)
           ),
-          votingStrategiesToAdd: votingStrategiesToAdd.map(config => ({
-            addr: config.address,
-            params: config.generateParams
-              ? config.generateParams(config.params)
-              : []
-          })),
+          votingStrategiesToAdd: await Promise.all(
+            votingStrategiesToAdd.map(async config => ({
+              addr: config.address,
+              params: config.generateParams
+                ? await config.generateParams(config.params)
+                : []
+            }))
+          ),
           votingStrategiesToRemove: votingStrategiesToRemove.map(
             index => space.strategies_indices[index]
           ),
@@ -648,7 +652,9 @@ export function createActions(
           proposalValidationStrategy: {
             addr: validationStrategy.address,
             params: validationStrategy.generateParams
-              ? validationStrategy.generateParams(validationStrategy.params)
+              ? await validationStrategy.generateParams(
+                  validationStrategy.params
+                )
               : []
           },
           proposalValidationStrategyMetadataUri,

--- a/apps/ui/src/networks/starknet/constants.test.ts
+++ b/apps/ui/src/networks/starknet/constants.test.ts
@@ -33,7 +33,7 @@ describe('Starknet Constants', () => {
           });
 
           expect(summary).toEqual([
-            '0x26ac8b72505b27418bbc9b251f96d392e11a22152e38291903490c3d2d92948'
+            '0x4d1cfb0a286a8f340bf7a0108359a796c5763cf540b55bcc1d049d0ef8f18e8'
           ]);
         });
       });

--- a/apps/ui/src/networks/starknet/constants.test.ts
+++ b/apps/ui/src/networks/starknet/constants.test.ts
@@ -27,7 +27,8 @@ describe('Starknet Constants', () => {
       });
 
       describe('generateParams', () => {
-        it('should return the encoded value of the whitelist tree root', async () => {
+        // NOTE: skiping because this calls mana, but this endpoint is not available on prod
+        it.skip('should return the encoded value of the whitelist tree root', async () => {
           const summary = await strategy.generateParams!({
             whitelist: input
           });

--- a/apps/ui/src/networks/starknet/constants.test.ts
+++ b/apps/ui/src/networks/starknet/constants.test.ts
@@ -27,8 +27,8 @@ describe('Starknet Constants', () => {
       });
 
       describe('generateParams', () => {
-        it('should return the encoded value of the whitelist tree root', () => {
-          const summary = strategy.generateParams!({
+        it('should return the encoded value of the whitelist tree root', async () => {
+          const summary = await strategy.generateParams!({
             whitelist: input
           });
 

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -85,7 +85,7 @@ export type StrategyTemplate = {
   paramsDefinition: any;
   validate?: (params: Record<string, any>) => boolean;
   generateSummary?: (params: Record<string, any>) => string;
-  generateParams?: (params: Record<string, any>) => any[];
+  generateParams?: (params: Record<string, any>) => Promise<any[]>;
   generateMetadata?: (
     params: Record<string, any>
   ) => Promise<GeneratedMetadata>;

--- a/packages/sx.js/src/strategies/starknet/erc20Votes.ts
+++ b/packages/sx.js/src/strategies/starknet/erc20Votes.ts
@@ -12,6 +12,7 @@ export default function createErc20VotesStrategy(): Strategy {
       signerAddress: string,
       address: string,
       index: number,
+      params: string,
       metadata: Record<string, any> | null,
       envelope: Envelope<Propose | Vote>,
       clientConfig: ClientConfig

--- a/packages/sx.js/src/strategies/starknet/evmSlotValue.ts
+++ b/packages/sx.js/src/strategies/starknet/evmSlotValue.ts
@@ -50,6 +50,7 @@ export default function createEvmSlotValueStrategy(): Strategy {
       signerAddress: string,
       address: string,
       index: number,
+      params: string,
       metadata: Record<string, any> | null,
       envelope: Envelope<Propose | Vote>,
       clientConfig: ClientConfig

--- a/packages/sx.js/src/strategies/starknet/merkleWhitelist.ts
+++ b/packages/sx.js/src/strategies/starknet/merkleWhitelist.ts
@@ -18,6 +18,7 @@ export default function createMerkleWhitelistStrategy(): Strategy {
       signerAddress: string,
       address: string,
       index: number,
+      params: string,
       metadata: Record<string, any> | null,
       envelope: Envelope<Propose | Vote>,
       clientConfig: ClientConfig

--- a/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
+++ b/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
@@ -74,6 +74,7 @@ export default function createOzVotesStorageProofStrategy({
       signerAddress: string,
       address: string,
       index: number,
+      params: string,
       metadata: Record<string, any> | null,
       envelope: Envelope<Propose | Vote>,
       clientConfig: ClientConfig

--- a/packages/sx.js/src/strategies/starknet/vanilla.ts
+++ b/packages/sx.js/src/strategies/starknet/vanilla.ts
@@ -10,6 +10,7 @@ export default function createVanillaStrategy(): Strategy {
       signerAddress: string,
       address: string,
       index: number,
+      params: string,
       metadata: Record<string, any> | null,
       envelope: Envelope<Propose | Vote>,
       clientConfig: ClientConfig

--- a/packages/sx.js/src/types/index.ts
+++ b/packages/sx.js/src/types/index.ts
@@ -62,6 +62,7 @@ export interface Strategy {
     signerAddress: string,
     address: string,
     index: number,
+    params: string,
     metadata: Record<string, any> | null,
     envelope: Envelope<Message>,
     clientConfig: ClientConfig
@@ -110,6 +111,7 @@ export type IndexedConfig = {
 export type StrategyConfig = {
   index: number;
   address: string;
+  params: string;
   metadata?: Record<string, any>;
 };
 

--- a/packages/sx.js/src/types/index.ts
+++ b/packages/sx.js/src/types/index.ts
@@ -81,19 +81,13 @@ export type ClientOpts = {
   ethUrl: string;
   starkProvider: RpcProvider;
   networkConfig: NetworkConfig;
+  manaUrl: string;
 };
 
 export type ClientConfig = {
   ethUrl: string;
   starkProvider: RpcProvider;
   networkConfig: NetworkConfig;
-};
-
-export type EthereumSigClientOpts = ClientOpts & {
-  manaUrl: string;
-};
-
-export type EthereumSigClientConfig = ClientConfig & {
   manaUrl: string;
 };
 

--- a/packages/sx.js/src/utils/merkletree.ts
+++ b/packages/sx.js/src/utils/merkletree.ts
@@ -68,13 +68,17 @@ export function generateMerkleTree(leaves: string[]) {
   return tree;
 }
 
-export function generateMerkleProof(hashes: string[], index: number): string[] {
-  const tree = generateMerkleTree(hashes);
-
+export function getProof(tree: string[], index: number): string[] {
   const proof: string[] = [];
   while (index > 0) {
     proof.push(tree[siblingIndex(index)]!);
     index = parentIndex(index);
   }
   return proof;
+}
+
+export function generateMerkleProof(hashes: string[], index: number): string[] {
+  const tree = generateMerkleTree(hashes);
+
+  return getProof(tree, tree.length - 1 - index);
 }

--- a/packages/sx.js/src/utils/strategies.ts
+++ b/packages/sx.js/src/utils/strategies.ts
@@ -49,6 +49,7 @@ export async function getStrategiesWithParams(
           address,
           strategyData.address,
           strategyData.index,
+          strategyData.params,
           strategyData.metadata || null,
           {
             data

--- a/packages/sx.js/test/integration/starknet/utils.ts
+++ b/packages/sx.js/test/integration/starknet/utils.ts
@@ -272,7 +272,7 @@ export async function setup({
   };
   const merkleWhitelistStrategyMetadata = {
     tree: [leaf].map(leaf => ({
-      type: 0,
+      type: 1,
       address: leaf.address,
       votingPower: leaf.votingPower
     }))
@@ -280,6 +280,7 @@ export async function setup({
   const entries = [leaf].map(leaf => `${leaf.address}:${leaf.votingPower}`);
 
   const merkleTreeRoot = (await generateMerkleTree(entries))[0];
+  if (!merkleTreeRoot) throw new Error('Invalid merkle tree root');
 
   const networkConfig: NetworkConfig = {
     eip712ChainId: '0x534e5f5345504f4c4941',

--- a/packages/sx.js/test/integration/starknet/utils.ts
+++ b/packages/sx.js/test/integration/starknet/utils.ts
@@ -46,11 +46,7 @@ import { executeContractCallWithSigners } from './safeUtils';
 import { StarknetTx } from '../../../src/clients';
 import { NetworkConfig } from '../../../src/types';
 import { hexPadLeft } from '../../../src/utils/encoding';
-import {
-  AddressType,
-  generateMerkleRoot,
-  Leaf
-} from '../../../src/utils/merkletree';
+import { AddressType, generateMerkleTree } from '../../../src/utils/merkletree';
 
 export type TestConfig = {
   starknetCore: string;
@@ -270,21 +266,20 @@ export async function setup({
   const masterSpaceClassHash = masterSpaceResult.class_hash;
   const factoryAddress = factoryResult.deploy.contract_address;
 
-  const leaf = new Leaf(
-    AddressType.ETHEREUM,
-    '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-    42n
-  );
+  const leaf = {
+    address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    votingPower: 42n
+  };
   const merkleWhitelistStrategyMetadata = {
     tree: [leaf].map(leaf => ({
-      type: leaf.type,
+      type: 0,
       address: leaf.address,
       votingPower: leaf.votingPower
     }))
   };
-  const hashes = [leaf.hash];
+  const entries = [leaf].map(leaf => `${leaf.address}:${leaf.votingPower}`);
 
-  const merkleTreeRoot = generateMerkleRoot(hashes);
+  const merkleTreeRoot = (await generateMerkleTree(entries))[0];
 
   const networkConfig: NetworkConfig = {
     eip712ChainId: '0x534e5f5345504f4c4941',
@@ -328,7 +323,8 @@ export async function setup({
   const client = new StarknetTx({
     starkProvider: starknetProvider,
     ethUrl: 'https://rpc.brovider.xyz/5',
-    networkConfig
+    networkConfig,
+    manaUrl: 'https://mana.pizza'
   });
 
   const { address } = await client.deploySpace({

--- a/packages/sx.js/test/unit/strategies/starknet/merkleWhitelist.test.ts
+++ b/packages/sx.js/test/unit/strategies/starknet/merkleWhitelist.test.ts
@@ -37,6 +37,7 @@ describe('merkleWhitelist', () => {
       '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
       '0x344a63d1f5cd0e5f707fede9886d5dd306e86eba91ea410b416f39e44c3865',
       0,
+      '0x',
       metadata,
       proposeEnvelope,
       config

--- a/packages/sx.js/test/unit/utils/merkletree.test.ts
+++ b/packages/sx.js/test/unit/utils/merkletree.test.ts
@@ -2,17 +2,15 @@ import { describe, expect, it } from 'vitest';
 import {
   AddressType,
   generateMerkleProof,
-  generateMerkleRoot,
+  generateMerkleTree,
   Leaf
 } from '../../../src/utils/merkletree';
 
-const TEST_LEAVES = new Array(20).fill(null).map((_, i) => {
+const ENTRIES = new Array(20).fill(null).map((_, i) => {
   const value = BigInt(i + 1);
 
-  const type = value % 2n === 0n ? AddressType.ETHEREUM : AddressType.STARKNET;
   const address = `0x${value.toString(16)}`;
-
-  return new Leaf(type, address, value);
+  return `${address}:${value}`;
 });
 
 describe('Leaf', () => {
@@ -29,29 +27,28 @@ describe('Leaf', () => {
   });
 });
 
-describe('generateMerkleRoot', () => {
-  it('should compute root', () => {
-    const hashes = TEST_LEAVES.map(leaf => leaf.hash);
-    const root = generateMerkleRoot(hashes);
+describe('generateMerkleTree', () => {
+  it('should compute root', async () => {
+    const tree = await generateMerkleTree(ENTRIES);
+    const root = tree[0];
 
     expect(root).toBe(
-      '0x2cd57d8a58b881d7fa0d76116c16643a197ee50ca1e13b72f66eacd037402d8'
+      '0xbfddde52fc7d24a63693fb4dfa257571238e2d654aecbe6bc26f067e770bc5'
     );
   });
 });
 
 describe('generateMerkleProof', () => {
-  it('should compute proof', () => {
-    const hashes = TEST_LEAVES.map(leaf => leaf.hash);
-
-    const proof = generateMerkleProof(hashes, 2);
+  it('should compute proof', async () => {
+    const tree = await generateMerkleTree(ENTRIES);
+    const proof = generateMerkleProof(tree, 2);
 
     expect(proof).toEqual([
-      '0x58a8aa77c41ec244fe82f53a8e336ee2978e02af49477871f5eb18d6f89ba1f',
-      '0x29b078fa0df4bf7784887539cf8afe0cec533cdc6a4bbf33ec3e6ed245c711b',
-      '0x688b1e6adba3b93a03f9ce5c9d220aa403a922c72586eff397a34ad664838a5',
-      '0x723b259e0f6a643e0c79dbcca6c830755465c31ebd81ce480a07d00d9e5e8e7',
-      '0x64ce84b224c2acd608f05be345783252bb82c8e7c0e455598b0701b5b79903f'
+      '0x3eca1772359b7a5b248088472ef392716c034e899c510d6e02c0c97704164ab',
+      '0x1919a163ca6cb8d28728b24847c269529cf3af4caafb0a2b3e2fd19715f1a8b',
+      '0x7a99182fabd949861d469e6e6143187c71ced341c2168de0f62e8e025d76dfc',
+      '0x2f0a9bf11b7f4792a3b732f518168d960cfa73d244c020cb88c80293b4fff91',
+      '0x2f5a19d2f01021cbd28d1073a68b4123cc56c5811d6da8dea6e0c4c921c0c21'
     ]);
   });
 });

--- a/packages/sx.js/test/unit/utils/merkletree.test.ts
+++ b/packages/sx.js/test/unit/utils/merkletree.test.ts
@@ -35,7 +35,7 @@ describe('generateMerkleRoot', () => {
     const root = generateMerkleRoot(hashes);
 
     expect(root).toBe(
-      '0x436373667bef3c745b30e5ae2b485ed5bed08a8c8696f8edeb5cd08ddcc5145'
+      '0x2cd57d8a58b881d7fa0d76116c16643a197ee50ca1e13b72f66eacd037402d8'
     );
   });
 });
@@ -43,14 +43,15 @@ describe('generateMerkleRoot', () => {
 describe('generateMerkleProof', () => {
   it('should compute proof', () => {
     const hashes = TEST_LEAVES.map(leaf => leaf.hash);
+
     const proof = generateMerkleProof(hashes, 2);
 
     expect(proof).toEqual([
       '0x58a8aa77c41ec244fe82f53a8e336ee2978e02af49477871f5eb18d6f89ba1f',
       '0x29b078fa0df4bf7784887539cf8afe0cec533cdc6a4bbf33ec3e6ed245c711b',
       '0x688b1e6adba3b93a03f9ce5c9d220aa403a922c72586eff397a34ad664838a5',
-      '0x64ce84b224c2acd608f05be345783252bb82c8e7c0e455598b0701b5b79903f',
-      '0x2637f8ef64f8b31c1901c56757722fe1dfa15678f5e8df4b7684c966bac16c2'
+      '0x723b259e0f6a643e0c79dbcca6c830755465c31ebd81ce480a07d00d9e5e8e7',
+      '0x64ce84b224c2acd608f05be345783252bb82c8e7c0e455598b0701b5b79903f'
     ]);
   });
 });


### PR DESCRIPTION
### Summary

In some cases merkle tree is hard to compute (example Starknet with 63k entries). It takes around 5 minutes to generate all entries hashes and precompute tree). All this generation was synchronous previously and would cause issues:
1. Saving settings would freeze the app.
2. Voting/proposing will freeze the app (because proof is being computed from raw tree).
3. Voting/proposing will freeze mana (because Mana generates payload for voting for StarkTx client).

This PR addresses this by moving tree computation to the server, preventing UI from freezing and speeding up voting/proposing, necessary changes were:
1. Different way of computing merkle tree so it can be computed and persisted (functionally the same, but differences come from the lack of insertion of "0x0" entries at levels with odd number of nodes).
2. Merkle tree computation now uses `setImmediate` to prevent freezing server when computations are ongoing (using requestAnimationFrame on UI as fallback, but ideally it should not be used for long whitelists).
3. Strategy `getParams` method now accepts `params` - those are params of strategy used (in case of whitelist it's merkle root, this way we can ask server for proof using just root and index, instead of sending entire tree back).
4. `getParams` for StrategyConfig are now async as they need to call Mana to generate root.

Annoying bits:
1. Mana is used to compute root and proofs, but because Mana internally uses sx.js it ends up calling itself - it should work but is ugly.
2. 63k whitelist takes ~5-6 minutes on machine to compute, might be slower on DigitalOcean - ~~not sure if it's going to be killed by timeouts.~~ - it's now starting a request to process and checks periodically if it has completed, timeouts won't be an issue now.
3. ~~Tests will fail now because generateParams now calls mana.~~ disabled this test for now.
4. Spaces that use old whitelist format won't work after this PR due to changes in the tree computation - they will need to update settings to fix it.

### Test plan

1. Apply this patch.
2. Run `yarn dev`.
3. Go to your Starknet space.
5. Add whitelist from below to your proposal/voting validation (add yourself to the list so you can vote/propose).
6. It will take a while to process when saving, but it won't freeze the UI.
7. Go on to create proposal or vote (on proposal that uses those new settings).
8. It works and is quick.

```diff
diff --git a/apps/ui/.env b/apps/ui/.env
index c136c279..a3104101 100644
--- a/apps/ui/.env
+++ b/apps/ui/.env
@@ -1,6 +1,6 @@
 VITE_ENABLED_NETWORKS=
 VITE_METADATA_NETWORK=
-VITE_MANA_URL=https://mana.box
+VITE_MANA_URL=http://localhost:3001
 VITE_HIGHLIGHT_URL=https://testnet.highlight.red
 VITE_IPFS_GATEWAY=ipfs.snapshot.box
 VITE_INFURA_API_KEY=46a5dd9727bf48d4a132672d3f376146
diff --git a/package.json b/package.json
index a7cad219..fb45ac8c 100644
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git@github.com:snapshot-labs/sx-monorepo.git"
   },
   "scripts": {
-    "dev": "turbo run dev --filter=!mana --filter=!api --filter=!api-subgraph",
+    "dev": "turbo run dev --filter=!api --filter=!api-subgraph",
     "dev:full": "./scripts/dev-full.sh",
     "build": "turbo run build",
     "test": "turbo run test",
```

[staker_validator_list_block_1115000.txt](https://github.com/user-attachments/files/18768408/staker_validator_list_block_1115000.txt)
