### PR TITLE
Reapply "feat: add form to update skin settings (#1148)" (#1192)

### DIFF
--- a/apps/ui/src/components/Breadcrumb.vue
+++ b/apps/ui/src/components/Breadcrumb.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { getCacheHash } from '@/helpers/utils';
 import { NetworkID } from '@/types';
 
 defineOptions({ inheritAttrs: false });
@@ -27,6 +28,14 @@ const space = computed(() => {
 
   return spacesStore.spacesMap.get(`${networkId.value}:${spaceAddress.value}`);
 });
+
+const logo = computed(() => {
+  if (!isWhiteLabel.value) return;
+
+  return space.value?.additionalRawData?.skinSettings?.logo;
+});
+
+const cb = computed(() => (logo.value ? getCacheHash(logo.value) : undefined));
 </script>
 
 <template>
@@ -38,13 +47,24 @@ const space = computed(() => {
     class="flex item-center space-x-2.5 truncate text-[24px]"
     v-bind="$attrs"
   >
-    <div class="shrink-0">
-      <SpaceAvatar
-        :space="{ ...space, network: networkId as NetworkID }"
-        :size="36"
-        class="!rounded-[4px]"
-      />
-    </div>
-    <span class="truncate" v-text="space.name" />
+    <UiStamp
+      v-if="logo"
+      :id="space.id"
+      type="space-logo"
+      :width="190"
+      :height="38"
+      class="rounded-none border-none"
+      :cb="cb"
+    />
+    <template v-else>
+      <div class="shrink-0">
+        <SpaceAvatar
+          :space="{ ...space, network: networkId as NetworkID }"
+          :size="36"
+          class="!rounded-[4px]"
+        />
+      </div>
+      <span class="truncate" v-text="space.name" />
+    </template>
   </AppLink>
 </template>

--- a/apps/ui/src/components/FormSpaceWhitelabel.vue
+++ b/apps/ui/src/components/FormSpaceWhitelabel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
+import { TURBO_URL } from '@/helpers/constants';
 import { getValidator } from '@/helpers/validation';
-import { Space } from '@/types';
+import { SkinSettings, Space } from '@/types';
 
 const CUSTOM_DOMAIN_DEFINITION = {
   type: 'string',
@@ -10,26 +11,88 @@ const CUSTOM_DOMAIN_DEFINITION = {
   examples: ['vote.balancer.fi']
 };
 
-const customDomain = defineModel<string>('customDomain', { required: true });
+const COLOR_VALIDATION = {
+  type: 'string',
+  format: 'color',
+  examples: ['#FF0000']
+};
 
-defineProps<{
+const SKIN_DEFINITION = {
+  type: 'object',
+  title: 'Skin settings',
+  additionalProperties: false,
+  required: [],
+  properties: {
+    bg_color: {
+      ...COLOR_VALIDATION,
+      title: 'Background color'
+    },
+    text_color: {
+      ...COLOR_VALIDATION,
+      title: 'Text color'
+    },
+    link_color: {
+      ...COLOR_VALIDATION,
+      title: 'Link color'
+    },
+    content_color: {
+      ...COLOR_VALIDATION,
+      title: 'Content color',
+      tooltip: 'Proposal text color'
+    },
+    border_color: {
+      ...COLOR_VALIDATION,
+      title: 'Border color'
+    },
+    heading_color: {
+      ...COLOR_VALIDATION,
+      title: 'Heading color'
+    },
+    primary_color: {
+      ...COLOR_VALIDATION,
+      title: 'Primary color'
+    },
+    theme: {
+      type: 'string',
+      title: 'Base theme',
+      enum: ['light', 'dark'],
+      options: [
+        { id: 'light', name: 'Light' },
+        { id: 'dark', name: 'Dark' }
+      ]
+    }
+  }
+};
+
+const customDomain = defineModel<string>('customDomain', { required: true });
+const skinSettings = defineModel<SkinSettings>('skinSettings', {
+  required: true
+});
+
+const props = defineProps<{
   space: Space;
+}>();
+
+const emit = defineEmits<{
+  (e: 'errors', value: any);
 }>();
 
 const formErrors = computed(() => {
   const validator = getValidator({
     type: 'object',
-    title: 'White Label',
+    title: 'Whitelabel',
     additionalProperties: false,
     required: [],
     properties: {
-      customDomain: CUSTOM_DOMAIN_DEFINITION
+      customDomain: CUSTOM_DOMAIN_DEFINITION,
+      ...SKIN_DEFINITION.properties
     }
   });
 
   const errors = validator.validate(
     {
-      customDomain: customDomain.value
+      customDomain: customDomain.value,
+      ...skinSettings.value
     },
     {
       skipEmptyOptionalFields: true
@@ -37,24 +100,76 @@ const formErrors = computed(() => {
   );
   return errors;
 });
+
+const disabled = computed(() => {
+  return !props.space.turbo && !props.space.additionalRawData?.domain;
+});
+
+watch(formErrors, value => emit('errors', value));
+
+onMounted(() => {
+  emit('errors', formErrors.value);
+});
 </script>
 
 <template>
-  <h4 class="eyebrow mb-2 font-medium mt-4">Custom domain</h4>
   <UiMessage
+    v-if="disabled"
     type="info"
-    :learn-more-link="'https://docs.snapshot.box/spaces/add-custom-domain'"
+    :learn-more-link="TURBO_URL"
+    class="mb-4"
   >
-    To set up a custom domain, you must subscribe to the Turbo plan and create a
-    CNAME record pointing to "cname.snapshot.box" with your DNS provider or
-    registrar.
+    Whitelabel features are only available for Turbo subscribers.
   </UiMessage>
-  <div class="s-box mt-3">
-    <UiInputString
-      v-model="customDomain"
-      :definition="CUSTOM_DOMAIN_DEFINITION"
-      :error="formErrors.customDomain"
-      :disabled="!space.turbo && !space.additionalRawData?.domain"
-    />
+  <div class="s-box space-y-4">
+    <div>
+      <h4 class="eyebrow mb-2 font-medium">Custom domain</h4>
+      <UiMessage
+        type="info"
+        class="mb-3"
+        :learn-more-link="'https://docs.snapshot.box/spaces/add-custom-domain'"
+      >
+        To set up a custom domain, you need to create a CNAME record pointing to
+        "cname.snapshot.box" with your DNS provider or registrar.
+      </UiMessage>
+      <UiInputString
+        v-model="customDomain"
+        :definition="CUSTOM_DOMAIN_DEFINITION"
+        :error="formErrors.customDomain"
+        :disabled="disabled"
+      />
+    </div>
+    <div>
+      <h4 class="eyebrow font-medium">Skin colors</h4>
+      <div class="mb-2">
+        Empty colors value will fallback to the base theme color.
+      </div>
+      <UiForm
+        v-model="skinSettings"
+        :definition="SKIN_DEFINITION"
+        :error="formErrors"
+        :disabled="disabled"
+      />
+    </div>
+    <div>
+      <h4 class="eyebrow font-medium">Custom logo</h4>
+      <div class="mb-2">
+        You can replace your space name in the upper left corner by a custom
+        logo. Recommended size is 380x76 pixels.
+      </div>
+      <UiInputStamp
+        v-model="skinSettings.logo"
+        :disabled="disabled"
+        :fallback="false"
+        :width="380"
+        :height="76"
+        class="border-0"
+        :definition="{
+          type: 'string',
+          format: 'stamp',
+          title: 'Logo'
+        }"
+      />
+    </div>
   </div>
 </template>

--- a/apps/ui/src/components/Ui/InputStamp.vue
+++ b/apps/ui/src/components/Ui/InputStamp.vue
@@ -3,10 +3,21 @@ import { getUrl, imageUpload } from '@/helpers/utils';
 
 const model = defineModel<string>();
 
-defineProps<{
-  error?: string;
-  definition: any;
-}>();
+withDefaults(
+  defineProps<{
+    error?: string;
+    definition: any;
+    width?: number;
+    height?: number;
+    disabled?: boolean;
+    fallback?: boolean;
+  }>(),
+  {
+    width: 80,
+    height: 80,
+    fallback: true
+  }
+);
 
 const uiStore = useUiStore();
 
@@ -49,25 +60,35 @@ async function handleFileChange(e: Event) {
     type="button"
     v-bind="$attrs"
     class="relative group max-w-max cursor-pointer mb-3 border-4 border-skin-bg rounded-lg overflow-hidden bg-skin-border"
+    :disabled="disabled"
     @click="openFilePicker()"
   >
     <img
       v-if="imgUrl"
       :src="imgUrl"
-      class="size-[80px] object-cover group-hover:opacity-80"
-      :class="{
-        'opacity-80': isUploadingImage
-      }"
+      :class="[
+        `object-cover group-hover:opacity-80`,
+        {
+          'opacity-80': isUploadingImage
+        }
+      ]"
+      :style="{ width: `${width}px`, height: `${height}px` }"
     />
     <UiStamp
-      v-else
+      v-else-if="fallback"
       :id="definition.default"
-      :size="80"
+      :width="width"
+      :height="height"
       class="pointer-events-none !rounded-none group-hover:opacity-80"
       type="space"
       :class="{
         'opacity-80': isUploadingImage
       }"
+    />
+    <div
+      v-else
+      class="block"
+      :style="{ width: ` ${width}px`, height: `${height}px` }"
     />
     <div
       class="pointer-events-none absolute group-hover:visible inset-0 z-10 flex flex-row size-full items-center content-center justify-center"
@@ -84,3 +105,9 @@ async function handleFileChange(e: Event) {
     @change="handleFileChange"
   />
 </template>
+
+<style lang="scss" scoped>
+button:disabled {
+  @apply cursor-not-allowed;
+}
+</style>

--- a/apps/ui/src/components/Ui/Select.vue
+++ b/apps/ui/src/components/Ui/Select.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
   error?: string;
   required?: boolean;
   definition: DefinitionWithOptions<T>;
+  disabled?: boolean;
 }>();
 
 const dirty = ref(false);
@@ -37,7 +38,7 @@ watch(model, () => {
     :dirty="dirty"
     :required="required"
   >
-    <select v-model="inputValue" class="s-input">
+    <select v-model="inputValue" class="s-input" :disabled="disabled">
       <option disabled value="">Please select one</option>
       <option
         v-for="option in definition.options"
@@ -49,3 +50,9 @@ watch(model, () => {
     </select>
   </UiWrapperInput>
 </template>
+
+<style lang="scss" scoped>
+select:disabled {
+  @apply cursor-not-allowed opacity-100;
+}
+</style>

--- a/apps/ui/src/components/Ui/Stamp.vue
+++ b/apps/ui/src/components/Ui/Stamp.vue
@@ -3,7 +3,13 @@ import { getStampUrl } from '@/helpers/utils';
 
 withDefaults(
   defineProps<{
-    type?: 'avatar' | 'user-cover' | 'space' | 'space-cover' | 'token';
+    type?:
+      | 'avatar'
+      | 'user-cover'
+      | 'space'
+      | 'space-cover'
+      | 'space-logo'
+      | 'token';
     id: string;
     size?: number;
     width?: number;

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -626,11 +626,15 @@ export function useSpaceSettings(space: Ref<Space>) {
       delete prunedSaveData.voting.quorumType;
     }
     if (prunedSaveData.skinSettings) {
-      Object.entries(prunedSaveData.skinSettings).forEach(([key, value]) => {
-        if (value === null || value === '') {
-          delete prunedSaveData.skinSettings?.[key];
-        }
-      });
+      if (!customDomain.value && !space.value.turbo) {
+        delete prunedSaveData.skinSettings;
+      } else {
+        Object.entries(prunedSaveData.skinSettings).forEach(([key, value]) => {
+          if (value === null || value === '') {
+            delete prunedSaveData.skinSettings?.[key];
+          }
+        });
+      }
     }
 
     return updateSettingsRaw(space.value, JSON.stringify(prunedSaveData));

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -11,6 +11,7 @@ import {
 } from '@/networks/types';
 import {
   Member,
+  SkinSettings,
   Space,
   SpaceMetadata,
   SpaceMetadataLabel,
@@ -52,6 +53,7 @@ export type OffchainSpaceSettings = {
   boost: OffchainApiSpace['boost'];
   validation: OffchainApiSpace['validation'];
   voteValidation: OffchainApiSpace['voteValidation'];
+  skinSettings: SkinSettings;
 };
 
 type Form = SpaceMetadata & {
@@ -75,6 +77,18 @@ const DEFAULT_FORM_STATE: Form = {
   treasuries: [],
   labels: [],
   delegations: []
+};
+
+const DEFAULT_SKIN_SETTINGS = {
+  bg_color: '',
+  link_color: '',
+  text_color: '',
+  content_color: '',
+  border_color: '',
+  heading_color: '',
+  primary_color: '',
+  theme: 'light',
+  logo: undefined
 };
 
 export function useSpaceSettings(space: Ref<Space>) {
@@ -173,6 +187,7 @@ export function useSpaceSettings(space: Ref<Space>) {
   const termsOfServices = ref('');
   const customDomain = ref('');
   const isPrivate = ref(false);
+  const skinSettings = ref<SkinSettings>(clone(DEFAULT_SKIN_SETTINGS));
 
   function currentToMinutesOnly(value: number) {
     const duration = getDurationFromCurrent(space.value.network, value);
@@ -590,9 +605,9 @@ export function useSpaceSettings(space: Ref<Space>) {
           ? space.value.additionalRawData.validation
           : proposalValidation.value,
       voteValidation: voteValidation.value,
-      boost: space.value.additionalRawData.boost
+      boost: space.value.additionalRawData.boost,
+      skinSettings: skinSettings.value
     };
-
     const prunedSaveData: Partial<OffchainSpaceSettings> = clone(saveData);
     Object.entries(prunedSaveData).forEach(([key, value]) => {
       if (value === null || value === '') delete prunedSaveData[key];
@@ -609,6 +624,13 @@ export function useSpaceSettings(space: Ref<Space>) {
       prunedSaveData.voting.quorumType === 'default'
     ) {
       delete prunedSaveData.voting.quorumType;
+    }
+    if (prunedSaveData.skinSettings) {
+      Object.entries(prunedSaveData.skinSettings).forEach(([key, value]) => {
+        if (value === null || value === '') {
+          delete prunedSaveData.skinSettings?.[key];
+        }
+      });
     }
 
     return updateSettingsRaw(space.value, JSON.stringify(prunedSaveData));
@@ -735,6 +757,9 @@ export function useSpaceSettings(space: Ref<Space>) {
       termsOfServices.value = space.value.terms ?? '';
       customDomain.value = space.value.additionalRawData?.domain ?? '';
       isPrivate.value = space.value.additionalRawData?.private ?? false;
+      skinSettings.value = clone(
+        space.value.additionalRawData?.skinSettings || DEFAULT_SKIN_SETTINGS
+      );
     }
   }
 
@@ -768,6 +793,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     const termsOfServicesValue = termsOfServices.value;
     const customDomainValue = customDomain.value;
     const isPrivateValue = isPrivate.value;
+    const skinSettingsValue = skinSettings.value;
 
     if (loading.value) {
       isModified.value = false;
@@ -922,6 +948,14 @@ export function useSpaceSettings(space: Ref<Space>) {
         isModified.value = true;
         return;
       }
+
+      if (
+        objectHash(space.value.additionalRawData?.skinSettings) !==
+        objectHash(skinSettingsValue)
+      ) {
+        isModified.value = true;
+        return;
+      }
     } else {
       const [authenticatorsToAdd, authenticatorsToRemove] =
         await processChanges(
@@ -993,6 +1027,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     termsOfServices,
     customDomain,
     isPrivate,
+    skinSettings,
     save,
     saveController,
     deleteSpace,

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -487,7 +487,13 @@ export function getCacheHash(value?: string) {
 }
 
 export function getStampUrl(
-  type: 'avatar' | 'user-cover' | 'space' | 'space-cover' | 'token',
+  type:
+    | 'avatar'
+    | 'user-cover'
+    | 'space'
+    | 'space-cover'
+    | 'space-logo'
+    | 'token',
   id: string,
   size: number | { width: number; height: number },
   hash?: string

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -26,6 +26,7 @@ import {
   ProposalState,
   RelatedSpace,
   Setting,
+  SkinSettings,
   Space,
   SpaceMetadataDelegation,
   SpaceMetadataTreasury,
@@ -152,12 +153,26 @@ function formatSpace(
     };
   }
 
+  function formatSkinSettings(skinSettings: SkinSettings): SkinSettings {
+    return {
+      bg_color: skinSettings?.bg_color || '',
+      link_color: skinSettings?.link_color || '',
+      text_color: skinSettings?.text_color || '',
+      content_color: skinSettings?.content_color || '',
+      border_color: skinSettings?.border_color || '',
+      heading_color: skinSettings?.heading_color || '',
+      primary_color: skinSettings?.primary_color || '',
+      theme: skinSettings?.theme || 'light',
+      logo: skinSettings?.logo
+    };
+  }
+
   const additionalRawData: OffchainAdditionalRawData = {
     type: 'offchain',
     private: space.private,
     domain: space.domain,
     skin: space.skin,
-    skinSettings: space.skinSettings,
+    skinSettings: formatSkinSettings(space.skinSettings),
     strategies: space.strategies,
     categories: space.categories,
     admins: space.admins,

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -100,6 +100,7 @@ const SPACE_FRAGMENT = gql`
       heading_color
       primary_color
       theme
+      logo
     }
     guidelines
     template

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -78,7 +78,7 @@ export type ApiSpace = {
   private: boolean;
   domain: string | null;
   skin: string | null;
-  skinSettings: SkinSettings | null;
+  skinSettings: SkinSettings;
   template: string | null;
   guidelines: string | null;
   categories: string[];

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -395,14 +395,15 @@ export type Metadata = {
 };
 
 export type SkinSettings = {
-  bg_color?: string;
-  link_color?: string;
-  text_color?: string;
-  content_color?: string;
-  border_color?: string;
-  heading_color?: string;
-  primary_color?: string;
-  theme?: string;
+  bg_color: string;
+  link_color: string;
+  text_color: string;
+  content_color: string;
+  border_color: string;
+  heading_color: string;
+  primary_color: string;
+  theme: string;
+  logo?: string;
 };
 
 export type Drafts = Record<string, Draft>;

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -39,6 +39,7 @@ const {
   termsOfServices,
   customDomain,
   isPrivate,
+  skinSettings,
   save,
   saveController,
   deleteSpace,
@@ -181,7 +182,7 @@ const isTicketValid = computed(() => {
 
 const error = computed(() => {
   if (Object.values(formErrors.value).length > 0) {
-    return 'Space profile is invalid';
+    return 'Some settings are invalid';
   }
 
   if (!isOffchainNetwork.value) {
@@ -456,10 +457,13 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
       <UiContainerSettings
         v-show="activeTab === 'whitelabel'"
         title="Whitelabel"
+        description="Customize the appearance of your space to match your brand."
       >
         <FormSpaceWhitelabel
           v-model:custom-domain="customDomain"
+          v-model:skin-settings="skinSettings"
           :space="space"
+          @errors="v => (formErrors = v)"
         />
       </UiContainerSettings>
       <UiContainerSettings v-show="activeTab === 'advanced'" title="Advanced">


### PR DESCRIPTION
This reverts commit a901721ec185d78853c3dd236b696dc4cf5a5398.

### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

The commit about skin settings edition has been reverted, due to sequencer rejecting payload when non-turbo spaces has a `skinSettings` property.

This PR will re-submit the same PR, with a patch to remove the `skinSettings` payload from the space settings object before submitting, for non-whitelabel spaces (= space without existing domain, or non-turbo spaces)

### How to test

1. Save a regular space with whitelabel disabled
2. It should save, and in the sequencer payload, the `skinSettings` params should be missing from the payload
3. Save a whitelabel space
4. It should save, and the `skinSettings` params should be present in the sequencer payload 
 