### PR TITLE
feat: use unified API for all SX spaces

### DIFF
--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -10,8 +10,8 @@ export const APP_NAME = 'Snapshot';
 
 export const SIDEKICK_URL = 'https://sh5.co';
 
-export const UNIFIED_API_URL =
-  'https://sx-api-unified-l4gfp.ondigitalocean.app';
+export const UNIFIED_API_URL = 'https://api-u.snapshot.box';
+export const UNIFIED_API_TESTNET_URL = 'https://testnet-api-u.snapshot.box';
 
 export const HELPDESK_URL = 'https://help.snapshot.box';
 

--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -10,6 +10,9 @@ export const APP_NAME = 'Snapshot';
 
 export const SIDEKICK_URL = 'https://sh5.co';
 
+export const UNIFIED_API_URL =
+  'https://sx-api-unified-l4gfp.ondigitalocean.app';
+
 export const HELPDESK_URL = 'https://help.snapshot.box';
 
 export const TURBO_URL =

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -415,6 +415,7 @@ export function createApi(
       const { data } = await apollo.query({
         query: VOTES_QUERY,
         variables: {
+          indexer: networkId,
           first: limit,
           skip,
           orderBy,
@@ -484,12 +485,7 @@ export function createApi(
     ): Promise<{ [key: string]: Vote }> => {
       const { data } = await apollo.query({
         query: USER_VOTES_QUERY,
-        variables: {
-          spaceIds,
-          voter,
-          first: limit,
-          skip
-        }
+        variables: { indexer: networkId, spaceIds, voter, first: limit, skip }
       });
 
       return Object.fromEntries(
@@ -613,6 +609,7 @@ export function createApi(
       const { data } = await apollo.query({
         query: SPACES_QUERY,
         variables: {
+          indexer: networkId,
           first: limit,
           skip,
           where: {
@@ -645,7 +642,7 @@ export function createApi(
       const [{ data }, highlightResult] = await Promise.all([
         apollo.query({
           query: SPACE_QUERY,
-          variables: { id }
+          variables: { indexer: networkId, id }
         }),
         highlightApolloClient
           ?.query({
@@ -669,7 +666,7 @@ export function createApi(
       const [{ data }, highlightResult] = await Promise.all([
         apollo.query({
           query: USER_QUERY,
-          variables: { id }
+          variables: { indexer: networkId, id }
         }),
         highlightApolloClient
           ?.query({
@@ -688,6 +685,7 @@ export function createApi(
       const { data } = await apollo.query({
         query: LEADERBOARD_QUERY,
         variables: {
+          indexer: networkId,
           first: 1000,
           skip: 0,
           orderBy: 'proposal_count',
@@ -723,6 +721,7 @@ export function createApi(
       const { data } = await apollo.query({
         query: LEADERBOARD_QUERY,
         variables: {
+          indexer: networkId,
           first: limit,
           skip,
           orderBy,

--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -21,6 +21,7 @@ gql(`
 
   fragment spaceFields on Space {
     id
+    _indexer
     verified
     turbo
     metadata {
@@ -244,7 +245,7 @@ export const SPACE_QUERY = gql(`
 `);
 
 export const SPACES_QUERY = gql(`
-  query Spaces($indexer: String!, $first: Int!, $skip: Int!, $where: Space_filter) {
+  query Spaces($indexer: String, $first: Int!, $skip: Int!, $where: Space_filter) {
     spaces(
       indexer: $indexer
       first: $first

--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -196,6 +196,7 @@ export const PROPOSALS_QUERY = gql(`
 
 export const VOTES_QUERY = gql(`
   query Votes(
+    $indexer: String!
     $first: Int!
     $skip: Int!
     $orderBy: Vote_orderBy!
@@ -203,6 +204,7 @@ export const VOTES_QUERY = gql(`
     $where: Vote_filter
   ) {
     votes(
+      indexer: $indexer
       first: $first
       skip: $skip
       where: $where
@@ -216,12 +218,14 @@ export const VOTES_QUERY = gql(`
 
 export const USER_VOTES_QUERY = gql(`
   query UserVotes(
+    $indexer: String!
     $first: Int
     $skip: Int
     $spaceIds: [String]
     $voter: String
   ) {
     votes(
+      indexer: $indexer
       first: $first
       skip: $skip
       where: { space_in: $spaceIds, voter: $voter }
@@ -232,16 +236,17 @@ export const USER_VOTES_QUERY = gql(`
 `);
 
 export const SPACE_QUERY = gql(`
-  query Space($id: String!) {
-    space(id: $id) {
+  query Space($indexer: String!, $id: String!) {
+    space(indexer: $indexer, id: $id) {
       ...spaceFields
     }
   }
 `);
 
 export const SPACES_QUERY = gql(`
-  query Spaces($first: Int!, $skip: Int!, $where: Space_filter) {
+  query Spaces($indexer: String!, $first: Int!, $skip: Int!, $where: Space_filter) {
     spaces(
+      indexer: $indexer
       first: $first
       skip: $skip
       orderBy: vote_count
@@ -254,8 +259,8 @@ export const SPACES_QUERY = gql(`
 `);
 
 export const USER_QUERY = gql(`
-  query User($id: String!) {
-    user(id: $id) {
+  query User($indexer: String!, $id: String!) {
+    user(indexer: $indexer, id: $id) {
       id
       proposal_count
       vote_count
@@ -266,6 +271,7 @@ export const USER_QUERY = gql(`
 
 export const LEADERBOARD_QUERY = gql(`
   query Leaderboard(
+    $indexer: String!
     $first: Int!
     $skip: Int!
     $orderBy: Leaderboard_orderBy
@@ -273,6 +279,7 @@ export const LEADERBOARD_QUERY = gql(`
     $where: Leaderboard_filter
   ) {
     leaderboards(
+      indexer: $indexer
       first: $first
       skip: $skip
       orderBy: $orderBy

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -1,4 +1,5 @@
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { UNIFIED_API_URL } from '@/helpers/constants';
 import { pinGraph, pinPineapple } from '@/helpers/pin';
 import { getProvider } from '@/helpers/provider';
 import { Network } from '@/networks/types';
@@ -26,8 +27,7 @@ export const METADATA: Record<string, Metadata> = {
     name: 'Polygon',
     ticker: 'MATIC',
     chainId: 137,
-    apiUrl:
-      'https://subgrapher.snapshot.org/subgraph/arbitrum/5DzKWssJUVKA1imXGyExrycUjdz7t5t7gzTsE9GQhBUn',
+    apiUrl: UNIFIED_API_URL,
     avatar:
       'ipfs://bafkreihcx4zkpfjfcs6fazjp6lcyes4pdhqx3uvnjuo5uj2dlsjopxv5am',
     blockTime: 2.15812
@@ -36,8 +36,7 @@ export const METADATA: Record<string, Metadata> = {
     name: 'Arbitrum One',
     chainId: 42161,
     currentChainId: 1,
-    apiUrl:
-      'https://subgrapher.snapshot.org/subgraph/arbitrum/4QovVxoK3TBLwZKPD1YPHHko5Zz87HvdjpEDBvitCWcH',
+    apiUrl: UNIFIED_API_URL,
     avatar:
       'ipfs://bafkreic2p3zzafvz34y4tnx2kaoj6osqo66fpdo3xnagocil452y766gdq',
     blockTime: ETH_MAINNET_BLOCK_TIME
@@ -45,8 +44,7 @@ export const METADATA: Record<string, Metadata> = {
   oeth: {
     name: 'OP Mainnet',
     chainId: 10,
-    apiUrl:
-      'https://subgrapher.snapshot.org/subgraph/arbitrum/4zXNNp5B34DUNACzonVsHivNJRUHnFBqhvBPYJVaNyks',
+    apiUrl: UNIFIED_API_URL,
     avatar:
       'ipfs://bafkreifu2remiqfpsb4hgisbwb3qxedrzpwsea7ik4el45znjcf56xf2ku',
     blockTime: 2
@@ -54,15 +52,14 @@ export const METADATA: Record<string, Metadata> = {
   base: {
     name: 'Base',
     chainId: 8453,
-    apiUrl:
-      'https://subgrapher.snapshot.org/subgraph/arbitrum/BmcnmDYyCcN7NmQuWXyx3p1xLEiq3sYmvFct8uvBQfum',
+    apiUrl: UNIFIED_API_URL,
     avatar: 'ipfs://QmaxRoHpxZd8PqccAynherrMznMufG6sdmHZLihkECXmZv',
     blockTime: 2
   },
   mnt: {
     name: 'Mantle',
     chainId: 5000,
-    apiUrl: 'https://mantle-api.snapshot.box',
+    apiUrl: UNIFIED_API_URL,
     avatar:
       'ipfs://bafkreidkucwfn4mzo2gtydrt2wogk3je5xpugom67vhi4h4comaxxjzoz4',
     blockTime: 2
@@ -70,8 +67,7 @@ export const METADATA: Record<string, Metadata> = {
   eth: {
     name: 'Ethereum',
     chainId: 1,
-    apiUrl:
-      'https://subgrapher.snapshot.org/subgraph/arbitrum/GerdwbJnTbEz45K7S3D2MLET6VFiY8VqwrqWZg52x2vx',
+    apiUrl: UNIFIED_API_URL,
     avatar:
       'ipfs://bafkreid7ndxh6y2ljw2jhbisodiyrhcy2udvnwqgon5wgells3kh4si5z4',
     blockTime: ETH_MAINNET_BLOCK_TIME
@@ -79,9 +75,7 @@ export const METADATA: Record<string, Metadata> = {
   sep: {
     name: 'Ethereum Sepolia',
     chainId: 11155111,
-    apiUrl:
-      import.meta.env.VITE_EVM_SEPOLIA_API ??
-      'https://subgrapher.snapshot.org/subgraph/arbitrum/3682UpSJVQ89v6BMSzxDSiQWZKa3Hbn6RKucpT8jZ5nT',
+    apiUrl: import.meta.env.VITE_EVM_SEPOLIA_API ?? UNIFIED_API_URL,
     avatar:
       'ipfs://bafkreid7ndxh6y2ljw2jhbisodiyrhcy2udvnwqgon5wgells3kh4si5z4',
     blockTime: 13.2816

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -1,5 +1,5 @@
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
-import { UNIFIED_API_URL } from '@/helpers/constants';
+import { UNIFIED_API_TESTNET_URL, UNIFIED_API_URL } from '@/helpers/constants';
 import { pinGraph, pinPineapple } from '@/helpers/pin';
 import { getProvider } from '@/helpers/provider';
 import { Network } from '@/networks/types';
@@ -75,7 +75,7 @@ export const METADATA: Record<string, Metadata> = {
   sep: {
     name: 'Ethereum Sepolia',
     chainId: 11155111,
-    apiUrl: import.meta.env.VITE_EVM_SEPOLIA_API ?? UNIFIED_API_URL,
+    apiUrl: import.meta.env.VITE_EVM_SEPOLIA_API ?? UNIFIED_API_TESTNET_URL,
     avatar:
       'ipfs://bafkreid7ndxh6y2ljw2jhbisodiyrhcy2udvnwqgon5wgells3kh4si5z4',
     blockTime: 13.2816

--- a/apps/ui/src/networks/index.ts
+++ b/apps/ui/src/networks/index.ts
@@ -87,22 +87,24 @@ export const supportsNullCurrent = (networkID: NetworkID) => {
   return !evmNetworks.includes(networkID);
 };
 
-export const DEFAULT_SPACES_LIMIT = 1000;
-
 export const explorePageProtocols: Record<ExplorePageProtocol, ProtocolConfig> =
   {
     snapshot: {
       key: 'snapshot',
       label: 'Snapshot',
+      apiNetwork: metadataNetwork,
       networks: [metadataNetwork],
       limit: 18
     },
     'snapshot-x': {
       key: 'snapshot-x',
       label: 'Snapshot X',
+      apiNetwork:
+        enabledNetworks.find(network => !offchainNetworks.includes(network)) ||
+        'eth',
       networks: enabledNetworks.filter(
         network => !offchainNetworks.includes(network)
       ),
-      limit: DEFAULT_SPACES_LIMIT
+      limit: 18
     }
   };

--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -3,7 +3,7 @@ import {
   ReceiptTx,
   constants as starknetConstants
 } from 'starknet';
-import { UNIFIED_API_URL } from '@/helpers/constants';
+import { UNIFIED_API_TESTNET_URL, UNIFIED_API_URL } from '@/helpers/constants';
 import { pinPineapple } from '@/helpers/pin';
 import { Network } from '@/networks/types';
 import { NetworkID, Space } from '@/types';
@@ -44,7 +44,8 @@ export const METADATA: Partial<Record<NetworkID, Metadata>> = {
     baseNetworkId: 'sep',
     rpcUrl: `https://starknet-sepolia.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
     ethRpcUrl: `https://sepolia.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
-    apiUrl: import.meta.env.VITE_STARKNET_SEPOLIA_API ?? UNIFIED_API_URL,
+    apiUrl:
+      import.meta.env.VITE_STARKNET_SEPOLIA_API ?? UNIFIED_API_TESTNET_URL,
     explorerUrl: 'https://sepolia.starkscan.co',
     avatar: 'ipfs://bafkreihbjafyh7eud7r6e5743esaamifcttsvbspfwcrfoc5ykodjdi67m'
   }

--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -3,6 +3,7 @@ import {
   ReceiptTx,
   constants as starknetConstants
 } from 'starknet';
+import { UNIFIED_API_URL } from '@/helpers/constants';
 import { pinPineapple } from '@/helpers/pin';
 import { Network } from '@/networks/types';
 import { NetworkID, Space } from '@/types';
@@ -32,7 +33,7 @@ export const METADATA: Partial<Record<NetworkID, Metadata>> = {
     baseNetworkId: 'eth',
     rpcUrl: `https://starknet-mainnet.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
     ethRpcUrl: `https://mainnet.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
-    apiUrl: 'https://api.snapshot.box',
+    apiUrl: UNIFIED_API_URL,
     explorerUrl: 'https://starkscan.co',
     avatar: 'ipfs://bafkreihbjafyh7eud7r6e5743esaamifcttsvbspfwcrfoc5ykodjdi67m'
   },
@@ -43,9 +44,7 @@ export const METADATA: Partial<Record<NetworkID, Metadata>> = {
     baseNetworkId: 'sep',
     rpcUrl: `https://starknet-sepolia.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
     ethRpcUrl: `https://sepolia.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
-    apiUrl:
-      import.meta.env.VITE_STARKNET_SEPOLIA_API ??
-      'https://testnet-api.snapshot.box',
+    apiUrl: import.meta.env.VITE_STARKNET_SEPOLIA_API ?? UNIFIED_API_URL,
     explorerUrl: 'https://sepolia.starkscan.co',
     avatar: 'ipfs://bafkreihbjafyh7eud7r6e5743esaamifcttsvbspfwcrfoc5ykodjdi67m'
   }

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -430,6 +430,7 @@ export type ExplorePageProtocol = 'snapshot' | 'snapshot-x';
 export type ProtocolConfig = {
   key: ExplorePageProtocol;
   label: string;
+  apiNetwork: NetworkID;
   networks: NetworkID[];
   limit: number;
 };

--- a/turbo.json
+++ b/turbo.json
@@ -27,7 +27,12 @@
         "generated/**",
         "src/networks/common/graphqlApi/gql/**"
       ],
-      "inputs": ["**/*.graphql", "**/*.gql", "codegen.ts"]
+      "inputs": [
+        "**/*.graphql",
+        "**/*.gql",
+        "codegen.ts",
+        "src/networks/common/graphqlApi/queries.ts"
+      ]
     }
   }
 }


### PR DESCRIPTION
### Summary

This PR moves UI to use unified API.

Currently used instance only contains mainnet spaces (excluding Mantle), so trying to access testnet spaces will result in 404.

API is a bit slow, I will see if we can improve it.

Closes: https://github.com/snapshot-labs/workflow/issues/155

### How to test

1. Go to explore page.
2. Select SnapshotX -> All Networks.
3. Only one API is queried.
4. You see results from all networks sorted by votes.
5. There is working pagination.
6. Other stuff works as well.