### PR TITLE
refactor: reduce number of RPC calls for controller checks

### DIFF
--- a/apps/ui/src/components/App/Nav.vue
+++ b/apps/ui/src/components/App/Nav.vue
@@ -1,8 +1,7 @@
 <script lang="ts" setup>
 import { FunctionalComponent } from 'vue';
+import { useSpaceController } from '@/composables/useSpaceController';
 import { SPACES_DISCUSSIONS } from '@/helpers/discourse';
-import { compareAddresses } from '@/helpers/utils';
-import { getNetwork } from '@/networks';
 import IHAnnotation from '~icons/heroicons-outline/annotation';
 import IHBell from '~icons/heroicons-outline/bell';
 import IHCash from '~icons/heroicons-outline/cash';
@@ -36,22 +35,14 @@ const { resolved, address, networkId } = useResolve(param);
 const { web3 } = useWeb3();
 
 const currentRouteName = computed(() => String(route.matched[0]?.name));
+const spaceIdComposite = computed(() => `${networkId.value}:${address.value}`);
 const space = computed(() =>
   currentRouteName.value === 'space' && resolved.value
-    ? spacesStore.spacesMap.get(`${networkId.value}:${address.value}`)
+    ? spacesStore.spacesMap.get(spaceIdComposite.value) ?? null
     : null
 );
 
-const isController = computedAsync(async () => {
-  if (!networkId.value || !space.value) return false;
-
-  const { account } = web3.value;
-
-  const network = getNetwork(networkId.value);
-  const controller = await network.helpers.getSpaceController(space.value);
-
-  return compareAddresses(controller, account);
-});
+const { isController } = useSpaceController(space);
 
 const canSeeSettings = computed(() => {
   if (isController.value) return true;

--- a/apps/ui/src/composables/useSpaceController.ts
+++ b/apps/ui/src/composables/useSpaceController.ts
@@ -1,0 +1,47 @@
+import { useQuery, useQueryClient } from '@tanstack/vue-query';
+import { MaybeRefOrGetter } from 'vue';
+import { compareAddresses } from '@/helpers/utils';
+import { getNetwork } from '@/networks';
+import { Space } from '@/types';
+
+export const SPACE_CONTROLLER_KEY = (space: MaybeRefOrGetter<Space | null>) => [
+  'spaceController',
+  () => {
+    const spaceValue = toValue(space);
+    return spaceValue ? `${spaceValue.network}:${spaceValue.id}` : null;
+  }
+];
+
+export function useSpaceController(space: MaybeRefOrGetter<Space | null>) {
+  const queryClient = useQueryClient();
+  const { web3 } = useWeb3();
+
+  const { data } = useQuery({
+    queryKey: SPACE_CONTROLLER_KEY(space),
+    queryFn: async () => {
+      const spaceValue = toValue(space);
+      if (!spaceValue) return null;
+
+      const network = getNetwork(spaceValue.network);
+      return network.helpers.getSpaceController(spaceValue);
+    },
+    enabled: () => toValue(space) !== null,
+    staleTime: 5 * 60 * 1000
+  });
+
+  const controller = computed(() => data.value ?? null);
+  const isController = computed(() => {
+    if (controller.value === null) return false;
+
+    return compareAddresses(controller.value, web3.value.account);
+  });
+
+  return {
+    controller,
+    isController,
+    invalidateController: () =>
+      queryClient.invalidateQueries({
+        queryKey: SPACE_CONTROLLER_KEY(space)
+      })
+  };
+}

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -105,15 +105,8 @@ export function useSpaceSettings(space: Ref<Space>) {
   const isModified = ref(false);
 
   const network = computed(() => getNetwork(space.value.network));
-  const isController = computedAsync(async () => {
-    const { account } = web3.value;
 
-    const controller = await network.value.helpers.getSpaceController(
-      space.value
-    );
-
-    return compareAddresses(controller, account);
-  }, false);
+  const { isController } = useSpaceController(space);
   const isOwner = computedAsync(async () => {
     if (!offchainNetworks.includes(space.value.network)) {
       return isController.value;

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -107,20 +107,24 @@ export function useSpaceSettings(space: Ref<Space>) {
   const network = computed(() => getNetwork(space.value.network));
 
   const { isController } = useSpaceController(space);
-  const isOwner = computedAsync(async () => {
-    if (!offchainNetworks.includes(space.value.network)) {
-      return isController.value;
-    }
+  const isOwner = computedAsync(
+    async () => {
+      if (!offchainNetworks.includes(space.value.network)) {
+        return isController.value;
+      }
 
-    const { account } = web3.value;
+      const { account } = web3.value;
 
-    const owner = await getNameOwner(
-      space.value.id,
-      network.value.chainId as ENSChainId
-    );
+      const owner = await getNameOwner(
+        space.value.id,
+        network.value.chainId as ENSChainId
+      );
 
-    return compareAddresses(owner, account);
-  }, false);
+      return compareAddresses(owner, account);
+    },
+    false,
+    { lazy: true }
+  );
   const isAdmin = computed(() => {
     if (!offchainNetworks.includes(space.value.network)) return false;
 

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -45,6 +45,7 @@ const {
   deleteSpace,
   reset
 } = useSpaceSettings(toRef(props, 'space'));
+const { invalidateController } = useSpaceController(toRef(props, 'space'));
 const spacesStore = useSpacesStore();
 const { setTitle } = useTitle();
 
@@ -225,6 +226,9 @@ function isValidTab(param: string | string[]): param is Tab['id'] {
 
 async function reloadSpaceAndReset() {
   await spacesStore.fetchSpace(props.space.id, props.space.network);
+
+  invalidateController();
+
   await reset({ force: true });
 }
 

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -238,7 +238,7 @@ function handleSettingsSave() {
 }
 
 function handleControllerSave(value: string) {
-  if (!isOwner.value) return;
+  if (!isController.value) return;
   controller.value = value;
 
   saving.value = true;


### PR DESCRIPTION
### Summary

This PR reduces number of requests made to RPC node on offchain spaces when checking for controller.
This is achieved by addition of `useSpaceController` composable that managed fetching space controller and caches it
via `vue-query`. I also added stale time to this query so it will be cached for 1 minute.

This way space controller fetched for `Nav` and `useSpaceSettings` will use only single call (or 3 depending on ENS configuration), instead of double that.

Additionally `isOwner` is now lazy computable so when `useSpaceSettings` it won't be computed (in some cases it results in 2 RPC calls) unless used (for example `OnboardingSpace` uses that composable but doesn't need `isOwner`).

Closes: https://github.com/snapshot-labs/workflow/issues/448

### How to test

1. Have http://localhost:8080/#/s:shutterdao0x36.eth and some SX space followed.
2. Go to SX space from followed tab.
3. Delete all requests in Networks tab.
4. Click on ShutterDAO.
5. You see only 3 requests to RPC (those are needed to resolve controller).
6. Go back to SX space, delete all requests again.
7. Click on ShutterDAO.
8. No requests to RPC (if within 1 minute).
