### PR TITLE
feat: add EthSig authenticator with EIP-1271 support

### DIFF
--- a/apps/ui/src/components/StrategiesConfigurator.vue
+++ b/apps/ui/src/components/StrategiesConfigurator.vue
@@ -94,7 +94,7 @@ function handleStrategySave(value: Record<string, any>) {
     <div v-if="availableStrategies.length === 0">No strategies available</div>
     <div v-else class="space-y-3">
       <ButtonStrategy
-        v-for="strategy in availableStrategies"
+        v-for="strategy in availableStrategies.filter(s => !s.deprecated)"
         :key="strategy.address"
         :disabled="
           limitReached || (unique && !!activeStrategiesMap[strategy.name])

--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -23,11 +23,13 @@ export function createConstants(
   if (!config) throw new Error(`Unsupported network ${networkId}`);
 
   const SUPPORTED_AUTHENTICATORS = {
+    [config.Authenticators.EthSigV2]: true,
     [config.Authenticators.EthSig]: true,
     [config.Authenticators.EthTx]: true
   };
 
   const CONTRACT_SUPPORTED_AUTHENTICATORS = {
+    [config.Authenticators.EthSigV2]: true,
     [config.Authenticators.EthTx]: true
   };
 
@@ -46,11 +48,13 @@ export function createConstants(
   };
 
   const RELAYER_AUTHENTICATORS = {
-    [config.Authenticators.EthSig]: 'evm'
+    [config.Authenticators.EthSig]: 'evm',
+    [config.Authenticators.EthSigV2]: 'evm'
   } as const;
 
   const AUTHS = {
-    [config.Authenticators.EthSig]: 'Ethereum signature',
+    [config.Authenticators.EthSig]: 'Ethereum signature (deprecated)',
+    [config.Authenticators.EthSigV2]: 'Ethereum signature',
     [config.Authenticators.EthTx]: 'Ethereum transaction'
   };
 
@@ -82,7 +86,17 @@ export function createConstants(
       paramsDefinition: null
     },
     {
+      // Deprecated because of missing EIP-1271 support, superseded by EthSigV2
       address: config.Authenticators.EthSig,
+      name: 'Ethereum signature (deprecated)',
+      deprecated: true,
+      about:
+        'Will authenticate a user based on an EIP-712 message signed by an Ethereum private key.',
+      icon: IHPencil,
+      paramsDefinition: null
+    },
+    {
+      address: config.Authenticators.EthSigV2,
       name: 'Ethereum signature',
       about:
         'Will authenticate a user based on an EIP-712 message signed by an Ethereum private key.',

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -76,7 +76,7 @@ export type StrategyTemplate = {
   address: string;
   name: string;
   /**
-   * Deprecated startegy can still be used but can't be added to new spaces.
+   * Deprecated strategy can still be used but can't be added to new spaces.
    */
   deprecated?: boolean;
   about?: string;

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -75,6 +75,10 @@ export type GeneratedMetadata =
 export type StrategyTemplate = {
   address: string;
   name: string;
+  /**
+   * Deprecated startegy can still be used but can't be added to new spaces.
+   */
+  deprecated?: boolean;
   about?: string;
   author?: string;
   version?: string;

--- a/packages/sx.js/src/authenticators/evm/ethSig.ts
+++ b/packages/sx.js/src/authenticators/evm/ethSig.ts
@@ -9,9 +9,11 @@ import {
 } from '../../clients/evm/types';
 import { getRSVFromSig, hexPadLeft } from '../../utils/encoding';
 
-export default function createEthSigAuthenticator(): Authenticator {
+export default function createEthSigAuthenticator(
+  type: 'ethSig' | 'ethSigV2'
+): Authenticator {
   return {
-    type: 'ethSig',
+    type,
     createCall(
       envelope: Envelope<Propose | UpdateProposal | Vote>,
       selector: string,

--- a/packages/sx.js/src/authenticators/evm/index.ts
+++ b/packages/sx.js/src/authenticators/evm/index.ts
@@ -19,8 +19,8 @@ export function getAuthenticator(
     return createEthTxAuthenticator();
   }
 
-  if (authenticator.type === 'ethSig') {
-    return createEthSigAuthenticator();
+  if (authenticator.type === 'ethSig' || authenticator.type === 'ethSigV2') {
+    return createEthSigAuthenticator(authenticator.type);
   }
 
   return null;

--- a/packages/sx.js/src/evmNetworks.ts
+++ b/packages/sx.js/src/evmNetworks.ts
@@ -29,6 +29,7 @@ function createStandardConfig(
     },
     Authenticators: {
       EthSig: '0x5f9B7D78c9a37a439D78f801E0E339C6E711e260',
+      EthSigV2: '0x95CF9B585fDb12DeB78002B5643dFF8fe67a496D',
       EthTx: '0xBA06E6cCb877C332181A6867c05c8b746A21Aed1',
       ...additionalAuthenticators
     },
@@ -60,6 +61,9 @@ function createEvmConfig(
   const authenticators = {
     [network.Authenticators.EthSig]: {
       type: 'ethSig'
+    },
+    [network.Authenticators.EthSigV2]: {
+      type: 'ethSigV2'
     },
     [network.Authenticators.EthTx]: {
       type: 'ethTx'

--- a/packages/sx.js/src/types/networkConfig.ts
+++ b/packages/sx.js/src/types/networkConfig.ts
@@ -20,6 +20,10 @@ export type EthSigAuthenticatorConfig = {
   type: 'ethSig';
 };
 
+export type EthSigV2AuthenticatorConfig = {
+  type: 'ethSigV2';
+};
+
 export type StarkSigAuthenticatorConfig = {
   type: 'starkSig';
 };
@@ -74,6 +78,7 @@ export type NetworkConfig = {
       | VanillaAuthenticatorConfig
       | EthTxAuthenticatorConfig
       | EthSigAuthenticatorConfig
+      | EthSigV2AuthenticatorConfig
       | StarkSigAuthenticatorConfig
       | StarkTxAuthenticatorConfig
       | undefined;


### PR DESCRIPTION
### Summary

Our previous EVM EthSig authenticators didn't support EIP-1271 which meant contract signatures (like from Safe wallets)
were not supported.

EIP-1271 support was added on the contract side [here](https://github.com/snapshot-labs/sx-evm/pull/254). This PR adds support for it on the UI. Old versions will continue to work but will be marked by legacy and won't be possible to be added to new spaces.

Closes: https://github.com/snapshot-labs/workflow/issues/329

### How to test


1. Run local mana and use it in .env for UI.
2. Edit your space so you have VP to propose/vote with your Safe, and remove legacy EthSig authenticator.
3. Connect with your Safe (via Safe app or via WalletConnect - in case of WC you need to disable on chain signatures).
4. Try proposing or voting.
5. You get prompted in Safe to sign your message.
6. Proposal/vote gets created.
