### PR TITLE
chore: use esnext tsconfig for building dev version of sx.js

### DIFF
--- a/packages/sx.js/package.json
+++ b/packages/sx.js/package.json
@@ -16,7 +16,7 @@
     }
   },
   "scripts": {
-    "dev": "tsc -w",
+    "dev": "tsc -w -p tsconfig.esnext.json",
     "build": "tsc -p tsconfig.esnext.json && tsc -p tsconfig.cjs.json",
     "typecheck": "tsc --noEmit",
     "lint": "eslint ./src ./test --ext .ts",


### PR DESCRIPTION
### Summary

As our default config (used in IDEs) includes both src/ and test/ then building project with it will create those subdirectories in dist/

But this is not the structure our npm package exposes (files should be in dist directly). Because of this UI won't automatically reload when there are changes in sx.js.

Regression from https://github.com/snapshot-labs/sx-monorepo/pull/1320


### How to test

1. Run `yarn dev`.
2. Open UI in your browser.
3. Make some change in sx.js package.
4. UI reloads.

