### PR TITLE
fix: always show closed state for non-basic proposals

### DIFF
--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -86,6 +86,7 @@ function getProposalState(
     if (proposal.type !== 'basic') {
       return 'closed';
     }
+
     const currentQuorum = getProposalCurrentQuorum(networkId, {
       scores: proposal.scores,
       scores_total: proposal.scores_total,

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -83,6 +83,9 @@ function getProposalState(
   proposal: ApiProposal
 ): ProposalState {
   if (proposal.state === 'closed') {
+    if (proposal.type !== 'basic') {
+      return 'closed';
+    }
     const currentQuorum = getProposalCurrentQuorum(networkId, {
       scores: proposal.scores,
       scores_total: proposal.scores_total,
@@ -95,10 +98,6 @@ function getProposalState(
 
     if (currentQuorum < proposal.quorum) {
       return 'rejected';
-    }
-
-    if (proposal.type !== 'basic') {
-      return 'closed';
     }
 
     return proposal.scores[0] > proposal.scores[1] ? 'passed' : 'rejected';


### PR DESCRIPTION
### Summary
- Adjusted logic to return 'closed' for non-basic proposals


### How to test

1. Go to http://localhost:8080/#/s:citizenshouse.eth/proposal/0xd07e5c85dae5f59dc444838cbfba8ecf6bd5cabdc3e3787bfa7559877bfd2b1d
2. Proposal state should be closed instead of rejected