### PR TITLE
refactor: move delegatees fetching to own query file

### DIFF
--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -121,7 +121,7 @@ export function useDelegateesQuery(
     queryKey: [
       'delegatees',
       () => toValue(delegation).contractAddress,
-      () => toValue(account)
+      account
     ],
     queryFn: () =>
       FETCH_DELEGATEE_FN[

--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -1,0 +1,135 @@
+import { getAddress } from '@ethersproject/address';
+import { useQuery } from '@tanstack/vue-query';
+import { MaybeRefOrGetter } from 'vue';
+import { getNames } from '@/helpers/stamp';
+import { getNetwork, supportsNullCurrent } from '@/networks';
+import { RequiredProperty, Space, SpaceMetadataDelegation } from '@/types';
+
+type Delegatee = {
+  id: string;
+  balance: number;
+  share: number;
+  name?: string;
+};
+
+const FETCH_DELEGATEE_FN = {
+  'governor-subgraph': fetchGovernorSubgraphDelegatee,
+  'delegate-registry': fetchDelegateRegistryDelegatee
+} as const;
+
+async function fetchGovernorSubgraphDelegatee(
+  account: string,
+  delegation: SpaceMetadataDelegation,
+  space: Space
+): Promise<Delegatee | null> {
+  const { getDelegatee } = useActions();
+  const { getDelegates } = useDelegates(
+    delegation as RequiredProperty<typeof delegation>,
+    space
+  );
+
+  const delegateeData = await getDelegatee(delegation, account);
+
+  if (!delegateeData) return null;
+
+  const [names, [apiDelegate]] = await Promise.all([
+    getNames([delegateeData.address]),
+    getDelegates({
+      first: 1,
+      skip: 0,
+      orderBy: 'delegatedVotes',
+      orderDirection: 'desc',
+      where: {
+        // NOTE: This is subgraph, needs to be lowercase
+        user: delegateeData.address.toLocaleLowerCase()
+      }
+    })
+  ]);
+
+  return {
+    id: delegateeData.address,
+    balance: Number(delegateeData.balance) / 10 ** delegateeData.decimals,
+    share:
+      apiDelegate && apiDelegate.delegatedVotesRaw !== '0'
+        ? Number(delegateeData.balance) / Number(apiDelegate.delegatedVotesRaw)
+        : 1,
+    name: names[delegateeData.address]
+  };
+}
+
+async function fetchDelegateRegistryDelegatee(
+  account: string,
+  delegation: SpaceMetadataDelegation,
+  space: Space
+): Promise<Delegatee | null> {
+  const { getDelegates, getDelegation } = useDelegates(
+    delegation as RequiredProperty<typeof delegation>,
+    space
+  );
+  const { getCurrent } = useMetaStore();
+
+  const accountDelegation = await getDelegation(account);
+
+  if (!accountDelegation) return null;
+
+  const [names, votingPowers, [apiDelegate]] = await Promise.all([
+    getNames([accountDelegation.delegate]),
+    getNetwork(space.network).actions.getVotingPower(
+      space.id,
+      space.strategies,
+      space.strategies_params,
+      space.strategies_parsed_metadata,
+      account,
+      {
+        at: supportsNullCurrent(space.network)
+          ? null
+          : getCurrent(space.network) || 0,
+        chainId: space.snapshot_chain_id
+      }
+    ),
+    getDelegates({
+      first: 1,
+      skip: 0,
+      orderBy: 'delegatedVotes',
+      orderDirection: 'desc',
+      where: {
+        // NOTE: this is delegate registry, needs to be checksummed
+        user: getAddress(accountDelegation.delegate)
+      }
+    })
+  ]);
+
+  const balance = votingPowers.reduce(
+    (acc, b) => acc + Number(b.value) / 10 ** b.cumulativeDecimals,
+    0
+  );
+
+  return {
+    id: accountDelegation.delegate,
+    balance,
+    share: apiDelegate ? balance / Number(apiDelegate.delegatedVotes) : 1,
+    name: names[accountDelegation.delegate]
+  };
+}
+
+export function useDelegateesQuery(
+  account: MaybeRefOrGetter<string>,
+  space: MaybeRefOrGetter<Space>,
+  delegation: MaybeRefOrGetter<SpaceMetadataDelegation>
+) {
+  return useQuery({
+    queryKey: [
+      'delegatees',
+      () => toValue(delegation).contractAddress,
+      () => toValue(account)
+    ],
+    queryFn: () =>
+      FETCH_DELEGATEE_FN[
+        toValue(delegation).apiType as keyof typeof FETCH_DELEGATEE_FN
+      ](toValue(account), toValue(delegation), toValue(space)),
+    enabled:
+      !!toValue(account) &&
+      !!toValue(delegation).chainId &&
+      !!toValue(delegation).apiType
+  });
+}


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward https://github.com/snapshot-labs/workflow/issues/540

This PR start a refactoring process on the SpaceDelegation vue file, by moving the delegatee fetching using tanstack query into its own file, to make the vue file more slim, in anticipation of future code, handling the split delegation.

### How to test

1. Go to http://localhost:8080/#/sn:0x009fedaf0d7a480d21a27683b0965c0f8ded35b3f1cac39827a25a06a8a682a4/delegates?as=0cf5e.eth then ethereum tab
2. Go to https://snapshot.box/#/sn:0x009fedaf0d7a480d21a27683b0965c0f8ded35b3f1cac39827a25a06a8a682a4/delegates?as=0cf5e.eth then ethereum tab
3. The 2 pages above should give the same result
4. Changing wallet should reflect 
