### PR TITLE
feat: add hardcoded whitelabel support for onchain spaces

### DIFF
--- a/apps/ui/src/components/Breadcrumb.vue
+++ b/apps/ui/src/components/Breadcrumb.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { getCacheHash, getUrl } from '@/helpers/utils';
+import { offchainNetworks } from '@/networks';
 import { useSpaceQuery } from '@/queries/spaces';
 import { NetworkID } from '@/types';
 
@@ -9,7 +10,7 @@ const SPACE_LOGO_HEIGHT = 38;
 defineOptions({ inheritAttrs: false });
 
 const route = useRoute();
-const { isWhiteLabel } = useWhiteLabel();
+const { isWhiteLabel, skinSettings } = useWhiteLabel();
 const { logo } = useSkin();
 const { param } = useRouteParser('space');
 const { resolved, address: spaceAddress, networkId } = useResolve(param);
@@ -41,16 +42,29 @@ const previewLogoUrl = computed(() => {
   if (
     !isWhiteLabel.value ||
     !logo.value ||
-    logo.value === space.value?.additionalRawData?.skinSettings?.logo
+    logo.value === skinSettings.value?.logo
   )
     return;
   return getUrl(logo.value);
 });
 
-const hasWhiteLabelLogo = computed(() => {
-  if (!isWhiteLabel.value) return;
-  return space.value?.additionalRawData?.skinSettings?.logo;
+const onchainLogoUrl = computed(() => {
+  if (
+    !space.value ||
+    offchainNetworks.includes(space.value.network) ||
+    !skinSettings.value?.logo
+  )
+    return;
+  return getUrl(skinSettings.value?.logo);
 });
+
+const directUrlLogo = computed(() => {
+  return previewLogoUrl.value || onchainLogoUrl.value;
+});
+
+const hasWhiteLabelLogo = computed(
+  () => isWhiteLabel.value && skinSettings.value?.logo
+);
 
 const cb = computed(() => (logo.value ? getCacheHash(logo.value) : undefined));
 </script>
@@ -65,8 +79,8 @@ const cb = computed(() => (logo.value ? getCacheHash(logo.value) : undefined));
     v-bind="$attrs"
   >
     <img
-      v-if="previewLogoUrl"
-      :src="previewLogoUrl"
+      v-if="directUrlLogo"
+      :src="directUrlLogo"
       :style="`max-width:${SPACE_LOGO_WIDTH}px; max-height:${SPACE_LOGO_HEIGHT}px;`"
       :alt="space.name"
     />

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -22,7 +22,7 @@ const uiStore = useUiStore();
 const { modalOpen } = useModal();
 const { init, setAppName, app } = useApp();
 const { setSkin } = useSkin();
-const { isWhiteLabel, space: whiteLabelSpace } = useWhiteLabel();
+const { isWhiteLabel, space: whiteLabelSpace, skinSettings } = useWhiteLabel();
 const { setFavicon } = useFavicon();
 const { web3 } = useWeb3();
 const { isSwiping, direction } = useSwipe(el, {
@@ -150,7 +150,7 @@ watch(
 
     setFavicon(faviconUrl);
     setAppName(whiteLabelSpace.value.name);
-    setSkin(whiteLabelSpace.value.additionalRawData?.skinSettings);
+    setSkin(skinSettings.value);
   },
   { immediate: true }
 );

--- a/apps/ui/src/composables/useWhiteLabel.ts
+++ b/apps/ui/src/composables/useWhiteLabel.ts
@@ -5,7 +5,7 @@ import { SkinSettings, Space } from '@/types';
 const DEFAULT_DOMAIN = import.meta.env.VITE_HOST || 'localhost';
 const domain = window.location.hostname;
 
-// Hardcoded white label mappings for onchain spaces
+// Hardcoded whitelabel mappings for onchain spaces
 const MAPPING = {
   'vanilla.box': {
     network: 'base',

--- a/apps/ui/src/composables/useWhiteLabel.ts
+++ b/apps/ui/src/composables/useWhiteLabel.ts
@@ -35,7 +35,7 @@ async function getSpace(domain: string): Promise<Space | null> {
 
   // Resolve white label domain locally if mapping is provided
   // for easier local testing
-  // e.g. VITE_WHITE_LABEL_MAPPING='127.0.0.1;snapshot.eth'
+  // e.g. VITE_WHITE_LABEL_MAPPING='127.0.0.1;s:snapshot.eth'
   const localMapping = import.meta.env.VITE_WHITE_LABEL_MAPPING;
   if (localMapping) {
     const [localDomain, localSpaceId] = localMapping.split(';');

--- a/apps/ui/src/composables/useWhiteLabel.ts
+++ b/apps/ui/src/composables/useWhiteLabel.ts
@@ -13,6 +13,7 @@ const space = ref<Space | null>(null);
 
 async function getSpace(domain: string): Promise<Space | null> {
   const loadSpacesParams: Record<string, string> = {};
+  let spaceNetwork = metadataNetwork;
 
   // Resolve white label domain locally if mapping is provided
   // for easier local testing
@@ -21,14 +22,15 @@ async function getSpace(domain: string): Promise<Space | null> {
   if (localMapping) {
     const [localDomain, localSpaceId] = localMapping.split(';');
     if (domain === localDomain) {
-      loadSpacesParams.id = localSpaceId;
+      spaceNetwork = localSpaceId.split(':')[0];
+      loadSpacesParams.id = localSpaceId.split(':')[1];
     }
   } else {
     loadSpacesParams.domain = domain;
   }
 
   const queryClient = useQueryClient();
-  const network = getNetwork(metadataNetwork);
+  const network = getNetwork(spaceNetwork);
   const space = (
     await network.api.loadSpaces({ limit: 1 }, loadSpacesParams)
   )[0];


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/506

This PR will adds whitelabel support for onchain spaces, albeit only hardcoded for now.

All whitelabel features are supported.

### How to test

1. Run 

```diff --git a/apps/ui/src/composables/useWhiteLabel.ts b/apps/ui/src/composables/useWhiteLabel.ts
index e1ff9984..6a82299e 100644
--- a/apps/ui/src/composables/useWhiteLabel.ts
+++ b/apps/ui/src/composables/useWhiteLabel.ts
@@ -7,7 +7,7 @@ const domain = window.location.hostname;
 
 // Hardcoded white label mappings for onchain spaces
 const MAPPING = {
-  'vanilla.box': {
+  '127.0.0.1': {
     network: 'base',
     id: '0x8cF43759f3d4E72cB72cED6bd69cCe43d4428264',
     skinSettings: {
```

2. ```yarn dev```
3. the app will start with the `0x8cF43759f3d4E72cB72cED6bd69cCe43d4428264` space as whitelabel, with custom colors and logo
