### PR TITLE
Sekhmet/custom execution

### DIFF
--- a/.changeset/gold-papayas-fly.md
+++ b/.changeset/gold-papayas-fly.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+generate standard execution payload for any execution with transactions

--- a/apps/ui/src/components/Modal/CustomStrategy.vue
+++ b/apps/ui/src/components/Modal/CustomStrategy.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { Contract } from '@ethersproject/contracts';
+import { getProvider } from '@/helpers/provider';
+import { getValidator } from '@/helpers/validation';
+import { ChainId, NetworkID } from '@/types';
+
+const ABI = ['function getStrategyType() pure returns (string)'];
+
+const props = withDefaults(
+  defineProps<{
+    open: boolean;
+    networkId: NetworkID;
+    chainId: ChainId;
+  }>(),
+  {}
+);
+
+const emit = defineEmits<{
+  (e: 'close');
+  (e: 'save', strategy: { address: string; type: string });
+}>();
+
+const uiStore = useUiStore();
+
+const showPicker = ref(false);
+const searchValue = ref('');
+const contractAddress = ref('');
+const isSubmitting = ref(false);
+
+const definition = computed(() => ({
+  type: 'string',
+  title: 'Contract Address',
+  format: 'address',
+  examples: ['0x0000…'],
+  chainId: props.chainId
+}));
+
+const formErrors = computed(() => {
+  return getValidator({
+    type: 'object',
+    required: ['contractAddress'],
+    properties: {
+      contractAddress: definition.value
+    }
+  }).validate({ contractAddress: contractAddress.value });
+});
+
+async function handleSubmit() {
+  if (Object.keys(formErrors.value).length > 0) return;
+
+  try {
+    isSubmitting.value = true;
+
+    const contract = new Contract(
+      contractAddress.value,
+      ABI,
+      getProvider(props.chainId as number)
+    );
+
+    const type = await contract.getStrategyType();
+
+    emit('save', {
+      address: contractAddress.value,
+      type
+    });
+  } catch (e) {
+    console.error('Failed to fetch strategy type', e);
+    uiStore.addNotification(
+      'error',
+      'Failed to load strategy details. Make sure correct address is used.'
+    );
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+watchEffect(() => {
+  if (props.open) {
+    contractAddress.value = '';
+  }
+});
+</script>
+
+<template>
+  <UiModal :open="open" @close="$emit('close')">
+    <template #header>
+      <h3>Add Custom Strategy</h3>
+      <template v-if="showPicker">
+        <button
+          type="button"
+          class="absolute left-0 -top-1 p-4"
+          @click="showPicker = false"
+        >
+          <IH-arrow-narrow-left class="mr-2" />
+        </button>
+        <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
+          <IH-search class="mx-2" />
+          <input
+            ref="searchInput"
+            v-model="searchValue"
+            type="text"
+            placeholder="Search name or paste address"
+            class="flex-auto bg-transparent text-skin-link"
+          />
+        </div>
+      </template>
+    </template>
+    <PickerContact
+      v-if="showPicker"
+      :loading="false"
+      :search-value="searchValue"
+      @pick="
+        value => {
+          contractAddress = value;
+          showPicker = false;
+        }
+      "
+    />
+    <div v-else class="s-box p-4">
+      <UiInputAddress
+        v-model="contractAddress"
+        :definition="definition"
+        :error="formErrors.contractAddress"
+        @pick="showPicker = true"
+      />
+    </div>
+    <template v-if="!showPicker" #footer>
+      <UiButton
+        :loading="isSubmitting"
+        class="w-full"
+        :disabled="Object.keys(formErrors).length > 0"
+        @click="handleSubmit"
+      >
+        Confirm
+      </UiButton>
+    </template>
+  </UiModal>
+</template>

--- a/apps/ui/src/components/ProposalExecutionsList.vue
+++ b/apps/ui/src/components/ProposalExecutionsList.vue
@@ -4,12 +4,16 @@ import { getProposalCurrentQuorum } from '@/helpers/quorum';
 import { buildBatchFile } from '@/helpers/safe/ build';
 import { getExecutionName } from '@/helpers/ui';
 import { shorten, toBigIntOrNumber } from '@/helpers/utils';
-import { Proposal, ProposalExecution } from '@/types';
+import { getNetwork } from '@/networks';
+import { NetworkID, Proposal, ProposalExecution } from '@/types';
 
-defineProps<{
+const props = defineProps<{
+  networkId: NetworkID;
   proposal: Proposal;
   executions: ProposalExecution[];
 }>();
+
+const network = computed(() => getNetwork(props.networkId));
 
 function downloadExecution(execution: ProposalExecution) {
   if (!execution.chainId) return;
@@ -69,10 +73,7 @@ function downloadExecution(execution: ProposalExecution) {
         />
         <div
           class="text-skin-text text-[17px] truncate"
-          v-text="
-            getExecutionName(proposal.network, execution.strategyType) ||
-            shorten(execution.safeAddress)
-          "
+          v-text="getExecutionName(proposal.network, execution.strategyType)"
         />
       </div>
     </a>
@@ -106,7 +107,8 @@ function downloadExecution(execution: ProposalExecution) {
           proposal.quorum &&
         toBigIntOrNumber(proposal.scores[0]) >
           toBigIntOrNumber(proposal.scores[1]) &&
-        proposal.has_execution_window_opened
+        proposal.has_execution_window_opened &&
+        network.helpers.isExecutorActionsSupported(execution.strategyType)
       "
       :proposal="proposal"
       :execution="execution"

--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -553,6 +553,7 @@ export function useActions() {
     votingStrategiesToAdd: StrategyConfig[],
     votingStrategiesToRemove: number[],
     validationStrategy: StrategyConfig,
+    executionStrategies: StrategyConfig[],
     votingDelay: number | null,
     minVotingDuration: number | null,
     maxVotingDuration: number | null
@@ -581,6 +582,7 @@ export function useActions() {
         votingStrategiesToAdd,
         votingStrategiesToRemove,
         validationStrategy,
+        executionStrategies,
         votingDelay !== null
           ? getCurrentFromDuration(space.network, votingDelay)
           : null,

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -155,7 +155,9 @@ export function useSpaceSettings(space: Ref<Space>) {
   // Onchain properties
   const authenticators = ref([] as StrategyConfig[]);
   const validationStrategy = ref(null as StrategyConfig | null);
+  const executionStrategies = ref([] as StrategyConfig[]);
   const votingStrategies = ref([] as StrategyConfig[]);
+  const initialExecutionStrategiesObjectHash = ref(null as string | null);
   const initialValidationStrategyObjectHash = ref(null as string | null);
 
   // Offchain properties
@@ -281,6 +283,25 @@ export function useSpaceSettings(space: Ref<Space>) {
       },
       ...strategy
     };
+  }
+
+  async function getInitialExecutionStrategies(
+    executors: string[],
+    executorTypes: string[]
+  ) {
+    return executors.map((executor, i) => {
+      return {
+        id: executor,
+        address: executor,
+        type: executorTypes[i],
+        name:
+          network.value.constants.EXECUTORS[executor] ||
+          network.value.constants.EXECUTORS[executorTypes[i]] ||
+          executorTypes[i],
+        params: {},
+        paramsDefinition: {}
+      };
+    });
   }
 
   async function hasStrategyChanged(
@@ -668,6 +689,7 @@ export function useSpaceSettings(space: Ref<Space>) {
       strategiesToAdd,
       strategiesToRemove,
       validationStrategy.value,
+      executionStrategies.value,
       votingDelay.value,
       minVotingPeriod.value,
       maxVotingPeriod.value
@@ -712,6 +734,11 @@ export function useSpaceSettings(space: Ref<Space>) {
       space.value.voting_power_validation_strategies_parsed_metadata
     );
 
+    const executionStrategiesValue = await getInitialExecutionStrategies(
+      space.value.executors,
+      space.value.executors_types
+    );
+
     controller.value = force
       ? await network.value.helpers.getSpaceController(space.value)
       : initialController.value;
@@ -729,6 +756,10 @@ export function useSpaceSettings(space: Ref<Space>) {
     validationStrategy.value = validationStrategyValue;
     initialValidationStrategyObjectHash.value = objectHash(
       validationStrategyValue
+    );
+    executionStrategies.value = executionStrategiesValue;
+    initialExecutionStrategiesObjectHash.value = objectHash(
+      executionStrategiesValue
     );
 
     if (offchainNetworks.includes(space.value.network)) {
@@ -783,6 +814,9 @@ export function useSpaceSettings(space: Ref<Space>) {
       const validationStrategyValue = validationStrategy.value;
       const initialValidationStrategyObjectHashValue =
         initialValidationStrategyObjectHash.value;
+      const executionStrategiesValue = executionStrategies.value;
+      const initialExecutionStrategiesObjectHashValue =
+        initialExecutionStrategiesObjectHash.value;
       const proposalValidationValue = proposalValidation.value;
       const guidelinesValue = guidelines.value;
       const templateValue = template.value;
@@ -975,6 +1009,13 @@ export function useSpaceSettings(space: Ref<Space>) {
         if (hasValidationStrategyChanged) {
           return true;
         }
+
+        const hasExecutionStrategiesChanged =
+          objectHash(executionStrategiesValue) !==
+          initialExecutionStrategiesObjectHashValue;
+        if (hasExecutionStrategiesChanged) {
+          return true;
+        }
       }
     },
     false,
@@ -1000,6 +1041,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     validationStrategy,
     votingStrategies,
     proposalValidation,
+    executionStrategies,
     guidelines,
     template,
     quorumType,

--- a/apps/ui/src/helpers/ui.ts
+++ b/apps/ui/src/helpers/ui.ts
@@ -7,7 +7,11 @@ export function getExecutionName(networkId: NetworkID, strategyType: string) {
     if (strategyType === 'oSnap') return 'oSnap execution';
 
     const network = getNetwork(networkId);
-    return `${network.constants.EXECUTORS[strategyType]} execution`;
+
+    const name = network.constants.EXECUTORS[strategyType];
+    if (name) return `${network.constants.EXECUTORS[strategyType]} execution`;
+
+    return 'Custom execution';
   } catch (e) {
     return null;
   }

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -188,20 +188,14 @@ function processExecutions(
   proposal: ApiProposal,
   executionNetworkId: NetworkID
 ): ProposalExecution[] {
-  // NOTE: This is unstable, meaning that if executors_strategies or treasuries
-  // are modified in the future it will affect pass proposals.
-  // We should persist those values on proposal directly so it's stable.
-  // Right now we can't really update subgraphs because of TheGraph issue.
   if (!proposal.metadata?.execution) return [];
 
   const transactions = formatExecution(proposal.metadata?.execution);
   if (transactions.length === 0) return [];
 
-  const match = proposal.space.metadata?.executors_strategies.find(
-    strategy => strategy.address === proposal.execution_strategy
-  );
+  const match = proposal.execution_strategy_details;
 
-  const treasuries = proposal.space.metadata?.treasuries.map(treasury =>
+  const treasuries = proposal.treasuries.map(treasury =>
     formatMetadataTreasury(treasury)
   );
 

--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -104,17 +104,6 @@ gql(`
         avatar
         labels
         voting_power_symbol
-        treasuries
-        executors
-        executors_types
-        executors_strategies {
-          id
-          address
-          destination_address
-          type
-          treasury_chain
-          treasury
-        }
       }
       strategies_parsed_metadata {
         index
@@ -154,8 +143,17 @@ gql(`
     scores_total
     execution_time
     execution_strategy
+    execution_strategy_details {
+      id
+      address
+      destination_address
+      type
+      treasury_chain
+      treasury
+    }
     execution_strategy_type
     execution_destination
+    treasuries
     timelock_veto_guardian
     strategies_indices
     strategies

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -679,6 +679,7 @@ export function createActions(
       votingStrategiesToAdd: StrategyConfig[],
       votingStrategiesToRemove: number[],
       validationStrategy: StrategyConfig,
+      executionStrategies: StrategyConfig[],
       votingDelay: number | null,
       minVotingDuration: number | null,
       maxVotingDuration: number | null
@@ -690,9 +691,15 @@ export function createActions(
 
       const pinned = await helpers.pin(
         createErc1155Metadata(metadata, {
-          execution_strategies: space.executors,
-          execution_strategies_types: space.executors_types,
-          execution_destinations: space.executors_destinations
+          execution_strategies: executionStrategies.map(
+            config => config.address
+          ),
+          execution_strategies_types: executionStrategies.map(
+            config => config.type
+          ),
+          execution_destinations: executionStrategies.map(
+            (_, i) => space.executors_destinations[i] ?? ''
+          )
         })
       );
 

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -124,7 +124,8 @@ export function createEvmNetwork(networkId: NetworkID): Network {
       constants.RELAYER_AUTHENTICATORS[authenticator],
     isStrategySupported: (strategy: string) =>
       constants.SUPPORTED_STRATEGIES[strategy],
-    isExecutorSupported: () => true,
+    isExecutorSupported: (executorType: string) =>
+      executorType !== 'ReadOnlyExecution',
     isExecutorActionsSupported: (executorType: string) =>
       constants.SUPPORTED_EXECUTORS[executorType],
     pin,

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -124,8 +124,9 @@ export function createEvmNetwork(networkId: NetworkID): Network {
       constants.RELAYER_AUTHENTICATORS[authenticator],
     isStrategySupported: (strategy: string) =>
       constants.SUPPORTED_STRATEGIES[strategy],
-    isExecutorSupported: (executor: string) =>
-      constants.SUPPORTED_EXECUTORS[executor],
+    isExecutorSupported: () => true,
+    isExecutorActionsSupported: (executorType: string) =>
+      constants.SUPPORTED_EXECUTORS[executorType],
     pin,
     getSpaceController: async (space: Space) => space.controller,
     getTransaction: (txId: string) => provider.getTransaction(txId),

--- a/apps/ui/src/networks/offchain/index.ts
+++ b/apps/ui/src/networks/offchain/index.ts
@@ -29,16 +29,19 @@ export function createOffchainNetwork(networkId: NetworkID): Network {
   const provider = getProvider(l1ChainId);
   const api = createApi(hubUrl, networkId, constants);
 
+  const isExecutorSupported = (executorType: string) => {
+    if (executorType === 'oSnap') return true;
+    if (executorType === 'ReadOnlyExecution') return true;
+    return false;
+  };
+
   const helpers = {
     isAuthenticatorSupported: () => true,
     isAuthenticatorContractSupported: () => false,
     getRelayerAuthenticatorType: () => null,
     isStrategySupported: () => true,
-    isExecutorSupported: (executorType: string) => {
-      if (executorType === 'oSnap') return true;
-      if (executorType === 'ReadOnlyExecution') return true;
-      return false;
-    },
+    isExecutorSupported: isExecutorSupported,
+    isExecutorActionsSupported: isExecutorSupported,
     pin: pinPineapple,
     getSpaceController: async (space: Space) =>
       getSpaceController(space.id, l1ChainId),

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -603,6 +603,7 @@ export function createActions(
       votingStrategiesToAdd: StrategyConfig[],
       votingStrategiesToRemove: number[],
       validationStrategy: StrategyConfig,
+      executionStrategies: StrategyConfig[],
       votingDelay: number | null,
       minVotingDuration: number | null,
       maxVotingDuration: number | null
@@ -611,8 +612,12 @@ export function createActions(
 
       const pinned = await helpers.pin(
         createErc1155Metadata(metadata, {
-          execution_strategies: space.executors,
-          execution_strategies_types: space.executors_types,
+          execution_strategies: executionStrategies.map(
+            config => config.address
+          ),
+          execution_strategies_types: executionStrategies.map(
+            config => config.type
+          ),
           execution_destinations: space.executors_destinations
         })
       );

--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -83,6 +83,8 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
       constants.SUPPORTED_STRATEGIES[strategy],
     isExecutorSupported: (executor: string) =>
       constants.SUPPORTED_EXECUTORS[executor],
+    isExecutorActionsSupported: (executor: string) =>
+      constants.SUPPORTED_EXECUTORS[executor],
     pin: pinPineapple,
     getSpaceController: async (space: Space) => space.controller,
     getTransaction: txId => provider.getTransactionReceipt(txId),

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -286,6 +286,7 @@ export type NetworkActions = ReadOnlyNetworkActions & {
     votingStrategiesToAdd: StrategyConfig[],
     votingStrategiesToRemove: number[],
     validationStrategy: StrategyConfig,
+    executionStrategies: StrategyConfig[],
     votingDelay: number | null,
     minVotingDuration: number | null,
     maxVotingDuration: number | null

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -394,7 +394,18 @@ export type NetworkHelpers = {
     authenticator: string
   ): 'evm' | 'evm-tx' | 'starknet' | null;
   isStrategySupported(strategy: string): boolean;
-  isExecutorSupported(executor: string): boolean;
+  /**
+   * Checks if the executor type is supported.
+   * If supported executor can be used to create proposal execution.
+   * @param executorType executor type
+   */
+  isExecutorSupported(executorType: string): boolean;
+  /**
+   * Checks if the executor actions are supported.
+   * If supported UI will show execution actions for the executor.
+   * @param executorType executor type
+   */
+  isExecutorActionsSupported(executorType: string): boolean;
   pin: (content: any) => Promise<{ cid: string; provider: string }>;
   getSpaceController(space: Space): Promise<string>;
   getTransaction(txId: string): Promise<any>;

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -505,6 +505,7 @@ onBeforeUnmount(() => destroyAudio());
             .
           </UiAlert>
           <ProposalExecutionsList
+            :network-id="proposal.network"
             :proposal="proposal"
             :executions="proposal.executions"
           />

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useQueryClient } from '@tanstack/vue-query';
-import { getNetwork, offchainNetworks } from '@/networks';
+import { evmNetworks, getNetwork, offchainNetworks } from '@/networks';
 import { Space } from '@/types';
 
 const props = defineProps<{ space: Space }>();
@@ -26,6 +26,7 @@ const {
   validationStrategy,
   votingStrategies,
   proposalValidation,
+  executionStrategies,
   guidelines,
   template,
   quorumType,
@@ -63,6 +64,7 @@ const hasAdvancedErrors = ref(false);
 
 const executeFn = ref(save);
 const saving = ref(false);
+const customStrategyModalOpen = ref(false);
 
 type Tab = {
   id:
@@ -165,21 +167,6 @@ const activeTab: Ref<Tab['id']> = computed(() => {
   return 'profile';
 });
 const network = computed(() => getNetwork(props.space.network));
-
-const executionStrategies = computed(() => {
-  return props.space.executors.map((executor, i) => {
-    return {
-      id: executor,
-      address: executor,
-      name:
-        network.value.constants.EXECUTORS[executor] ||
-        network.value.constants.EXECUTORS[props.space.executors_types[i]] ||
-        props.space.executors_types[i],
-      params: {},
-      paramsDefinition: {}
-    };
-  });
-});
 
 const isTicketValid = computed(() => {
   return !(
@@ -284,6 +271,23 @@ function handleSpaceDelete() {
 
     return null;
   };
+}
+
+function addCustomStrategy(strategy: { address: string; type: string }) {
+  customStrategyModalOpen.value = false;
+
+  executionStrategies.value = [
+    ...executionStrategies.value,
+    {
+      id: crypto.randomUUID(),
+      address: strategy.address,
+      type: strategy.type,
+      generateSummary: () => strategy.type,
+      name: 'Custom strategy',
+      params: {},
+      paramsDefinition: {}
+    }
+  ];
 }
 
 function handleTabFocus(event: FocusEvent) {
@@ -451,6 +455,12 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
             :network-id="space.network"
             :strategy="strategy"
           />
+          <UiButton
+            v-if="evmNetworks.includes(space.network)"
+            @click="customStrategyModalOpen = true"
+          >
+            Add custom strategy
+          </UiButton>
         </div>
       </UiContainerSettings>
       <FormStrategies
@@ -569,6 +579,13 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
     </div>
   </UiToolbarBottom>
   <teleport to="#modal">
+    <ModalCustomStrategy
+      :open="customStrategyModalOpen"
+      :network-id="space.network"
+      :chain-id="network.chainId"
+      @close="customStrategyModalOpen = false"
+      @save="addCustomStrategy"
+    />
     <ModalTransactionProgress
       :open="saving && (!isOffchainNetwork || executeFn === saveController)"
       :chain-id="network.chainId"

--- a/packages/sx.js/src/executors/index.ts
+++ b/packages/sx.js/src/executors/index.ts
@@ -44,6 +44,13 @@ export function getExecutionData(
     );
   }
 
+  if (input?.transactions) {
+    return createAvatarExecutor().getExecutionData(
+      executorAddress,
+      input.transactions
+    );
+  }
+
   throw new Error(
     `Not enough data to create execution for executor ${executorAddress}`
   );


### PR DESCRIPTION
### Summary

This PR is resubmit of https://github.com/snapshot-labs/sx-monorepo/pull/1276, but now UI part.

1. Separated `isExecutorSupported` and `isExecutorActionsSupported` helpers. First one specifies if executor can be used to create execution, second one specifies if actions (like Execute transactions on passed proposals) are supported.
2. Added modal to add custom strategies to space.
3. Made changes so those custom strategies can be used at proposal creation.

### How to test

1. Create new Sepolia space.
2. Go to Settings and add custom execution strategy (`0x2afB54fcaECd41BE4Ecd05d7bd2e193F2F05B99d`).
3. Go to Treasuries and add the same address as treasury.
4. Save.
5. Try creating proposal, you can create execution on that treasury.
6. After proposal is created you can see execution.

### Out of scope for this PR

1. Ability to modify execution strategies (previously it was impossible to make any changes to executions on the UI, now you can add new strategy). With those changes we can in the future make it possible to add full editor support for executors (adding new strategies, removing same as in Space creation).