### PR TITLE
fix: fix wrong label for starknet address input

### DIFF
--- a/apps/ui/src/components/Modal/ChangeController.vue
+++ b/apps/ui/src/components/Modal/ChangeController.vue
@@ -22,8 +22,7 @@ const controllerDefinition = computed(() => ({
   type: 'string',
   format: 'ens-or-address',
   chainId: props.chainId,
-  title: 'Controller',
-  examples: ['Address or ENS']
+  title: 'Controller'
 }));
 
 const formValidator = computed(() =>

--- a/apps/ui/src/components/Modal/Delegate.vue
+++ b/apps/ui/src/components/Modal/Delegate.vue
@@ -37,9 +37,8 @@ const formErrors = ref({} as Record<string, any>);
 const delegateDefinition = computed(() => ({
   type: 'string',
   format: 'ens-or-address',
-  chainId: props.delegation?.chainId ?? undefined,
-  title: 'Delegatee',
-  examples: ['Address or ENS']
+  chainId: selectedDelegation.value?.chainId ?? undefined,
+  title: 'Delegatee'
 }));
 
 const formValidator = computed(() =>

--- a/apps/ui/src/components/Modal/SendNft.vue
+++ b/apps/ui/src/components/Modal/SendNft.vue
@@ -22,8 +22,7 @@ const recipientDefinition = computed(() => ({
   type: 'string',
   format: 'ens-or-address',
   chainId: props.network,
-  title: 'Recipient',
-  examples: ['Address or ENS']
+  title: 'Recipient'
 }));
 
 const formValidator = computed(() =>

--- a/apps/ui/src/components/Modal/SendToken.vue
+++ b/apps/ui/src/components/Modal/SendToken.vue
@@ -81,8 +81,7 @@ const recipientDefinition = computed(() => ({
   type: 'string',
   format: 'ens-or-address',
   chainId: props.network,
-  title: 'Recipient',
-  examples: ['Address or ENS']
+  title: 'Recipient'
 }));
 
 const amountDefinition = computed(() => ({

--- a/apps/ui/src/components/Modal/Transaction.vue
+++ b/apps/ui/src/components/Modal/Transaction.vue
@@ -311,7 +311,6 @@ watchEffect(async () => {
           :definition="{
             type: 'string',
             title: 'Contract address',
-            examples: ['Address or ENS'],
             chainId: props.network
           }"
           @pick="handlePickerClick('to')"

--- a/apps/ui/src/components/Ui/InputAddress.vue
+++ b/apps/ui/src/components/Ui/InputAddress.vue
@@ -39,12 +39,19 @@ const emit = defineEmits<{
   (e: 'pick', path: string);
 }>();
 
+const isStarknetChainId = computed(() => {
+  return (
+    typeof props.definition?.chainId === 'string' &&
+    props.definition?.chainId in STARKNET_NETWORKS
+  );
+});
+
 const networkDetails = computed<NetworkDetails | null>(() => {
   const chainId = props.definition?.chainId;
 
   if (!chainId) return null;
 
-  if (typeof chainId === 'string' && chainId in STARKNET_NETWORKS) {
+  if (isStarknetChainId.value) {
     return STARKNET_NETWORKS[chainId];
   } else if (chainId in snapshotJsNetworks) {
     const network = snapshotJsNetworks[chainId];
@@ -55,6 +62,20 @@ const networkDetails = computed<NetworkDetails | null>(() => {
   }
 
   return null;
+});
+
+const definition = computed(() => {
+  const definition = props.definition;
+  if (!definition) return null;
+
+  return {
+    ...definition,
+    examples: definition.examples ?? [
+      !isStarknetChainId.value && definition.format === 'ens-or-address'
+        ? 'Address or ENS'
+        : '0x0000....'
+    ]
+  };
 });
 </script>
 
@@ -76,7 +97,7 @@ const networkDetails = computed<NetworkDetails | null>(() => {
       />
     </UiTooltip>
     <UiInputString
-      :definition="props.definition"
+      :definition="definition"
       :required="required"
       v-bind="$attrs as any"
       class="!pr-7"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1113

This PR fix an issue where the placeholder for a starknet address input is returning `Address or ENS`, even though ENS is not supported

This fix will return `Address or ENS` for evm address, and just `0x0000...` for starknet address.

In the current state, having this logic inside InputAddress component is a little weird, the better solution would be to use the `address` format for starknet, and `address-or-ens` for the rest, but it will lead to a lot more `if` condition in a lot of place.

In a later PR, we could refactor `address-or-ens` to `address-or-name`, and support .stark name, which will make putting all this logic inside this component logic.

### How to test

1. Go to http://localhost:8080/#/sn:0x07c251045154318a2376a3bb65be47d3c90df1740d8e35c9b9d943aa3f240e50/delegates
2. When delegating to a starknet address, the address input placeholder should show `0x0000....`
3. When delegating to a evm address, the address input placeholder should show `Address or ENS`
