### PR TITLE
feat: improve color input

### DIFF
--- a/apps/ui/src/components/Modal/LabelConfig.vue
+++ b/apps/ui/src/components/Modal/LabelConfig.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { clone } from '@/helpers/utils';
+import { clone, getRandomHexColor } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
 import { SpaceMetadataLabel } from '@/types';
 
@@ -40,7 +40,8 @@ const definition = {
       type: 'string',
       format: 'color',
       title: 'Color',
-      examples: ['#FF0000']
+      examples: ['#FF0000'],
+      default: () => getRandomHexColor()
     }
   }
 };

--- a/apps/ui/src/components/Modal/LabelConfig.vue
+++ b/apps/ui/src/components/Modal/LabelConfig.vue
@@ -41,6 +41,7 @@ const definition = {
       format: 'color',
       title: 'Color',
       examples: ['#FF0000'],
+      showControls: true,
       default: () => getRandomHexColor()
     }
   }

--- a/apps/ui/src/components/Ui/InputColor.vue
+++ b/apps/ui/src/components/Ui/InputColor.vue
@@ -5,6 +5,8 @@ export default {
 </script>
 
 <script setup lang="ts">
+import { getRandomHexColor } from '@/helpers/utils';
+
 const props = defineProps<{
   loading?: boolean;
   error?: string;
@@ -21,7 +23,9 @@ const dirty = ref(false);
 const inputValue = computed({
   get() {
     if (!model.value && !dirty.value && props.definition.default) {
-      return props.definition.default;
+      return typeof props.definition.default === 'function'
+        ? props.definition.default()
+        : props.definition.default;
     }
     return model.value;
   },
@@ -41,9 +45,7 @@ const backgroundColor = computed(() => {
 });
 
 function generateRandomColor() {
-  model.value = `#${Math.floor(Math.random() * 16777215)
-    .toString(16)
-    .padStart(6, '0')}`.toUpperCase();
+  model.value = getRandomHexColor();
 }
 
 watch(model, () => {
@@ -57,12 +59,6 @@ debouncedWatch(
   },
   { debounce: 1000 }
 );
-
-onMounted(() => {
-  if (!model.value) {
-    generateRandomColor();
-  }
-});
 
 function validateAndConvertColor(color: string): string {
   if (!color) return color;

--- a/apps/ui/src/components/Ui/InputColor.vue
+++ b/apps/ui/src/components/Ui/InputColor.vue
@@ -35,14 +35,21 @@ const inputValue = computed({
   }
 });
 
-const backgroundColor = computed(() => {
-  const color = inputValue.value;
-  return /^#[0-9A-F]{6}$/i.test(color)
-    ? color
-    : currentMode.value === 'dark'
-      ? '#000000'
-      : '#FFFFFF';
+const shadowColor = computed({
+  get() {
+    if (inputValue.value && isColorValid(inputValue.value)) {
+      return inputValue.value;
+    }
+    return currentMode.value === 'dark' ? '#000000' : '#FFFFFF';
+  },
+  set(newValue: string) {
+    model.value = newValue.toUpperCase();
+  }
 });
+
+function isColorValid(color: string): boolean {
+  return /^#[0-9A-F]{6}$/i.test(color);
+}
 
 function generateRandomColor() {
   model.value = getRandomHexColor();
@@ -95,9 +102,10 @@ function validateAndConvertColor(color: string): string {
     :input-value-length="inputValue?.length"
   >
     <div class="flex">
-      <div
-        class="absolute size-[18px] mt-[30px] ml-3 rounded border border-skin-text border-opacity-20"
-        :style="{ backgroundColor: backgroundColor }"
+      <input
+        v-model="shadowColor"
+        type="color"
+        class="absolute appearance-none cursor-pointer size-[18px] mt-[30px] ml-3 rounded border border-skin-text border-opacity-20 padding-0 margin-0"
       />
       <input
         :id="id"
@@ -118,3 +126,20 @@ function validateAndConvertColor(color: string): string {
     </div>
   </UiWrapperInput>
 </template>
+
+<style scoped>
+::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+::-webkit-color-swatch {
+  border: 0;
+  border-radius: 0;
+}
+
+::-moz-color-swatch,
+::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+</style>

--- a/apps/ui/src/components/Ui/InputColor.vue
+++ b/apps/ui/src/components/Ui/InputColor.vue
@@ -107,7 +107,12 @@ function validateAndConvertColor(color: string): string {
         v-bind="$attrs"
         :placeholder="definition.examples && definition.examples[0]"
       />
-      <button class="absolute right-3 mt-[20px]" @click="generateRandomColor">
+      <button
+        v-if="definition.showControls"
+        title="Generate random color"
+        class="absolute right-3 mt-[20px]"
+        @click="generateRandomColor"
+      >
         <IH-refresh class="text-skin-link" />
       </button>
     </div>

--- a/apps/ui/src/components/Ui/InputColor.vue
+++ b/apps/ui/src/components/Ui/InputColor.vue
@@ -22,10 +22,10 @@ const dirty = ref(false);
 
 const inputValue = computed({
   get() {
-    if (!model.value && !dirty.value && props.definition.default) {
-      return typeof props.definition.default === 'function'
-        ? props.definition.default()
-        : props.definition.default;
+    const defaultValue = props.definition.default;
+
+    if (!model.value && !dirty.value && defaultValue) {
+      return typeof defaultValue === 'function' ? defaultValue() : defaultValue;
     }
     return model.value;
   },

--- a/apps/ui/src/components/Ui/InputColor.vue
+++ b/apps/ui/src/components/Ui/InputColor.vue
@@ -51,7 +51,7 @@ function isColorValid(color: string): boolean {
   return /^#[0-9A-F]{6}$/i.test(color);
 }
 
-function generateRandomColor() {
+function setRandomColor() {
   model.value = getRandomHexColor();
 }
 
@@ -119,7 +119,7 @@ function validateAndConvertColor(color: string): string {
         v-if="definition.showControls"
         title="Generate random color"
         class="absolute right-3 mt-[20px]"
-        @click="generateRandomColor"
+        @click="setRandomColor"
       >
         <IH-refresh class="text-skin-link" />
       </button>

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -644,3 +644,9 @@ export function hexToRgb(hex: string): { r: number; g: number; b: number } {
   const b = parseInt(hex.substring(4, 6), 16);
   return { r, g, b };
 }
+
+export function getRandomHexColor(): string {
+  return `#${Math.floor(Math.random() * 16777215)
+    .toString(16)
+    .padStart(6, '0')}`.toUpperCase();
+}

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -248,6 +248,7 @@ ajv.addKeyword({
 });
 ajv.addKeyword('options');
 ajv.addKeyword('tooltip');
+ajv.addKeyword('showControls');
 
 // UiSelectorNetwork
 ajv.addFormat('network', {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR adds a few improvements to the color input, following comments/reviews in the other PR (https://github.com/snapshot-labs/sx-monorepo/pull/1153)

- Add a native color picker when clicking on the color preview, which is sync with the input value

![Screenshot 2025-02-12 at 22 03 44](https://github.com/user-attachments/assets/3b94be3e-5080-473c-9ca8-25072be4dd18)

- Add a new option to the definition, to control when to show the "generate random color" control
- Move the default value out of the input (default random color is set by the component using the InputColor, and not triggered inside the Input anymore), to allow empty default color

### How to test

1. Go to the label edition modal in the space settings
2. It should set a random default color when empty
3. Clicking on the color preview will open the OS color picker
4. Picking a color from that picker will fill the input 
