### PR TITLE
feat: add global counters in API

### DIFF
--- a/apps/api/src/common/utils.ts
+++ b/apps/api/src/common/utils.ts
@@ -1,6 +1,24 @@
 import { faker } from '@faker-js/faker';
 import fetch from 'cross-fetch';
 import { hash } from 'starknet';
+import { Counter } from '../../.checkpoint/models';
+
+const COUNTER_ID = 'global_counter';
+
+export async function updateCounter(
+  indexerName: string,
+  value: 'space_count' | 'proposal_count' | 'vote_count',
+  increment: number
+) {
+  let counter = await Counter.loadEntity(COUNTER_ID, indexerName);
+  if (!counter) {
+    counter = new Counter(COUNTER_ID, indexerName);
+  }
+
+  counter[value] = counter[value] + increment;
+
+  await counter.save();
+}
 
 export function getUrl(uri: string, gateway = 'pineapple.fyi') {
   const ipfsGateway = `https://${gateway}`;

--- a/apps/api/src/common/utils.ts
+++ b/apps/api/src/common/utils.ts
@@ -1,18 +1,16 @@
 import { faker } from '@faker-js/faker';
 import fetch from 'cross-fetch';
 import { hash } from 'starknet';
-import { Counter } from '../../.checkpoint/models';
-
-const COUNTER_ID = 'global_counter';
+import { Network } from '../../.checkpoint/models';
 
 export async function updateCounter(
   indexerName: string,
   value: 'space_count' | 'proposal_count' | 'vote_count',
   increment: number
 ) {
-  let counter = await Counter.loadEntity(COUNTER_ID, indexerName);
+  let counter = await Network.loadEntity(indexerName, indexerName);
   if (!counter) {
-    counter = new Counter(COUNTER_ID, indexerName);
+    counter = new Network(indexerName, indexerName);
   }
 
   counter[value] = counter[value] + increment;

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -194,7 +194,7 @@ type Leaderboard {
   vote_count: Int!
 }
 
-type Counter {
+type Network {
   id: String!
   space_count: Int!
   proposal_count: Int!

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -194,6 +194,13 @@ type Leaderboard {
   vote_count: Int!
 }
 
+type Counter {
+  id: String!
+  space_count: Int!
+  proposal_count: Int!
+  vote_count: Int!
+}
+
 type StarknetL1Execution {
   id: String!
   space: String!


### PR DESCRIPTION
### Summary

This PR adds `networks` entity to API so you can keep track of `space_count`, `proposal_count`, `vote_count`.

Closes: https://github.com/snapshot-labs/workflow/issues/377

### How to test

1. Run API with `yarn dev:interactive`.
2. Let it run for a while.
3. Run following query:

```graphql
{
  networks {
    id
    _indexer
    space_count
    proposal_count
    vote_count
  }
}
```