### PR TITLE
fix: allow empty voting power symbol in space settings

### DIFF
--- a/apps/ui/src/components/FormSpaceProfile.vue
+++ b/apps/ui/src/components/FormSpaceProfile.vue
@@ -151,7 +151,6 @@ onMounted(() => {
 </script>
 
 <template>
-  {{ form }}
   <UiInputStampCover v-model="(form as any).cover" :space="space" />
   <div class="s-box p-4 mt-[-80px] max-w-[640px]">
     <UiInputStamp

--- a/apps/ui/src/components/FormSpaceProfile.vue
+++ b/apps/ui/src/components/FormSpaceProfile.vue
@@ -74,8 +74,7 @@ const votingPowerDefinition = computed(() => ({
       type: 'string',
       title: 'Voting power symbol',
       examples: ['e.g. VP'],
-      maxLength: isOffchainNetwork.value ? 16 : MAX_SYMBOL_LENGTH,
-      minLength: isOffchainNetwork.value ? 1 : undefined
+      maxLength: isOffchainNetwork.value ? 16 : MAX_SYMBOL_LENGTH
     }
   }
 }));
@@ -152,6 +151,7 @@ onMounted(() => {
 </script>
 
 <template>
+  {{ form }}
   <UiInputStampCover v-model="(form as any).cover" :space="space" />
   <div class="s-box p-4 mt-[-80px] max-w-[640px]">
     <UiInputStamp

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -193,7 +193,7 @@ function formatSpace(
     proposal_count: space.proposalsCount,
     vote_count: space.votesCount,
     follower_count: space.followersCount,
-    voting_power_symbol: space.symbol,
+    voting_power_symbol: space.symbol || '',
     active_proposals: space.activeProposals,
     voting_delay: space.voting.delay ?? 0,
     voting_types: space.voting.type
@@ -326,7 +326,7 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
       controller: '',
       admins: proposal.space.admins,
       moderators: proposal.space.moderators,
-      voting_power_symbol: proposal.space.symbol,
+      voting_power_symbol: proposal.space.symbol || '',
       authenticators: [DEFAULT_AUTHENTICATOR],
       executors: [],
       executors_types: [],


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

When an offchain space is created without voting power symbol, going to the new space settings will show that the settings are invalid by default, without dirtying the form (see toobar in page bottom)

See https://snapshot.box/#/s:%E3%81%8A%E3%81%AF%E3%82%88%E3%81%86.wa0x6e.eth/settings 

### How to test

1. Go to https://snapshot.box/#/s:%E3%81%8A%E3%81%AF%E3%82%88%E3%81%86.wa0x6e.eth/settings
2. After PR, space profile is valid
