### PR TITLE
fix: make proposition power query reactive on enabled flag

### DIFF
--- a/apps/ui/src/queries/propositionPower.ts
+++ b/apps/ui/src/queries/propositionPower.ts
@@ -71,7 +71,7 @@ export function usePropositionPowerQuery(space: Space) {
   return useQuery({
     queryKey: ['propositionPower', () => web3.value.account, space.id, block],
     queryFn: async () => getPropositionPower(space, block),
-    enabled: !!web3.value.account && !web3.value.authLoading,
+    enabled: () => !!web3.value.account && !web3.value.authLoading,
     staleTime: 60 * 1000
   });
 }

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -170,6 +170,16 @@ const formErrors = computed(() => {
     }
   );
 });
+const isSubmitButtonLoading = computed(() => {
+  if (web3.value.authLoading) return true;
+  if (!web3.value.account) return false;
+
+  return (
+    sending.value ||
+    (!propositionPower.value && !isPropositionPowerError.value) ||
+    isPropositionPowerPending.value
+  );
+});
 const canSubmit = computed(() => {
   const hasUnsupportedNetworks =
     !props.space.turbo &&
@@ -449,12 +459,7 @@ watchEffect(() => {
       </UiTooltip>
       <UiButton
         class="primary min-w-[46px] flex gap-2 justify-center items-center !px-0 md:!px-3"
-        :loading="
-          !!web3.account &&
-          (sending ||
-            (!propositionPower && !isPropositionPowerError) ||
-            isPropositionPowerPending)
-        "
+        :loading="isSubmitButtonLoading"
         :disabled="!canSubmit"
         @click="handleProposeClick"
       >


### PR DESCRIPTION
### Summary

Previously proposition query wasn't enabled reactively. If I refresh editor page with ArgentX it would end up as always pending (with submit button loading).

Additionally handled case where it would before show as Publish button, then loading indicator and Publish button again as it wouldn't show loading indicator if there was no account (and it might be on refresh) by extracting it into new computed value and showing loading indicator if auth is loading.

### How to test

1. Connect with ArgentX.
2. Go to editor.
3. Refresh page.
4. It has short loading indicator (for authLoading and proposition power loading step), but then turns into Publish button.
