### PR TITLE
chore: run dev:interactive script with node

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
     "type": "git",
     "url": "git@github.com:snapshot-labs/sx-monorepo.git"
   },
+  "type": "module",
   "scripts": {
     "dev": "turbo run dev --filter=!mana --filter=!api --filter=!api-subgraph",
-    "dev:interactive": "ts-node ./scripts/dev-interactive.ts",
+    "dev:interactive": "node --experimental-strip-types --no-warnings=ExperimentalWarning ./scripts/dev-interactive.ts",
     "build": "turbo run build",
     "test": "turbo run test",
     "test:integration": "turbo run test:integration",
@@ -28,12 +29,11 @@
     "@snapshot-labs/prettier-config": "^0.1.0-beta.19",
     "eslint": "^8.57.0",
     "prettier": "^3.1.0",
-    "ts-node": "^10.9.2",
     "turbo": "^2.4.0",
     "typescript": "^5.8.3"
   },
   "engines": {
-    "node": ">=22.x"
+    "node": ">=22.6"
   },
   "packageManager": "yarn@1.22.19",
   "workspaces": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15515,7 +15515,7 @@ ts-mixer@^6.0.3:
   resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-6.0.4.tgz#1da39ceabc09d947a82140d9f09db0f84919ca28"
   integrity sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==
 
-ts-node@^10.9.1, ts-node@^10.9.2:
+ts-node@^10.9.1:
   version "10.9.2"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
   integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==


### PR DESCRIPTION
### Summary

Currently we run that script with ts-node, but it has its own latency so it takes a while for our code to run.

Node v22.6.0 shipped with TS type stripping (behind experimental flag). It's no longer exerimental in Node v23, but we keep those flags for now.

By using node directly we make this script startup faster.

### How to test

1. Run `yarn dev:interactive`.
2. It works.

