### PR TITLE
refactor: use vue-query to fetch Home page proposals

### DIFF
--- a/apps/ui/src/components/ProposalsList.vue
+++ b/apps/ui/src/components/ProposalsList.vue
@@ -4,6 +4,7 @@ import { Proposal as ProposalType } from '@/types';
 const props = withDefaults(
   defineProps<{
     title?: string;
+    isError?: boolean;
     loading?: boolean;
     loadingMore?: boolean;
     limit?: number | 'off';
@@ -36,6 +37,13 @@ const currentLimit = computed(() => {
   <div>
     <UiLabel v-if="title" :label="title" sticky />
     <UiLoading v-if="loading" class="block px-4 py-3" />
+    <div
+      v-else-if="isError"
+      class="px-4 py-3 flex items-center text-skin-link gap-2"
+    >
+      <IH-exclamation-circle />
+      <span v-text="'Failed to load proposals.'" />
+    </div>
     <div v-else>
       <UiContainerInfiniteScroll
         :loading-more="loadingMore"

--- a/apps/ui/src/views/My/Home.vue
+++ b/apps/ui/src/views/My/Home.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
+import { useQuery } from '@tanstack/vue-query';
 import ProposalIconStatus from '@/components/ProposalIconStatus.vue';
-import { getNames } from '@/helpers/stamp';
-import { getNetwork, metadataNetwork } from '@/networks';
+import { metadataNetwork } from '@/networks';
 import { ProposalsFilter } from '@/networks/types';
-import { NetworkID, Proposal } from '@/types';
+import { useHomeProposalsQuery } from '@/queries/proposals';
 
-const PROPOSALS_LIMIT = 20;
+const selectIconBaseProps = {
+  size: 16
+};
 
 useTitle('Home');
 
@@ -15,99 +17,45 @@ const followedSpacesStore = useFollowedSpacesStore();
 const { web3 } = useWeb3();
 const { loadVotes } = useAccount();
 
-const loaded = ref(false);
-const loadingMore = ref(false);
-const hasMore = ref(false);
-const proposals = ref<Proposal[]>([]);
 const state = ref<NonNullable<ProposalsFilter['state']>>('any');
 
-const selectIconBaseProps = {
-  size: 16
-};
+const spacesIds = computed(
+  () => followedSpacesStore.followedSpaceIdsByNetwork[metadataNetwork]
+);
 
-// TODO: Support multiple networks
-const network = computed(() => getNetwork(metadataNetwork));
+const {
+  data,
+  fetchNextPage,
+  hasNextPage,
+  isPending,
+  isError,
+  isFetchingNextPage
+} = useHomeProposalsQuery(metadataNetwork, spacesIds, { state });
 
-async function withAuthorNames(proposals: Proposal[]) {
-  if (!proposals.length) return proposals;
+// NOTE: This is just wrapper for loadVotes that handles its own state.
+// We only care about the loading state here.
+const { isPending: isVotesQueryPending, isError: isVotesQueryError } = useQuery(
+  {
+    queryKey: ['homeFollowedSpacesVotes', spacesIds],
+    queryFn: async () => {
+      if (spacesIds.value.length === 0) return null;
 
-  const names = await getNames(proposals.map(proposal => proposal.author.id));
+      await loadVotes(metadataNetwork, spacesIds.value);
 
-  return proposals.map(proposal => {
-    proposal.author.name = names[proposal.author.id];
-
-    return proposal;
-  });
-}
-
-async function loadProposalsPage(skip = 0) {
-  return withAuthorNames(
-    await network.value.api.loadProposals(
-      followedSpacesStore.followedSpacesIds.map(
-        compositeSpaceId => compositeSpaceId.split(':')[1]
-      ),
-      { limit: PROPOSALS_LIMIT, skip },
-      metaStore.getCurrent(metadataNetwork) || 0,
-      { state: state.value }
-    )
-  );
-}
-
-async function fetch() {
-  loaded.value = false;
-  proposals.value = await loadProposalsPage();
-  hasMore.value = proposals.value.length === PROPOSALS_LIMIT;
-  loaded.value = true;
-}
-
-async function fetchMore() {
-  loadingMore.value = true;
-
-  const moreProposals = await loadProposalsPage(proposals.value.length);
-
-  proposals.value = [...proposals.value, ...moreProposals];
-  hasMore.value = moreProposals.length === PROPOSALS_LIMIT;
-  loadingMore.value = false;
-}
-
-async function handleEndReached() {
-  if (hasMore.value) fetchMore();
-}
+      return null;
+    }
+  }
+);
 
 onMounted(() => {
   metaStore.fetchBlock(metadataNetwork);
 });
 
-watch(
-  [
-    () => followedSpacesStore.followedSpacesLoaded,
-    () => followedSpacesStore.followedSpacesIds
-  ],
-  ([followedSpacesloaded, followedSpacesIds]) => {
-    if (!followedSpacesloaded) return;
+async function handleEndReached() {
+  if (!hasNextPage.value) return;
 
-    loaded.value = false;
-    proposals.value = [];
-
-    if (!followedSpacesIds.length) {
-      loaded.value = true;
-      return;
-    }
-
-    for (const network in followedSpacesStore.followedSpaceIdsByNetwork) {
-      loadVotes(
-        network as NetworkID,
-        followedSpacesStore.followedSpaceIdsByNetwork[network]
-      );
-    }
-    fetch();
-  },
-  { immediate: true }
-);
-
-watch(state, (toState, fromState) => {
-  if (toState !== fromState && web3.value.account) fetch();
-});
+  fetchNextPage();
+}
 
 watch(
   [() => web3.value.account, () => web3.value.authLoading],
@@ -160,9 +108,14 @@ watch(
     <ProposalsList
       title="Proposals"
       limit="off"
-      :loading="!followedSpacesStore.followedSpacesLoaded || !loaded"
-      :loading-more="loadingMore"
-      :proposals="proposals"
+      :is-error="isError || isVotesQueryError"
+      :loading="
+        !followedSpacesStore.followedSpacesLoaded ||
+        isPending ||
+        isVotesQueryPending
+      "
+      :loading-more="isFetchingNextPage"
+      :proposals="data?.pages.flat() ?? []"
       show-space
       @end-reached="handleEndReached"
     />

--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -18,7 +18,7 @@ const isOffchainSpace = computed(() =>
 
 const socials = computed(() => getSocialNetworksLink(props.space));
 
-const { data, isPending } = useProposalsSummaryQuery(
+const { data, isPending, isError } = useProposalsSummaryQuery(
   toRef(() => props.space.network),
   toRef(() => props.space.id)
 );
@@ -152,6 +152,7 @@ watchEffect(() => setTitle(props.space.name));
     <div>
       <ProposalsList
         title="Proposals"
+        :is-error="isError"
         :loading="isPending"
         :limit="PROPOSALS_SUMMARY_LIMIT - 1"
         :proposals="data ?? []"

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -28,15 +28,21 @@ const spaceLabels = computed(() => {
   return Object.fromEntries(props.space.labels.map(label => [label.id, label]));
 });
 
-const { data, fetchNextPage, hasNextPage, isPending, isFetchingNextPage } =
-  useProposalsQuery(
-    toRef(() => props.space.network),
-    toRef(() => props.space.id),
-    {
-      state,
-      labels
-    }
-  );
+const {
+  data,
+  fetchNextPage,
+  hasNextPage,
+  isPending,
+  isError,
+  isFetchingNextPage
+} = useProposalsQuery(
+  toRef(() => props.space.network),
+  toRef(() => props.space.id),
+  {
+    state,
+    labels
+  }
+);
 
 function handleClearLabelsFilter(close: () => void) {
   labels.value = [];
@@ -225,6 +231,7 @@ watchEffect(() => setTitle(`Proposals - ${props.space.name}`));
     <ProposalsList
       title="Proposals"
       limit="off"
+      :is-error="isError"
       :loading="isPending"
       :loading-more="isFetchingNextPage"
       :proposals="data?.pages.flat() ?? []"

--- a/apps/ui/src/views/Space/Search.vue
+++ b/apps/ui/src/views/Space/Search.vue
@@ -9,13 +9,19 @@ const route = useRoute();
 
 const query = computed(() => (route.query.q as string) || '');
 
-const { data, fetchNextPage, hasNextPage, isPending, isFetchingNextPage } =
-  useProposalsQuery(
-    toRef(() => props.space.network),
-    toRef(() => props.space.id),
-    {},
-    query
-  );
+const {
+  data,
+  fetchNextPage,
+  hasNextPage,
+  isPending,
+  isError,
+  isFetchingNextPage
+} = useProposalsQuery(
+  toRef(() => props.space.network),
+  toRef(() => props.space.id),
+  {},
+  query
+);
 
 async function handleEndReached() {
   if (!hasNextPage.value) return;
@@ -30,6 +36,7 @@ watchEffect(() => setTitle(`Search - ${props.space.name}`));
   <ProposalsList
     title="Proposals"
     limit="off"
+    :is-error="isError"
     :loading="isPending"
     :loading-more="isFetchingNextPage"
     :proposals="data?.pages.flat() ?? []"


### PR DESCRIPTION
### Summary

This PR refactors Home page proposals to be fetched with vue-query.

Also added `isError `state to proposals list.

Closes: Towards

### How to test

1. Go to http://localhost:8080/#/
2. Sign in.
3. You see proposals from followed (offchain) spaces.
4. Switching between Home and Explore pages you don't see loading states.
5. Status filter works.
6. Clicking on proposal from the list opens proposal without loading.

