### PR TITLE
fix: issues with InputCheckbox and transaction handling

### DIFF
--- a/apps/ui/src/components/Ui/InputCheckbox.vue
+++ b/apps/ui/src/components/Ui/InputCheckbox.vue
@@ -27,6 +27,12 @@ const inputValue = computed({
   }
 });
 
+onMounted(() => {
+  if (model.value === undefined && !dirty.value) {
+    model.value = props.definition.default ?? false;
+  }
+});
+
 watch(model, () => {
   dirty.value = true;
 });
@@ -34,11 +40,11 @@ watch(model, () => {
 
 <template>
   <UiWrapperInput
+    v-slot="{ id }"
     :definition="definition"
     :error="error"
     :dirty="dirty"
-    :required="required"
   >
-    <input v-model="inputValue" type="checkbox" />
+    <input :id="id" v-model="inputValue" type="checkbox" class="mt-[7px]" />
   </UiWrapperInput>
 </template>

--- a/apps/ui/src/helpers/transactions.ts
+++ b/apps/ui/src/helpers/transactions.ts
@@ -122,7 +122,7 @@ export async function createSendNftTransaction({
 export async function createContractCallTransaction({
   form
 }): Promise<ContractCallTransaction> {
-  const args: any[] = Object.values(form.args);
+  let args: any[] = Object.values(form.args);
 
   let recipientAddress = form.to;
   const resolvedTo = await resolver.resolveName(form.to);
@@ -133,6 +133,11 @@ export async function createContractCallTransaction({
   const methodAbi = iface.functions[form.method];
 
   if (methodAbi) {
+    // Send in same order as the ABI
+    args = methodAbi.inputs.map(({ name }) => {
+      return form.args[name];
+    });
+
     await Promise.all(
       methodAbi.inputs.map(async (input, i) => {
         if (input.type === 'address') {

--- a/apps/ui/src/style.scss
+++ b/apps/ui/src/style.scss
@@ -377,6 +377,9 @@ input:placeholder-shown {
 
   .s-label {
     @apply absolute px-3 mt-1 text-[17px];
+    &:has(+ input[type="checkbox"]) {
+      @apply px-0 m-0 ml-3.5;
+    }
   }
 
   .s-input {


### PR DESCRIPTION
Two issues are handled in this

1. Unable to click checkbox
    Users are not able to click the checkbox
    <img width="537" alt="Untitled 4" src="https://github.com/user-attachments/assets/b25bba6b-feae-4a68-9b48-b0d399286cc7" />
    There are multiple reasons for this:
      - Padding is overlaping
      - No default value
      - No id for label
     

2.  Unable to submit the form because we are passing wrong args order than ABI
In this case it is expecting `bytes32,uint256,bool` but we are passing `[true,"0x7d0de5791c9acd069e616817b7b1ce2becaa81e7a4d236e44c9e400c1a9e7b91","114440878338729613389"]`


### Summary
- Improved InputCheckbox component to ensure default value is set correctly on mount (false), 
- Removed required mark and style fixes for checkbox
- Updated transaction helper to maintain argument order as per ABI


### How to test

1. Go to http://localhost:8080/#/s:paraswap-dao.eth/create/yrbww
2. Add a `contract call` on `GovCo Optimism` 
3. Use contract address `0x17e29ff036f3a4feb18393cc0df53619be3cb739`
4. Select `updateMerkleRootAndTransferRewards(bytes32,uint256,bool)`
5. Enter `0x7d0de5791c9acd069e616817b7b1ce2becaa81e7a4d236e44c9e400c1a9e7b91` in markelroot
6. Enter `114440878338729613389` in rewards
7. Checkbox should be clickable and value should change accordingly (default to false)
8. Once you submit the form, transaction should show on proposal
