### PR TITLE
fix: quorum of rejection should default to passed state if quorum is not reach

### DIFF
--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -89,11 +89,11 @@ function getProposalState(
       quorum_type: proposal.quorumType
     });
 
-    if (
-      proposal.quorumType === 'rejection'
-        ? currentQuorum > proposal.quorum
-        : currentQuorum < proposal.quorum
-    ) {
+    if (proposal.quorumType === 'rejection') {
+      return currentQuorum > proposal.quorum ? 'rejected' : 'passed';
+    }
+
+    if (currentQuorum < proposal.quorum) {
       return 'rejected';
     }
 


### PR DESCRIPTION
### Issue
- https://snapshot.box/#/s:metislayer2.eth/proposal/0x3fe7f9f946a9157d37093c6800e39cb3a4f8f7094c06a1d73ee53804e80f49b9 
- This proposal is displaying "Rejected" based on Basic voting type but ignoring the "Quorum of rejection" 

### Summary
If a proposal is using "Quorum of rejection" display either "Passed" or "Rejected"

### How to test

1. Go to http://localhost:8080/#/s:metislayer2.eth/proposal/0x3fe7f9f946a9157d37093c6800e39cb3a4f8f7094c06a1d73ee53804e80f49b9 and 
http://localhost:8080/#/s:usualmoney.eth/proposal/0x1b1938083ec6b3f630b888d6d7d756aff26f0a0a693ed8f97caf835d04dc1018
2. You should see passed instead of rejected 
3. [Proposal with quorum of rejection and quroum less than 100% + Basic voting](http://localhost:8080/#/s:usualmoney.eth/proposal/0x1b081d3b3dd611094e96b690dc5d981d86bb724cce5ef562d9eecbe580b535c2) Should still display "Passed"
3. [Proposal with a quorum of rejection and quorum more than 100%](http://localhost:8080/#/s:metislayer2.eth/proposal/0x3c0a2e5e310f42ea4f762f072beb6b225099122a75ab2f0cea22c716ee7384ce) should show "Rejected"
3. [Active proposals](http://localhost:8080/#/s:pistachiodao.eth/proposal/0xa5077ef17097b1d59304b110337bd1c7ce98d95d3ff81d138c3886a80074b4d9) should show "Active"
4. [Non basic proposal and quorum more than 100%](http://localhost:8080/#/s:gitcoindao.eth/proposal/0xb8dfbefd47373a98ac4684af50f61dad738650830f4f106347cb3c4a8dec79ab) should show "closed"
5. [Non basic proposal and quorum less than 100%](http://localhost:8080/#/s:gitcoindao.eth/proposal/0x8b698644c08b424f87709228caa0ee11af6a3a047d47032b0f45a7f971d15696) should show "rejected"
