### PR TITLE
fix: use null snapshot for onchain pending proposals

### DIFF
--- a/apps/ui/src/queries/votingPower.ts
+++ b/apps/ui/src/queries/votingPower.ts
@@ -37,16 +37,16 @@ const VOTING_POWER_KEYS = {
 
 const { web3 } = useWeb3();
 
-function isOffchainPendingProposal(proposal: Proposal): boolean {
+function isOnchainPendingProposal(proposal: Proposal): boolean {
   return (
-    proposal.state === 'pending' && offchainNetworks.includes(proposal.network)
+    proposal.state === 'pending' && !offchainNetworks.includes(proposal.network)
   );
 }
 
 function getProposalSnapshot(proposal?: Proposal | null): Snapshot {
   if (!proposal) return null;
 
-  const snapshot = isOffchainPendingProposal(proposal)
+  const snapshot = isOnchainPendingProposal(proposal)
     ? null
     : proposal.snapshot;
 


### PR DESCRIPTION
### Summary

It used to be the case, but this check got flipped in https://github.com/snapshot-labs/sx-monorepo/pull/1220

https://github.com/snapshot-labs/sx-monorepo/pull/1220/files#diff-a5eb90aaca074d576a85d84efe9da82dc0aaf9a1563ff46112f858f8b8028b7cL14-L22


### How to test

1. Go to (while it's pending) http://localhost:8080/#/sn:0x009fedaf0d7a480d21a27683b0965c0f8ded35b3f1cac39827a25a06a8a682a4/proposal/8
2. Sign in with Starknet wallet.
3. Voting power is visible.
