### PR TITLE
fix: make strategies order stable

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,7 +25,7 @@
     "@ethersproject/providers": "^5.7.2",
     "@ethersproject/units": "^5.6.1",
     "@faker-js/faker": "^7.4.0",
-    "@snapshot-labs/checkpoint": "^0.1.0-beta.56",
+    "@snapshot-labs/checkpoint": "^0.1.0-beta.57",
     "@snapshot-labs/sx": "^0.1.0",
     "@types/bn.js": "^5.1.0",
     "@types/mysql": "^2.15.21",

--- a/apps/api/src/common/ipfs.ts
+++ b/apps/api/src/common/ipfs.ts
@@ -124,10 +124,7 @@ export async function handleStrategiesMetadata(
     if (!metadataUri) continue;
 
     const index = startingIndex + i;
-    const uniqueId = `${spaceId}/${index}/${dropIpfs(metadataUri)}`;
-
-    const exists = await type.loadEntity(uniqueId, config.indexerName);
-    if (exists) continue;
+    const uniqueId = crypto.randomUUID();
 
     const strategiesParsedMetadataItem = new type(uniqueId, config.indexerName);
     strategiesParsedMetadataItem.space = spaceId;

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -162,7 +162,10 @@ function processStrategiesMetadata(
 ) {
   if (parsedMetadata.length === 0) return [];
 
-  const maxIndex = Math.max(...parsedMetadata.map(metadata => metadata.index));
+  // Those values are default sorted by block_range so newest entries are at the end
+  // To find *current* maxIndex we can just look at the last item.
+  // In the past there could be more strategies so we can't check for max index among all entries.
+  const maxIndex = parsedMetadata[parsedMetadata.length - 1].index;
 
   const metadataMap = Object.fromEntries(
     parsedMetadata.map(metadata => [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4089,10 +4089,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
-"@snapshot-labs/checkpoint@^0.1.0-beta.56":
-  version "0.1.0-beta.56"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/checkpoint/-/checkpoint-0.1.0-beta.56.tgz#f0220c24dc6d93b8ee85f0a114b4e1b4982d16ed"
-  integrity sha512-wWGq3HdzLiAiR6FCnl1mfhDW19G8VaSZpZhd/bjFvDpmfoe1NZDiZLnB7hwY9v7jaai8YWtSamkFtgmS9Q1dwA==
+"@snapshot-labs/checkpoint@^0.1.0-beta.57":
+  version "0.1.0-beta.57"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/checkpoint/-/checkpoint-0.1.0-beta.57.tgz#1df638a628a4c8bccf1c86cb660567d51bffe9f6"
+  integrity sha512-zUqHRxSD4UBU0B2BG4Ajm8+W7vAEhs+S+OfBV/c4C1ID2SojQ+oaY05ZDnHr5VoDS5sk+XzHhOnb31xjCQO0+A==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/address" "^5.7.0"


### PR DESCRIPTION
### Summary

Depends on: https://github.com/checkpoint-labs/checkpoint/pull/353

This PR addresses various issues related to proposal validation strategies mostly caused by unstable ordering, which has been now addressed at Checkpoint (now entities are sorted by `block_range`).

Testing against unstable ordering is problematic because it can't be reproduced reliably, but it should be addressed by the following changes:
#### 1. Order by block_range (in Checkpoint)
Newest entries are now last in results.

#### 2. fix: use unique ID for strategies metadata

For proposal validation strategies metadata we take last N items as current.

If we use try to reuse existing entities it can result in issues, for example:
1. Add whitelist strategy (ID: `0x001/0/ipfs-hash-1`).
2. Remove whitelist strategy and add ERC20 strategy (ID: `0x001/0/ipfs-hash-2`).
3. Remove ERC20 strategy and add *same* whitelist strategy (ID: `0x001/0/ipfs-hash-1`).

Because we already had that ID we won't create it, so
`voting_power_validation_strategies_parsed_metadata` would have `0x001/0/ipfs-hash-2`
as last entry, which isn't correct.

#### 3. fix: compute maxIndex from last entry in strategies metadatas

Previously we computed maxIndex just by looking at entire list of entries, but
this is not correct.

For example if in the past you had 3 strategies and now only have 1
maxIndex would end up being at 2 (because it's max index in all entries),
but it doesn't matter for current state.

We can compute it from last item which is now expected to be also
inserted last.

### How to test

1. `yarn dev:interactive` with UI + API using diff below and with Checkpoint linked.
2. Create new space on Starknet Sepolia with whitelist **proposal validation**.
3. Go to settings.
4. Copy whitelist contents and symbol (we will need it later).
5. Remove whitelist and add ERC20 Votes strategy instead.
6. Save.
7. Remove ERC20 Votes and add whitelist (with same contents and symbol as before).
8. It looks good.
9. Compare it on testnet.snapshot.box and there it's broken (whitelist is empty, symbol is from ERC20 Votes).
10. Try changing it more, adding, removing strategies.
11. It never breaks and updates as expected.
```diff
diff --git a/apps/api/src/starknet/config.ts b/apps/api/src/starknet/config.ts
index 49ef0f3a..2d40cb90 100644
--- a/apps/api/src/starknet/config.ts
+++ b/apps/api/src/starknet/config.ts
@@ -37,7 +37,7 @@ const CONFIG = {
     networkNodeUrl: snSepNetworkNodeUrl,
     l1NetworkNodeUrl: 'https://rpc.brovider.xyz/11155111',
     contract: starknetNetworks['sn-sep'].Meta.spaceFactory,
-    start: 17960,
+    start: 644773,
     verifiedSpaces: [
       '0x0141464688e48ae5b7c83045edb10ecc242ce0e1ad4ff44aca3402f7f47c1ab9'
     ]
```

### Before
<img width="625" alt="image" src="https://github.com/user-attachments/assets/96129c19-b2cd-4a28-923d-b82ca9a03eff" />

### After
<img width="564" alt="image" src="https://github.com/user-attachments/assets/82917a55-0e96-4e00-834c-b60bfd44420c" />

