### PR TITLE
fix: hide finalizing vote message from proposal list

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -128,7 +128,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div v-if="isFinalizing" class="border rounded-lg px-3 py-2.5">
+  <div v-if="isFinalizing && withDetails" class="border rounded-lg px-3 py-2.5">
     <div class="flex items-center gap-2 text-skin-link">
       <IH-exclamation-circle class="shrink-0" />
       Finalizing results


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1156

This PR fix an issue where the "finalizing vote" message is showing in the proposal list

### How to test

1. Go go http://localhost:8080/#/s:frami.eth/search?q=poi+list
2. It should not show the "finalizing results" message in the proposals list
3. Go to http://localhost:8080/#/s:frami.eth/proposal/QmXLRQ3AibPJiLzqYz2vykTGvYS5e7PYJicnTA8cgmqQpA
4. It should show the "finalizing message" in the sidebar
