### PR TITLE
feat(api): add custom strategy support

### DIFF
--- a/apps/api/src/evm/abis/IExecutionStrategy.json
+++ b/apps/api/src/evm/abis/IExecutionStrategy.json
@@ -1,0 +1,187 @@
+[
+  {
+    "type": "function",
+    "name": "execute",
+    "inputs": [
+      {
+        "name": "proposalId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "proposal",
+        "type": "tuple",
+        "internalType": "struct Proposal",
+        "components": [
+          {
+            "name": "author",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "startBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "executionStrategy",
+            "type": "address",
+            "internalType": "contract IExecutionStrategy"
+          },
+          {
+            "name": "minEndBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "maxEndBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "finalizationStatus",
+            "type": "uint8",
+            "internalType": "enum FinalizationStatus"
+          },
+          {
+            "name": "executionPayloadHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "activeVotingStrategies",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "votesFor",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "votesAgainst",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "votesAbstain",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "payload",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getProposalStatus",
+    "inputs": [
+      {
+        "name": "proposal",
+        "type": "tuple",
+        "internalType": "struct Proposal",
+        "components": [
+          {
+            "name": "author",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "startBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "executionStrategy",
+            "type": "address",
+            "internalType": "contract IExecutionStrategy"
+          },
+          {
+            "name": "minEndBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "maxEndBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "finalizationStatus",
+            "type": "uint8",
+            "internalType": "enum FinalizationStatus"
+          },
+          {
+            "name": "executionPayloadHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "activeVotingStrategies",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "votesFor",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "votesAgainst",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "votesAbstain",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum ProposalStatus"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getStrategyType",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "error",
+    "name": "ExecutionFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidProposalStatus",
+    "inputs": [
+      {
+        "name": "status",
+        "type": "uint8",
+        "internalType": "enum ProposalStatus"
+      }
+    ]
+  }
+]

--- a/apps/api/src/evm/ipfs.ts
+++ b/apps/api/src/evm/ipfs.ts
@@ -95,4 +95,6 @@ export async function handleSpaceMetadata(
   }
 
   await spaceMetadataItem.save();
+
+  return spaceMetadataItem;
 }

--- a/apps/api/src/evm/utils.ts
+++ b/apps/api/src/evm/utils.ts
@@ -1,8 +1,11 @@
 import { defaultAbiCoder } from '@ethersproject/abi';
 import { getAddress } from '@ethersproject/address';
 import { BigNumber } from '@ethersproject/bignumber';
+import { Contract } from '@ethersproject/contracts';
+import { JsonRpcProvider } from '@ethersproject/providers';
+import IExecutionStrategy from './abis/IExecutionStrategy.json';
 import { FullConfig } from './config';
-import { Space } from '../../.checkpoint/models';
+import { ExecutionStrategy, Space } from '../../.checkpoint/models';
 import { handleVotingPowerValidationMetadata } from '../common/ipfs';
 
 /**
@@ -68,4 +71,36 @@ export async function updateProposalValidationStrategy(
       space.voting_power_validation_strategy_strategies_params = [];
     }
   }
+}
+
+export async function handleCustomExecutionStrategy(
+  address: string,
+  blockNumber: number,
+  provider: JsonRpcProvider,
+  config: FullConfig
+) {
+  const contract = new Contract(address, IExecutionStrategy, provider);
+
+  const overrides = {
+    blockTag: blockNumber
+  };
+
+  const type = await contract.getStrategyType(overrides);
+
+  let executionStrategy = await ExecutionStrategy.loadEntity(
+    address,
+    config.indexerName
+  );
+
+  if (executionStrategy) return;
+
+  executionStrategy = new ExecutionStrategy(address, config.indexerName);
+  executionStrategy.address = address;
+  executionStrategy.type = type;
+  executionStrategy.quorum = '0';
+  executionStrategy.treasury_chain = config.chainId;
+  executionStrategy.treasury = getAddress(address);
+  executionStrategy.timelock_delay = 0n;
+
+  await executionStrategy.save();
 }

--- a/apps/api/src/evm/writers.ts
+++ b/apps/api/src/evm/writers.ts
@@ -8,7 +8,11 @@ import SimpleQuorumAvatarExecutionStrategy from './abis/SimpleQuorumAvatarExecut
 import SimpleQuorumTimelockExecutionStrategy from './abis/SimpleQuorumTimelockExecutionStrategy.json';
 import { FullConfig } from './config';
 import { handleSpaceMetadata } from './ipfs';
-import { convertChoice, updateProposalValidationStrategy } from './utils';
+import {
+  convertChoice,
+  handleCustomExecutionStrategy,
+  updateProposalValidationStrategy
+} from './utils';
 import {
   ExecutionHash,
   ExecutionStrategy,
@@ -26,6 +30,18 @@ import {
   handleVoteMetadata
 } from '../common/ipfs';
 import { dropIpfs, getCurrentTimestamp } from '../common/utils';
+
+/**
+ * List of execution strategies type that are known and we expect them to be deployed via factory.
+ * Other execution strategies will be treated as custom execution and will be resolved once
+ * they are added to space.
+ */
+const KNOWN_EXECUTION_STRATEGIES = [
+  'SimpleQuorumAvatar',
+  'SimpleQuorumTimelock',
+  'Axiom',
+  'Isokratia'
+];
 
 const EMPTY_EXECUTION_HASH =
   '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470';
@@ -179,7 +195,12 @@ export function createWriters(config: FullConfig) {
     }
   };
 
-  const handleSpaceCreated: evm.Writer = async ({ block, tx, event }) => {
+  const handleSpaceCreated: evm.Writer = async ({
+    block,
+    blockNumber,
+    tx,
+    event
+  }) => {
     console.log('Handle space created');
 
     if (!event) return;
@@ -222,13 +243,33 @@ export function createWriters(config: FullConfig) {
       config
     );
 
+    let spaceMetadataItem: SpaceMetadataItem | undefined;
     try {
       const metadataUri = event.args.input.metadataURI;
-      await handleSpaceMetadata(space.id, metadataUri, config);
+      spaceMetadataItem = await handleSpaceMetadata(
+        space.id,
+        metadataUri,
+        config
+      );
 
       space.metadata = dropIpfs(metadataUri);
     } catch (e) {
       console.log('failed to parse space metadata', e);
+    }
+
+    if (spaceMetadataItem) {
+      for (const [i, executor] of spaceMetadataItem.executors.entries()) {
+        const type = spaceMetadataItem.executors_types[i];
+
+        if (type && !KNOWN_EXECUTION_STRATEGIES.includes(type)) {
+          await handleCustomExecutionStrategy(
+            executor,
+            blockNumber,
+            provider,
+            config
+          );
+        }
+      }
     }
 
     try {
@@ -245,16 +286,25 @@ export function createWriters(config: FullConfig) {
     await space.save();
   };
 
-  const handleMetadataUriUpdated: evm.Writer = async ({ rawEvent, event }) => {
+  const handleMetadataUriUpdated: evm.Writer = async ({
+    blockNumber,
+    rawEvent,
+    event
+  }) => {
     if (!event || !rawEvent) return;
 
     console.log('Handle space metadata uri updated');
 
     const spaceId = getAddress(rawEvent.address);
 
+    let spaceMetadataItem: SpaceMetadataItem | undefined;
     try {
       const metadataUri = event.args.newMetadataURI;
-      await handleSpaceMetadata(spaceId, metadataUri, config);
+      spaceMetadataItem = await handleSpaceMetadata(
+        spaceId,
+        metadataUri,
+        config
+      );
 
       const space = await Space.loadEntity(spaceId, config.indexerName);
       if (!space) return;
@@ -264,6 +314,21 @@ export function createWriters(config: FullConfig) {
       await space.save();
     } catch (e) {
       console.log('failed to update space metadata', e);
+    }
+
+    if (spaceMetadataItem) {
+      for (const [i, executor] of spaceMetadataItem.executors.entries()) {
+        const type = spaceMetadataItem.executors_types[i];
+
+        if (type && !KNOWN_EXECUTION_STRATEGIES.includes(type)) {
+          await handleCustomExecutionStrategy(
+            executor,
+            blockNumber,
+            provider,
+            config
+          );
+        }
+      }
     }
   };
 

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -116,12 +116,15 @@ type Proposal {
   snapshot: Int!
   execution_time: Int!
   execution_strategy: String!
+  # Note: in the future move this field to execution_strategy
+  execution_strategy_details: ExecutionStrategy
   execution_strategy_type: String!
   execution_destination: String
   timelock_veto_guardian: String
   timelock_delay: BigInt
   axiom_snapshot_address: String
   axiom_snapshot_slot: BigInt
+  treasuries: [String!]!
   strategies_indices: [Int!]!
   # Deprecated
   strategies_indicies: [Int!]!

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -12,9 +12,11 @@ import {
   updateProposalValidationStrategy
 } from './utils';
 import {
+  ExecutionStrategy,
   Leaderboard,
   Proposal,
   Space,
+  SpaceMetadataItem,
   User,
   Vote
 } from '../../.checkpoint/models';
@@ -474,6 +476,38 @@ export function createWriters(config: FullConfig) {
         executionStrategy.executionStrategyType;
       proposal.execution_destination = executionStrategy.destinationAddress;
       proposal.quorum = executionStrategy.quorum;
+
+      // Find matching strategy and persist it on space object
+      // We use this on UI to properly display execution with treasury
+      // information.
+      // Current way of persisting it isn't great, because we need to fetch every strategy
+      // for space and compare it with execution strategy address.
+      // In the future we should find way to optimize it for example by adding where lookup
+      // via ORM
+      if (space.metadata) {
+        const spaceMetadata = await SpaceMetadataItem.loadEntity(
+          space.metadata,
+          config.indexerName
+        );
+
+        if (spaceMetadata) {
+          proposal.treasuries = spaceMetadata.treasuries;
+
+          const strategies = await Promise.all(
+            spaceMetadata.executors_strategies.map(id =>
+              ExecutionStrategy.loadEntity(id, config.indexerName)
+            )
+          );
+
+          const matchingStrategy = strategies.find(
+            strategy => strategy?.address === proposal.execution_strategy
+          );
+
+          if (matchingStrategy) {
+            proposal.execution_strategy_details = matchingStrategy.id;
+          }
+        }
+      }
     }
 
     try {


### PR DESCRIPTION
### Summary

This PR is resubmit of https://github.com/snapshot-labs/sx-monorepo/pull/1276, but only API part so we can deploy it from master and once synced merge the rest.

Changes:
1. `treasuries` and `execution_strategy_details` are now persisted on proposal so changing executors or treasuries at space level won't cause changes in existing proposals.
2. Custom strategies can be deployed without proxy. When execution strategy is added to space it will be fetched and data will be read from it to create ExecutionStrategy entity on API.