### PR TITLE
fix: show proposal start time for pending proposal

### DIFF
--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { formatQuorum, quorumLabel, quorumProgress } from '@/helpers/quorum';
-import { _n, _rt, getProposalId, shortenAddress } from '@/helpers/utils';
+import { _n, _rt, _tt, getProposalId, shortenAddress } from '@/helpers/utils';
 import { Proposal as ProposalType } from '@/types';
 
 const props = withDefaults(
@@ -136,7 +136,12 @@ const totalProgress = computed(() => quorumProgress(props.proposal));
         type="button"
         class="text-skin-text"
         @click="modalOpenTimeline = true"
-        v-text="_rt(getTsFromCurrent(proposal.network, proposal.max_end))"
+        v-text="
+          proposal.state === 'pending'
+            ? 'Start in ' +
+              _tt(getTsFromCurrent(proposal.network, proposal.start))
+            : _rt(getTsFromCurrent(proposal.network, proposal.max_end))
+        "
       />
     </span>
   </div>

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -258,6 +258,15 @@ export function _rt(number) {
   }
 }
 
+export function _tt(number) {
+  try {
+    return dayjs().to(number * 1000, true);
+  } catch (e) {
+    console.log(e);
+    return '';
+  }
+}
+
 export function abiToDefinition(abi, chainId?: ChainId) {
   const definition = {
     $async: true,

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -4,6 +4,7 @@ import { EMPTY_ADDRESS } from '@/helpers/constants';
 import {
   _n,
   _rt,
+  _tt,
   compareAddresses,
   getProposalId,
   getUrl,
@@ -114,6 +115,10 @@ const votingTime = computed(() => {
 
   const current = getCurrent(props.proposal.network);
   if (!current) return null;
+
+  if (props.proposal.state === 'pending') {
+    return `Start in ${_tt(getTsFromCurrent(props.proposal.network, props.proposal.start))}`;
+  }
 
   const time = _rt(
     getTsFromCurrent(props.proposal.network, props.proposal.max_end)


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #1018 

### How to test

1. Go to http://localhost:8080/#/sn:0x07bd3419669f9f0cc8f19e9e2457089cdd4804a4c41a5729ee9c7fd02ab8ab62
2. For pending proposals, it should now explicitly show the time left to the proposal start ("Start in xxx"), instead of the more ambiguous "x days left", which can make user think that it's the time left before proposal start, but which is actually time left to the proposal end.

Reasoning is that for pending proposal, the time more important to the user is the start time. 
