### PR TITLE
fix: hide ticket strategy in offchain space creation

### DIFF
--- a/apps/ui/src/components/Modal/Strategies.vue
+++ b/apps/ui/src/components/Modal/Strategies.vue
@@ -11,6 +11,7 @@ import { NetworkID } from '@/types';
 const props = defineProps<{
   open: boolean;
   networkId: NetworkID;
+  hiddenStrategies?: string[];
 }>();
 
 const emit = defineEmits<{
@@ -25,6 +26,8 @@ const hasError = ref(false);
 const network = computed(() => getNetwork(props.networkId));
 const filteredStrategies = computed(() => {
   return strategies.value.filter(strategy => {
+    if (props.hiddenStrategies?.includes(strategy.name)) return false;
+
     if (!searchValue.value) return true;
 
     return strategy.name

--- a/apps/ui/src/components/SetupStrategiesConfiguratorOffchain.vue
+++ b/apps/ui/src/components/SetupStrategiesConfiguratorOffchain.vue
@@ -104,6 +104,7 @@ onMounted(() => {
         v-model:model-value="strategies"
         :network-id="networkId"
         :default-chain-id="chainId"
+        :hidden-strategies="['ticket']"
         :limit="limits['space.default.strategies_limit']"
       >
         <template #empty>

--- a/apps/ui/src/components/Ui/StrategiesConfiguratorOffchain.vue
+++ b/apps/ui/src/components/Ui/StrategiesConfiguratorOffchain.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
   allowDuplicates?: boolean;
   defaultChainId?: ChainId;
   limit?: number;
+  hiddenStrategies?: string[];
 }>();
 
 const isStrategiesModalOpen = ref(false);
@@ -109,6 +110,7 @@ function handleRemoveStrategy(strategy: StrategyConfig) {
       <ModalStrategies
         :open="isStrategiesModalOpen"
         :network-id="networkId"
+        :hidden-strategies="hiddenStrategies"
         @add-strategy="handleAddStrategy"
         @close="isStrategiesModalOpen = false"
       />


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1193

This PR hides the `ticket` strategy from the strategies list on offchain space creation.

Offchain space creation does not have the vote validation step, required to setup this strategy.

### How to test

1. Go to http://localhost:8080/#/create/snapshot and to the strategies step
2. Add a strategy
3. The `ticket` strategy should be unavailable
4. Go to your offchain space settings > strategies > open the add strategy modal
5. The `ticket` strategy should be available
