### PR TITLE
fix: randomize proposal choices order in Ranked Choice voting

### DIFF
--- a/apps/ui/src/components/ProposalVoteRankedChoice.vue
+++ b/apps/ui/src/components/ProposalVoteRankedChoice.vue
@@ -16,7 +16,10 @@ const emit = defineEmits<{
 const selectedChoices = ref<RankedChoice>(
   (props.proposal.privacy === 'none' &&
     (props.defaultChoice as RankedChoice)) ||
-    props.proposal.choices.map((_, i) => i + 1)
+    [...props.proposal.choices.map((_, i) => i + 1)]
+      .map(value => ({ value, sort: Math.random() }))
+      .sort((a, b) => a.sort - b.sort)
+      .map(({ value }) => value)
 );
 </script>
 


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/486

### How to test

1. Go to a proposal with ranked choice voting or copeland choice (testnet) http://localhost:8080/#/s:pistachiodao.eth/proposal/0x5003da0f03e718b461e53fe10a998b60172e2e108472153282fcef781c300f23
2. You should see random order of choices everytime you reload
3. Once you vote, you should see same order as your vote

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
