### PR TITLE
feat: set up migrations for Mana

### DIFF
--- a/apps/mana/knexfile.ts
+++ b/apps/mana/knexfile.ts
@@ -1,0 +1,48 @@
+import 'dotenv/config';
+import fs from 'fs';
+import { ConnectionString } from 'connection-string';
+import { Knex } from 'knex';
+
+const connectionConfig = new ConnectionString(process.env.DATABASE_URL);
+if (
+  !connectionConfig.protocol ||
+  !connectionConfig.hosts ||
+  !connectionConfig.path
+) {
+  throw new Error('invalid connection string provided');
+}
+
+const sslConfig: {
+  rejectUnauthorized?: boolean;
+  sslmode?: string;
+  ca?: string;
+} = {};
+if (
+  connectionConfig.params?.sslaccept === 'strict' ||
+  connectionConfig.params?.ssl === 'rejectUnauthorized'
+) {
+  sslConfig.rejectUnauthorized = true;
+}
+if (connectionConfig.params?.sslmode) {
+  sslConfig.sslmode = connectionConfig.params.sslmode;
+}
+
+if (process.env.CA_CERT) {
+  sslConfig.ca = process.env.CA_CERT.replace(/\\n/g, '\n');
+} else if (process.env.CA_CERT_FILE) {
+  sslConfig.ca = fs.readFileSync(process.env.CA_CERT_FILE).toString();
+}
+
+const config: Knex.Config = {
+  client: 'pg',
+  connection: {
+    database: connectionConfig.path[0],
+    user: connectionConfig.user,
+    password: connectionConfig.password,
+    host: connectionConfig?.hosts[0]?.name,
+    port: connectionConfig?.hosts[0]?.port,
+    ssl: Object.keys(sslConfig).length > 0 ? sslConfig : undefined
+  }
+};
+
+export default config;

--- a/apps/mana/migrations/20250328123634_create_registered_transactions_table.ts
+++ b/apps/mana/migrations/20250328123634_create_registered_transactions_table.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  const exists = await knex.schema.hasTable('registered_transactions');
+  if (exists) return;
+
+  return knex.schema.createTable('registered_transactions', t => {
+    t.increments('id').primary();
+    t.timestamps(true, true);
+    t.boolean('processed').defaultTo(false).index();
+    t.boolean('failed').defaultTo(false).index();
+    t.string('network').index();
+    t.string('type').index();
+    t.string('sender');
+    t.string('hash');
+    t.json('data');
+    t.unique(['sender', 'hash']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTable('registered_transactions');
+}

--- a/apps/mana/migrations/20250328123755_create_registered_proposals_table.ts
+++ b/apps/mana/migrations/20250328123755_create_registered_proposals_table.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  const exists = await knex.schema.hasTable('registered_proposals');
+  if (exists) return;
+
+  return knex.schema.createTable('registered_proposals', t => {
+    t.string('id').primary();
+    t.timestamps(true, true);
+    t.string('chainId');
+    t.integer('timestamp');
+    t.string('strategyAddress');
+    t.string('herodotusId');
+    t.boolean('processed').defaultTo(false).index();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTable('registered_proposals');
+}

--- a/apps/mana/migrations/20250328123900_create_merkletree_requests_table.ts
+++ b/apps/mana/migrations/20250328123900_create_merkletree_requests_table.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  const exists = await knex.schema.hasTable('merkletree_requests');
+  if (exists) return;
+
+  return knex.schema.createTable('merkletree_requests', t => {
+    t.string('id').primary();
+    t.timestamps(true, true);
+    t.boolean('processed').defaultTo(false).index();
+    t.string('root');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTable('merkletree_requests');
+}

--- a/apps/mana/migrations/20250328124001_create_merkletrees_table.ts
+++ b/apps/mana/migrations/20250328124001_create_merkletrees_table.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  const exists = await knex.schema.hasTable('merkletrees');
+  if (exists) return;
+
+  return knex.schema.createTable('merkletrees', t => {
+    t.string('id').primary();
+    t.timestamps(true, true);
+    t.jsonb('tree');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTable('merkletrees');
+}

--- a/apps/mana/package.json
+++ b/apps/mana/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "lint": "eslint . --ext .ts",
     "build": "tsc",
+    "migrate": "yarn knex migrate:latest",
+    "predev": "yarn migrate",
     "dev": "nodemon src/index.ts",
+    "prestart": "yarn migrate",
     "start": "node dist/src/index.js"
   },
   "eslintConfig": {

--- a/apps/mana/src/db.ts
+++ b/apps/mana/src/db.ts
@@ -5,61 +5,6 @@ export const REGISTERED_PROPOSALS = 'registered_proposals';
 export const MERKLETREE_REQUESTS = 'merkletree_requests';
 export const MERKLETREES = 'merkletrees';
 
-export async function createTables() {
-  const registeredTransactionsTableExists = await knex.schema.hasTable(
-    REGISTERED_TRANSACTIONS
-  );
-  const registeredProposalsTableExists =
-    await knex.schema.hasTable(REGISTERED_PROPOSALS);
-  const merkletreeRequestsTableExists =
-    await knex.schema.hasTable(MERKLETREE_REQUESTS);
-  const merkletreesTableExists = await knex.schema.hasTable(MERKLETREES);
-
-  if (!registeredTransactionsTableExists) {
-    await knex.schema.createTable(REGISTERED_TRANSACTIONS, t => {
-      t.increments('id').primary();
-      t.timestamps(true, true);
-      t.boolean('processed').defaultTo(false).index();
-      t.boolean('failed').defaultTo(false).index();
-      t.string('network').index();
-      t.string('type').index();
-      t.string('sender');
-      t.string('hash');
-      t.json('data');
-      t.unique(['sender', 'hash']);
-    });
-  }
-
-  if (!registeredProposalsTableExists) {
-    await knex.schema.createTable(REGISTERED_PROPOSALS, t => {
-      t.string('id').primary();
-      t.timestamps(true, true);
-      t.string('chainId');
-      t.integer('timestamp');
-      t.string('strategyAddress');
-      t.string('herodotusId');
-      t.boolean('processed').defaultTo(false).index();
-    });
-  }
-
-  if (!merkletreeRequestsTableExists) {
-    await knex.schema.createTable(MERKLETREE_REQUESTS, t => {
-      t.string('id').primary();
-      t.timestamps(true, true);
-      t.boolean('processed').defaultTo(false).index();
-      t.string('root');
-    });
-  }
-
-  if (!merkletreesTableExists) {
-    await knex.schema.createTable(MERKLETREES, t => {
-      t.string('id').primary();
-      t.timestamps(true, true);
-      t.jsonb('tree');
-    });
-  }
-}
-
 export async function registerTransaction(
   network: string,
   type: string,

--- a/apps/mana/src/index.ts
+++ b/apps/mana/src/index.ts
@@ -2,7 +2,6 @@ import 'dotenv/config';
 import cors from 'cors';
 import express from 'express';
 import { PORT } from './constants';
-import { createTables } from './db';
 import ethRpc from './eth';
 import starkRpc from './stark';
 import {
@@ -30,8 +29,6 @@ app.get('/', (req, res) =>
 );
 
 async function start() {
-  await createTables();
-
   registeredTransactionsLoop();
   registeredProposalsLoop();
 

--- a/apps/mana/src/knex.ts
+++ b/apps/mana/src/knex.ts
@@ -1,45 +1,4 @@
-import fs from 'fs';
-import { ConnectionString } from 'connection-string';
 import knex from 'knex';
+import knexConfig from '../knexfile';
 
-const connectionConfig = new ConnectionString(process.env.DATABASE_URL);
-if (
-  !connectionConfig.protocol ||
-  !connectionConfig.hosts ||
-  !connectionConfig.path
-) {
-  throw new Error('invalid connection string provided');
-}
-
-const sslConfig: {
-  rejectUnauthorized?: boolean;
-  sslmode?: string;
-  ca?: string;
-} = {};
-if (
-  connectionConfig.params?.sslaccept === 'strict' ||
-  connectionConfig.params?.ssl === 'rejectUnauthorized'
-) {
-  sslConfig.rejectUnauthorized = true;
-}
-if (connectionConfig.params?.sslmode) {
-  sslConfig.sslmode = connectionConfig.params.sslmode;
-}
-
-if (process.env.CA_CERT) {
-  sslConfig.ca = process.env.CA_CERT.replace(/\\n/g, '\n');
-} else if (process.env.CA_CERT_FILE) {
-  sslConfig.ca = fs.readFileSync(process.env.CA_CERT_FILE).toString();
-}
-
-export default knex({
-  client: 'pg',
-  connection: {
-    database: connectionConfig.path[0],
-    user: connectionConfig.user,
-    password: connectionConfig.password,
-    host: connectionConfig?.hosts[0]?.name,
-    port: connectionConfig?.hosts[0]?.port,
-    ssl: Object.keys(sslConfig).length > 0 ? sslConfig : undefined
-  }
-});
+export default knex(knexConfig);


### PR DESCRIPTION
### Summary

Currently it's not great when we need to make some changes to database schema on prod when we can't just drop the database.

Adding migrations so changes (like adding `chainId` to merkletrees) can be done smoothly.