### PR TITLE
fix: include 'closed' state in finalizing logic

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -96,7 +96,7 @@ const otherResultsSummary = computed(() => {
 const isFinalizing = computed(() => {
   return (
     !props.proposal.completed &&
-    ['passed', 'executed', 'rejected'].includes(props.proposal.state)
+    ['passed', 'executed', 'rejected', 'closed'].includes(props.proposal.state)
   );
 });
 


### PR DESCRIPTION
### Issue
- Originally reported by Aura, for this [proposal](http://localhost:8080/#/s:gauges.aurafinance.eth/proposal/0xcb1770f2c1f1a2d822d0eed697149bbefc8cef6d702a94ccd8fdf0887128bc40)
- Was showing results for score_state with `pending` state + non basic proposals
- Instead, it should show the "Finalizing results" message


### How to test

1. Go to http://localhost:8080/#/s:aave.eth/proposal/0x95a80ac25f97e0fc06528452e2c33d7cc179b801ddc4d8dd164964ce8e1d450e/votes
2. Before the fix, You should see results even if `scores_state` is `pending`
3. After the fix, you should see "Finalizing results"
