### PR TITLE
fix: display today mark only in current month

### DIFF
--- a/apps/ui/src/components/Ui/Calendar.vue
+++ b/apps/ui/src/components/Ui/Calendar.vue
@@ -85,7 +85,7 @@ function isSelectable(date: dayjs.Dayjs) {
         class="cell day unselectable"
         :class="{
           '!cursor-default !bg-transparent': !date.isSame(currentView, 'month'),
-          today: date.isSame(today),
+          today: date.isSame(today) && date.isSame(currentView, 'month'),
           selected: selectedDate && selectedDate.isSame(date),
           selectable: isSelectable(date)
         }"


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/459

### How to test

1.  Open calander
2. Go to next month

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/2a9afe3e-0c76-4084-9458-6bbb897b9718) | ![image](https://github.com/user-attachments/assets/0df0a430-c372-4eb0-a332-9683f3e8054a) |

### To-Do

- [ ]

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
