### PR TITLE
fix: remove link on avatar in space overview

### DIFF
--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -61,13 +61,11 @@ watchEffect(() => setTitle(props.space.name));
     </div>
     <div class="px-4">
       <div class="mb-4 relative">
-        <AppLink :to="{ name: 'space-overview' }">
-          <SpaceAvatar
-            :space="space"
-            :size="90"
-            class="relative mb-2 border-4 border-skin-bg !rounded-lg -left-1"
-          />
-        </AppLink>
+        <SpaceAvatar
+          :space="space"
+          :size="90"
+          class="relative mb-2 border-4 border-skin-bg !rounded-lg -left-1"
+        />
         <div class="flex items-center">
           <h1 v-text="space.name" />
           <UiBadgeVerified


### PR DESCRIPTION
### Summary
Remove unwanted link on avatar

Closes: https://github.com/snapshot-labs/workflow/issues/465

### How to test

1. Go to space overview http://localhost:8080/#/s:walletconnect.eth
2. Should not show hand mouse on space avatar
3. Test in mobile
4. Test with whitelabel

