### PR TITLE
fix: fix missing default color in label modal

### DIFF
--- a/apps/ui/src/components/Modal/LabelConfig.vue
+++ b/apps/ui/src/components/Modal/LabelConfig.vue
@@ -41,8 +41,7 @@ const definition = {
       format: 'color',
       title: 'Color',
       examples: ['#FF0000'],
-      showControls: true,
-      default: () => getRandomHexColor()
+      showControls: true
     }
   }
 };
@@ -61,7 +60,7 @@ function generateDefaultState(): SpaceMetadataLabel {
     id: crypto.randomUUID().substring(0, 8),
     name: '',
     description: '',
-    color: ''
+    color: getRandomHexColor()
   };
 }
 

--- a/apps/ui/src/components/Ui/InputColor.vue
+++ b/apps/ui/src/components/Ui/InputColor.vue
@@ -22,10 +22,8 @@ const dirty = ref(false);
 
 const inputValue = computed({
   get() {
-    const defaultValue = props.definition.default;
-
-    if (!model.value && !dirty.value && defaultValue) {
-      return typeof defaultValue === 'function' ? defaultValue() : defaultValue;
+    if (!model.value && !dirty.value && props.definition.default) {
+      return props.definition.default;
     }
     return model.value;
   },


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

When adding a new label, the label preview was missing the background color.

This PR fix this issue, by generating and setting the default color in the form ref, instead of the definition default

![Screenshot 2025-02-13 at 02 06 40](https://github.com/user-attachments/assets/0bc8e859-ff9b-4686-8274-6dfd3c31f007)

### How to test

1. Go to a space settings, and add a new label
2. The label preview should have the same background color as the color in the input color
