### PR TITLE
fix: update OwnershipTransferred event signature

### DIFF
--- a/apps/api/src/evm/config.ts
+++ b/apps/api/src/evm/config.ts
@@ -112,7 +112,7 @@ export function createConfig(indexerName: NetworkID): FullConfig {
             fn: 'handleVotingDelayUpdated'
           },
           {
-            name: 'OwnershipTransferred(indexed address,indexed address)',
+            name: 'OwnershipTransferred(address,address)',
             fn: 'handleOwnershipTransferred'
           },
           {


### PR DESCRIPTION
### Summary

For computation of topic indexed modifier is omitted.
Because of this OwnershipTransferred event wasn't indexed.


