### PR TITLE
fix: fix ui stamp input dimension on small screen

### DIFF
--- a/apps/ui/src/components/FormSpaceWhitelabel.vue
+++ b/apps/ui/src/components/FormSpaceWhitelabel.vue
@@ -163,7 +163,7 @@ onMounted(() => {
         :fallback="false"
         :width="380"
         :height="76"
-        class="border-0"
+        class="!border-0"
         :definition="{
           type: 'string',
           format: 'stamp',

--- a/apps/ui/src/components/Ui/InputStamp.vue
+++ b/apps/ui/src/components/Ui/InputStamp.vue
@@ -61,6 +61,11 @@ async function handleFileChange(e: Event) {
     v-bind="$attrs"
     class="relative group max-w-max cursor-pointer mb-3 border-4 border-skin-bg rounded-lg overflow-hidden bg-skin-border"
     :disabled="disabled"
+    :style="{
+      'max-width': `${width}px`,
+      height: `${height}px`,
+      width: '100%'
+    }"
     @click="openFilePicker()"
   >
     <img
@@ -72,7 +77,6 @@ async function handleFileChange(e: Event) {
           'opacity-80': isUploadingImage
         }
       ]"
-      :style="{ width: `${width}px`, height: `${height}px` }"
     />
     <UiStamp
       v-else-if="fallback"
@@ -85,11 +89,7 @@ async function handleFileChange(e: Event) {
         'opacity-80': isUploadingImage
       }"
     />
-    <div
-      v-else
-      class="block"
-      :style="{ width: ` ${width}px`, height: `${height}px` }"
-    />
+    <div v-else class="block w-full h-full" />
     <div
       class="pointer-events-none absolute group-hover:visible inset-0 z-10 flex flex-row size-full items-center content-center justify-center"
     >


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/464

This PR fix an issue where the stamp input field is using a fixed size, breaking layout on small sceeen.

### How to test

1. Go to your space settings > whitelabel on a small screen
2. The custom logo input field is max 380px, and responsive on small screen
