### PR TITLE
fix: show warning message when all available ens names are used on offchain space creation

### DIFF
--- a/apps/ui/src/components/EnsConfiguratorOffchain.vue
+++ b/apps/ui/src/components/EnsConfiguratorOffchain.vue
@@ -136,6 +136,12 @@ function handleSelect(value: string) {
               </div>
             </div>
           </UiSelector>
+          <UiMessage
+            v-if="!validNames.length && !invalidNames.length"
+            type="danger"
+          >
+            No more ENS names available for space creation found.
+          </UiMessage>
         </div>
         <UiMessage v-else type="danger">
           No ENS names found for the current wallet.


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an issue on offchain space creation, when all the user's ens names are already attached to an active space.

### How to test

1. impersonate with `tonycpo.eth`
2. create an offchain space
3. in the ens step, it should show a warning message instead of nothing
