### PR TITLE
fix: remove legacy code from old coinbase version

### DIFF
--- a/apps/ui/src/helpers/connectors/coinbase.ts
+++ b/apps/ui/src/helpers/connectors/coinbase.ts
@@ -8,18 +8,21 @@ export default class Coinbase extends Connector {
         CoinbaseWalletSDK = CoinbaseWalletSDK.default;
       if (CoinbaseWalletSDK.default)
         CoinbaseWalletSDK = CoinbaseWalletSDK.default;
+
       const walletSDK = new CoinbaseWalletSDK(this.options);
-      this.provider = walletSDK.makeWeb3Provider(
-        this.options.ethJsonrpcUrl,
-        this.options.chainId
-      );
-      await this.provider.request({ method: 'eth_requestAccounts' });
+      const provider = walletSDK.makeWeb3Provider();
+
+      await provider.request({ method: 'eth_requestAccounts' });
+
+      this.provider = provider;
     } catch (e) {
       console.error(e);
     }
   }
 
   async disconnect() {
-    this.provider.disconnect();
+    if (this.provider) {
+      await this.provider.disconnect();
+    }
   }
 }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

- [ ] Fix invalid arguments passed to `makeWeb3Provider` (see https://docs.base.org/identity/smart-wallet/sdk/make-web3-provider)
- [ ] Set provider only when connection is successful

### How to test

1. Login using coinbase, but cancel the connection inside the coinbase modal
2. In the console panel, should not have any other error than the 4001 error