### PR TITLE
fix: ensure network verification only for sequence provider

### DIFF
--- a/apps/ui/src/networks/offchain/actions.ts
+++ b/apps/ui/src/networks/offchain/actions.ts
@@ -140,7 +140,10 @@ export function createActions(
       max_end: number,
       executions: ExecutionInfo[]
     ) {
-      if (space.snapshot_chain_id) {
+      if (
+        space.snapshot_chain_id &&
+        (web3.provider as any)._isSequenceProvider
+      ) {
         await verifyNetwork(web3, space.snapshot_chain_id);
       }
 
@@ -180,7 +183,10 @@ export function createActions(
       labels: string[],
       executions: ExecutionInfo[]
     ) {
-      if (space.snapshot_chain_id) {
+      if (
+        space.snapshot_chain_id &&
+        (web3.provider as any)._isSequenceProvider
+      ) {
         await verifyNetwork(web3, space.snapshot_chain_id);
       }
 
@@ -202,7 +208,10 @@ export function createActions(
       return client.updateProposal({ signer: web3.getSigner(), data });
     },
     async flagProposal(web3: Web3Provider, proposal: Proposal) {
-      if (proposal.space.snapshot_chain_id) {
+      if (
+        proposal.space.snapshot_chain_id &&
+        (web3.provider as any)._isSequenceProvider
+      ) {
         await verifyNetwork(web3, proposal.space.snapshot_chain_id);
       }
 
@@ -219,7 +228,10 @@ export function createActions(
       connectorType: ConnectorType,
       proposal: Proposal
     ) {
-      if (proposal.space.snapshot_chain_id) {
+      if (
+        proposal.space.snapshot_chain_id &&
+        (web3.provider as any)._isSequenceProvider
+      ) {
         await verifyNetwork(web3, proposal.space.snapshot_chain_id);
       }
 
@@ -240,7 +252,10 @@ export function createActions(
       reason: string,
       app: string
     ): Promise<any> {
-      if (proposal.space.snapshot_chain_id) {
+      if (
+        proposal.space.snapshot_chain_id &&
+        (web3.provider as any)._isSequenceProvider
+      ) {
         await verifyNetwork(web3, proposal.space.snapshot_chain_id);
       }
 
@@ -393,9 +408,7 @@ export function createActions(
       space: Space,
       owner: string
     ) => {
-      if (space.snapshot_chain_id) {
-        await verifyNetwork(web3, space.snapshot_chain_id);
-      }
+      await verifyNetwork(web3, chainId);
 
       return setEnsTextRecord(
         web3.getSigner(),
@@ -410,6 +423,8 @@ export function createActions(
       id: string,
       settings: string
     ) => {
+      await verifyNetwork(web3, chainId);
+
       return client.createSpace({
         signer: web3.getSigner(),
         data: { space: id, settings }
@@ -428,9 +443,7 @@ export function createActions(
       });
     },
     deleteSpace: async (web3: Web3Provider, space: Space) => {
-      if (space.snapshot_chain_id) {
-        await verifyNetwork(web3, space.snapshot_chain_id);
-      }
+      await verifyNetwork(web3, chainId);
 
       return client.deleteSpace({
         signer: web3.getSigner(),


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/461

### How to test

1. Go to http://localhost:8080/#/s:stakersunion.eth/proposal/0x45bbcac34dd8e32080815692720ba28bf1651aa7f846c280446197a0a68d8c93
2. Use matamask wallet (remove gnosis chain from networks list)
3. You should still be able to vote without error
4. Use sequence wallet
5. You should still be able to vote
