### PR TITLE
fix: make proposals queries reactive by accepting MaybeRefOrGetter

### DIFF
--- a/apps/ui/src/queries/proposals.ts
+++ b/apps/ui/src/queries/proposals.ts
@@ -4,15 +4,15 @@ import {
   useQuery,
   useQueryClient
 } from '@tanstack/vue-query';
-import { MaybeRef } from 'vue';
+import { MaybeRefOrGetter } from 'vue';
 import { getNames } from '@/helpers/stamp';
 import { getNetwork } from '@/networks';
 import { ProposalsFilter } from '@/networks/types';
 import { NetworkID, Proposal } from '@/types';
 
 type Filters = {
-  state?: MaybeRef<NonNullable<ProposalsFilter['state']>>;
-  labels?: MaybeRef<string[]>;
+  state?: MaybeRefOrGetter<NonNullable<ProposalsFilter['state']>>;
+  labels?: MaybeRefOrGetter<string[]>;
 };
 
 export const PROPOSALS_LIMIT = 20;
@@ -20,27 +20,33 @@ export const PROPOSALS_SUMMARY_LIMIT = 6;
 
 export const PROPOSALS_KEYS = {
   all: ['proposals'] as const,
-  space: (networkId: NetworkID, spaceId: string) =>
-    [...PROPOSALS_KEYS.all, `${networkId}:${spaceId}`] as const,
-  spaceSummary: (networkId: NetworkID, spaceId: string) =>
-    [...PROPOSALS_KEYS.space(networkId, spaceId), 'summary'] as const,
+  space: (
+    networkId: MaybeRefOrGetter<NetworkID>,
+    spaceId: MaybeRefOrGetter<string>
+  ) => [...PROPOSALS_KEYS.all, networkId, spaceId] as const,
+  spaceSummary: (
+    networkId: MaybeRefOrGetter<NetworkID>,
+    spaceId: MaybeRefOrGetter<string>
+  ) => [...PROPOSALS_KEYS.space(networkId, spaceId), 'summary'] as const,
   spaceList: (
-    networkId: NetworkID,
-    spaceId: string,
+    networkId: MaybeRefOrGetter<NetworkID>,
+    spaceId: MaybeRefOrGetter<string>,
     filters: Filters,
-    query?: MaybeRef<string>
+    query?: MaybeRefOrGetter<string>
   ) =>
     [
       ...PROPOSALS_KEYS.space(networkId, spaceId),
       'list',
       { ...filters, query }
     ] as const,
-  details: (networkId: NetworkID, spaceId: string) =>
-    [...PROPOSALS_KEYS.space(networkId, spaceId), 'detail'] as const,
+  details: (
+    networkId: MaybeRefOrGetter<NetworkID>,
+    spaceId: MaybeRefOrGetter<string>
+  ) => [...PROPOSALS_KEYS.space(networkId, spaceId), 'detail'] as const,
   detail: (
-    networkId: NetworkID,
-    spaceId: string,
-    proposalId: MaybeRef<string>
+    networkId: MaybeRefOrGetter<NetworkID>,
+    spaceId: MaybeRefOrGetter<string>,
+    proposalId: MaybeRefOrGetter<string>
   ) => [...PROPOSALS_KEYS.details(networkId, spaceId), proposalId] as const
 };
 
@@ -97,10 +103,10 @@ async function getProposals(
 }
 
 export function useProposalsQuery(
-  networkId: NetworkID,
-  spaceId: string,
+  networkId: MaybeRefOrGetter<NetworkID>,
+  spaceId: MaybeRefOrGetter<string>,
   filters: Filters,
-  query?: MaybeRef<string>
+  query?: MaybeRefOrGetter<string>
 ) {
   const queryClient = useQueryClient();
   return useInfiniteQuery({
@@ -108,20 +114,25 @@ export function useProposalsQuery(
     queryKey: PROPOSALS_KEYS.spaceList(networkId, spaceId, filters, query),
     queryFn: async ({ pageParam = 0 }) => {
       const proposals = await getProposals(
-        spaceId,
-        networkId,
+        toValue(spaceId),
+        toValue(networkId),
         {
           limit: PROPOSALS_LIMIT,
           skip: pageParam
         },
         {
-          state: unref(filters.state),
-          labels: unref(filters.labels)
+          state: toValue(filters.state),
+          labels: toValue(filters.labels)
         },
-        unref(query)
+        toValue(query)
       );
 
-      setProposalsDetails(queryClient, networkId, spaceId, proposals);
+      setProposalsDetails(
+        queryClient,
+        toValue(networkId),
+        toValue(spaceId),
+        proposals
+      );
 
       return proposals;
     },
@@ -134,20 +145,29 @@ export function useProposalsQuery(
 }
 
 export function useProposalsSummaryQuery(
-  networkId: NetworkID,
-  spaceId: string
+  networkId: MaybeRefOrGetter<NetworkID>,
+  spaceId: MaybeRefOrGetter<string>
 ) {
   const queryClient = useQueryClient();
 
   return useQuery({
     queryKey: PROPOSALS_KEYS.spaceSummary(networkId, spaceId),
     queryFn: async () => {
-      const proposals = await getProposals(spaceId, networkId, {
-        skip: 0,
-        limit: PROPOSALS_SUMMARY_LIMIT
-      });
+      const proposals = await getProposals(
+        toValue(spaceId),
+        toValue(networkId),
+        {
+          skip: 0,
+          limit: PROPOSALS_SUMMARY_LIMIT
+        }
+      );
 
-      setProposalsDetails(queryClient, networkId, spaceId, proposals);
+      setProposalsDetails(
+        queryClient,
+        toValue(networkId),
+        toValue(spaceId),
+        proposals
+      );
 
       return proposals;
     }
@@ -155,20 +175,22 @@ export function useProposalsSummaryQuery(
 }
 
 export function useProposalQuery(
-  networkId: NetworkID,
-  spaceId: string,
-  proposalId: MaybeRef<string>
+  networkId: MaybeRefOrGetter<NetworkID>,
+  spaceId: MaybeRefOrGetter<string>,
+  proposalId: MaybeRefOrGetter<string>
 ) {
   return useQuery({
     queryKey: PROPOSALS_KEYS.detail(networkId, spaceId, proposalId),
     queryFn: async () => {
-      const metaStore = useMetaStore();
-      await metaStore.fetchBlock(networkId);
+      const networkIdValue = toValue(networkId);
 
-      const proposal = await getNetwork(networkId).api.loadProposal(
-        spaceId,
-        unref(proposalId),
-        metaStore.getCurrent(networkId) || 0
+      const metaStore = useMetaStore();
+      await metaStore.fetchBlock(networkIdValue);
+
+      const proposal = await getNetwork(networkIdValue).api.loadProposal(
+        toValue(spaceId),
+        toValue(proposalId),
+        metaStore.getCurrent(networkIdValue) || 0
       );
       if (!proposal) return null;
 

--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -17,8 +17,8 @@ const isOffchainSpace = offchainNetworks.includes(props.space.network);
 const socials = computed(() => getSocialNetworksLink(props.space));
 
 const { data, isPending } = useProposalsSummaryQuery(
-  props.space.network,
-  props.space.id
+  toRef(() => props.space.network),
+  toRef(() => props.space.id)
 );
 
 watchEffect(() => setTitle(props.space.name));

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -29,10 +29,14 @@ const spaceLabels = computed(() => {
 });
 
 const { data, fetchNextPage, hasNextPage, isPending, isFetchingNextPage } =
-  useProposalsQuery(props.space.network, props.space.id, {
-    state,
-    labels
-  });
+  useProposalsQuery(
+    toRef(() => props.space.network),
+    toRef(() => props.space.id),
+    {
+      state,
+      labels
+    }
+  );
 
 function handleClearLabelsFilter(close: () => void) {
   labels.value = [];

--- a/apps/ui/src/views/Space/Search.vue
+++ b/apps/ui/src/views/Space/Search.vue
@@ -10,7 +10,12 @@ const route = useRoute();
 const query = computed(() => (route.query.q as string) || '');
 
 const { data, fetchNextPage, hasNextPage, isPending, isFetchingNextPage } =
-  useProposalsQuery(props.space.network, props.space.id, {}, query);
+  useProposalsQuery(
+    toRef(() => props.space.network),
+    toRef(() => props.space.id),
+    {},
+    query
+  );
 
 async function handleEndReached() {
   if (!hasNextPage.value) return;


### PR DESCRIPTION
### Summary

Previously our proposals queries were not reactive as they should, because we only accepted rawValues. However we should make those values refs, so queries are properly reactive.

We do this by following composables recommendation and making all values accept MaybeRefOrGetter: https://vuejs.org/guide/reusability/composables.html#input-arguments

Lack of this reactivity caused bunch of issues as we migrated to use vue-query for Spaces. This might not have any effect in current state (so it's more of a refactor now), but is needed for resubmit of that PR.

### How to test

1. Go to proposals page, space overview, proposal page, search proposals pages.
2. Everything works as expected.
