### PR TITLE
fix: updated provider to use the delegation's chain ID instead of wallet's chainid

### DIFF
--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -679,11 +679,7 @@ export function useActions() {
     const actionNetwork = getDelegationNetwork(delegation.chainId);
     const network = getReadWriteNetwork(actionNetwork);
 
-    return network.actions.getDelegatee(
-      auth.value.provider,
-      delegation,
-      delegator
-    );
+    return network.actions.getDelegatee(delegation, delegator);
   }
 
   async function followSpace(networkId: NetworkID, spaceId: string) {

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -660,19 +660,22 @@ export function createActions(
       );
     },
     getDelegatee: async (
-      web3: any,
       delegation: SpaceMetadataDelegation,
       delegator: string
     ) => {
       const { contractAddress } = delegation;
-      if (!contractAddress) return null;
-      if (!isAddress(delegator)) return null;
+      if (!contractAddress || !delegation.chainId || !isAddress(delegator))
+        return null;
 
-      const multi = new Multicaller(chainId.toString(), provider, [
-        'function decimals() view returns (uint8)',
-        'function balanceOf(address account) view returns (uint256)',
-        'function delegates(address) view returns (address)'
-      ]);
+      const multi = new Multicaller(
+        delegation.chainId.toString(),
+        getProvider(delegation.chainId as number),
+        [
+          'function decimals() view returns (uint8)',
+          'function balanceOf(address account) view returns (uint256)',
+          'function delegates(address) view returns (address)'
+        ]
+      );
       multi.call('decimals', contractAddress, 'decimals');
       multi.call('balanceOf', contractAddress, 'balanceOf', [delegator]);
       multi.call('delegatee', contractAddress, 'delegates', [delegator]);

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -717,7 +717,6 @@ export function createActions(
       return account.execute(calls);
     },
     getDelegatee: async (
-      web3: any,
       delegation: SpaceMetadataDelegation,
       delegator: string
     ) => {

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -301,7 +301,6 @@ export type NetworkActions = ReadOnlyNetworkActions & {
     chainIdOverride?: ChainId
   );
   getDelegatee(
-    web3: Web3Provider,
     delegation: SpaceMetadataDelegation,
     delegator: string
   ): Promise<{ address: string; balance: bigint; decimals: number } | null>;


### PR DESCRIPTION

### Summary

- Updated provider to use the delegation's chain ID instead of wallet's chainID
- Removed unnecessary `web3` parameter from `getDelegatee` in EVM and Starknet actions

Closes: https://github.com/snapshot-labs/workflow/issues/537

### How to test

1. Go to http://localhost:8080/#/s:arcadiafi.eth/delegates
2. Delegations should work

### To-Do

- [ ]

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
