### PR TITLE
feat: add custom strategies support

### DIFF
--- a/.changeset/gold-papayas-fly.md
+++ b/.changeset/gold-papayas-fly.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+generate standard execution payload for any execution with transactions

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,7 +25,7 @@
     "@ethersproject/providers": "^5.7.2",
     "@ethersproject/units": "^5.6.1",
     "@faker-js/faker": "^7.4.0",
-    "@snapshot-labs/checkpoint": "^0.1.0-beta.54",
+    "@snapshot-labs/checkpoint": "^0.1.0-beta.55",
     "@snapshot-labs/sx": "^0.1.0",
     "@types/bn.js": "^5.1.0",
     "@types/mysql": "^2.15.21",

--- a/apps/api/src/evm/abis/IExecutionStrategy.json
+++ b/apps/api/src/evm/abis/IExecutionStrategy.json
@@ -1,0 +1,187 @@
+[
+  {
+    "type": "function",
+    "name": "execute",
+    "inputs": [
+      {
+        "name": "proposalId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "proposal",
+        "type": "tuple",
+        "internalType": "struct Proposal",
+        "components": [
+          {
+            "name": "author",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "startBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "executionStrategy",
+            "type": "address",
+            "internalType": "contract IExecutionStrategy"
+          },
+          {
+            "name": "minEndBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "maxEndBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "finalizationStatus",
+            "type": "uint8",
+            "internalType": "enum FinalizationStatus"
+          },
+          {
+            "name": "executionPayloadHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "activeVotingStrategies",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "votesFor",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "votesAgainst",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "votesAbstain",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "payload",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getProposalStatus",
+    "inputs": [
+      {
+        "name": "proposal",
+        "type": "tuple",
+        "internalType": "struct Proposal",
+        "components": [
+          {
+            "name": "author",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "startBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "executionStrategy",
+            "type": "address",
+            "internalType": "contract IExecutionStrategy"
+          },
+          {
+            "name": "minEndBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "maxEndBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "finalizationStatus",
+            "type": "uint8",
+            "internalType": "enum FinalizationStatus"
+          },
+          {
+            "name": "executionPayloadHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "activeVotingStrategies",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "votesFor",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "votesAgainst",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "votesAbstain",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum ProposalStatus"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getStrategyType",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "error",
+    "name": "ExecutionFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidProposalStatus",
+    "inputs": [
+      {
+        "name": "status",
+        "type": "uint8",
+        "internalType": "enum ProposalStatus"
+      }
+    ]
+  }
+]

--- a/apps/api/src/evm/ipfs.ts
+++ b/apps/api/src/evm/ipfs.ts
@@ -95,4 +95,6 @@ export async function handleSpaceMetadata(
   }
 
   await spaceMetadataItem.save();
+
+  return spaceMetadataItem;
 }

--- a/apps/api/src/evm/utils.ts
+++ b/apps/api/src/evm/utils.ts
@@ -1,8 +1,11 @@
 import { defaultAbiCoder } from '@ethersproject/abi';
 import { getAddress } from '@ethersproject/address';
 import { BigNumber } from '@ethersproject/bignumber';
+import { Contract } from '@ethersproject/contracts';
+import { JsonRpcProvider } from '@ethersproject/providers';
+import IExecutionStrategy from './abis/IExecutionStrategy.json';
 import { FullConfig } from './config';
-import { Space } from '../../.checkpoint/models';
+import { ExecutionStrategy, Space } from '../../.checkpoint/models';
 import { handleVotingPowerValidationMetadata } from '../common/ipfs';
 
 /**
@@ -68,4 +71,36 @@ export async function updateProposalValidationStrategy(
       space.voting_power_validation_strategy_strategies_params = [];
     }
   }
+}
+
+export async function handleCustomExecutionStrategy(
+  address: string,
+  blockNumber: number,
+  provider: JsonRpcProvider,
+  config: FullConfig
+) {
+  const contract = new Contract(address, IExecutionStrategy, provider);
+
+  const overrides = {
+    blockTag: blockNumber
+  };
+
+  const type = await contract.getStrategyType(overrides);
+
+  let executionStrategy = await ExecutionStrategy.loadEntity(
+    address,
+    config.indexerName
+  );
+
+  if (executionStrategy) return;
+
+  executionStrategy = new ExecutionStrategy(address, config.indexerName);
+  executionStrategy.address = address;
+  executionStrategy.type = type;
+  executionStrategy.quorum = '0';
+  executionStrategy.treasury_chain = config.chainId;
+  executionStrategy.treasury = getAddress(address);
+  executionStrategy.timelock_delay = 0n;
+
+  await executionStrategy.save();
 }

--- a/apps/api/src/evm/writers.ts
+++ b/apps/api/src/evm/writers.ts
@@ -8,7 +8,11 @@ import SimpleQuorumAvatarExecutionStrategy from './abis/SimpleQuorumAvatarExecut
 import SimpleQuorumTimelockExecutionStrategy from './abis/SimpleQuorumTimelockExecutionStrategy.json';
 import { FullConfig } from './config';
 import { handleSpaceMetadata } from './ipfs';
-import { convertChoice, updateProposalValidationStrategy } from './utils';
+import {
+  convertChoice,
+  handleCustomExecutionStrategy,
+  updateProposalValidationStrategy
+} from './utils';
 import {
   ExecutionHash,
   ExecutionStrategy,
@@ -26,6 +30,18 @@ import {
   handleVoteMetadata
 } from '../common/ipfs';
 import { dropIpfs, getCurrentTimestamp } from '../common/utils';
+
+/**
+ * List of execution strategies type that are known and we expect them to be deployed via factory.
+ * Other execution strategies will be treated as custom execution and will be resolved once
+ * they are added to space.
+ */
+const KNOWN_EXECUTION_STRATEGIES = [
+  'SimpleQuorumAvatar',
+  'SimpleQuorumTimelock',
+  'Axiom',
+  'Isokratia'
+];
 
 const EMPTY_EXECUTION_HASH =
   '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470';
@@ -179,7 +195,12 @@ export function createWriters(config: FullConfig) {
     }
   };
 
-  const handleSpaceCreated: evm.Writer = async ({ block, tx, event }) => {
+  const handleSpaceCreated: evm.Writer = async ({
+    block,
+    blockNumber,
+    tx,
+    event
+  }) => {
     console.log('Handle space created');
 
     if (!event) return;
@@ -222,13 +243,33 @@ export function createWriters(config: FullConfig) {
       config
     );
 
+    let spaceMetadataItem: SpaceMetadataItem | undefined;
     try {
       const metadataUri = event.args.input.metadataURI;
-      await handleSpaceMetadata(space.id, metadataUri, config);
+      spaceMetadataItem = await handleSpaceMetadata(
+        space.id,
+        metadataUri,
+        config
+      );
 
       space.metadata = dropIpfs(metadataUri);
     } catch (e) {
       console.log('failed to parse space metadata', e);
+    }
+
+    if (spaceMetadataItem) {
+      for (const [i, executor] of spaceMetadataItem.executors.entries()) {
+        const type = spaceMetadataItem.executors_types[i];
+
+        if (type && !KNOWN_EXECUTION_STRATEGIES.includes(type)) {
+          await handleCustomExecutionStrategy(
+            executor,
+            blockNumber,
+            provider,
+            config
+          );
+        }
+      }
     }
 
     try {
@@ -245,16 +286,25 @@ export function createWriters(config: FullConfig) {
     await space.save();
   };
 
-  const handleMetadataUriUpdated: evm.Writer = async ({ rawEvent, event }) => {
+  const handleMetadataUriUpdated: evm.Writer = async ({
+    blockNumber,
+    rawEvent,
+    event
+  }) => {
     if (!event || !rawEvent) return;
 
     console.log('Handle space metadata uri updated');
 
     const spaceId = getAddress(rawEvent.address);
 
+    let spaceMetadataItem: SpaceMetadataItem | undefined;
     try {
       const metadataUri = event.args.newMetadataURI;
-      await handleSpaceMetadata(spaceId, metadataUri, config);
+      spaceMetadataItem = await handleSpaceMetadata(
+        spaceId,
+        metadataUri,
+        config
+      );
 
       const space = await Space.loadEntity(spaceId, config.indexerName);
       if (!space) return;
@@ -264,6 +314,21 @@ export function createWriters(config: FullConfig) {
       await space.save();
     } catch (e) {
       console.log('failed to update space metadata', e);
+    }
+
+    if (spaceMetadataItem) {
+      for (const [i, executor] of spaceMetadataItem.executors.entries()) {
+        const type = spaceMetadataItem.executors_types[i];
+
+        if (type && !KNOWN_EXECUTION_STRATEGIES.includes(type)) {
+          await handleCustomExecutionStrategy(
+            executor,
+            blockNumber,
+            provider,
+            config
+          );
+        }
+      }
     }
   };
 

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -116,12 +116,15 @@ type Proposal {
   snapshot: Int!
   execution_time: Int!
   execution_strategy: String!
+  # Note: in the future move this field to execution_strategy
+  execution_strategy_details: ExecutionStrategy
   execution_strategy_type: String!
   execution_destination: String
   timelock_veto_guardian: String
   timelock_delay: BigInt
   axiom_snapshot_address: String
   axiom_snapshot_slot: BigInt
+  treasuries: [String!]!
   strategies_indices: [Int!]!
   # Deprecated
   strategies_indicies: [Int!]!

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -12,9 +12,11 @@ import {
   updateProposalValidationStrategy
 } from './utils';
 import {
+  ExecutionStrategy,
   Leaderboard,
   Proposal,
   Space,
+  SpaceMetadataItem,
   User,
   Vote
 } from '../../.checkpoint/models';
@@ -474,6 +476,38 @@ export function createWriters(config: FullConfig) {
         executionStrategy.executionStrategyType;
       proposal.execution_destination = executionStrategy.destinationAddress;
       proposal.quorum = executionStrategy.quorum;
+
+      // Find matching strategy and persist it on space object
+      // We use this on UI to properly display execution with treasury
+      // information.
+      // Current way of persisting it isn't great, because we need to fetch every strategy
+      // for space and compare it with execution strategy address.
+      // In the future we should find way to optimize it for example by adding where lookup
+      // via ORM
+      if (space.metadata) {
+        const spaceMetadata = await SpaceMetadataItem.loadEntity(
+          space.metadata,
+          config.indexerName
+        );
+
+        if (spaceMetadata) {
+          proposal.treasuries = spaceMetadata.treasuries;
+
+          const strategies = await Promise.all(
+            spaceMetadata.executors_strategies.map(id =>
+              ExecutionStrategy.loadEntity(id, config.indexerName)
+            )
+          );
+
+          const matchingStrategy = strategies.find(
+            strategy => strategy?.address === proposal.execution_strategy
+          );
+
+          if (matchingStrategy) {
+            proposal.execution_strategy_details = matchingStrategy.id;
+          }
+        }
+      }
     }
 
     try {

--- a/apps/ui/src/components/Modal/CustomStrategy.vue
+++ b/apps/ui/src/components/Modal/CustomStrategy.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { Contract } from '@ethersproject/contracts';
+import { getProvider } from '@/helpers/provider';
+import { getValidator } from '@/helpers/validation';
+import { ChainId, NetworkID } from '@/types';
+
+const ABI = ['function getStrategyType() pure returns (string)'];
+
+const props = withDefaults(
+  defineProps<{
+    open: boolean;
+    networkId: NetworkID;
+    chainId: ChainId;
+  }>(),
+  {}
+);
+
+const emit = defineEmits<{
+  (e: 'close');
+  (e: 'save', strategy: { address: string; type: string });
+}>();
+
+const uiStore = useUiStore();
+
+const showPicker = ref(false);
+const searchValue = ref('');
+const contractAddress = ref('');
+const isSubmitting = ref(false);
+
+const definition = computed(() => ({
+  type: 'string',
+  title: 'Contract Address',
+  format: 'address',
+  examples: ['0x0000…'],
+  chainId: props.chainId
+}));
+
+const formErrors = computed(() => {
+  return getValidator({
+    type: 'object',
+    required: ['contractAddress'],
+    properties: {
+      contractAddress: definition.value
+    }
+  }).validate({ contractAddress: contractAddress.value });
+});
+
+async function handleSubmit() {
+  if (Object.keys(formErrors.value).length > 0) return;
+
+  try {
+    isSubmitting.value = true;
+
+    const contract = new Contract(
+      contractAddress.value,
+      ABI,
+      getProvider(props.chainId as number)
+    );
+
+    const type = await contract.getStrategyType();
+
+    emit('save', {
+      address: contractAddress.value,
+      type
+    });
+  } catch (e) {
+    console.error('Failed to fetch strategy type', e);
+    uiStore.addNotification(
+      'error',
+      'Failed to load strategy details. Make sure correct address is used.'
+    );
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+watchEffect(() => {
+  if (props.open) {
+    contractAddress.value = '';
+  }
+});
+</script>
+
+<template>
+  <UiModal :open="open" @close="$emit('close')">
+    <template #header>
+      <h3>Add Custom Strategy</h3>
+      <template v-if="showPicker">
+        <button
+          type="button"
+          class="absolute left-0 -top-1 p-4"
+          @click="showPicker = false"
+        >
+          <IH-arrow-narrow-left class="mr-2" />
+        </button>
+        <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
+          <IH-search class="mx-2" />
+          <input
+            ref="searchInput"
+            v-model="searchValue"
+            type="text"
+            placeholder="Search name or paste address"
+            class="flex-auto bg-transparent text-skin-link"
+          />
+        </div>
+      </template>
+    </template>
+    <PickerContact
+      v-if="showPicker"
+      :loading="false"
+      :search-value="searchValue"
+      @pick="
+        value => {
+          contractAddress = value;
+          showPicker = false;
+        }
+      "
+    />
+    <div v-else class="s-box p-4">
+      <UiInputAddress
+        v-model="contractAddress"
+        :definition="definition"
+        :error="formErrors.contractAddress"
+        @pick="showPicker = true"
+      />
+    </div>
+    <template v-if="!showPicker" #footer>
+      <UiButton
+        :loading="isSubmitting"
+        class="w-full"
+        :disabled="Object.keys(formErrors).length > 0"
+        @click="handleSubmit"
+      >
+        Confirm
+      </UiButton>
+    </template>
+  </UiModal>
+</template>

--- a/apps/ui/src/components/ProposalExecutionsList.vue
+++ b/apps/ui/src/components/ProposalExecutionsList.vue
@@ -4,12 +4,16 @@ import { getProposalCurrentQuorum } from '@/helpers/quorum';
 import { buildBatchFile } from '@/helpers/safe/ build';
 import { getExecutionName } from '@/helpers/ui';
 import { shorten, toBigIntOrNumber } from '@/helpers/utils';
-import { Proposal, ProposalExecution } from '@/types';
+import { getNetwork } from '@/networks';
+import { NetworkID, Proposal, ProposalExecution } from '@/types';
 
-defineProps<{
+const props = defineProps<{
+  networkId: NetworkID;
   proposal: Proposal;
   executions: ProposalExecution[];
 }>();
+
+const network = computed(() => getNetwork(props.networkId));
 
 function downloadExecution(execution: ProposalExecution) {
   if (!execution.chainId) return;
@@ -69,10 +73,7 @@ function downloadExecution(execution: ProposalExecution) {
         />
         <div
           class="text-skin-text text-[17px] truncate"
-          v-text="
-            getExecutionName(proposal.network, execution.strategyType) ||
-            shorten(execution.safeAddress)
-          "
+          v-text="getExecutionName(proposal.network, execution.strategyType)"
         />
       </div>
     </a>
@@ -106,7 +107,8 @@ function downloadExecution(execution: ProposalExecution) {
           proposal.quorum &&
         toBigIntOrNumber(proposal.scores[0]) >
           toBigIntOrNumber(proposal.scores[1]) &&
-        proposal.has_execution_window_opened
+        proposal.has_execution_window_opened &&
+        network.helpers.isExecutorActionsSupported(execution.strategyType)
       "
       :proposal="proposal"
       :execution="execution"

--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -553,6 +553,7 @@ export function useActions() {
     votingStrategiesToAdd: StrategyConfig[],
     votingStrategiesToRemove: number[],
     validationStrategy: StrategyConfig,
+    executionStrategies: StrategyConfig[],
     votingDelay: number | null,
     minVotingDuration: number | null,
     maxVotingDuration: number | null
@@ -581,6 +582,7 @@ export function useActions() {
         votingStrategiesToAdd,
         votingStrategiesToRemove,
         validationStrategy,
+        executionStrategies,
         votingDelay !== null
           ? getCurrentFromDuration(space.network, votingDelay)
           : null,

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -155,7 +155,9 @@ export function useSpaceSettings(space: Ref<Space>) {
   // Onchain properties
   const authenticators = ref([] as StrategyConfig[]);
   const validationStrategy = ref(null as StrategyConfig | null);
+  const executionStrategies = ref([] as StrategyConfig[]);
   const votingStrategies = ref([] as StrategyConfig[]);
+  const initialExecutionStrategiesObjectHash = ref(null as string | null);
   const initialValidationStrategyObjectHash = ref(null as string | null);
 
   // Offchain properties
@@ -281,6 +283,25 @@ export function useSpaceSettings(space: Ref<Space>) {
       },
       ...strategy
     };
+  }
+
+  async function getInitialExecutionStrategies(
+    executors: string[],
+    executorTypes: string[]
+  ) {
+    return executors.map((executor, i) => {
+      return {
+        id: executor,
+        address: executor,
+        type: executorTypes[i],
+        name:
+          network.value.constants.EXECUTORS[executor] ||
+          network.value.constants.EXECUTORS[executorTypes[i]] ||
+          executorTypes[i],
+        params: {},
+        paramsDefinition: {}
+      };
+    });
   }
 
   async function hasStrategyChanged(
@@ -668,6 +689,7 @@ export function useSpaceSettings(space: Ref<Space>) {
       strategiesToAdd,
       strategiesToRemove,
       validationStrategy.value,
+      executionStrategies.value,
       votingDelay.value,
       minVotingPeriod.value,
       maxVotingPeriod.value
@@ -712,6 +734,11 @@ export function useSpaceSettings(space: Ref<Space>) {
       space.value.voting_power_validation_strategies_parsed_metadata
     );
 
+    const executionStrategiesValue = await getInitialExecutionStrategies(
+      space.value.executors,
+      space.value.executors_types
+    );
+
     controller.value = force
       ? await network.value.helpers.getSpaceController(space.value)
       : initialController.value;
@@ -729,6 +756,10 @@ export function useSpaceSettings(space: Ref<Space>) {
     validationStrategy.value = validationStrategyValue;
     initialValidationStrategyObjectHash.value = objectHash(
       validationStrategyValue
+    );
+    executionStrategies.value = executionStrategiesValue;
+    initialExecutionStrategiesObjectHash.value = objectHash(
+      executionStrategiesValue
     );
 
     if (offchainNetworks.includes(space.value.network)) {
@@ -783,6 +814,9 @@ export function useSpaceSettings(space: Ref<Space>) {
       const validationStrategyValue = validationStrategy.value;
       const initialValidationStrategyObjectHashValue =
         initialValidationStrategyObjectHash.value;
+      const executionStrategiesValue = executionStrategies.value;
+      const initialExecutionStrategiesObjectHashValue =
+        initialExecutionStrategiesObjectHash.value;
       const proposalValidationValue = proposalValidation.value;
       const guidelinesValue = guidelines.value;
       const templateValue = template.value;
@@ -975,6 +1009,13 @@ export function useSpaceSettings(space: Ref<Space>) {
         if (hasValidationStrategyChanged) {
           return true;
         }
+
+        const hasExecutionStrategiesChanged =
+          objectHash(executionStrategiesValue) !==
+          initialExecutionStrategiesObjectHashValue;
+        if (hasExecutionStrategiesChanged) {
+          return true;
+        }
       }
     },
     false,
@@ -1000,6 +1041,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     validationStrategy,
     votingStrategies,
     proposalValidation,
+    executionStrategies,
     guidelines,
     template,
     quorumType,

--- a/apps/ui/src/helpers/ui.ts
+++ b/apps/ui/src/helpers/ui.ts
@@ -7,7 +7,11 @@ export function getExecutionName(networkId: NetworkID, strategyType: string) {
     if (strategyType === 'oSnap') return 'oSnap execution';
 
     const network = getNetwork(networkId);
-    return `${network.constants.EXECUTORS[strategyType]} execution`;
+
+    const name = network.constants.EXECUTORS[strategyType];
+    if (name) return `${network.constants.EXECUTORS[strategyType]} execution`;
+
+    return 'Custom execution';
   } catch (e) {
     return null;
   }

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -188,20 +188,14 @@ function processExecutions(
   proposal: ApiProposal,
   executionNetworkId: NetworkID
 ): ProposalExecution[] {
-  // NOTE: This is unstable, meaning that if executors_strategies or treasuries
-  // are modified in the future it will affect pass proposals.
-  // We should persist those values on proposal directly so it's stable.
-  // Right now we can't really update subgraphs because of TheGraph issue.
   if (!proposal.metadata?.execution) return [];
 
   const transactions = formatExecution(proposal.metadata?.execution);
   if (transactions.length === 0) return [];
 
-  const match = proposal.space.metadata?.executors_strategies.find(
-    strategy => strategy.address === proposal.execution_strategy
-  );
+  const match = proposal.execution_strategy_details;
 
-  const treasuries = proposal.space.metadata?.treasuries.map(treasury =>
+  const treasuries = proposal.treasuries.map(treasury =>
     formatMetadataTreasury(treasury)
   );
 

--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -104,17 +104,6 @@ gql(`
         avatar
         labels
         voting_power_symbol
-        treasuries
-        executors
-        executors_types
-        executors_strategies {
-          id
-          address
-          destination_address
-          type
-          treasury_chain
-          treasury
-        }
       }
       strategies_parsed_metadata {
         index
@@ -154,8 +143,17 @@ gql(`
     scores_total
     execution_time
     execution_strategy
+    execution_strategy_details {
+      id
+      address
+      destination_address
+      type
+      treasury_chain
+      treasury
+    }
     execution_strategy_type
     execution_destination
+    treasuries
     timelock_veto_guardian
     strategies_indices
     strategies

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -679,6 +679,7 @@ export function createActions(
       votingStrategiesToAdd: StrategyConfig[],
       votingStrategiesToRemove: number[],
       validationStrategy: StrategyConfig,
+      executionStrategies: StrategyConfig[],
       votingDelay: number | null,
       minVotingDuration: number | null,
       maxVotingDuration: number | null
@@ -690,9 +691,15 @@ export function createActions(
 
       const pinned = await helpers.pin(
         createErc1155Metadata(metadata, {
-          execution_strategies: space.executors,
-          execution_strategies_types: space.executors_types,
-          execution_destinations: space.executors_destinations
+          execution_strategies: executionStrategies.map(
+            config => config.address
+          ),
+          execution_strategies_types: executionStrategies.map(
+            config => config.type
+          ),
+          execution_destinations: executionStrategies.map(
+            (_, i) => space.executors_destinations[i] ?? ''
+          )
         })
       );
 

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -123,8 +123,9 @@ export function createEvmNetwork(networkId: NetworkID): Network {
       constants.RELAYER_AUTHENTICATORS[authenticator],
     isStrategySupported: (strategy: string) =>
       constants.SUPPORTED_STRATEGIES[strategy],
-    isExecutorSupported: (executor: string) =>
-      constants.SUPPORTED_EXECUTORS[executor],
+    isExecutorSupported: () => true,
+    isExecutorActionsSupported: (executorType: string) =>
+      constants.SUPPORTED_EXECUTORS[executorType],
     pin,
     getSpaceController: async (space: Space) => space.controller,
     getTransaction: (txId: string) => provider.getTransaction(txId),

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -123,7 +123,8 @@ export function createEvmNetwork(networkId: NetworkID): Network {
       constants.RELAYER_AUTHENTICATORS[authenticator],
     isStrategySupported: (strategy: string) =>
       constants.SUPPORTED_STRATEGIES[strategy],
-    isExecutorSupported: () => true,
+    isExecutorSupported: (executorType: string) =>
+      executorType !== 'ReadOnlyExecution',
     isExecutorActionsSupported: (executorType: string) =>
       constants.SUPPORTED_EXECUTORS[executorType],
     pin,

--- a/apps/ui/src/networks/offchain/index.ts
+++ b/apps/ui/src/networks/offchain/index.ts
@@ -29,16 +29,19 @@ export function createOffchainNetwork(networkId: NetworkID): Network {
   const provider = getProvider(l1ChainId);
   const api = createApi(hubUrl, networkId, constants);
 
+  const isExecutorSupported = (executorType: string) => {
+    if (executorType === 'oSnap') return true;
+    if (executorType === 'ReadOnlyExecution') return true;
+    return false;
+  };
+
   const helpers = {
     isAuthenticatorSupported: () => true,
     isAuthenticatorContractSupported: () => false,
     getRelayerAuthenticatorType: () => null,
     isStrategySupported: () => true,
-    isExecutorSupported: (executorType: string) => {
-      if (executorType === 'oSnap') return true;
-      if (executorType === 'ReadOnlyExecution') return true;
-      return false;
-    },
+    isExecutorSupported: isExecutorSupported,
+    isExecutorActionsSupported: isExecutorSupported,
     pin: pinPineapple,
     getSpaceController: async (space: Space) =>
       getSpaceController(space.id, l1ChainId),

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -603,6 +603,7 @@ export function createActions(
       votingStrategiesToAdd: StrategyConfig[],
       votingStrategiesToRemove: number[],
       validationStrategy: StrategyConfig,
+      executionStrategies: StrategyConfig[],
       votingDelay: number | null,
       minVotingDuration: number | null,
       maxVotingDuration: number | null
@@ -611,8 +612,12 @@ export function createActions(
 
       const pinned = await helpers.pin(
         createErc1155Metadata(metadata, {
-          execution_strategies: space.executors,
-          execution_strategies_types: space.executors_types,
+          execution_strategies: executionStrategies.map(
+            config => config.address
+          ),
+          execution_strategies_types: executionStrategies.map(
+            config => config.type
+          ),
           execution_destinations: space.executors_destinations
         })
       );

--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -84,6 +84,8 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
       constants.SUPPORTED_STRATEGIES[strategy],
     isExecutorSupported: (executor: string) =>
       constants.SUPPORTED_EXECUTORS[executor],
+    isExecutorActionsSupported: (executor: string) =>
+      constants.SUPPORTED_EXECUTORS[executor],
     pin: pinPineapple,
     getSpaceController: async (space: Space) => space.controller,
     getTransaction: txId => provider.getTransactionReceipt(txId),

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -284,6 +284,7 @@ export type NetworkActions = ReadOnlyNetworkActions & {
     votingStrategiesToAdd: StrategyConfig[],
     votingStrategiesToRemove: number[],
     validationStrategy: StrategyConfig,
+    executionStrategies: StrategyConfig[],
     votingDelay: number | null,
     minVotingDuration: number | null,
     maxVotingDuration: number | null

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -392,7 +392,18 @@ export type NetworkHelpers = {
     authenticator: string
   ): 'evm' | 'evm-tx' | 'starknet' | null;
   isStrategySupported(strategy: string): boolean;
-  isExecutorSupported(executor: string): boolean;
+  /**
+   * Checks if the executor type is supported.
+   * If supported executor can be used to create proposal execution.
+   * @param executorType executor type
+   */
+  isExecutorSupported(executorType: string): boolean;
+  /**
+   * Checks if the executor actions are supported.
+   * If supported UI will show execution actions for the executor.
+   * @param executorType executor type
+   */
+  isExecutorActionsSupported(executorType: string): boolean;
   pin: (content: any) => Promise<{ cid: string; provider: string }>;
   getSpaceController(space: Space): Promise<string>;
   getTransaction(txId: string): Promise<any>;

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -505,6 +505,7 @@ onBeforeUnmount(() => destroyAudio());
             .
           </UiAlert>
           <ProposalExecutionsList
+            :network-id="proposal.network"
             :proposal="proposal"
             :executions="proposal.executions"
           />

--- a/packages/sx.js/src/executors/index.ts
+++ b/packages/sx.js/src/executors/index.ts
@@ -44,6 +44,13 @@ export function getExecutionData(
     );
   }
 
+  if (input?.transactions) {
+    return createAvatarExecutor().getExecutionData(
+      executorAddress,
+      input.transactions
+    );
+  }
+
   throw new Error(
     `Not enough data to create execution for executor ${executorAddress}`
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3957,10 +3957,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
-"@snapshot-labs/checkpoint@^0.1.0-beta.54":
-  version "0.1.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/checkpoint/-/checkpoint-0.1.0-beta.54.tgz#a3b864b4375c74679b85f5471c4ea742139fbc8b"
-  integrity sha512-H9pgapLt7wlimdxC887e4ApgVwSUT+hpxUZXjC3v/kUqsl8achQa7sXOw6eruU125p0Jt9WR7tdyXB54/RsbMg==
+"@snapshot-labs/checkpoint@^0.1.0-beta.55":
+  version "0.1.0-beta.55"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/checkpoint/-/checkpoint-0.1.0-beta.55.tgz#e7b63329ad5db81b3554567e498c9dd6597078a8"
+  integrity sha512-NOuDQFH3FnpsyNCQbaBgV5fEjgBPCXvnsGOFUgIO/pjAQjECW/0G1WQAulQJFhgRE8ZkXMlMKnNCrHngZ5ap5A==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/address" "^5.7.0"


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/470

This PR adds ability to add custom execution strategy to EVM spaces.
This required couple of changes:
1. `treasuries` and `execution_strategy_details` are now persisted on proposal so changing executors or treasuries at space level won't cause changes in existing proposals.
2. Custom strategies can be deployed without proxy. When execution strategy is added to space it will be fetched and data will be read from it to create ExecutionStrategy entity on API.
3. Separated `isExecutorSupported` and `isExecutorActionsSupported` helpers. First one specifies if executor can be used to create execution, second one specifies if actions (like Execute transactions on passed proposals) are supported.
4. Added modal to add custom strategies to space.
5. Made changes so those custom strategies can be used at proposal creation.

### How to test

1. Apply diff below.
2. Run local API server for Sepolia (`ENABLED_NETWORKS=sep IS_INDEXER=true  yarn dev` in `apps/api`.
3. Create new Sepolia space.
4. Go to Settings and add custom execution strategy (`0x2afB54fcaECd41BE4Ecd05d7bd2e193F2F05B99d`).
5. Go to Treasuries and add the same address as treasury.
6. Save.
7. Try creating proposal, you can create execution on that treasury.
8. After proposal is created you can see execution.

```diff
diff --git a/apps/api/src/evm/config.ts b/apps/api/src/evm/config.ts
index 398467e8..c749ef6d 100644
--- a/apps/api/src/evm/config.ts
+++ b/apps/api/src/evm/config.ts
@@ -20,7 +20,7 @@ type NetworkID =
 
 const START_BLOCKS: Record<NetworkID, number> = {
   eth: 18962278,
-  sep: 4519171,
+  sep: 7977835,
   oeth: 118359200,
   matic: 50858232,
   arb1: 157825417,
@@ -59,19 +59,19 @@ export function createConfig(indexerName: NetworkID): FullConfig {
     }
   ];
 
-  if (indexerName === 'sep') {
-    sources.push({
-      contract: '0x27981a29ec87f2fbf873a2dcb0325405648ffce1',
-      start: 6106288,
-      abi: 'L1AvatarExecutionStrategyFactory',
-      events: [
-        {
-          name: 'ContractDeployed(address)',
-          fn: 'handleL1AvatarExecutionContractDeployed'
-        }
-      ]
-    });
-  }
+  // if (indexerName === 'sep') {
+  //   sources.push({
+  //     contract: '0x27981a29ec87f2fbf873a2dcb0325405648ffce1',
+  //     start: 6106288,
+  //     abi: 'L1AvatarExecutionStrategyFactory',
+  //     events: [
+  //       {
+  //         name: 'ContractDeployed(address)',
+  //         fn: 'handleL1AvatarExecutionContractDeployed'
+  //       }
+  //     ]
+  //   });
+  // }
 
   return {
     indexerName,
diff --git a/apps/ui/src/helpers/constants.ts b/apps/ui/src/helpers/constants.ts
index 72271ead..448416c4 100644
--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -11,7 +11,7 @@ export const APP_NAME = 'Snapshot';
 export const SIDEKICK_URL = 'https://sh5.co';
 
 export const UNIFIED_API_URL = 'https://api.snapshot.box';
-export const UNIFIED_API_TESTNET_URL = 'https://testnet-api.snapshot.box';
+export const UNIFIED_API_TESTNET_URL = 'http://localhost:3000';
 
 export const HELPDESK_URL = 'https://help.snapshot.box';
 
```

### Out of scope for this PR

1. Ability to modify execution strategies (previously it was impossible to make any changes to executions on the UI, now you can add new strategy). With those changes we can in the future make it possible to add full editor support for executors (adding new strategies, removing same as in Space creation).