### PR TITLE
feat: use whitelist server to compute EVM merkletrees

### DIFF
--- a/.changeset/fluffy-dogs-shake.md
+++ b/.changeset/fluffy-dogs-shake.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+use whitelist server to compute EVM merkleWhitelist proof

--- a/.changeset/loud-shoes-attend.md
+++ b/.changeset/loud-shoes-attend.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+require params to be included in EMV strategies for propose and vote

--- a/apps/mana/src/eth/rpc.ts
+++ b/apps/mana/src/eth/rpc.ts
@@ -34,7 +34,10 @@ export const createNetworkHandler = (chainId: number) => {
 
   const getWallet = createWalletProxy(process.env.ETH_MNEMONIC || '', chainId);
 
-  const client = new clients.EvmEthereumTx({ networkConfig });
+  const client = new clients.EvmEthereumTx({
+    networkConfig,
+    whitelistServerUrl: 'https://wls.snapshot.box'
+  });
   const l1ExecutorClient = new clients.L1Executor();
 
   async function send(id: number, params: any, res: Response) {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -48,7 +48,6 @@
     "@ethersproject/wallet": "^5.7.0",
     "@headlessui-float/vue": "^0.15.0",
     "@headlessui/vue": "^1.7.23",
-    "@openzeppelin/merkle-tree": "^1.0.5",
     "@reown/appkit": "^1.6.8",
     "@safe-global/safe-apps-provider": "^0.17.1",
     "@safe-global/safe-apps-sdk": "^8.0.0",

--- a/apps/ui/src/helpers/whitelistServer.ts
+++ b/apps/ui/src/helpers/whitelistServer.ts
@@ -21,7 +21,7 @@ async function rpcCall(method: string, params: any) {
 }
 
 export async function generateMerkleTree(params: {
-  network: 'starknet';
+  network: 'starknet' | 'evm';
   entries: string[];
 }): Promise<string> {
   return rpcCall('generateMerkleTree', params);

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -290,6 +290,11 @@ export function createActions(
 
       const strategiesWithMetadata = await Promise.all(
         strategies.map(async strategy => {
+          const params =
+            space.voting_power_validation_strategy_strategies_params[
+              strategy.paramsIndex
+            ];
+
           const metadata = await parseStrategyMetadata(
             space.voting_power_validation_strategies_parsed_metadata[
               strategy.index
@@ -298,6 +303,7 @@ export function createActions(
 
           return {
             ...strategy,
+            params,
             metadata
           };
         })
@@ -469,12 +475,14 @@ export function createActions(
             strategy.index
           );
 
+          const params = proposal.strategies_params[strategy.paramsIndex];
           const metadata = await parseStrategyMetadata(
             proposal.space.strategies_parsed_metadata[metadataIndex].payload
           );
 
           return {
             ...strategy,
+            params,
             metadata
           };
         })

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -23,6 +23,7 @@ import Multicaller from '@/helpers/multicaller';
 import { getProvider } from '@/helpers/provider';
 import { convertToMetaTransactions } from '@/helpers/transactions';
 import { createErc1155Metadata, verifyNetwork } from '@/helpers/utils';
+import { WHITELIST_SERVER_URL } from '@/helpers/whitelistServer';
 import { EVM_CONNECTORS } from '@/networks/common/constants';
 import {
   buildMetadata,
@@ -79,9 +80,14 @@ export function createActions(
     managerConnectors: EVM_CONNECTORS
   });
 
-  const client = new clients.EvmEthereumTx({ networkConfig });
-  const ethSigClient = new clients.EvmEthereumSig({
+  const clientOpts = {
     networkConfig,
+    whitelistServerUrl: WHITELIST_SERVER_URL
+  };
+
+  const client = new clients.EvmEthereumTx(clientOpts);
+  const ethSigClient = new clients.EvmEthereumSig({
+    ...clientOpts,
     manaUrl: MANA_URL
   });
 

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -286,7 +286,8 @@ export function createConstants(
       generateParams: async (params: Record<string, any>) => {
         const entries = params.whitelist
           .split(/[\n,]/)
-          .filter((s: string) => s.trim().length);
+          .map((s: string) => s.trim())
+          .filter((s: string) => s.length);
 
         const requestId = await generateMerkleTree({
           network: 'starknet',

--- a/packages/sx.js/src/clients/evm/ethereum-sig/index.ts
+++ b/packages/sx.js/src/clients/evm/ethereum-sig/index.ts
@@ -12,10 +12,11 @@ import {
   voteTypes
 } from './types';
 import { getStrategiesWithParams } from '../../../strategies/evm';
-import { EvmNetworkConfig } from '../../../types';
 import { bytesToHex } from '../../../utils/bytes';
 import { SplitUint256 } from '../../../utils/split-uint256';
 import {
+  ClientConfig,
+  ClientOpts,
   EIP712ProposeMessage,
   EIP712UpdateProposalMessage,
   EIP712VoteMessage,
@@ -26,18 +27,11 @@ import {
   Vote
 } from '../types';
 
-type EthereumSigClientOpts = {
-  networkConfig: EvmNetworkConfig;
-  manaUrl?: string;
-};
-
 export class EthereumSig {
-  manaUrl: string;
-  networkConfig: EvmNetworkConfig;
+  config: ClientConfig & { manaUrl: string };
 
-  constructor(opts: EthereumSigClientOpts) {
-    this.networkConfig = opts?.networkConfig;
-    this.manaUrl = opts?.manaUrl || 'https://mana.box';
+  constructor(opts: ClientOpts & { manaUrl: string }) {
+    this.config = opts;
   }
 
   generateSalt() {
@@ -59,7 +53,7 @@ export class EthereumSig {
 
     const domain = {
       ...baseDomain,
-      chainId: this.networkConfig.eip712ChainId,
+      chainId: this.config.networkConfig.eip712ChainId,
       verifyingContract
     };
 
@@ -90,7 +84,7 @@ export class EthereumSig {
     };
 
     const res = await fetch(
-      `${this.manaUrl}/eth_rpc/${this.networkConfig.eip712ChainId}`,
+      `${this.config.manaUrl}/eth_rpc/${this.config.networkConfig.eip712ChainId}`,
       body
     );
     const json = await res.json();
@@ -112,7 +106,7 @@ export class EthereumSig {
       data.strategies,
       author,
       data,
-      this.networkConfig
+      this.config
     );
 
     const abiCoder = new AbiCoder();
@@ -186,7 +180,7 @@ export class EthereumSig {
       data.strategies,
       voter,
       data,
-      this.networkConfig
+      this.config
     );
 
     const message: EIP712VoteMessage = {

--- a/packages/sx.js/src/clients/evm/ethereum-tx/index.ts
+++ b/packages/sx.js/src/clients/evm/ethereum-tx/index.ts
@@ -11,9 +11,10 @@ import SpaceAbi from './abis/Space.json';
 import TimelockExecutionStrategyAbi from './abis/TimelockExecutionStrategy.json';
 import { getAuthenticator } from '../../../authenticators/evm';
 import { getStrategiesWithParams } from '../../../strategies/evm';
-import { EvmNetworkConfig } from '../../../types';
 import {
   AddressConfig,
+  ClientConfig,
+  ClientOpts,
   Envelope,
   Propose,
   UpdateProposal,
@@ -90,15 +91,15 @@ const NO_UPDATE_ADDRESS = '0xf2cda9b13ed04e585461605c0d6e804933ca8281';
 const NO_UPDATE_UINT32 = '0xf2cda9b1';
 
 export class EthereumTx {
-  networkConfig: EvmNetworkConfig;
+  config: ClientConfig;
 
-  constructor(opts: { networkConfig: EvmNetworkConfig }) {
-    this.networkConfig = opts.networkConfig;
+  constructor(opts: ClientOpts) {
+    this.config = opts;
   }
 
   get defaultTransactionOverrides() {
     return {
-      maxPriorityFeePerGas: this.networkConfig.maxPriorityFeePerGas
+      maxPriorityFeePerGas: this.config.networkConfig.maxPriorityFeePerGas
     };
   }
 
@@ -114,7 +115,7 @@ export class EthereumTx {
     saltNonce = saltNonce || `0x${randomBytes(32).toString('hex')}`;
 
     const implementationAddress =
-      this.networkConfig.executionStrategiesImplementations[
+      this.config.networkConfig.executionStrategiesImplementations[
         'SimpleQuorumAvatar'
       ];
 
@@ -127,7 +128,7 @@ export class EthereumTx {
       AvatarExecutionStrategyAbi
     );
     const proxyFactoryContract = new Contract(
-      this.networkConfig.proxyFactory,
+      this.config.networkConfig.proxyFactory,
       ProxyFactoryAbi,
       signer
     );
@@ -172,7 +173,7 @@ export class EthereumTx {
     saltNonce = saltNonce || `0x${randomBytes(32).toString('hex')}`;
 
     const implementationAddress =
-      this.networkConfig.executionStrategiesImplementations[
+      this.config.networkConfig.executionStrategiesImplementations[
         'SimpleQuorumTimelock'
       ];
 
@@ -185,7 +186,7 @@ export class EthereumTx {
       TimelockExecutionStrategyAbi
     );
     const proxyFactoryContract = new Contract(
-      this.networkConfig.proxyFactory,
+      this.config.networkConfig.proxyFactory,
       ProxyFactoryAbi,
       signer
     );
@@ -237,7 +238,7 @@ export class EthereumTx {
     saltNonce = saltNonce || `0x${randomBytes(32).toString('hex')}`;
 
     const implementationAddress =
-      this.networkConfig.executionStrategiesImplementations['Axiom'];
+      this.config.networkConfig.executionStrategiesImplementations['Axiom'];
 
     if (!implementationAddress) {
       throw new Error('Missing Axiom implementation address');
@@ -248,7 +249,7 @@ export class EthereumTx {
       AxiomExecutionStrategyAbi
     );
     const proxyFactoryContract = new Contract(
-      this.networkConfig.proxyFactory,
+      this.config.networkConfig.proxyFactory,
       ProxyFactoryAbi,
       signer
     );
@@ -299,7 +300,7 @@ export class EthereumTx {
     saltNonce = saltNonce || `0x${randomBytes(32).toString('hex')}`;
 
     const implementationAddress =
-      this.networkConfig.executionStrategiesImplementations['Isokratia'];
+      this.config.networkConfig.executionStrategiesImplementations['Isokratia'];
 
     if (!implementationAddress) {
       throw new Error('Missing Isokratia implementation address');
@@ -310,7 +311,7 @@ export class EthereumTx {
       IsokratiaExecutionStrategyAbi
     );
     const proxyFactoryContract = new Contract(
-      this.networkConfig.proxyFactory,
+      this.config.networkConfig.proxyFactory,
       ProxyFactoryAbi,
       signer
     );
@@ -368,7 +369,7 @@ export class EthereumTx {
 
     const spaceInterface = new Interface(SpaceAbi);
     const proxyFactoryContract = new Contract(
-      this.networkConfig.proxyFactory,
+      this.config.networkConfig.proxyFactory,
       ProxyFactoryAbi,
       signer
     );
@@ -395,11 +396,11 @@ export class EthereumTx {
       saltNonce
     });
     const address = await proxyFactoryContract.predictProxyAddress(
-      this.networkConfig.masterSpace,
+      this.config.networkConfig.masterSpace,
       salt
     );
     const response = await proxyFactoryContract.deployProxy(
-      this.networkConfig.masterSpace,
+      this.config.networkConfig.masterSpace,
       functionData,
       saltNonce,
       this.defaultTransactionOverrides
@@ -420,7 +421,7 @@ export class EthereumTx {
     saltNonce: string;
   }) {
     const proxyFactoryContract = new Contract(
-      this.networkConfig.proxyFactory,
+      this.config.networkConfig.proxyFactory,
       ProxyFactoryAbi,
       signer
     );
@@ -432,7 +433,7 @@ export class EthereumTx {
     });
 
     return proxyFactoryContract.predictProxyAddress(
-      this.networkConfig.masterSpace,
+      this.config.networkConfig.masterSpace,
       salt
     );
   }
@@ -449,7 +450,7 @@ export class EthereumTx {
       envelope.data.strategies,
       proposerAddress,
       envelope.data,
-      this.networkConfig
+      this.config
     );
 
     const abiCoder = new AbiCoder();
@@ -466,7 +467,7 @@ export class EthereumTx {
 
     const authenticator = getAuthenticator(
       envelope.data.authenticator,
-      this.networkConfig
+      this.config.networkConfig
     );
     if (!authenticator) {
       throw new Error('Invalid authenticator');
@@ -515,7 +516,7 @@ export class EthereumTx {
 
     const authenticator = getAuthenticator(
       envelope.data.authenticator,
-      this.networkConfig
+      this.config.networkConfig
     );
     if (!authenticator) {
       throw new Error('Invalid authenticator');
@@ -549,7 +550,7 @@ export class EthereumTx {
       envelope.data.strategies,
       voterAddress,
       envelope.data,
-      this.networkConfig
+      this.config
     );
 
     const spaceInterface = new Interface(SpaceAbi);
@@ -566,7 +567,7 @@ export class EthereumTx {
 
     const authenticator = getAuthenticator(
       envelope.data.authenticator,
-      this.networkConfig
+      this.config.networkConfig
     );
     if (!authenticator) {
       throw new Error('Invalid authenticator');

--- a/packages/sx.js/src/clients/evm/types.ts
+++ b/packages/sx.js/src/clients/evm/types.ts
@@ -4,6 +4,7 @@ import {
 } from '@ethersproject/abstract-signer';
 import { ContractInterface } from '@ethersproject/contracts';
 import { Provider } from '@ethersproject/providers';
+import { EvmNetworkConfig } from '../../types';
 
 enum Choice {
   Against = 0,
@@ -25,6 +26,16 @@ export type StrategyConfig = {
   index: number;
   address: string;
   metadata?: Record<string, any>;
+};
+
+export type ClientOpts = {
+  networkConfig: EvmNetworkConfig;
+  whitelistServerUrl: string;
+};
+
+export type ClientConfig = {
+  networkConfig: EvmNetworkConfig;
+  whitelistServerUrl: string;
 };
 
 export type Propose = {
@@ -73,7 +84,8 @@ export type Strategy = {
     strategyConfig: StrategyConfig,
     signerAddress: string,
     metadata: Record<string, any> | null,
-    data: Propose | Vote
+    data: Propose | Vote,
+    clientConfig: ClientConfig
   ): Promise<string>;
   getVotingPower(
     strategyAddress: string,

--- a/packages/sx.js/src/clients/evm/types.ts
+++ b/packages/sx.js/src/clients/evm/types.ts
@@ -25,6 +25,7 @@ export type IndexedConfig = {
 export type StrategyConfig = {
   index: number;
   address: string;
+  params: string;
   metadata?: Record<string, any>;
 };
 

--- a/packages/sx.js/src/strategies/evm/index.ts
+++ b/packages/sx.js/src/strategies/evm/index.ts
@@ -3,6 +3,7 @@ import createMerkleWhitelist from './merkleWhitelist';
 import createOzVotesStrategy from './ozVotes';
 import createVanillaStrategy from './vanilla';
 import {
+  ClientConfig,
   IndexedConfig,
   Propose,
   Strategy,
@@ -42,11 +43,14 @@ export async function getStrategiesWithParams(
   strategies: StrategyConfig[],
   signerAddress: string,
   data: Propose | Vote,
-  networkConfig: EvmNetworkConfig
+  config: ClientConfig
 ): Promise<IndexedConfig[]> {
   const results = await Promise.all(
     strategies.map(async strategyConfig => {
-      const strategy = getStrategy(strategyConfig.address, networkConfig);
+      const strategy = getStrategy(
+        strategyConfig.address,
+        config.networkConfig
+      );
       if (!strategy) throw new Error('Invalid strategy');
 
       try {
@@ -55,7 +59,8 @@ export async function getStrategiesWithParams(
           strategyConfig,
           signerAddress,
           strategyConfig.metadata || null,
-          data
+          data,
+          config
         );
 
         return {

--- a/packages/sx.js/test/integration/evm/index.test.ts
+++ b/packages/sx.js/test/integration/evm/index.test.ts
@@ -27,8 +27,14 @@ describe('EthereumTx', () => {
     testConfig = await setup(provider, signer);
     spaceAddress = testConfig.spaceAddress;
 
-    ethTxClient = new EthereumTx({ networkConfig: testConfig.networkConfig });
-    ethSigClient = new EthereumSig({ networkConfig: testConfig.networkConfig });
+    const clientOpts = {
+      networkConfig: testConfig.networkConfig,
+      whitelistServerUrl: 'https://wls.snapshot.box',
+      manaUrl: 'https://mana.box'
+    };
+
+    ethTxClient = new EthereumTx(clientOpts);
+    ethSigClient = new EthereumSig(clientOpts);
   });
 
   describe('vanilla authenticator', () => {

--- a/packages/sx.js/test/integration/evm/index.test.ts
+++ b/packages/sx.js/test/integration/evm/index.test.ts
@@ -43,7 +43,13 @@ describe('EthereumTx', () => {
         data: {
           space: spaceAddress,
           authenticator: testConfig.vanillaAuthenticator,
-          strategies: [{ index: 0, address: testConfig.vanillaVotingStrategy }],
+          strategies: [
+            {
+              index: 0,
+              address: testConfig.vanillaVotingStrategy,
+              params: testConfig.vanillaVotingStrategyParams
+            }
+          ],
           executionStrategy: {
             addr: testConfig.vanillaExecutionStrategy,
             params: '0x00'
@@ -64,7 +70,13 @@ describe('EthereumTx', () => {
         data: {
           space: spaceAddress,
           authenticator: testConfig.vanillaAuthenticator,
-          strategies: [{ index: 0, address: testConfig.vanillaVotingStrategy }],
+          strategies: [
+            {
+              index: 0,
+              address: testConfig.vanillaVotingStrategy,
+              params: testConfig.vanillaVotingStrategyParams
+            }
+          ],
           proposal: 1,
           choice: 0,
           metadataUri: ''
@@ -85,7 +97,13 @@ describe('EthereumTx', () => {
         data: {
           space: spaceAddress,
           authenticator: testConfig.ethTxAuthenticator,
-          strategies: [{ index: 0, address: testConfig.vanillaVotingStrategy }],
+          strategies: [
+            {
+              index: 0,
+              address: testConfig.vanillaVotingStrategy,
+              params: testConfig.vanillaVotingStrategyParams
+            }
+          ],
           executionStrategy: {
             addr: testConfig.vanillaExecutionStrategy,
             params: '0x00'
@@ -106,7 +124,13 @@ describe('EthereumTx', () => {
         data: {
           space: spaceAddress,
           authenticator: testConfig.ethTxAuthenticator,
-          strategies: [{ index: 0, address: testConfig.vanillaVotingStrategy }],
+          strategies: [
+            {
+              index: 0,
+              address: testConfig.vanillaVotingStrategy,
+              params: testConfig.vanillaVotingStrategyParams
+            }
+          ],
           proposal: 2,
           choice: 0,
           metadataUri: ''
@@ -128,7 +152,13 @@ describe('EthereumTx', () => {
         data: {
           space: spaceAddress,
           authenticator: testConfig.ethSigAuthenticator,
-          strategies: [{ index: 0, address: testConfig.vanillaVotingStrategy }],
+          strategies: [
+            {
+              index: 0,
+              address: testConfig.vanillaVotingStrategy,
+              params: testConfig.vanillaVotingStrategyParams
+            }
+          ],
           executionStrategy: {
             addr: testConfig.vanillaExecutionStrategy,
             params: '0x00'
@@ -150,7 +180,13 @@ describe('EthereumTx', () => {
         data: {
           space: spaceAddress,
           authenticator: testConfig.ethSigAuthenticator,
-          strategies: [{ index: 0, address: testConfig.vanillaVotingStrategy }],
+          strategies: [
+            {
+              index: 0,
+              address: testConfig.vanillaVotingStrategy,
+              params: testConfig.vanillaVotingStrategyParams
+            }
+          ],
           proposal: 3,
           choice: 0,
           metadataUri: ''
@@ -173,7 +209,13 @@ describe('EthereumTx', () => {
         data: {
           space: spaceAddress,
           authenticator: testConfig.vanillaAuthenticator,
-          strategies: [{ index: 0, address: testConfig.vanillaVotingStrategy }],
+          strategies: [
+            {
+              index: 0,
+              address: testConfig.vanillaVotingStrategy,
+              params: testConfig.vanillaVotingStrategyParams
+            }
+          ],
           executionStrategy: {
             addr: testConfig.vanillaExecutionStrategy,
             params: '0x00'
@@ -194,7 +236,13 @@ describe('EthereumTx', () => {
         data: {
           space: spaceAddress,
           authenticator: testConfig.vanillaAuthenticator,
-          strategies: [{ index: 1, address: testConfig.compVotingStrategy }],
+          strategies: [
+            {
+              index: 1,
+              address: testConfig.compVotingStrategy,
+              params: testConfig.compVotingStrategyParams
+            }
+          ],
           proposal: 4,
           choice: 0,
           metadataUri: ''
@@ -217,7 +265,13 @@ describe('EthereumTx', () => {
         data: {
           space: spaceAddress,
           authenticator: testConfig.vanillaAuthenticator,
-          strategies: [{ index: 0, address: testConfig.vanillaVotingStrategy }],
+          strategies: [
+            {
+              index: 0,
+              address: testConfig.vanillaVotingStrategy,
+              params: testConfig.vanillaVotingStrategyParams
+            }
+          ],
           executionStrategy: {
             addr: testConfig.vanillaExecutionStrategy,
             params: '0x00'
@@ -238,7 +292,13 @@ describe('EthereumTx', () => {
         data: {
           space: spaceAddress,
           authenticator: testConfig.vanillaAuthenticator,
-          strategies: [{ index: 2, address: testConfig.ozVotesVotingStrategy }],
+          strategies: [
+            {
+              index: 2,
+              address: testConfig.ozVotesVotingStrategy,
+              params: testConfig.ozVotesVotingStrategyParams
+            }
+          ],
           proposal: 5,
           choice: 0,
           metadataUri: ''
@@ -263,6 +323,7 @@ describe('EthereumTx', () => {
             {
               index: 3,
               address: testConfig.merkleWhitelistVotingStrategy,
+              params: testConfig.merkleWhitelistVotingStrategyParams,
               metadata: testConfig.merkleWhitelistStrategyMetadata
             }
           ],
@@ -290,6 +351,7 @@ describe('EthereumTx', () => {
             {
               index: 3,
               address: testConfig.merkleWhitelistVotingStrategy,
+              params: testConfig.merkleWhitelistVotingStrategyParams,
               metadata: testConfig.merkleWhitelistStrategyMetadata
             }
           ],
@@ -339,7 +401,13 @@ describe('EthereumTx', () => {
         data: {
           space: spaceAddress,
           authenticator: testConfig.vanillaAuthenticator,
-          strategies: [{ index: 0, address: testConfig.vanillaVotingStrategy }],
+          strategies: [
+            {
+              index: 0,
+              address: testConfig.vanillaVotingStrategy,
+              params: testConfig.vanillaVotingStrategyParams
+            }
+          ],
           executionStrategy: {
             addr: testConfig.avatarExecutionStrategy,
             params: executionStrategyParams
@@ -364,7 +432,13 @@ describe('EthereumTx', () => {
         data: {
           space: spaceAddress,
           authenticator: testConfig.vanillaAuthenticator,
-          strategies: [{ index: 0, address: testConfig.vanillaVotingStrategy }],
+          strategies: [
+            {
+              index: 0,
+              address: testConfig.vanillaVotingStrategy,
+              params: testConfig.vanillaVotingStrategyParams
+            }
+          ],
           proposal: 7,
           choice: 1,
           metadataUri: ''
@@ -425,7 +499,13 @@ describe('EthereumTx', () => {
         data: {
           space: spaceAddress,
           authenticator: testConfig.vanillaAuthenticator,
-          strategies: [{ index: 0, address: testConfig.vanillaVotingStrategy }],
+          strategies: [
+            {
+              index: 0,
+              address: testConfig.vanillaVotingStrategy,
+              params: testConfig.vanillaVotingStrategyParams
+            }
+          ],
           executionStrategy: {
             addr: testConfig.timelockExecutionStrategy,
             params: executionStrategyParams
@@ -450,7 +530,13 @@ describe('EthereumTx', () => {
         data: {
           space: spaceAddress,
           authenticator: testConfig.vanillaAuthenticator,
-          strategies: [{ index: 0, address: testConfig.vanillaVotingStrategy }],
+          strategies: [
+            {
+              index: 0,
+              address: testConfig.vanillaVotingStrategy,
+              params: testConfig.vanillaVotingStrategyParams
+            }
+          ],
           proposal: 8,
           choice: 1,
           metadataUri: ''

--- a/packages/sx.js/test/integration/evm/utils.ts
+++ b/packages/sx.js/test/integration/evm/utils.ts
@@ -39,9 +39,13 @@ export type TestConfig = {
   vanillaProposalValidationStrategy: string;
   votingPowerProposalValidationStrategy: string;
   vanillaVotingStrategy: string;
+  vanillaVotingStrategyParams: string;
   compVotingStrategy: string;
+  compVotingStrategyParams: string;
   ozVotesVotingStrategy: string;
+  ozVotesVotingStrategyParams: string;
   merkleWhitelistVotingStrategy: string;
+  merkleWhitelistVotingStrategyParams: string;
   vanillaExecutionStrategy: string;
   avatarExecutionStrategy: string;
   timelockExecutionStrategy: string;
@@ -353,9 +357,13 @@ export async function setup(
     vanillaProposalValidationStrategy,
     votingPowerProposalValidationStrategy,
     vanillaVotingStrategy,
+    vanillaVotingStrategyParams: '0x00',
     compVotingStrategy,
+    compVotingStrategyParams: compToken,
     ozVotesVotingStrategy,
+    ozVotesVotingStrategyParams: erc20VotesToken,
     merkleWhitelistVotingStrategy,
+    merkleWhitelistVotingStrategyParams: whitelistVotingStrategyParams,
     vanillaExecutionStrategy,
     avatarExecutionStrategy,
     timelockExecutionStrategy,

--- a/packages/sx.js/test/integration/evm/utils.ts
+++ b/packages/sx.js/test/integration/evm/utils.ts
@@ -191,7 +191,10 @@ export async function setup(
     }
   } as const;
 
-  const ethTxClient = new EthereumTx({ networkConfig });
+  const ethTxClient = new EthereumTx({
+    networkConfig,
+    whitelistServerUrl: 'https://wls.snapshot.box'
+  });
   const spaceAddress = await ethTxClient.predictSpaceAddress({
     signer,
     saltNonce: precomputedSpaceSalt

--- a/packages/sx.js/test/unit/clients/evm/ethereum-sig/__snapshots__/index.test.ts.snap
+++ b/packages/sx.js/test/unit/clients/evm/ethereum-sig/__snapshots__/index.test.ts.snap
@@ -14,6 +14,7 @@ exports[`EthereumSig > should create propose envelope 1`] = `
       {
         "address": "0xC1245C5DCa7885C73E32294140F1e5d30688c202",
         "index": 0,
+        "params": "0x00",
       },
     ],
   },
@@ -165,6 +166,7 @@ exports[`EthereumSig > should create vote envelope 1`] = `
       {
         "address": "0xC1245C5DCa7885C73E32294140F1e5d30688c202",
         "index": 0,
+        "params": "0x00",
       },
     ],
   },

--- a/packages/sx.js/test/unit/clients/evm/ethereum-sig/index.test.ts
+++ b/packages/sx.js/test/unit/clients/evm/ethereum-sig/index.test.ts
@@ -15,7 +15,9 @@ describe('EthereumSig', () => {
     provider
   );
   const ethSigClient = new EthereumSig({
-    networkConfig: evmSepolia
+    networkConfig: evmSepolia,
+    whitelistServerUrl: 'https://wls.snapshot.box',
+    manaUrl: 'https://mana.box'
   });
 
   beforeAll(() => {

--- a/packages/sx.js/test/unit/clients/evm/ethereum-sig/index.test.ts
+++ b/packages/sx.js/test/unit/clients/evm/ethereum-sig/index.test.ts
@@ -35,7 +35,11 @@ describe('EthereumSig', () => {
         space,
         authenticator,
         strategies: [
-          { index: 0, address: '0xC1245C5DCa7885C73E32294140F1e5d30688c202' }
+          {
+            index: 0,
+            address: '0xC1245C5DCa7885C73E32294140F1e5d30688c202',
+            params: '0x00'
+          }
         ],
         executionStrategy: { addr: executor, params: '0x00' },
         metadataUri: 'ipfs://QmNrm6xKuib1THtWkiN5CKtBEerQCDpUtmgDqiaU2xDmca'
@@ -67,7 +71,11 @@ describe('EthereumSig', () => {
         space,
         authenticator,
         strategies: [
-          { index: 0, address: '0xC1245C5DCa7885C73E32294140F1e5d30688c202' }
+          {
+            index: 0,
+            address: '0xC1245C5DCa7885C73E32294140F1e5d30688c202',
+            params: '0x00'
+          }
         ],
         proposal: 1,
         choice: 1,


### PR DESCRIPTION
### Summary

This PR moves computation of EVM merkletrees to [whitelist-server](https://github.com/snapshot-labs/whitelist-server).

Depends on: https://github.com/snapshot-labs/sx-monorepo/pull/1303
Closes: https://github.com/snapshot-labs/workflow/issues/517

### How to test

1. Run local UI and Mana (using `yarn dev:interactive`).
2. Copy whitelist from https://snapshot.box/#/base:0x282d013BF31374D0046F04D6a7644d97751ed339/settings/voting-strategies
3. Add it your space as voting strategy, before saving check voting strategy params is equals to `0xd94deeb88599f74495bb0b5eca0c62c8b3468f15afeffb8bad4714137535ecea` (same as before).
4. Create new proposal (if you are in that whitelist, if not add yourself first).
5. Vote on this proposal.
6. It works.

