### PR TITLE
fix: move away from position fixed

### DIFF
--- a/apps/ui/src/App.vue
+++ b/apps/ui/src/App.vue
@@ -45,6 +45,5 @@ onMounted(() => initWhiteLabel());
     <LayoutSplash v-if="!whiteLabelResolved" />
     <LayoutSite v-else-if="routeName === 'site'" />
     <LayoutApp v-else />
-    <AppFooter />
   </div>
 </template>

--- a/apps/ui/src/components/App/BottomNav.vue
+++ b/apps/ui/src/components/App/BottomNav.vue
@@ -32,20 +32,20 @@ const menu = [
 </script>
 
 <template>
-  <nav class="bg-skin-bg border-t text-xs">
-    <div class="flex gap-2 px-3 justify-center">
-      <AppLink
-        v-for="(item, i) in menu"
-        :key="i"
-        :to="item.link"
-        class="inline-flex flex-col text-center gap-1 truncate justify-center w-[25%] max-w-[120px]"
-        :class="
-          route.name === item.link.name ? 'text-skin-link' : 'text-skin-text'
-        "
-      >
-        <component :is="item.icon" class="mx-auto" />
-        <span class="truncate" v-text="item.label" />
-      </AppLink>
-    </div>
+  <nav
+    class="bg-skin-bg border-t text-xs h-[72px] flex gap-2 px-3 justify-center"
+  >
+    <AppLink
+      v-for="(item, i) in menu"
+      :key="i"
+      :to="item.link"
+      class="flex flex-col text-center justify-center w-[25%] max-w-[120px] gap-1 truncate"
+      :class="
+        route.name === item.link.name ? 'text-skin-link' : 'text-skin-text'
+      "
+    >
+      <component :is="item.icon" class="mx-auto" />
+      <span class="truncate" v-text="item.label" />
+    </AppLink>
   </nav>
 </template>

--- a/apps/ui/src/components/App/Footer.vue
+++ b/apps/ui/src/components/App/Footer.vue
@@ -14,27 +14,23 @@ const isSiteRoute = computed(() => {
 </script>
 
 <template>
-  <div
-    class="hidden xl:flex fixed bottom-3 pr-4 inset-x-0 max-w-maximum !mx-auto justify-end z-50 pointer-events-none"
-  >
-    <div class="flex space-x-2 pointer-events-auto">
-      <UiTooltip
-        v-if="resolved && !isWhiteLabel && !isSiteRoute"
-        title="About Snapshot"
-      >
-        <router-link :to="{ name: 'site-landing' }" tabindex="-1">
-          <UiButton class="!px-0 w-[46px]">
-            <IC-zap class="inline-block size-[24px]" />
-          </UiButton>
-        </router-link>
-      </UiTooltip>
-      <UiTooltip title="Get help">
-        <a :href="HELPDESK_URL" target="_blank" tabindex="-1">
-          <UiButton class="!px-0 w-[46px]">
-            <IH-chat class="inline-block" />
-          </UiButton>
-        </a>
-      </UiTooltip>
-    </div>
+  <div class="hidden xl:flex absolute bottom-3 right-4 space-x-2">
+    <UiTooltip
+      v-if="resolved && !isWhiteLabel && !isSiteRoute"
+      title="About Snapshot"
+    >
+      <router-link :to="{ name: 'site-landing' }" tabindex="-1">
+        <UiButton class="!px-0 w-[46px]">
+          <IC-zap class="inline-block size-[24px]" />
+        </UiButton>
+      </router-link>
+    </UiTooltip>
+    <UiTooltip title="Get help">
+      <AppLink :to="HELPDESK_URL" tabindex="-1">
+        <UiButton class="!px-0 w-[46px]">
+          <IH-chat class="inline-block" />
+        </UiButton>
+      </AppLink>
+    </UiTooltip>
   </div>
 </template>

--- a/apps/ui/src/components/App/Nav.vue
+++ b/apps/ui/src/components/App/Nav.vue
@@ -26,6 +26,10 @@ type NavigationItem = {
   active?: boolean;
 };
 
+defineProps<{
+  bottom?: number;
+}>();
+
 const route = useRoute();
 const notificationsStore = useNotificationsStore();
 const { isWhiteLabel } = useWhiteLabel();
@@ -191,11 +195,15 @@ const navigationItems = computed(() =>
 
 <template>
   <div>
-    <div class="w-[240px] sticky top-0 h-full flex flex-col">
+    <div
+      :class="`w-[240px] sticky top-0 flex flex-col max-h-[calc(100vh-${bottom || 0}px)]`"
+    >
       <div class="border-b h-[72px] flex items-center px-4 shrink-0">
         <Breadcrumb />
       </div>
-      <div class="no-scrollbar overscroll-contain overflow-auto py-4">
+      <div
+        class="no-scrollbar overscroll-contain overflow-auto py-4 max-h-[calc(100vh-72px)]"
+      >
         <AppLink
           v-for="(item, key) in navigationItems"
           :key="key"

--- a/apps/ui/src/components/App/Nav.vue
+++ b/apps/ui/src/components/App/Nav.vue
@@ -191,11 +191,11 @@ const navigationItems = computed(() =>
 
 <template>
   <div>
-    <div class="w-[240px] sticky inset-y-0 space-y-4">
-      <div class="border-b h-[72px] flex items-center px-4">
+    <div class="w-[240px] sticky top-0 h-full flex flex-col">
+      <div class="border-b h-[72px] flex items-center px-4 shrink-0">
         <Breadcrumb />
       </div>
-      <div>
+      <div class="no-scrollbar overscroll-contain overflow-auto py-4">
         <AppLink
           v-for="(item, key) in navigationItems"
           :key="key"
@@ -203,7 +203,7 @@ const navigationItems = computed(() =>
           class="px-4 py-1.5 space-x-2 flex items-center"
           :class="item.active ? 'text-skin-link' : 'text-skin-text'"
         >
-          <component :is="item.icon" class="inline-block"></component>
+          <component :is="item.icon" />
           <span class="grow" v-text="item.name" />
           <span
             v-if="item.count"

--- a/apps/ui/src/components/App/Nav.vue
+++ b/apps/ui/src/components/App/Nav.vue
@@ -190,21 +190,28 @@ const navigationItems = computed(() =>
 </script>
 
 <template>
-  <div class="border-r bg-skin-bg py-4">
-    <AppLink
-      v-for="(item, key) in navigationItems"
-      :key="key"
-      :to="item.link"
-      class="px-4 py-1.5 space-x-2 flex items-center"
-      :class="item.active ? 'text-skin-link' : 'text-skin-text'"
-    >
-      <component :is="item.icon" class="inline-block"></component>
-      <span class="grow" v-text="item.name" />
-      <span
-        v-if="item.count"
-        class="bg-skin-border text-skin-link text-[13px] rounded-full px-1.5"
-        v-text="item.count"
-      />
-    </AppLink>
+  <div>
+    <div class="w-[240px] sticky inset-y-0 space-y-4">
+      <div class="border-b h-[72px] flex items-center px-4">
+        <Breadcrumb />
+      </div>
+      <div>
+        <AppLink
+          v-for="(item, key) in navigationItems"
+          :key="key"
+          :to="item.link"
+          class="px-4 py-1.5 space-x-2 flex items-center"
+          :class="item.active ? 'text-skin-link' : 'text-skin-text'"
+        >
+          <component :is="item.icon" class="inline-block"></component>
+          <span class="grow" v-text="item.name" />
+          <span
+            v-if="item.count"
+            class="bg-skin-border text-skin-link text-[13px] rounded-full px-1.5"
+            v-text="item.count"
+          />
+        </AppLink>
+      </div>
+    </div>
   </div>
 </template>

--- a/apps/ui/src/components/App/Notifications.vue
+++ b/apps/ui/src/components/App/Notifications.vue
@@ -3,13 +3,13 @@ const uiStore = useUiStore();
 </script>
 
 <template>
-  <div class="absolute bottom-4 inset-x-0 space-y-2">
+  <div class="absolute bottom-4 inset-x-0 space-y-2 pointer-events-none">
     <UiAlert
       v-for="notification in uiStore.notifications"
       :key="notification.id"
       dismissible
       :type="notification.type"
-      class="!w-fit max-w-[90%] mx-auto"
+      class="!w-fit max-w-[90%] mx-auto pointer-events-auto"
       @close="uiStore.dismissNotification(notification.id)"
     >
       {{ notification.message }}

--- a/apps/ui/src/components/App/Notifications.vue
+++ b/apps/ui/src/components/App/Notifications.vue
@@ -3,13 +3,13 @@ const uiStore = useUiStore();
 </script>
 
 <template>
-  <div class="fixed bottom-4 inset-x-0 z-[52]">
+  <div class="absolute bottom-4 inset-x-0 space-y-2">
     <UiAlert
       v-for="notification in uiStore.notifications"
       :key="notification.id"
       dismissible
       :type="notification.type"
-      class="!w-fit max-w-[90%] mx-auto mb-2 last:mb-0"
+      class="!w-fit max-w-[90%] mx-auto"
       @close="uiStore.dismissNotification(notification.id)"
     >
       {{ notification.message }}

--- a/apps/ui/src/components/App/Sidebar.vue
+++ b/apps/ui/src/components/App/Sidebar.vue
@@ -5,7 +5,7 @@ const followedSpacesStore = useFollowedSpacesStore();
 </script>
 
 <template>
-  <div class="flex-col w-[72px]">
+  <div class="w-[72px]">
     <div class="flex flex-col text-center sticky inset-y-0">
       <AppLink :to="{ name: 'my-home' }" class="h-[72px] block">
         <IC-zap class="inline-block my-[18px] size-[40px] text-skin-link" />

--- a/apps/ui/src/components/App/Sidebar.vue
+++ b/apps/ui/src/components/App/Sidebar.vue
@@ -5,14 +5,11 @@ const followedSpacesStore = useFollowedSpacesStore();
 </script>
 
 <template>
-  <div class="w-[72px]">
-    <div class="flex flex-col text-center sticky inset-y-0">
+  <div>
+    <div class="w-[72px] flex flex-col text-center sticky top-0 h-full">
       <AppLink :to="{ name: 'my-home' }" class="h-[72px] block">
         <IC-zap class="inline-block my-[18px] size-[40px] text-skin-link" />
       </AppLink>
-      <div
-        class="bg-gradient-to-b from-skin-bg top-[72px] h-[8px] w-[71px] absolute z-10"
-      />
       <UiLoading v-if="!followedSpacesStore.followedSpacesLoaded" />
       <draggable
         v-else
@@ -22,7 +19,7 @@ const followedSpacesStore = useFollowedSpacesStore();
         :touch-start-threshold="35"
         :item-key="i => i"
         v-bind="{ animation: 200 }"
-        class="space-y-3 p-2 no-scrollbar overscroll-contain overflow-auto pb-3"
+        class="space-y-3 p-2 no-scrollbar overscroll-contain overflow-auto pb-3 max-h-[calc(100vh-72px)]"
       >
         <template #item="{ element }">
           <AppLink
@@ -43,6 +40,9 @@ const followedSpacesStore = useFollowedSpacesStore();
           </AppLink>
         </template>
       </draggable>
+      <div
+        class="bg-gradient-to-b from-skin-bg top-[72px] h-[8px] w-full absolute"
+      />
     </div>
   </div>
 </template>

--- a/apps/ui/src/components/App/Sidebar.vue
+++ b/apps/ui/src/components/App/Sidebar.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
 import draggable from 'vuedraggable';
 
+defineProps<{
+  bottom?: number;
+}>();
+
 const followedSpacesStore = useFollowedSpacesStore();
 </script>
 
 <template>
   <div>
-    <div class="w-[72px] flex flex-col text-center sticky top-0 h-full">
+    <div
+      :class="`w-[72px] flex flex-col text-center sticky top-0 max-h-[calc(100vh-${bottom || 0}px)]`"
+    >
       <AppLink :to="{ name: 'my-home' }" class="h-[72px] block">
         <IC-zap class="inline-block my-[18px] size-[40px] text-skin-link" />
       </AppLink>

--- a/apps/ui/src/components/App/Sidebar.vue
+++ b/apps/ui/src/components/App/Sidebar.vue
@@ -5,42 +5,44 @@ const followedSpacesStore = useFollowedSpacesStore();
 </script>
 
 <template>
-  <div class="flex flex-col border-r text-center">
-    <AppLink :to="{ name: 'my-home' }" class="h-[72px] block">
-      <IC-zap class="inline-block my-[18px] size-[40px] text-skin-link" />
-    </AppLink>
-    <div
-      class="bg-gradient-to-b from-skin-bg top-[72px] h-[8px] w-[71px] absolute z-10"
-    />
-    <UiLoading v-if="!followedSpacesStore.followedSpacesLoaded" />
-    <draggable
-      v-else
-      v-model="followedSpacesStore.followedSpaces"
-      :delay="100"
-      :delay-on-touch-only="true"
-      :touch-start-threshold="35"
-      :item-key="i => i"
-      v-bind="{ animation: 200 }"
-      class="space-y-3 p-2 no-scrollbar overscroll-contain overflow-auto pb-3"
-    >
-      <template #item="{ element }">
-        <AppLink
-          :to="{
-            name: 'space-overview',
-            params: { space: `${element.network}:${element.id}` }
-          }"
-          class="block"
-        >
-          <UiTooltip :title="element.name" placement="right">
-            <SpaceAvatar
-              show-active-proposals
-              :space="element"
-              :size="32"
-              class="!rounded-[4px]"
-            />
-          </UiTooltip>
-        </AppLink>
-      </template>
-    </draggable>
+  <div class="flex-col w-[72px]">
+    <div class="flex flex-col text-center sticky inset-y-0">
+      <AppLink :to="{ name: 'my-home' }" class="h-[72px] block">
+        <IC-zap class="inline-block my-[18px] size-[40px] text-skin-link" />
+      </AppLink>
+      <div
+        class="bg-gradient-to-b from-skin-bg top-[72px] h-[8px] w-[71px] absolute z-10"
+      />
+      <UiLoading v-if="!followedSpacesStore.followedSpacesLoaded" />
+      <draggable
+        v-else
+        v-model="followedSpacesStore.followedSpaces"
+        :delay="100"
+        :delay-on-touch-only="true"
+        :touch-start-threshold="35"
+        :item-key="i => i"
+        v-bind="{ animation: 200 }"
+        class="space-y-3 p-2 no-scrollbar overscroll-contain overflow-auto pb-3"
+      >
+        <template #item="{ element }">
+          <AppLink
+            :to="{
+              name: 'space-overview',
+              params: { space: `${element.network}:${element.id}` }
+            }"
+            class="block"
+          >
+            <UiTooltip :title="element.name" placement="right">
+              <SpaceAvatar
+                show-active-proposals
+                :space="element"
+                :size="32"
+                class="!rounded-[4px]"
+              />
+            </UiTooltip>
+          </AppLink>
+        </template>
+      </draggable>
+    </div>
   </div>
 </template>

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -93,11 +93,11 @@ onUnmounted(() => {
 <template>
   <UiTopnav v-bind="$attrs">
     <slot name="toggle-sidebar-button" />
-    <Breadcrumb v-if="!searchConfig && !hasAppNav" class="flex-1" />
+    <Breadcrumb v-if="!searchConfig && !hasAppNav" class="flex-auto" />
     <form
       v-if="searchConfig"
       id="search-form group"
-      class="flex-1 group"
+      class="flex-auto group"
       @submit="handleSearchSubmit"
     >
       <label class="flex items-center space-x-2.5">
@@ -107,7 +107,7 @@ onUnmounted(() => {
           v-model.trim="searchValue"
           type="text"
           :placeholder="searchConfig.placeholder"
-          class="bg-transparent text-skin-link text-[19px] flex-1"
+          class="bg-transparent text-skin-link text-[19px] flex-auto"
         />
       </label>
     </form>

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -93,11 +93,11 @@ onUnmounted(() => {
 <template>
   <UiTopnav v-bind="$attrs">
     <slot name="toggle-sidebar-button" />
-    <Breadcrumb v-if="!searchConfig && !hasAppNav" class="flex-auto" />
+    <Breadcrumb v-if="!searchConfig && !hasAppNav" class="grow-[20]" />
     <form
       v-if="searchConfig"
       id="search-form group"
-      class="flex-auto group"
+      class="grow-[20] group"
       @submit="handleSearchSubmit"
     >
       <label class="flex items-center space-x-2.5">
@@ -111,7 +111,7 @@ onUnmounted(() => {
         />
       </label>
     </form>
-    <div class="flex gap-x-2 shrink-0">
+    <div class="flex gap-x-2 grow shrink-0 justify-end">
       <UiButton v-if="loading || web3.authLoading" loading />
       <UiButton
         v-else

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -96,7 +96,6 @@ onUnmounted(() => {
     <Breadcrumb v-if="!searchConfig && !hasAppNav" class="grow-[20]" />
     <form
       v-if="searchConfig"
-      id="search-form group"
       class="grow-[20] group"
       @submit="handleSearchSubmit"
     >
@@ -107,7 +106,7 @@ onUnmounted(() => {
           v-model.trim="searchValue"
           type="text"
           :placeholder="searchConfig.placeholder"
-          class="bg-transparent text-skin-link text-[19px] flex-auto"
+          class="bg-transparent text-skin-link text-[19px] w-full"
         />
       </label>
     </form>

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -93,33 +93,32 @@ onUnmounted(() => {
 <template>
   <UiTopnav v-bind="$attrs">
     <slot name="toggle-sidebar-button" />
-    <Breadcrumb v-if="!searchConfig && !hasAppNav" />
+    <Breadcrumb v-if="!searchConfig && !hasAppNav" class="flex-1" />
     <form
       v-if="searchConfig"
-      id="search-form"
-      class="flex flex-1 py-3 h-full"
+      id="search-form group"
+      class="flex-1 group"
       @submit="handleSearchSubmit"
     >
-      <label class="flex items-center w-full space-x-2.5">
-        <IH-search class="shrink-0" />
+      <label class="flex items-center space-x-2.5">
+        <IH-search class="shrink-0 group-focus-within:text-skin-link" />
         <input
           ref="searchInput"
           v-model.trim="searchValue"
           type="text"
           :placeholder="searchConfig.placeholder"
-          class="bg-transparent text-skin-link text-[19px] w-full"
+          class="bg-transparent text-skin-link text-[19px] flex-1"
         />
       </label>
     </form>
-    <div></div>
-    <div class="flex space-x-2 shrink-0">
+    <div class="flex gap-x-2 shrink-0">
       <UiButton v-if="loading || web3.authLoading" loading />
       <UiButton
         v-else
-        class="float-left !px-0 w-[46px] sm:w-auto sm:!px-3 text-center"
+        class="!px-0 w-[46px] sm:w-auto sm:!px-3 text-center"
         @click="modalAccountOpen = true"
       >
-        <span v-if="web3.account" class="sm:flex items-center space-x-2">
+        <span v-if="web3.account" class="sm:flex items-center gap-x-2">
           <UiStamp :id="user.id" :size="18" :cb="cb" />
           <span
             class="hidden sm:block truncate max-w-[120px]"
@@ -151,9 +150,3 @@ onUnmounted(() => {
     />
   </teleport>
 </template>
-
-<style lang="scss" scoped>
-#search-form:focus-within svg {
-  color: rgba(var(--link));
-}
-</style>

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -9,7 +9,6 @@ defineProps<{
 const route = useRoute();
 const router = useRouter();
 const usersStore = useUsersStore();
-const uiStore = useUiStore();
 const { modalAccountOpen, modalAccountWithoutDismissOpen, resetAccountModal } =
   useModal();
 const { login, web3 } = useWeb3();
@@ -93,21 +92,8 @@ onUnmounted(() => {
 
 <template>
   <UiTopnav v-bind="$attrs">
-    <div
-      class="flex items-center h-full truncate"
-      :class="{
-        'lg:border-r lg:pr-4 lg:w-[240px] shrink-0': hasAppNav,
-        'border-r pr-4 w-[240px]': hasAppNav && uiStore.sideMenuOpen
-      }"
-    >
-      <slot name="toggle-sidebar-button" />
-      <Breadcrumb
-        :class="[
-          'ml-4',
-          { 'hidden lg:flex': searchConfig && !uiStore.sideMenuOpen }
-        ]"
-      />
-    </div>
+    <slot name="toggle-sidebar-button" />
+    <Breadcrumb v-if="!searchConfig && !hasAppNav" />
     <form
       v-if="searchConfig"
       id="search-form"
@@ -125,7 +111,7 @@ onUnmounted(() => {
         />
       </label>
     </form>
-
+    <div></div>
     <div class="flex space-x-2 shrink-0">
       <UiButton v-if="loading || web3.authLoading" loading />
       <UiButton

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -93,10 +93,10 @@ onUnmounted(() => {
 <template>
   <UiTopnav v-bind="$attrs">
     <slot name="toggle-sidebar-button" />
-    <Breadcrumb v-if="!searchConfig && !hasAppNav" class="grow-[20]" />
+    <Breadcrumb v-if="!searchConfig && !hasAppNav" class="grow-[50]" />
     <form
       v-if="searchConfig"
-      class="grow-[20] group"
+      class="grow-[50] group"
       @submit="handleSearchSubmit"
     >
       <label class="flex items-center space-x-2.5">

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -196,7 +196,7 @@ router.afterEach(() => {
             <button
               v-if="hasSwipeableContent"
               type="button"
-              class="text-skin-link lg:hidden"
+              class="text-skin-link lg:hidden shrink-0"
               :class="{ hidden: uiStore.sideMenuOpen }"
               @click="uiStore.toggleSidebar"
             >

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -193,7 +193,7 @@ router.afterEach(() => {
       <div class="flex flex-col flex-auto relative">
         <UiBackdrop
           v-if="uiStore.sideMenuOpen"
-          @click="uiStore.sideMenuOpen = false"
+          @close="uiStore.sideMenuOpen = false"
         />
         <AppTopnav :has-app-nav="hasAppNav" :class="{ hidden: !hasTopNav }">
           <template #toggle-sidebar-button>

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -178,17 +178,19 @@ router.afterEach(() => {
         v-if="hasSidebar"
         :class="[
           `hidden lg:flex flex-col border-r flex-none`,
-          { '!flex max-h-[calc(100vh-72px)]': uiStore.sideMenuOpen }
+          { '!flex': uiStore.sideMenuOpen }
         ]"
+        :bottom="uiStore.sideMenuOpen ? 72 : 0"
       />
       <AppNav
         v-if="hasAppNav"
         :class="[
           'hidden lg:flex flex-col border-r flex-none',
           {
-            '!flex max-h-[calc(100vh-72px)]': uiStore.sideMenuOpen
+            '!flex': uiStore.sideMenuOpen
           }
         ]"
+        :bottom="uiStore.sideMenuOpen ? 72 : 0"
       />
       <div class="flex flex-col flex-auto relative">
         <UiBackdrop

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -212,7 +212,7 @@ router.afterEach(() => {
         </AppTopnav>
         <main
           :class="[
-            'relative flex-auto',
+            'flex-auto',
             { 'xl:border-r xl:mr-[240px]': hasPlaceHolderSidebar }
           ]"
         >

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -177,14 +177,14 @@ router.afterEach(() => {
       <AppSidebar
         v-if="hasSidebar"
         :class="[
-          `hidden lg:flex flex-none border-r`,
+          `hidden lg:flex flex-col border-r flex-none`,
           { '!flex': uiStore.sideMenuOpen }
         ]"
       />
       <AppNav
         v-if="hasAppNav"
         :class="[
-          'hidden lg:flex border-r flex-none',
+          'hidden lg:flex flex-col border-r flex-none',
           {
             '!flex': uiStore.sideMenuOpen
           }

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -178,7 +178,7 @@ router.afterEach(() => {
         v-if="hasSidebar"
         :class="[
           `hidden lg:flex flex-col border-r flex-none`,
-          { '!flex': uiStore.sideMenuOpen }
+          { '!flex max-h-[calc(100vh-72px)]': uiStore.sideMenuOpen }
         ]"
       />
       <AppNav
@@ -186,7 +186,7 @@ router.afterEach(() => {
         :class="[
           'hidden lg:flex flex-col border-r flex-none',
           {
-            '!flex': uiStore.sideMenuOpen
+            '!flex max-h-[calc(100vh-72px)]': uiStore.sideMenuOpen
           }
         ]"
       />

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -169,7 +169,11 @@ router.afterEach(() => {
     :class="{ 'overflow-clip': scrollDisabled }"
   >
     <UiLoading v-if="app.loading || !app.init" class="overlay big" />
-    <div v-else class="flex flex-auto">
+    <div
+      v-else
+      class="flex flex-auto maximum:border-r"
+      :class="{ 'maximum:border-l ': isWhiteLabel }"
+    >
       <AppSidebar
         v-if="hasSidebar"
         :class="[
@@ -186,7 +190,7 @@ router.afterEach(() => {
           }
         ]"
       />
-      <div class="flex flex-col flex-auto maximum:border-r relative">
+      <div class="flex flex-col flex-auto relative">
         <UiBackdrop
           v-if="uiStore.sideMenuOpen"
           @click="uiStore.sideMenuOpen = false"

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -165,72 +165,63 @@ router.afterEach(() => {
 <template>
   <div
     ref="el"
-    class="min-h-screen"
+    class="min-h-screen flex flex-col"
     :class="{ 'overflow-clip': scrollDisabled }"
   >
     <UiLoading v-if="app.loading || !app.init" class="overlay big" />
-    <div
-      v-else
-      class="flex min-h-screen maximum:border-r"
-      :class="{ 'maximum:border-l': isWhiteLabel }"
-    >
-      <AppBottomNav
-        v-if="web3.account && !isWhiteLabel"
-        :class="[
-          `fixed bottom-0 inset-x-0 hidden app-bottom-nav z-[100]`,
-          { 'app-bottom-nav-open': uiStore.sideMenuOpen }
-        ]"
-      />
+    <div v-else class="flex flex-auto">
       <AppSidebar
         v-if="hasSidebar"
         :class="[
-          `hidden lg:flex app-sidebar fixed inset-y-0`,
-          { '!flex app-sidebar-open': uiStore.sideMenuOpen }
+          `hidden lg:flex flex-none border-r`,
+          { '!flex': uiStore.sideMenuOpen }
         ]"
       />
-      <AppTopnav
-        :has-app-nav="hasAppNav"
-        :class="{ hidden: !hasTopNav, 'maximum:border-l': isWhiteLabel }"
-        class="maximum:border-r"
-      >
-        <template #toggle-sidebar-button>
-          <button
-            v-if="hasSwipeableContent"
-            type="button"
-            class="text-skin-link lg:hidden ml-4"
-            :class="{ hidden: uiStore.sideMenuOpen }"
-            @click="uiStore.toggleSidebar"
-          >
-            <IH-menu-alt-2 />
-          </button>
-        </template>
-      </AppTopnav>
       <AppNav
         v-if="hasAppNav"
         :class="[
-          'top-[72px] inset-y-0 z-10 hidden lg:block fixed app-nav',
+          'hidden lg:flex border-r flex-none',
           {
-            '!block app-nav-open': uiStore.sideMenuOpen
+            '!flex': uiStore.sideMenuOpen
           }
         ]"
       />
-      <button
-        v-if="uiStore.sideMenuOpen"
-        type="button"
-        class="backdrop"
-        @click="uiStore.sideMenuOpen = false"
-      />
-      <main class="flex-auto w-full flex">
-        <div class="flex-auto w-0" :class="{ 'mt-[72px]': hasTopNav }">
-          <router-view class="h-full pb-10" />
-        </div>
-        <div
-          v-if="hasPlaceHolderSidebar"
-          class="app-placeholder-sidebar hidden xl:block"
+      <div class="flex flex-col flex-auto maximum:border-r relative">
+        <UiBackdrop
+          v-if="uiStore.sideMenuOpen"
+          @click="uiStore.sideMenuOpen = false"
         />
-      </main>
+        <AppTopnav :has-app-nav="hasAppNav" :class="{ hidden: !hasTopNav }">
+          <template #toggle-sidebar-button>
+            <button
+              v-if="hasSwipeableContent"
+              type="button"
+              class="text-skin-link lg:hidden"
+              :class="{ hidden: uiStore.sideMenuOpen }"
+              @click="uiStore.toggleSidebar"
+            >
+              <IH-menu-alt-2 />
+            </button>
+          </template>
+        </AppTopnav>
+        <main
+          :class="[
+            'relative flex-auto',
+            { 'xl:border-r xl:mr-[240px]': hasPlaceHolderSidebar }
+          ]"
+        >
+          <router-view class="h-full pb-10" />
+        </main>
+      </div>
     </div>
-    <AppNotifications />
+    <div class="sticky bottom-0 inset-x-0 z-[101] flex flex-col flex-none">
+      <div class="relative">
+        <AppNotifications />
+      </div>
+      <AppBottomNav
+        v-if="web3.account && !isWhiteLabel && uiStore.sideMenuOpen"
+      />
+    </div>
     <ModalConfirmSafe
       v-if="uiStore.safeModal !== null"
       :open="uiStore.safeModal !== null"
@@ -252,103 +243,3 @@ router.afterEach(() => {
     />
   </div>
 </template>
-
-<style lang="scss" scoped>
-$sidebarWidth: 72px;
-$mobileMenuHeight: 72px;
-$navWidth: 240px;
-$placeholderSidebarWidth: 240px;
-
-.app-sidebar {
-  @apply w-[#{$sidebarWidth}];
-
-  @media (max-width: 1011px) {
-    &-open {
-      & ~ :deep(*) {
-        @apply translate-x-[#{$sidebarWidth}];
-
-        .app-toolbar-bottom {
-          @apply hidden;
-        }
-      }
-
-      &:has(~ .app-nav) ~ .app-nav ~ :deep(*) {
-        @apply translate-x-[#{$sidebarWidth + $navWidth}];
-      }
-    }
-  }
-}
-
-.app-nav {
-  @apply w-[#{$navWidth}];
-
-  @media (max-width: 1011px) {
-    &-open {
-      & ~ :deep(*) {
-        @apply translate-x-[#{$navWidth}];
-
-        .app-toolbar-bottom {
-          @apply hidden;
-        }
-      }
-    }
-  }
-}
-
-.app-bottom-nav {
-  height: $mobileMenuHeight;
-
-  @media (max-width: 767px) {
-    &-open {
-      @apply grid;
-
-      & ~ .backdrop,
-      & ~ .app-nav-open,
-      & ~ .app-sidebar-open {
-        @apply bottom-[#{$mobileMenuHeight}];
-      }
-    }
-  }
-}
-
-.app-placeholder-sidebar {
-  @apply w-[#{$placeholderSidebarWidth}];
-
-  &::before {
-    @apply block fixed border-l top-[72px] bottom-0 w-[#{$placeholderSidebarWidth}];
-
-    content: '';
-  }
-}
-
-@media (screen(lg)) {
-  .app-sidebar {
-    & ~ :deep(main),
-    & ~ .backdrop,
-    & ~ :deep(header.fixed > div),
-    & ~ :deep(main header.fixed > div),
-    & ~ :deep(.app-nav) {
-      @apply ml-[#{$sidebarWidth}];
-    }
-
-    &:has(~ .app-nav) ~ .app-nav {
-      & ~ :deep(main),
-      & ~ .backdrop,
-      & ~ :deep(header.fixed > div),
-      & ~ :deep(main header.fixed > div),
-      & ~ :deep(.app-nav) {
-        @apply ml-[#{$sidebarWidth + $navWidth}];
-      }
-    }
-  }
-
-  .app-nav ~ :deep(*) {
-    @apply ml-[#{$navWidth}];
-  }
-}
-
-.backdrop {
-  @apply fixed inset-0 z-[99];
-  @apply bg-[black]/40 #{!important};
-}
-</style>

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -216,6 +216,7 @@ router.afterEach(() => {
     </div>
     <div class="sticky bottom-0 inset-x-0 z-[101] flex flex-col flex-none">
       <div class="relative">
+        <UiBottomMenuFloating :show-about="!isWhiteLabel" />
         <AppNotifications />
       </div>
       <AppBottomNav

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -212,11 +212,13 @@ router.afterEach(() => {
         </AppTopnav>
         <main
           :class="[
-            'flex-auto',
+            'flex-auto flex',
             { 'xl:border-r xl:mr-[240px]': hasPlaceHolderSidebar }
           ]"
         >
-          <router-view class="h-full pb-10" />
+          <div class="flex-auto w-0">
+            <router-view class="h-full pb-10" />
+          </div>
         </main>
       </div>
     </div>

--- a/apps/ui/src/components/Layout/Site.vue
+++ b/apps/ui/src/components/Layout/Site.vue
@@ -2,4 +2,7 @@
   <SiteTopnav />
   <router-view />
   <SiteFooter />
+  <div class="sticky bottom-0 inset-x-0 z-[101]">
+    <UiBottomMenuFloating />
+  </div>
 </template>

--- a/apps/ui/src/components/Ui/Backdrop.vue
+++ b/apps/ui/src/components/Ui/Backdrop.vue
@@ -1,3 +1,25 @@
+<script setup lang="ts">
+const emit = defineEmits<{
+  (e: 'close');
+}>();
+
+function handleKeyboardEvent(ev: KeyboardEvent) {
+  if (ev.code === 'Escape') emit('close');
+}
+
+onMounted(() => {
+  document.addEventListener('keyup', handleKeyboardEvent);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keyup', handleKeyboardEvent);
+});
+</script>
+
 <template>
-  <button type="button" class="absolute inset-0 z-[99] bg-[black]/40" />
+  <button
+    type="button"
+    class="absolute inset-0 z-[99] bg-[black]/40"
+    @click="emit('close')"
+  />
 </template>

--- a/apps/ui/src/components/Ui/Backdrop.vue
+++ b/apps/ui/src/components/Ui/Backdrop.vue
@@ -1,0 +1,3 @@
+<template>
+  <button type="button" class="absolute inset-0 z-[99] bg-[black]/40" />
+</template>

--- a/apps/ui/src/components/Ui/BottomMenuFloating.vue
+++ b/apps/ui/src/components/Ui/BottomMenuFloating.vue
@@ -1,24 +1,14 @@
 <script setup lang="ts">
 import { HELPDESK_URL } from '@/helpers/constants';
 
-const { isWhiteLabel, resolved } = useWhiteLabel();
-const route = useRoute();
-
-const isSiteRoute = computed(() => {
-  if (typeof route.name === 'string') {
-    return route.name.startsWith('site-');
-  }
-
-  return false;
-});
+defineProps<{
+  showAbout?: boolean;
+}>();
 </script>
 
 <template>
   <div class="hidden xl:flex absolute bottom-3 right-4 space-x-2">
-    <UiTooltip
-      v-if="resolved && !isWhiteLabel && !isSiteRoute"
-      title="About Snapshot"
-    >
+    <UiTooltip v-if="showAbout" title="About Snapshot">
       <router-link :to="{ name: 'site-landing' }" tabindex="-1">
         <UiButton class="!px-0 w-[46px]">
           <IC-zap class="inline-block size-[24px]" />

--- a/apps/ui/src/components/Ui/Modal.vue
+++ b/apps/ui/src/components/Ui/Modal.vue
@@ -16,16 +16,13 @@ const props = withDefaults(
 const { open } = toRefs(props);
 const { modalOpen } = useModal();
 
-function handleKeyboardEvent(ev: KeyboardEvent) {
-  if (ev.code === 'Escape') emit('close');
+function handleClose() {
+  if (props.closeable) {
+    emit('close');
+  }
 }
 
-onMounted(() => {
-  document.addEventListener('keyup', handleKeyboardEvent);
-});
-
 onBeforeUnmount(() => {
-  document.removeEventListener('keyup', handleKeyboardEvent);
   modalOpen.value = false;
 });
 
@@ -37,7 +34,7 @@ watch(open, val => {
 <template>
   <transition name="fade">
     <div v-if="open" class="modal">
-      <UiBackdrop @click="closeable ? $emit('close') : null" />
+      <UiBackdrop @close="handleClose" />
       <div class="shell">
         <div v-if="$slots.header" class="border-b py-3 text-center">
           <slot name="header" />

--- a/apps/ui/src/components/Ui/Modal.vue
+++ b/apps/ui/src/components/Ui/Modal.vue
@@ -17,9 +17,8 @@ const { open } = toRefs(props);
 const { modalOpen } = useModal();
 
 function handleClose() {
-  if (props.closeable) {
-    emit('close');
-  }
+  if (!props.closeable) return;
+  emit('close');
 }
 
 onBeforeUnmount(() => {

--- a/apps/ui/src/components/Ui/Modal.vue
+++ b/apps/ui/src/components/Ui/Modal.vue
@@ -60,7 +60,7 @@ watch(open, val => {
 
 <style lang="scss" scoped>
 .modal {
-  @apply absolute flex items-center justify-center mx-auto inset-0 z-[51];
+  @apply fixed flex items-center justify-center mx-auto inset-0 z-[102];
 
   .shell {
     @apply relative bg-skin-bg md:border md:rounded-lg shadow-lg px-0 my-0 mx-auto flex flex-col z-[999] md:max-w-[440px] max-w-full max-h-full min-h-full w-full md:max-h-[calc(100vh-120px)] md:min-h-0;

--- a/apps/ui/src/components/Ui/Modal.vue
+++ b/apps/ui/src/components/Ui/Modal.vue
@@ -36,9 +36,9 @@ watch(open, val => {
 
 <template>
   <transition name="fade">
-    <div v-if="open" class="modal mx-auto">
-      <div class="backdrop" @click="closeable ? $emit('close') : null" />
-      <div class="shell overflow-hidden relative rounded-none md:rounded-lg">
+    <div v-if="open" class="modal">
+      <UiBackdrop @click="closeable ? $emit('close') : null" />
+      <div class="shell">
         <div v-if="$slots.header" class="border-b py-3 text-center">
           <slot name="header" />
         </div>
@@ -61,62 +61,16 @@ watch(open, val => {
   </transition>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 .modal {
-  position: fixed;
-  display: flex;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  align-items: center;
-  justify-content: center;
-  z-index: 51;
-
-  .backdrop {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    z-index: 99;
-    background: rgba(0, 0, 0, 0.4);
-  }
+  @apply absolute flex items-center justify-center mx-auto inset-0 z-[51];
 
   .shell {
-    border: 1px solid rgba(var(--border));
-    background-color: rgba(var(--bg));
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-    max-width: 440px;
-    overflow-y: auto !important;
-    max-height: calc(100vh - 120px);
-    display: flex;
-    flex-direction: column;
-    z-index: 999;
-    margin: 0 auto;
-    width: 100%;
+    @apply relative bg-skin-bg md:border md:rounded-lg shadow-lg px-0 my-0 mx-auto flex flex-col z-[999] md:max-w-[440px] max-w-full max-h-full min-h-full w-full md:max-h-[calc(100vh-120px)] md:min-h-0;
+  }
 
-    @media (max-width: 767px) {
-      border: 0;
-      width: 100% !important;
-      max-width: 100% !important;
-      max-height: 100% !important;
-      min-height: 100% !important;
-      margin-bottom: 0 !important;
-
-      .modal-body {
-        max-height: 100% !important;
-      }
-    }
-
-    .modal-body {
-      max-height: 420px;
-      flex: auto;
-      text-align: initial;
-      overflow-y: auto;
-      overflow-x: hidden;
-    }
+  &-body {
+    @apply max-h-[420px] md:max-w-full flex-auto overflow-y-auto overflow-x-hidden;
   }
 }
 </style>

--- a/apps/ui/src/components/Ui/Stepper.vue
+++ b/apps/ui/src/components/Ui/Stepper.vue
@@ -38,15 +38,15 @@ function goToStep(stepName: string) {
 </script>
 
 <template>
-  <div class="flex">
+  <div class="flex flex-col lg:flex-row lg:items-start">
     <div
-      class="flex fixed lg:sticky top-[72px] inset-x-0 p-3 border-b z-10 bg-skin-bg lg:top-auto lg:inset-x-auto lg:p-0 lg:pr-5 lg:border-0 lg:flex-col gap-1 min-w-[180px] overflow-auto"
+      class="flex z-40 top-[72px] inset-x-0 p-3 border-b bg-skin-bg lg:top-auto lg:inset-x-auto lg:p-0 lg:border-0 lg:flex-col gap-1 min-w-[180px] overflow-x-auto"
     >
       <button
         v-for="(step, stepName) in steps"
         :key="stepName"
         type="button"
-        class="px-3 py-1 flex items-center gap-2 lg:w-full text-skin-link rounded text-left scroll-mr-3 first:ml-auto last:mr-auto whitespace-nowrap hover:bg-skin-hover-bg"
+        class="px-3 py-1 flex items-center gap-2 text-skin-link rounded whitespace-nowrap hover:bg-skin-hover-bg"
         :class="{
           'bg-skin-active-bg': stepper.isCurrent(stepName)
         }"
@@ -58,13 +58,11 @@ function goToStep(stepName: string) {
       </button>
     </div>
     <div class="flex-1 space-y-4">
-      <div class="mt-8 lg:mt-0">
-        <slot
-          name="content"
-          :current-step="currentStep"
-          :go-to-next="stepper.goToNext"
-        />
-      </div>
+      <slot
+        name="content"
+        :current-step="currentStep"
+        :go-to-next="stepper.goToNext"
+      />
       <UiButton
         v-if="stepper.isLast.value"
         class="w-full primary"

--- a/apps/ui/src/components/Ui/Stepper.vue
+++ b/apps/ui/src/components/Ui/Stepper.vue
@@ -39,25 +39,27 @@ function goToStep(stepName: string) {
 
 <template>
   <div class="flex flex-col lg:flex-row lg:items-start">
-    <div
-      class="flex z-40 top-[72px] inset-x-0 p-3 border-b bg-skin-bg lg:top-auto lg:inset-x-auto lg:p-0 lg:border-0 lg:flex-col gap-1 min-w-[180px] overflow-x-auto"
-    >
-      <button
-        v-for="(step, stepName) in steps"
-        :key="stepName"
-        type="button"
-        class="px-3 py-1 flex items-center gap-2 text-skin-link rounded whitespace-nowrap hover:bg-skin-hover-bg"
-        :class="{
-          'bg-skin-active-bg': stepper.isCurrent(stepName)
-        }"
-        @click="goToStep(stepName)"
+    <div class="absolute inset-x-0 lg:static">
+      <div
+        class="flex p-3 border-b bg-skin-bg lg:p-0 lg:border-0 lg:flex-col gap-1 min-w-[180px] overflow-x-auto"
       >
-        <IH-check v-if="!step.isValid()" :class="'opacity-20'" />
-        <IS-check v-if="step.isValid()" class="text-skin-success" />
-        {{ step.title }}
-      </button>
+        <button
+          v-for="(step, stepName) in steps"
+          :key="stepName"
+          type="button"
+          class="px-3 py-1 flex items-center gap-2 text-skin-link rounded whitespace-nowrap hover:bg-skin-hover-bg"
+          :class="{
+            'bg-skin-active-bg': stepper.isCurrent(stepName)
+          }"
+          @click="goToStep(stepName)"
+        >
+          <IH-check v-if="!step.isValid()" :class="'opacity-20'" />
+          <IS-check v-if="step.isValid()" class="text-skin-success" />
+          {{ step.title }}
+        </button>
+      </div>
     </div>
-    <div class="flex-1 space-y-4">
+    <div class="flex-1 space-y-4 mt-[72px] lg:mt-0 pt-4 lg:pt-0">
       <slot
         name="content"
         :current-step="currentStep"

--- a/apps/ui/src/components/Ui/Topnav.vue
+++ b/apps/ui/src/components/Ui/Topnav.vue
@@ -1,6 +1,6 @@
 <template>
   <header
-    class="w-full z-50 pointer-events-auto sticky top-0 border-b h-[72px] bg-skin-bg flex items-center justify-between px-4 gap-4"
+    class="w-full z-50 pointer-events-auto sticky top-0 border-b h-[72px] bg-skin-bg flex items-center justify-end px-4 gap-4"
   >
     <slot />
   </header>

--- a/apps/ui/src/components/Ui/Topnav.vue
+++ b/apps/ui/src/components/Ui/Topnav.vue
@@ -1,11 +1,7 @@
 <template>
   <header
-    class="fixed top-0 inset-x-0 z-50 max-w-maximum !mx-auto pointer-events-none"
+    class="w-full z-50 pointer-events-auto sticky top-0 border-b h-[72px] bg-skin-bg flex items-center justify-between px-4 gap-4"
   >
-    <div
-      class="border-b h-[72px] bg-skin-bg flex items-center justify-between pr-4 gap-4 pointer-events-auto"
-    >
-      <slot />
-    </div>
+    <slot />
   </header>
 </template>

--- a/apps/ui/src/components/Ui/Topnav.vue
+++ b/apps/ui/src/components/Ui/Topnav.vue
@@ -1,6 +1,6 @@
 <template>
   <header
-    class="sticky z-50 top-0 border-b h-[72px] bg-skin-bg flex items-center justify-between px-4 gap-4"
+    class="sticky z-50 top-0 border-b h-[72px] bg-skin-bg flex items-center justify-between px-4 gap-4 shadow-[0_-1px_0_0_rgb(var(--bg))]"
   >
     <slot />
   </header>

--- a/apps/ui/src/components/Ui/Topnav.vue
+++ b/apps/ui/src/components/Ui/Topnav.vue
@@ -1,6 +1,6 @@
 <template>
   <header
-    class="w-full z-50 pointer-events-auto sticky top-0 border-b h-[72px] bg-skin-bg flex items-center justify-end px-4 gap-4"
+    class="sticky z-50 top-0 border-b h-[72px] bg-skin-bg flex items-center justify-between px-4 gap-4"
   >
     <slot />
   </header>

--- a/apps/ui/src/views/CreateSpaceSnapshot.vue
+++ b/apps/ui/src/views/CreateSpaceSnapshot.vue
@@ -208,7 +208,7 @@ watch(
   <UiStepper
     :steps="STEPS"
     :submitting="sending"
-    class="max-w-[50rem] mx-auto px-4 lg:pt-5 gap-y-8 gap-x-5"
+    class="lg:max-w-[50rem] max-w-[592px] mx-auto px-4 lg:pt-5 gap-x-5"
     @submit="handleSubmit"
   >
     <template #content="{ currentStep, goToNext }">

--- a/apps/ui/src/views/CreateSpaceSnapshot.vue
+++ b/apps/ui/src/views/CreateSpaceSnapshot.vue
@@ -205,77 +205,80 @@ watch(
 </script>
 
 <template>
-  <div class="pt-5 max-w-[50rem] mx-auto px-4">
-    <UiStepper :steps="STEPS" :submitting="sending" @submit="handleSubmit">
-      <template #content="{ currentStep, goToNext }">
-        <UiContainerSettings
-          :title="STEPS[currentStep].contentTitle"
-          :description="STEPS[currentStep].contentDescription"
-        >
-          <EnsConfiguratorOffchain
-            v-if="currentStep === 'id'"
-            v-model="settingsForm.id"
-            :network-id="networkId"
-            @select="goToNext()"
+  <UiStepper
+    :steps="STEPS"
+    :submitting="sending"
+    class="max-w-[50rem] mx-auto px-4 lg:pt-5 gap-y-8 gap-x-5"
+    @submit="handleSubmit"
+  >
+    <template #content="{ currentStep, goToNext }">
+      <UiContainerSettings
+        :title="STEPS[currentStep].contentTitle"
+        :description="STEPS[currentStep].contentDescription"
+      >
+        <EnsConfiguratorOffchain
+          v-if="currentStep === 'id'"
+          v-model="settingsForm.id"
+          :network-id="networkId"
+          @select="goToNext()"
+        />
+        <FormSpaceProfile
+          v-if="currentStep === 'profile'"
+          :form="settingsForm"
+          :space="space"
+          @errors="v => handleErrors('profile', v)"
+        />
+        <div v-if="currentStep === 'network'" class="s-box">
+          <UiSelectorNetwork
+            v-model="settingsForm.chainId"
+            class="!mb-0"
+            :definition="{
+              type: 'number',
+              title: 'Network',
+              tooltip:
+                'Networks can also be specified in individual strategies, delegations, treasuries, etc...',
+              examples: ['Select network'],
+              networkId: networkId,
+              networksListKind: 'offchain'
+            }"
           />
-          <FormSpaceProfile
-            v-if="currentStep === 'profile'"
-            :form="settingsForm"
-            :space="space"
-            @errors="v => handleErrors('profile', v)"
-          />
-          <div v-if="currentStep === 'network'" class="s-box">
-            <UiSelectorNetwork
-              v-model="settingsForm.chainId"
-              class="!mb-0"
-              :definition="{
-                type: 'number',
-                title: 'Network',
-                tooltip:
-                  'Networks can also be specified in individual strategies, delegations, treasuries, etc...',
-                examples: ['Select network'],
-                networkId: networkId,
-                networksListKind: 'offchain'
-              }"
-            />
+        </div>
+        <SetupStrategiesConfiguratorOffchain
+          v-if="currentStep === 'strategies'"
+          v-model="settingsForm.strategies"
+          :snapshot-chain-id="settingsForm.chainId"
+          :network-id="networkId"
+          :space="space"
+        />
+        <ProposalValidationConfigurator
+          v-if="currentStep === 'proposal'"
+          v-model="settingsForm.proposalValidation"
+          :network-id="networkId"
+          :snapshot-chain-id="settingsForm.chainId"
+        />
+        <template v-if="currentStep === 'voting'">
+          <div class="mb-3">
+            The voting delay is the time interval between the creation of a
+            proposal and the start of voting. The voting period is the duration
+            for which the proposal remains open for voting.<br />
+            If these values are left empty, the proposal author will be able to
+            set them.
           </div>
-          <SetupStrategiesConfiguratorOffchain
-            v-if="currentStep === 'strategies'"
-            v-model="settingsForm.strategies"
-            :snapshot-chain-id="settingsForm.chainId"
-            :network-id="networkId"
-            :space="space"
+          <FormVoting
+            :form="settingsForm"
+            :selected-network-id="networkId"
+            @errors="v => handleErrors('voting', v)"
           />
-          <ProposalValidationConfigurator
-            v-if="currentStep === 'proposal'"
-            v-model="settingsForm.proposalValidation"
-            :network-id="networkId"
-            :snapshot-chain-id="settingsForm.chainId"
-          />
-          <template v-if="currentStep === 'voting'">
-            <div class="mb-3">
-              The voting delay is the time interval between the creation of a
-              proposal and the start of voting. The voting period is the
-              duration for which the proposal remains open for voting.<br />
-              If these values are left empty, the proposal author will be able
-              to set them.
-            </div>
-            <FormVoting
-              :form="settingsForm"
-              :selected-network-id="networkId"
-              @errors="v => handleErrors('voting', v)"
-            />
-          </template>
-          <FormSpaceMembers
-            v-if="currentStep === 'members'"
-            v-model="settingsForm.members"
-            :network-id="networkId"
-            :is-controller="true"
-            :is-admin="true"
-          />
-        </UiContainerSettings>
-      </template>
-      <template #submit-text> Create space</template>
-    </UiStepper>
-  </div>
+        </template>
+        <FormSpaceMembers
+          v-if="currentStep === 'members'"
+          v-model="settingsForm.members"
+          :network-id="networkId"
+          :is-controller="true"
+          :is-admin="true"
+        />
+      </UiContainerSettings>
+    </template>
+    <template #submit-text> Create space</template>
+  </UiStepper>
 </template>

--- a/apps/ui/src/views/CreateSpaceSnapshotX.vue
+++ b/apps/ui/src/views/CreateSpaceSnapshotX.vue
@@ -122,108 +122,108 @@ watch(selectedNetworkId, () => {
 </script>
 
 <template>
-  <div class="pt-5 max-w-[50rem] mx-auto px-4">
-    <CreateDeploymentProgress
-      v-if="confirming && salt && predictedSpaceAddress && validationStrategy"
-      :network-id="selectedNetworkId"
-      :salt="salt"
-      :predicted-space-address="predictedSpaceAddress"
-      :metadata="metadataForm"
-      :settings="settingsForm"
-      :authenticators="authenticators"
-      :validation-strategy="validationStrategy"
-      :voting-strategies="votingStrategies"
-      :execution-strategies="executionStrategies"
-      :controller="controller"
-      @back="confirming = false"
-    />
-    <UiStepper v-else :steps="STEPS" @submit="handleSubmit">
-      <template #content="{ currentStep }">
-        <template v-if="currentStep === 'profile'">
-          <FormSpaceProfile
-            :form="metadataForm"
-            @errors="v => handleErrors('profile', v)"
+  <CreateDeploymentProgress
+    v-if="confirming && salt && predictedSpaceAddress && validationStrategy"
+    :network-id="selectedNetworkId"
+    :salt="salt"
+    :predicted-space-address="predictedSpaceAddress"
+    :metadata="metadataForm"
+    :settings="settingsForm"
+    :authenticators="authenticators"
+    :validation-strategy="validationStrategy"
+    :voting-strategies="votingStrategies"
+    :execution-strategies="executionStrategies"
+    :controller="controller"
+    @back="confirming = false"
+  />
+  <UiStepper
+    v-else
+    class="lg:max-w-[50rem] max-w-[592px] mx-auto px-4 lg:pt-5 gap-x-5"
+    :steps="STEPS"
+    @submit="handleSubmit"
+  >
+    <template #content="{ currentStep }">
+      <template v-if="currentStep === 'profile'">
+        <FormSpaceProfile
+          :form="metadataForm"
+          @errors="v => handleErrors('profile', v)"
+        />
+        <div class="px-4 pt-4">
+          <FormSpaceTreasuries
+            v-model="metadataForm.treasuries"
+            :network-id="selectedNetworkId"
           />
-          <div class="px-4 pt-4">
-            <FormSpaceTreasuries
-              v-model="metadataForm.treasuries"
-              :network-id="selectedNetworkId"
-            />
-            <FormSpaceDelegations
-              v-model="metadataForm.delegations"
-              :network-id="selectedNetworkId"
-              class="mt-4"
-            />
-          </div>
-        </template>
-        <FormNetwork
-          v-else-if="currentStep === 'network'"
-          v-model="selectedNetworkId"
-          title="Space network"
-        />
-        <FormStrategies
-          v-else-if="currentStep === 'strategies'"
-          v-model="votingStrategies"
-          :network-id="selectedNetworkId"
-          :available-strategies="
-            selectedNetwork.constants.EDITOR_VOTING_STRATEGIES
-          "
-          title="Voting strategies"
-          description="Voting strategies are customizable contracts used to define how much voting power each user has when casting a vote."
-        />
-        <FormStrategies
-          v-else-if="currentStep === 'auths'"
-          v-model="authenticators"
-          unique
-          :network-id="selectedNetworkId"
-          :available-strategies="
-            selectedNetwork.constants.EDITOR_AUTHENTICATORS
-          "
-          title="Authenticators"
-          description="Authenticators are customizable contracts that verify user identity for proposing and voting using different methods."
-        />
-        <FormValidation
-          v-else-if="currentStep === 'validations'"
-          v-model="validationStrategy"
-          :network-id="selectedNetworkId"
-          :available-strategies="
-            selectedNetwork.constants.EDITOR_PROPOSAL_VALIDATIONS
-          "
-          :available-voting-strategies="
-            selectedNetwork.constants
-              .EDITOR_PROPOSAL_VALIDATION_VOTING_STRATEGIES
-          "
-          title="Proposal validation"
-          description="Proposal validation strategies are used to determine if a user is allowed to create a proposal."
-        />
-        <FormStrategies
-          v-else-if="currentStep === 'executions'"
-          v-model="executionStrategies"
-          :network-id="selectedNetworkId"
-          :available-strategies="
-            selectedNetwork.constants.EDITOR_EXECUTION_STRATEGIES
-          "
-          :default-params="{ controller }"
-          title="Execution strategies"
-          description="Execution strategies are used to determine the status of a proposal and execute its payload if it's accepted."
-        />
-        <FormVoting
-          v-else-if="currentStep === 'voting'"
-          :form="settingsForm"
-          :selected-network-id="selectedNetworkId"
-          title="Voting settings"
-          @errors="v => handleErrors('voting', v)"
-        />
-        <FormController
-          v-else-if="currentStep === 'controller'"
-          v-model="controller"
-          class="s-input-pb-0"
-          title="Controller"
-          :chain-id="selectedNetwork.chainId"
-          @errors="v => handleErrors('controller', v)"
-        />
+          <FormSpaceDelegations
+            v-model="metadataForm.delegations"
+            :network-id="selectedNetworkId"
+            class="mt-4"
+          />
+        </div>
       </template>
-      <template #submit-text> Create </template>
-    </UiStepper>
-  </div>
+      <FormNetwork
+        v-else-if="currentStep === 'network'"
+        v-model="selectedNetworkId"
+        title="Space network"
+      />
+      <FormStrategies
+        v-else-if="currentStep === 'strategies'"
+        v-model="votingStrategies"
+        :network-id="selectedNetworkId"
+        :available-strategies="
+          selectedNetwork.constants.EDITOR_VOTING_STRATEGIES
+        "
+        title="Voting strategies"
+        description="Voting strategies are customizable contracts used to define how much voting power each user has when casting a vote."
+      />
+      <FormStrategies
+        v-else-if="currentStep === 'auths'"
+        v-model="authenticators"
+        unique
+        :network-id="selectedNetworkId"
+        :available-strategies="selectedNetwork.constants.EDITOR_AUTHENTICATORS"
+        title="Authenticators"
+        description="Authenticators are customizable contracts that verify user identity for proposing and voting using different methods."
+      />
+      <FormValidation
+        v-else-if="currentStep === 'validations'"
+        v-model="validationStrategy"
+        :network-id="selectedNetworkId"
+        :available-strategies="
+          selectedNetwork.constants.EDITOR_PROPOSAL_VALIDATIONS
+        "
+        :available-voting-strategies="
+          selectedNetwork.constants.EDITOR_PROPOSAL_VALIDATION_VOTING_STRATEGIES
+        "
+        title="Proposal validation"
+        description="Proposal validation strategies are used to determine if a user is allowed to create a proposal."
+      />
+      <FormStrategies
+        v-else-if="currentStep === 'executions'"
+        v-model="executionStrategies"
+        :network-id="selectedNetworkId"
+        :available-strategies="
+          selectedNetwork.constants.EDITOR_EXECUTION_STRATEGIES
+        "
+        :default-params="{ controller }"
+        title="Execution strategies"
+        description="Execution strategies are used to determine the status of a proposal and execute its payload if it's accepted."
+      />
+      <FormVoting
+        v-else-if="currentStep === 'voting'"
+        :form="settingsForm"
+        :selected-network-id="selectedNetworkId"
+        title="Voting settings"
+        @errors="v => handleErrors('voting', v)"
+      />
+      <FormController
+        v-else-if="currentStep === 'controller'"
+        v-model="controller"
+        class="s-input-pb-0"
+        title="Controller"
+        :chain-id="selectedNetwork.chainId"
+        @errors="v => handleErrors('controller', v)"
+      />
+    </template>
+    <template #submit-text> Create </template>
+  </UiStepper>
 </template>

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -457,7 +457,7 @@ watchEffect(() => {
 });
 </script>
 <template>
-  <div v-if="proposal" class="h-full">
+  <div v-if="proposal" class="flex flex-col h-full">
     <UiTopnav>
       <div class="flex items-center gap-3 shrink truncate">
         <UiButton
@@ -492,9 +492,9 @@ watchEffect(() => {
         </UiButton>
       </div>
     </UiTopnav>
-    <div class="flex items-stretch md:flex-row flex-col w-full md:h-full">
+    <div class="flex items-stretch md:flex-row flex-col flex-1">
       <div
-        class="flex-1 grow min-w-0 border-r-0 md:border-r max-md:pb-0"
+        class="flex-1 min-w-0 border-r-0 md:border-r max-md:pb-0"
         v-bind="$attrs"
       >
         <UiContainer class="pt-5 !max-w-[710px] mx-0 md:mx-auto s-box">
@@ -676,7 +676,7 @@ watchEffect(() => {
         </UiContainer>
       </div>
 
-      <Affix :class="['shrink-0 md:w-[340px]']" :top="72" :bottom="64">
+      <Affix class="shrink-0 md:w-[340px] h-0 md:h-full" :top="72" :bottom="64">
         <div v-bind="$attrs" class="flex flex-col px-4 gap-y-4 pt-4 !h-auto">
           <EditorVotingType
             v-model="proposal"

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -676,7 +676,7 @@ watchEffect(() => {
         </UiContainer>
       </div>
 
-      <Affix class="shrink-0 md:w-[340px] h-0 md:h-full" :top="72" :bottom="64">
+      <Affix class="shrink-0 md:w-[340px]" :top="72" :bottom="64">
         <div v-bind="$attrs" class="flex flex-col px-4 gap-y-4 pt-4 !h-auto">
           <EditorVotingType
             v-model="proposal"

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -57,7 +57,6 @@ const {
   loaded: networksLoaded
 } = useOffchainNetworksList(props.space.network);
 const { limits, lists } = useSettings();
-const { isWhiteLabel } = useWhiteLabel();
 
 const modalOpen = ref(false);
 const modalOpenTerms = ref(false);

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -458,14 +458,11 @@ watchEffect(() => {
 </script>
 <template>
   <div v-if="proposal" class="h-full">
-    <UiTopnav
-      :class="{ 'maximum:border-l': isWhiteLabel }"
-      class="maximum:border-r"
-    >
+    <UiTopnav>
       <div class="flex items-center gap-3 shrink truncate">
         <UiButton
           :to="{ name: 'space-overview', params: { space: spaceKey } }"
-          class="w-[46px] !px-0 ml-4 shrink-0"
+          class="w-[46px] !px-0 shrink-0"
         >
           <IH-arrow-narrow-left />
         </UiButton>
@@ -495,9 +492,7 @@ watchEffect(() => {
         </UiButton>
       </div>
     </UiTopnav>
-    <div
-      class="flex items-stretch md:flex-row flex-col w-full md:h-full mt-[72px]"
-    >
+    <div class="flex items-stretch md:flex-row flex-col w-full md:h-full">
       <div
         class="flex-1 grow min-w-0 border-r-0 md:border-r max-md:pb-0"
         v-bind="$attrs"

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -458,7 +458,7 @@ watchEffect(() => {
 </script>
 <template>
   <div v-if="proposal" class="flex flex-col h-full">
-    <UiTopnav>
+    <UiTopnav class="justify-between">
       <div class="flex items-center gap-3 shrink truncate">
         <UiButton
           :to="{ name: 'space-overview', params: { space: spaceKey } }"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #1305 

This PR is migrating the top nav, sidebar and side navigation away from `position: fixed`, which is causing positioning issue when the page has an overflow hidden.

Position fixed is not really needed for these elements, and same results can be achieved using sticky, which also dispense the fact to re-compute all elements position with a `translateX` on sidebar opening on narrow screen.

This also allow footer elements to not overlap:

![Screenshot 2025-04-04 at 03 34 26](https://github.com/user-attachments/assets/88270a62-a11b-4a1e-b9da-bb0bc03f0fcc)

Also fix an issue on the space creation page where the create button is larger than the content on some screen size

![Screenshot 2025-04-04 at 03 38 15](https://github.com/user-attachments/assets/3e5f5abc-8009-4476-a345-2364b3edfbda)

Sidebar navigation is now scrollable when needed



https://github.com/user-attachments/assets/d3135916-77f4-4bff-8861-9d2d460aaa53


### How to test

1. Open the app on a wide screen (>1900px)
2. Open any modal
3. All the content should remain fixed, the top nav and footer icons should not slide right by 15px.
4. Everything else should works as before
