### PR TITLE
fix: improve coinbase lazy import

### DIFF
--- a/apps/ui/src/helpers/connectors/coinbase.ts
+++ b/apps/ui/src/helpers/connectors/coinbase.ts
@@ -3,11 +3,9 @@ import Connector from './connector';
 export default class Coinbase extends Connector {
   async connect() {
     try {
-      let CoinbaseWalletSDK = await import('@coinbase/wallet-sdk'!);
-      if (CoinbaseWalletSDK.default)
-        CoinbaseWalletSDK = CoinbaseWalletSDK.default;
-      if (CoinbaseWalletSDK.default)
-        CoinbaseWalletSDK = CoinbaseWalletSDK.default;
+      const { default: CoinbaseWalletSDK } = await import(
+        '@coinbase/wallet-sdk'
+      );
 
       const walletSDK = new CoinbaseWalletSDK(this.options);
       const provider = walletSDK.makeWeb3Provider();

--- a/apps/ui/src/helpers/connectors/coinbase.ts
+++ b/apps/ui/src/helpers/connectors/coinbase.ts
@@ -3,9 +3,7 @@ import Connector from './connector';
 export default class Coinbase extends Connector {
   async connect() {
     try {
-      const { default: CoinbaseWalletSDK } = await import(
-        '@coinbase/wallet-sdk'
-      );
+      const { CoinbaseWalletSDK } = await import('@coinbase/wallet-sdk'!);
 
       const walletSDK = new CoinbaseWalletSDK(this.options);
       const provider = walletSDK.makeWeb3Provider();


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Use deconstuction to import coinbase sdk
Also remove the duplicate check, should be unnecessary on v4, will put back if we get this bug again.