### PR TITLE
fix: add guest connector to list of offchain supported connectors

### DIFF
--- a/apps/ui/src/networks/offchain/constants.ts
+++ b/apps/ui/src/networks/offchain/constants.ts
@@ -16,7 +16,8 @@ export const CONNECTORS: ConnectorType[] = [
   'walletconnect',
   'coinbase',
   'gnosis',
-  'sequence'
+  'sequence',
+  'guest'
 ];
 export const EDITOR_AUTHENTICATORS = [];
 export const EDITOR_PROPOSAL_VALIDATIONS = [];


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR adds the `guest` connector to the list of connectors supported by offchain networks.

Guest is already added to evm and starknet, adding it to offchain was missed.

This currently only fix an issue with a the future pr https://github.com/snapshot-labs/sx-monorepo/pull/1200, where the payment modal does not work when connected as guest
