### PR TITLE
feat: display proposals without metadata

### DIFF
--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -65,11 +65,11 @@ const totalProgress = computed(() => quorumProgress(props.proposal));
             class="text-[21px] inline [overflow-wrap:anywhere] min-w-0"
             v-text="proposal.title || `Proposal #${proposal.proposal_id}`"
           />
-          <span
-            v-if="proposal.isInvalid"
-            class="rounded truncate font-bold text-sm whitespace-nowrap px-1 py-1 bg-rose-100 border-rose-300 text-rose-500 dark:bg-rose-700 dark:border-rose-700 dark:text-neutral-100"
-            v-text="'FLAGGED'"
-          />
+          <UiTooltip v-if="proposal.isInvalid" title="This proposal is invalid">
+            <IH-exclamation-circle
+              class="inline-block text-skin-danger shrink-0 relative bottom-0.5"
+            />
+          </UiTooltip>
           <ProposalLabels
             v-if="proposal.space?.labels && proposal.labels.length"
             :space-id="`${proposal.network}:${proposal.space.id}`"

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -66,7 +66,7 @@ const totalProgress = computed(() => quorumProgress(props.proposal));
             v-text="proposal.title || `Proposal #${proposal.proposal_id}`"
           />
           <UiTooltip v-if="proposal.isInvalid" title="This proposal is invalid">
-            <IH-exclamation-circle
+            <IH-exclamation
               class="inline-block text-skin-danger shrink-0 relative bottom-0.5"
             />
           </UiTooltip>

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -65,6 +65,11 @@ const totalProgress = computed(() => quorumProgress(props.proposal));
             class="text-[21px] inline [overflow-wrap:anywhere] min-w-0"
             v-text="proposal.title || `Proposal #${proposal.proposal_id}`"
           />
+          <span
+            v-if="proposal.isInvalid"
+            class="rounded truncate font-bold text-sm whitespace-nowrap px-1 py-1 bg-rose-100 border-rose-300 text-rose-500 dark:bg-rose-700 dark:border-rose-700 dark:text-neutral-100"
+            v-text="'FLAGGED'"
+          />
           <ProposalLabels
             v-if="proposal.space?.labels && proposal.labels.length"
             :space-id="`${proposal.network}:${proposal.space.id}`"

--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -24,6 +24,7 @@ export const TURBO_URL =
 export const VERIFIED_URL =
   'https://help.snapshot.box/en/articles/9171639-how-to-get-my-space-verified';
 
+export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 export const ETH_CONTRACT = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 
 export const CHAIN_IDS: Record<Exclude<NetworkID, 's' | 's-tn'>, ChainId> = {

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -3,6 +3,7 @@ import { getAddress, isAddress } from '@ethersproject/address';
 import { Contract } from '@ethersproject/contracts';
 import { ensNormalize, namehash } from '@ethersproject/hash';
 import { call, multicall } from './call';
+import { EMPTY_ADDRESS } from './constants';
 import { getProvider } from './provider';
 import { getAddresses } from './stamp';
 
@@ -44,8 +45,6 @@ const ENS_CONTRACTS: ENSContracts = {
     11155111: '0x0635513f179D50A207757E05759CbD106d7dFcE8'
   }
 };
-
-const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 // see https://docs.ens.domains/registry/dns#gasless-import
 async function getDNSOwner(domain: string): Promise<string> {

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -3,7 +3,7 @@ import {
   createHttpLink,
   InMemoryCache
 } from '@apollo/client/core';
-import { CHAIN_IDS } from '@/helpers/constants';
+import { BASIC_CHOICES, CHAIN_IDS } from '@/helpers/constants';
 import { getProposalCurrentQuorum } from '@/helpers/quorum';
 import { getNames } from '@/helpers/stamp';
 import { clone, compareAddresses } from '@/helpers/utils';
@@ -81,13 +81,11 @@ function isSpaceWithMetadata(space: ApiSpace): space is ApiSpaceWithMetadata {
   );
 }
 
-function isProposalWithMetadata(
+function isProposalWithSpaceMetadata(
   proposal: ApiProposal
 ): proposal is ApiProposalWithMetadata {
   return (
-    !!proposal.metadata &&
-    !!proposal.space.metadata &&
-    !!proposal.space.strategies_parsed_metadata
+    !!proposal.space.metadata && !!proposal.space.strategies_parsed_metadata
   );
 }
 
@@ -306,6 +304,7 @@ function formatProposal(
 
   return {
     ...proposal,
+    isInvalid: proposal.metadata === null,
     space: {
       id: proposal.space.id,
       name: proposal.space.metadata.name,
@@ -327,14 +326,14 @@ function formatProposal(
       address_type: getAddressType(proposal.author),
       role: null
     },
-    metadata_uri: proposal.metadata.id,
+    metadata_uri: proposal.metadata?.id ?? '',
     type: 'basic',
-    choices: proposal.metadata.choices,
-    labels: proposal.metadata.labels,
+    choices: proposal.metadata?.choices ?? BASIC_CHOICES,
+    labels: proposal.metadata?.labels ?? [],
     scores: [proposal.scores_1, proposal.scores_2, proposal.scores_3],
-    title: proposal.metadata.title ?? '',
-    body: proposal.metadata.body ?? '',
-    discussion: proposal.metadata.discussion ?? '',
+    title: proposal.metadata?.title ?? `Proposal #${proposal.proposal_id}`,
+    body: proposal.metadata?.body ?? '',
+    discussion: proposal.metadata?.discussion ?? '',
     execution_network: executionNetworkId,
     executions: processExecutions(proposal, executionNetworkId),
     has_execution_window_opened: ['Axiom', 'EthRelayer'].includes(
@@ -504,9 +503,10 @@ export function createApi(
       searchQuery = ''
     ): Promise<Proposal[]> => {
       const _filters: ProposalsFilter = clone(filters || {});
-      const metadataFilters: Record<string, any> = {
-        title_contains_nocase: searchQuery
-      };
+
+      const metadataFilters: Record<string, any> = {};
+      if (searchQuery) metadataFilters.title_contains_nocase = searchQuery;
+
       const state = _filters.state;
 
       if (state === 'active') {
@@ -534,7 +534,9 @@ export function createApi(
           where: {
             space_in: spaceIds,
             cancelled: false,
-            metadata_: metadataFilters,
+            metadata_: Object.keys(metadataFilters).length
+              ? metadataFilters
+              : undefined,
             ..._filters
           }
         }
@@ -556,7 +558,7 @@ export function createApi(
       }
 
       return data.proposals
-        .filter(proposal => isProposalWithMetadata(proposal))
+        .filter(proposal => isProposalWithSpaceMetadata(proposal))
         .map(proposal =>
           formatProposal(proposal, networkId, current, opts.baseNetworkId)
         );
@@ -586,7 +588,7 @@ export function createApi(
         highlightResult?.data.sxproposal
       );
 
-      if (!isProposalWithMetadata(data.proposal)) return null;
+      if (!isProposalWithSpaceMetadata(data.proposal)) return null;
       return formatProposal(
         data.proposal,
         networkId,

--- a/apps/ui/src/networks/common/graphqlApi/types.ts
+++ b/apps/ui/src/networks/common/graphqlApi/types.ts
@@ -22,7 +22,6 @@ export type ApiSpaceWithMetadata = ApiSpace & {
   >[];
 };
 export type ApiProposalWithMetadata = ApiProposal & {
-  metadata: NonNullable<ApiProposal['metadata']>;
   space: NonNullable<ApiProposal['space']> & {
     metadata: NonNullable<ApiSpace['metadata']>;
     strategies_parsed_metadata: RequiredProperty<

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -332,6 +332,7 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     id: proposal.id,
     network: networkId,
     metadata_uri: proposal.ipfs,
+    isInvalid: false,
     author: {
       id: proposal.author,
       address_type: 1,

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -241,6 +241,10 @@ export type Proposal = {
   proposal_id: number | string;
   network: NetworkID;
   execution_network: NetworkID;
+  /**
+   * If proposal is invalid it means that it was not created correctly.
+   */
+  isInvalid: boolean;
   type: VoteType;
   quorum: number;
   quorum_type?: 'default' | 'rejection';

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useQueryClient } from '@tanstack/vue-query';
+import { EMPTY_ADDRESS } from '@/helpers/constants';
 import {
   _n,
   _rt,
@@ -285,6 +286,25 @@ onBeforeUnmount(() => destroyAudio());
       <UiAlert v-if="proposal.flagged" type="error" class="mb-3">
         This proposal might contain scams, offensive material, or be malicious
         in nature. Please proceed with caution.
+      </UiAlert>
+      <UiAlert v-if="proposal.isInvalid" type="error" class="mb-3">
+        <template v-if="proposal.execution_strategy === EMPTY_ADDRESS">
+          This proposal is invalid and was not created correctly. We cannot
+          display its details.
+        </template>
+        <template v-else>
+          <strong>Danger!</strong>
+
+          <div>
+            This proposal is invalid and was not created correctly. We cannot
+            display its details, and it <strong>includes execution</strong>.
+          </div>
+
+          <div>
+            This might mean possible malicious behavior. We strongly advise you
+            to reject this proposal.
+          </div>
+        </template>
       </UiAlert>
 
       <h1 class="mb-3 text-[40px] leading-[1.1em] break-words">

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -293,17 +293,10 @@ onBeforeUnmount(() => destroyAudio());
           display its details.
         </template>
         <template v-else>
-          <strong>Danger!</strong>
-
-          <div>
-            This proposal is invalid and was not created correctly. We cannot
-            display its details, and it <strong>includes execution</strong>.
-          </div>
-
-          <div>
-            This might mean possible malicious behavior. We strongly advise you
-            to reject this proposal.
-          </div>
+          This proposal is invalid and was not created correctly. We cannot
+          display its details, and it <strong>includes execution</strong>. This
+          might mean possible malicious behavior. We strongly advise you to
+          reject this proposal.
         </template>
       </UiAlert>
 


### PR DESCRIPTION
### Summary

This PR changes how we handle proposals without metadata.

Now they will be displayed with placeholder values.

At the same time it will be marked as invalid and appropriate label and message will be displayed on the UI.

If proposal also includes execution different messaging is used prompting users to reject it.

Closes: https://github.com/snapshot-labs/workflow/issues/498

### How to test

1. Go to http://localhost:8080/#/sep:0xB6f74Cf069E382E81834bBF4544277D2FC65b088
2. You see 3 proposals, 2 of them are flagged.
3. Go to first proposal, no message, it's valid proposal.
4. Go to second proposal, message is visible (it's invalid proposal without execution).
5. Go to third proposal, different message is visible (it's invalid proposal **with** execution).

### Screenshots

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/2c232902-e033-447a-97b1-e2b22a3f71d2" />


<img width="754" alt="image" src="https://github.com/user-attachments/assets/098c4dd3-82d7-4d85-b61c-4ba977f730f8" />

<img width="779" alt="image" src="https://github.com/user-attachments/assets/03fdb541-6904-4511-91c2-fb0787cbf7c8" />
