### PR TITLE
fix: show no proposals message if user has no follows

### DIFF
--- a/apps/ui/src/queries/proposals.ts
+++ b/apps/ui/src/queries/proposals.ts
@@ -100,6 +100,8 @@ async function getProposals(
   const metaStore = useMetaStore();
   await metaStore.fetchBlock(networkId);
 
+  if (spaceIds.length === 0) return [];
+
   return withAuthorNames(
     await getNetwork(networkId).api.loadProposals(
       spaceIds,

--- a/apps/ui/src/views/My/Home.vue
+++ b/apps/ui/src/views/My/Home.vue
@@ -20,7 +20,7 @@ const { loadVotes } = useAccount();
 const state = ref<NonNullable<ProposalsFilter['state']>>('any');
 
 const spacesIds = computed(
-  () => followedSpacesStore.followedSpaceIdsByNetwork[metadataNetwork]
+  () => followedSpacesStore.followedSpaceIdsByNetwork[metadataNetwork] ?? []
 );
 
 const {


### PR DESCRIPTION
### Summary

When not following any spaces we should show message about no proposals instead of error. 

Closes: https://github.com/snapshot-labs/workflow/issues/481

### How to test

1. Go to http://localhost:8080/#/ with account that has no follows.

### Screenshots

<img width="1334" alt="image" src="https://github.com/user-attachments/assets/4c847649-9d75-4bcc-8c26-442d8f4d1c3f" />
