### PR TITLE
fix: use proposalId in proposalVotesQuery

### DIFF
--- a/apps/ui/src/queries/votes.ts
+++ b/apps/ui/src/queries/votes.ts
@@ -22,7 +22,7 @@ export function useProposalVotesQuery({
     initialPageParam: 0,
     queryKey: [
       'votes',
-      proposal,
+      () => toValue(proposal).id,
       'list',
       {
         choiceFilter,


### PR DESCRIPTION
### Summary

Previously I used entire proposal object by mistake so new cache entry is used every time proposal changes (for example when new vote comes in it will be different because vote_count changes).

This would result in loading screen being displayed.

### How to test

1. Go to proposal with some decent activity (http://localhost:8080/#/sn:0x009fedaf0d7a480d21a27683b0965c0f8ded35b3f1cac39827a25a06a8a682a4/proposal/8/votes)
2. Go to votes tab.
3. Go to different tab.
4. Wait for some time - vote should happen in the background.
5. Go back to UI tab - no visible reload of votes.

