### PR TITLE
fix: do not retry fetching VP on NOT_READY_YET error

### DIFF
--- a/apps/ui/src/queries/votingPower.ts
+++ b/apps/ui/src/queries/votingPower.ts
@@ -116,6 +116,11 @@ export function useSpaceVotingPowerQuery(
         spaceValue.strategies_parsed_metadata
       ]);
     },
+    retry: (failureCount, error) => {
+      if (error?.message.includes('NOT_READY_YET')) return false;
+
+      return failureCount < 3;
+    },
     enabled: () => !!toValue(account),
     staleTime: CACHE_TTL
   });
@@ -150,6 +155,11 @@ export function useProposalVotingPowerQuery(
           proposalValue.space.strategies_parsed_metadata
         ]
       );
+    },
+    retry: (failureCount, error) => {
+      if (error?.message.includes('NOT_READY_YET')) return false;
+
+      return failureCount < 3;
     },
     enabled: () => !!toValue(account) && toValue(active),
     staleTime: CACHE_TTL


### PR DESCRIPTION
### Summary

This error is just used to convey information.

We shouldn't retry if we see it.

### How to test

1. Go to (while it's pending) http://localhost:8080/#/sn:0x009fedaf0d7a480d21a27683b0965c0f8ded35b3f1cac39827a25a06a8a682a4/proposal/8
2. Sing in with Metamask wallet.
3. You see your VP quickly.
4. You don't see multiple requests to Infura with error `Timestamp not cached`.
