### PR TITLE
chore: remove .vue from icon import path

### DIFF
--- a/apps/ui/src/views/Space/Pro.vue
+++ b/apps/ui/src/views/Space/Pro.vue
@@ -3,7 +3,7 @@ import { _n } from '@/helpers/utils';
 import { Space } from '@/types';
 import ICInfinity from '~icons/c/infinity.svg';
 import ICPro from '~icons/c/pro.svg';
-import ICCheck from '~icons/heroicons-outline/check.vue';
+import ICCheck from '~icons/heroicons-outline/check';
 
 type TierPlan = 'basic' | 'pro' | 'custom';
 type Feature = {


### PR DESCRIPTION
### Summary

Throws this error in my local
```js
✘ [ERROR] Do not know how to load path: html:~icons/heroicons-outline/check
141 │ import '~icons/heroicons-outline/check.vue'
ui:dev:           ╵        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ui:dev: 
ui:dev: 
ui:dev:     at failureErrorWithLog
```

All the other icon imports doesn't have `.vue` 
