### PR TITLE
chore: remove un-used `loaded` ref

### DIFF
--- a/apps/ui/src/views/Settings/Spaces.vue
+++ b/apps/ui/src/views/Settings/Spaces.vue
@@ -17,7 +17,6 @@ const route = useRoute();
 const router = useRouter();
 const { web3 } = useWeb3();
 
-const loaded = ref(false);
 const protocol = ref<ExplorePageProtocol>(DEFAULT_PROTOCOL);
 
 const { data, isPending } = useExploreSpacesQuery({
@@ -26,10 +25,7 @@ const { data, isPending } = useExploreSpacesQuery({
 });
 
 const loading = computed(
-  () =>
-    !loaded.value ||
-    (web3.value.account && isPending.value) ||
-    web3.value.authLoading
+  () => (web3.value.account && isPending.value) || web3.value.authLoading
 );
 
 watch(protocol, value => {


### PR DESCRIPTION
### Summary
Looks like we are not setting it to true anymore


### How to test
Go to http://localhost:8080/#/settings
you should see your spaces/a message instead of loading icon

