### PR TITLE
fix: improve controller save logic and transaction cancel behavior

### DIFF
--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -270,9 +270,8 @@ async function handleSettingsSave() {
 }
 
 function handleControllerSave(value: string) {
-  if (!isController.value) return;
+  if (!isOwner.value) return;
   controller.value = value;
-
   saving.value = true;
   executeFn.value = saveController;
 }
@@ -571,7 +570,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
   </UiToolbarBottom>
   <teleport to="#modal">
     <ModalTransactionProgress
-      :open="saving && !isOffchainNetwork"
+      :open="saving && (!isOffchainNetwork || executeFn === saveController)"
       :chain-id="network.chainId"
       :messages="{
         approveTitle: 'Confirm your changes',
@@ -581,6 +580,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
       :execute="executeFn"
       @confirmed="reloadSpaceAndReset"
       @close="saving = false"
+      @cancelled="saving = false"
     />
   </teleport>
 </template>


### PR DESCRIPTION
### Summary
- Updated controller save condition to check for owner instead of controller (isController === isOwner on onchain spaces)
- Open transaction modal if execute function is saving controller
- Close modal when the transaction is canceled on settings page

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1299

### How to test

1. Go to off-chain space settings
2. Updating the controller should open the transaction progress modal
3. Updating any other space settings should not open the transaction progress modal
4. Go to on-chain space settings
5. Updating the controller or any space settings should open transaction progress modal like before
6. Canceling the transaction in wallet should close transaction progress modal