### PR TITLE
fix: adapt scrollbar color to theme

### DIFF
--- a/apps/ui/src/style.scss
+++ b/apps/ui/src/style.scss
@@ -67,6 +67,10 @@
   --success-active: rgba(87, 179, 117, 0.12);
 }
 
+* {
+	scrollbar-color: rgba(var(--text), 0.5) rgb(var(--border)) !important;
+}
+
 @font-face {
   font-family: 'Calibre';
   src: url('./assets/fonts/Calibre-Medium-Custom.woff2') format('woff2');


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/534

This issue will customize the scrollbar color to the light/dark/whitelabel theme

### How to test

1. Run `VITE_WHITE_LABEL_MAPPING='127.0.0.1;s:test.wa0x6e.eth' yarn dev`
2. Visit http://127.0.0.1:8080/#/
3. The scrollbar color should match the theme
4. Visit localhost
5. The scrollbar color for the light and dark theme should match
