### PR TITLE
refactor: move delegates vue queries into its own file

### DIFF
--- a/apps/ui/src/queries/delegates.ts
+++ b/apps/ui/src/queries/delegates.ts
@@ -1,0 +1,47 @@
+import { useInfiniteQuery } from '@tanstack/vue-query';
+import { MaybeRefOrGetter } from 'vue';
+import { RequiredProperty, Space, SpaceMetadataDelegation } from '@/types';
+
+const ITEMS_PER_PAGE = 40;
+const RETRY_COUNT = 3;
+
+export function useDelegatesQuery(
+  delegation: MaybeRefOrGetter<SpaceMetadataDelegation>,
+  space: MaybeRefOrGetter<Space>,
+  sortBy: MaybeRefOrGetter<
+    | 'delegatedVotes-desc'
+    | 'delegatedVotes-asc'
+    | 'tokenHoldersRepresentedAmount-desc'
+    | 'tokenHoldersRepresentedAmount-asc'
+  >
+) {
+  const { getDelegates } = useDelegates(
+    toValue(delegation) as RequiredProperty<SpaceMetadataDelegation>,
+    toValue(space)
+  );
+
+  return useInfiniteQuery({
+    initialPageParam: 0,
+    queryKey: ['delegates', () => toValue(delegation).contractAddress, sortBy],
+    queryFn: ({ pageParam }) => {
+      const [orderBy, orderDirection] = toValue(sortBy).split('-');
+
+      return getDelegates({
+        orderBy,
+        orderDirection,
+        first: ITEMS_PER_PAGE,
+        skip: pageParam
+      });
+    },
+    getNextPageParam: (lastPage, pages) => {
+      if (lastPage.length < ITEMS_PER_PAGE) return null;
+
+      return pages.length * ITEMS_PER_PAGE;
+    },
+    retry: (failureCount, error) => {
+      if (error?.message.includes('Row not found')) return false;
+
+      return failureCount < RETRY_COUNT;
+    }
+  });
+}


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward https://github.com/snapshot-labs/workflow/issues/540

Similar to https://github.com/snapshot-labs/sx-monorepo/pull/1345 , this PR moves the delegates vue query into its own file

### How to test

1. Go to http://localhost:8080/#/s:starknet.eth/delegates
2. It should work as before