### PR TITLE
build: add dev:debug script to api

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint src/ test/ --ext .ts",
     "build": "tsc",
     "dev": "nodemon src/index.ts",
+    "dev:debug": "nodemon --exec \"node --inspect --require ts-node/register src/index.ts\"",
     "start": "node dist/src/index.js",
     "test": "vitest run"
   },


### PR DESCRIPTION
### Summary

This adds `dev:debug` script that will run API with inspect breakpoint.

###  Test plan

1. Run `yarn dev:debug` in `apps/api`.
2. Go to `chrome://inspect`.
3. You can attach to debugger.