### PR TITLE
fix: hide OZVotesTrace208StorageProof from proposal validation

### DIFF
--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -477,7 +477,8 @@ export function createConstants(
         !(
           [
             config.Strategies.EVMSlotValue,
-            config.Strategies.OZVotesStorageProof
+            config.Strategies.OZVotesStorageProof,
+            config.Strategies.OZVotesTrace208StorageProof
           ] as string[]
         ).includes(strategy.address)
     );


### PR DESCRIPTION
### Summary

OZVotesStorageProof is already hidden, but we forgot to hide trace 208 variant

### How to test

1. Go to http://localhost:8080/#/create/snapshot-x
2. Select Starknet network.
3. Go to Proposal validation and select Voting power.
4. You can only select whitelist and ERC20 Votes strategies.