### PR TITLE
fix: map v in RSV to 27 or 28

### DIFF
--- a/packages/sx.js/src/utils/encoding/eth-sig.ts
+++ b/packages/sx.js/src/utils/encoding/eth-sig.ts
@@ -5,8 +5,14 @@ export function getRSVFromSig(sig: string) {
   if (sig.startsWith('0x')) {
     sig = sig.substring(2);
   }
+
+  // NOTE: v needs to be 27 or 28
+  // Some wallets use 0 or 1 instead, so we need to map it.
+  let v = parseInt(`0x${sig.substring(64 * 2)}`, 16);
+  v = v < 27 ? v + 27 : v;
+
   const r = SplitUint256.fromHex(`0x${sig.substring(0, 64)}`);
   const s = SplitUint256.fromHex(`0x${sig.substring(64, 64 * 2)}`);
-  const v = `0x${sig.substring(64 * 2)}`;
-  return { r, s, v };
+
+  return { r, s, v: `0x${v.toString(16)}` };
 }


### PR DESCRIPTION
### Summary

V needs to be either 27 or 28, but some wallets use 0 and 1 so this needs to be mapped.
