### PR TITLE
fix: remove arbitrum proposal validation support

### DIFF
--- a/apps/ui/src/components/Modal/SelectValidation.vue
+++ b/apps/ui/src/components/Modal/SelectValidation.vue
@@ -5,7 +5,6 @@ type ValidationDetails = {
     | 'only-members'
     | 'basic'
     | 'passport-gated'
-    | 'arbitrum'
     | 'karma-eas-attestation';
   schema: Record<string, any> | null;
   proposalValidationOnly?: boolean;

--- a/apps/ui/src/components/ProposalValidationConfigurator.vue
+++ b/apps/ui/src/components/ProposalValidationConfigurator.vue
@@ -9,7 +9,6 @@ type ValidationDetailId =
   | 'only-members'
   | 'basic'
   | 'passport-gated'
-  | 'arbitrum'
   | 'karma-eas-attestation';
 type ValidationDetailsExtra = {
   tag?: string;
@@ -31,7 +30,6 @@ const PROPOSAL_VALIDATIONS: Record<ValidationDetailId, ValidationDetailsExtra> =
       tag: 'Beta',
       icon: IHBeaker
     },
-    arbitrum: {},
     'karma-eas-attestation': {}
   } as const;
 

--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -143,7 +143,6 @@ export const VALIDATION_TYPES_INFO: Record<
   | 'only-members'
   | 'basic'
   | 'passport-gated'
-  | 'arbitrum'
   | 'karma-eas-attestation',
   { label: string; description: string }
 > = {
@@ -164,11 +163,6 @@ export const VALIDATION_TYPES_INFO: Record<
     label: 'Gitcoin Passport gated',
     description:
       'Protect your space from spam by requiring users to have a Gitcoin Passport to create a proposal.'
-  },
-  arbitrum: {
-    label: 'Arbitrum DAO votable supply',
-    description:
-      'Use with erc20-votes to validate by percentage of votable supply.'
   },
   'karma-eas-attestation': {
     label: 'Karma EAS Attestation',

--- a/apps/ui/src/networks/offchain/constants.ts
+++ b/apps/ui/src/networks/offchain/constants.ts
@@ -6,7 +6,6 @@ export const PROPOSAL_VALIDATIONS = {
   any: 'Any',
   basic: 'Basic',
   'passport-gated': 'Passport gated',
-  arbitrum: 'Arbitrum',
   'karma-eas-attestation': 'Karma EAS Attestation',
   'only-members': 'Only members'
 };


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Discussion https://discord.com/channels/955773041898573854/1031838169282392144/1343016499639750727
Following https://github.com/snapshot-labs/score-api/pull/1268

This PR will drop support for the arbitrum proposal validation 

### How to test

1. Go to an offchain space settings, and open the proposal validation modal
2. `arbitrum` is missing from the list 

### To-Do

- [x] Wait for https://github.com/snapshot-labs/score-api/pull/1268 to be merged
