### PR TITLE
fix: fix page scroll to top on modal opening

### DIFF
--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -110,7 +110,7 @@ onMounted(async () => {
 
 watch(scrollDisabled, val => {
   const el = document.body;
-  el.classList[val ? 'add' : 'remove']('overflow-hidden');
+  el.classList[val ? 'add' : 'remove']('overflow-y-hidden');
 });
 
 watch(isSwiping, () => {

--- a/apps/ui/src/style.scss
+++ b/apps/ui/src/style.scss
@@ -94,13 +94,13 @@
   font-weight: 700;
   src: url('./assets/fonts/Stolzl-Medium.woff2') format('woff2');
 }
-
 html {
-  @apply overflow-y-scroll;
+  scrollbar-gutter: stable;
 }
-
 body {
-  @apply h-0 font-serif text-base min-h-screen bg-skin-bg text-skin-text antialiased;
+  @apply overflow-y-scroll font-serif text-base min-h-screen bg-skin-bg text-skin-text antialiased;
+  scrollbar-gutter: stable;
+
 }
 
 .font-display {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/504

### How to test

1. scroll the page and open any modal
2. the page should not scroll back to the top when opening the modal

### Notes

- these is a small issue, where all `fixed` element are not taking the scrollbar width into account, resulting in a margin right 15px smaller, on modal open.