### PR TITLE
fix: remove extra margin in offchain voting strategies

### DIFF
--- a/apps/ui/src/components/FormSpaceStrategies.vue
+++ b/apps/ui/src/components/FormSpaceStrategies.vue
@@ -47,6 +47,7 @@ const strategiesLimit = computed(() => {
   <UiContainerSettings
     :title="`Select up to ${strategiesLimit} strategies`"
     description="(Voting power is cumulative)"
+    class="!mx-0"
   >
     <UiMessage
       v-if="!isTicketValid"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/471

This PR removes the extra margin in the space voting strategies 

### How to test

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth/settings/voting-strategies
2. There is no extra margin in the voting strategies list
3. Go to http://localhost:8080/#/create/snapshot > strategies
4. There is a margin, like all other steps