### PR TITLE
feat: add beta tag for copeland voting type and allow in production

### DIFF
--- a/apps/ui/src/components/EditorVotingType.vue
+++ b/apps/ui/src/components/EditorVotingType.vue
@@ -62,7 +62,7 @@ watch(
         <h4 class="text-skin-link inline" v-text="activeVotingType.label" />
         <span
           v-if="activeVotingType.isBeta"
-          class="ml-2.5 bg-skin-border text-skin-link text-[13px] rounded-full px-1.5 py-0.5"
+          class="ml-2 bg-skin-border text-skin-link text-[13px] rounded-full px-1.5 py-0.5"
           >beta</span
         >
       </div>

--- a/apps/ui/src/components/EditorVotingType.vue
+++ b/apps/ui/src/components/EditorVotingType.vue
@@ -58,7 +58,14 @@ watch(
       :disabled="!hasMultipleVotingType"
       @click="handleVotingTypeClick"
     >
-      <h4 class="text-skin-link mr-3" v-text="activeVotingType.label" />
+      <div>
+        <h4 class="text-skin-link inline" v-text="activeVotingType.label" />
+        <span
+          v-if="activeVotingType.isBeta"
+          class="ml-2.5 bg-skin-border text-skin-link text-[13px] rounded-full px-1.5 py-0.5"
+          >beta</span
+        >
+      </div>
       <div
         v-if="hasMultipleVotingType"
         class="w-[20px] text-right text-skin-link absolute right-3 top-3"

--- a/apps/ui/src/components/FormSpaceVoting.vue
+++ b/apps/ui/src/components/FormSpaceVoting.vue
@@ -6,7 +6,7 @@ import {
 } from '@/helpers/constants';
 import { _d } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
-import { getNetwork, metadataNetwork, offchainNetworks } from '@/networks';
+import { getNetwork, offchainNetworks } from '@/networks';
 import { ChainId, Space, SpacePrivacy, Validation, VoteType } from '@/types';
 
 const votingDelay = defineModel<number | null>('votingDelay', {

--- a/apps/ui/src/components/FormSpaceVoting.vue
+++ b/apps/ui/src/components/FormSpaceVoting.vue
@@ -62,11 +62,6 @@ const isSelectPrivacyModalOpen = ref(false);
 const isSelectValidationModalOpen = ref(false);
 
 const network = computed(() => getNetwork(props.space.network));
-const votingTypes = computed(() =>
-  metadataNetwork !== 's-tn'
-    ? network.value.constants.EDITOR_VOTING_TYPES.filter(a => a !== 'copeland')
-    : network.value.constants.EDITOR_VOTING_TYPES
-);
 
 const isOffchainNetwork = computed(() =>
   offchainNetworks.includes(props.space.network)
@@ -302,7 +297,7 @@ watchEffect(() => {
       :open="isSelectVotingTypeModalOpen"
       :with-any="true"
       :initial-state="votingType"
-      :voting-types="votingTypes"
+      :voting-types="network.constants.EDITOR_VOTING_TYPES"
       @save="value => (votingType = value)"
       @close="isSelectVotingTypeModalOpen = false"
     />

--- a/apps/ui/src/components/Modal/SelectVotingType.vue
+++ b/apps/ui/src/components/Modal/SelectVotingType.vue
@@ -50,7 +50,7 @@ function handleSelect(type: AvailableVotingTypes) {
           />
           <span
             v-if="VOTING_TYPES_INFO[type].isBeta"
-            class="ml-2.5 bg-skin-border text-skin-link text-[13px] rounded-full px-1.5 py-0.5"
+            class="ml-2 bg-skin-border text-skin-link text-[13px] rounded-full px-1.5 py-0.5"
             >beta</span
           >
           <div v-text="VOTING_TYPES_INFO[type].description" />

--- a/apps/ui/src/components/Modal/SelectVotingType.vue
+++ b/apps/ui/src/components/Modal/SelectVotingType.vue
@@ -44,7 +44,15 @@ function handleSelect(type: AvailableVotingTypes) {
         @click="handleSelect(type)"
       >
         <div>
-          <h4 class="text-skin-link" v-text="VOTING_TYPES_INFO[type].label" />
+          <h4
+            class="text-skin-link inline"
+            v-text="VOTING_TYPES_INFO[type].label"
+          />
+          <span
+            v-if="VOTING_TYPES_INFO[type].isBeta"
+            class="ml-2.5 bg-skin-border text-skin-link text-[13px] rounded-full px-1.5 py-0.5"
+            >beta</span
+          >
           <div v-text="VOTING_TYPES_INFO[type].description" />
         </div>
       </UiSelector>

--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -81,8 +81,8 @@ export const SUPPORTED_VOTING_TYPES: VoteType[] = [
   'basic',
   'single-choice',
   'approval',
-  'copeland',
   'ranked-choice',
+  'copeland',
   'weighted',
   'quadratic'
 ] as const;
@@ -124,9 +124,10 @@ export const VOTING_TYPES_INFO: Record<
       'Each voter may spread voting power across any number of choices. Results are calculated quadratically.'
   },
   copeland: {
-    label: 'Copeland voting (BETA)',
+    label: 'Copeland voting',
     description:
-      'Voters can rank multiple choices. Results are calculated by Copeland method.'
+      'Voters can rank multiple choices. Results are calculated by Copeland method.',
+    isBeta: true
   }
 };
 

--- a/apps/ui/src/networks/offchain/constants.ts
+++ b/apps/ui/src/networks/offchain/constants.ts
@@ -28,8 +28,8 @@ export const EDITOR_VOTING_TYPES: VoteType[] = [
   'basic',
   'single-choice',
   'approval',
-  'copeland',
   'ranked-choice',
+  'copeland',
   'weighted',
   'quadratic'
 ];

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -49,9 +49,11 @@ export type VoteType =
   | 'quadratic'
   | 'weighted'
   | 'custom';
+
 export type VoteTypeInfo = {
   label: string;
   description: string;
+  isBeta?: boolean;
 };
 
 export type DelegationType =

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -241,12 +241,6 @@ const proposalMaxEnd = computed(() => {
   );
 });
 
-const votingTypes = computed(() =>
-  metadataNetwork !== 's-tn'
-    ? props.space.voting_types.filter(a => a !== 'copeland')
-    : props.space.voting_types
-);
-
 const {
   data: propositionPower,
   isPending: isPropositionPowerPending,
@@ -695,7 +689,9 @@ watchEffect(() => {
         <div class="flex flex-col p-4 space-y-4 md:mb-6">
           <EditorVotingType
             v-model="proposal"
-            :voting-types="enforcedVoteType ? [enforcedVoteType] : votingTypes"
+            :voting-types="
+              enforcedVoteType ? [enforcedVoteType] : space.voting_types
+            "
           />
           <EditorChoices
             v-model="proposal"


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/workflow/issues/487

### Summary
- Added "beta" label for Copeland voting type
- Updated voting types order to show Copeland after ranked choice
- Removed filtering of Copeland voting type to display it on production


### How to test
- Go to your space settings
- You should always see Copeland voting type after ranked choice
- You should see "beta" tag for copeland
- Should be same while proposal creation



### To-do:
- [x] Allow copeland on sequencer https://github.com/snapshot-labs/snapshot-sequencer/pull/517