### PR TITLE
fix: use placeholder names for inputs if they are missing

### DIFF
--- a/apps/ui/src/helpers/utils.test.ts
+++ b/apps/ui/src/helpers/utils.test.ts
@@ -1,8 +1,10 @@
+import { Interface } from '@ethersproject/abi';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
   _d,
   _rt,
   _vp,
+  abiToDefinition,
   createErc1155Metadata,
   formatAddress,
   getStampUrl,
@@ -266,6 +268,60 @@ describe('utils', () => {
       ).toBe(
         'https://cdn.stamp.fyi/space/0x000000000000000000000000000000000000dEaD?s=64&cb=1234'
       );
+    });
+  });
+
+  describe('abiToDefinition', () => {
+    it('should use placeholder input names if none are provided', () => {
+      const abi = [
+        'constructor(address _pool, address _lptoken, address _booster)',
+        'event Approval(address indexed owner, address indexed spender, uint256 value)',
+        'event Transfer(address indexed from, address indexed to, uint256 value)',
+        'function allowance(address, address) pure returns (uint256)',
+        'function approve(address, uint256) pure returns (bool)',
+        'function balanceOf(address account) view returns (uint256)',
+        'function booster() view returns (address)',
+        'function contractType() view returns (bytes32)',
+        'function curveToken() view returns (address)',
+        'function decimals() view returns (uint8)',
+        'function getPhantomTokenInfo() view returns (address, address)',
+        'function name() view returns (string)',
+        'function pool() view returns (address)',
+        'function symbol() view returns (string)',
+        'function totalSupply() view returns (uint256)',
+        'function transfer(address, uint256) pure returns (bool)',
+        'function transferFrom(address, address, uint256) pure returns (bool)',
+        'function underlying() view returns (address)',
+        'function version() view returns (uint256)'
+      ];
+
+      const iface = new Interface(abi);
+
+      const definition = abiToDefinition(iface.getFunction('allowance'), 1);
+
+      expect(definition).toEqual({
+        $async: true,
+        additionalProperties: false,
+        properties: {
+          input1: {
+            chainId: 1,
+            examples: ['0x0000…'],
+            format: 'ens-or-address',
+            title: 'input1 (address)',
+            type: 'string'
+          },
+          input2: {
+            chainId: 1,
+            examples: ['0x0000…'],
+            format: 'ens-or-address',
+            title: 'input2 (address)',
+            type: 'string'
+          }
+        },
+        required: ['input1', 'input2'],
+        title: 'allowance',
+        type: 'object'
+      });
     });
   });
 });

--- a/apps/ui/src/helpers/utils.test.ts
+++ b/apps/ui/src/helpers/utils.test.ts
@@ -303,14 +303,14 @@ describe('utils', () => {
         $async: true,
         additionalProperties: false,
         properties: {
-          input1: {
+          'Input 1': {
             chainId: 1,
             examples: ['0x0000…'],
             format: 'ens-or-address',
             title: 'Input 1 (address)',
             type: 'string'
           },
-          input2: {
+          'Input 2': {
             chainId: 1,
             examples: ['0x0000…'],
             format: 'ens-or-address',

--- a/apps/ui/src/helpers/utils.test.ts
+++ b/apps/ui/src/helpers/utils.test.ts
@@ -307,18 +307,18 @@ describe('utils', () => {
             chainId: 1,
             examples: ['0x0000…'],
             format: 'ens-or-address',
-            title: 'input1 (address)',
+            title: 'Input 1 (address)',
             type: 'string'
           },
           input2: {
             chainId: 1,
             examples: ['0x0000…'],
             format: 'ens-or-address',
-            title: 'input2 (address)',
+            title: 'Input 2 (address)',
             type: 'string'
           }
         },
-        required: ['input1', 'input2'],
+        required: ['Input 1', 'Input 2'],
         title: 'allowance',
         type: 'object'
       });

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -270,7 +270,7 @@ export function abiToDefinition(abi: FunctionFragment, chainId?: ChainId) {
   };
 
   abi.inputs.forEach((input, i) => {
-    const inputName = input.name ?? `input${i + 1}`;
+    const inputName = input.name ?? `Input ${i + 1}`;
 
     definition.properties[inputName] = {};
     definition.required.push(inputName);

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -1,4 +1,5 @@
 import { sanitizeUrl as baseSanitizeUrl } from '@braintree/sanitize-url';
+import { FunctionFragment } from '@ethersproject/abi';
 import { getAddress, isAddress } from '@ethersproject/address';
 import { Web3Provider } from '@ethersproject/providers';
 import { upload as pin } from '@snapshot-labs/pineapple';
@@ -258,7 +259,7 @@ export function _rt(number) {
   }
 }
 
-export function abiToDefinition(abi, chainId?: ChainId) {
+export function abiToDefinition(abi: FunctionFragment, chainId?: ChainId) {
   const definition = {
     $async: true,
     title: abi.name,
@@ -267,36 +268,39 @@ export function abiToDefinition(abi, chainId?: ChainId) {
     additionalProperties: false,
     properties: {}
   };
-  abi.inputs.forEach(input => {
-    definition.properties[input.name] = {};
-    definition.required.push(input.name);
+
+  abi.inputs.forEach((input, i) => {
+    const inputName = input.name ?? `input${i + 1}`;
+
+    definition.properties[inputName] = {};
+    definition.required.push(inputName);
     let type = 'string';
     if (input.type === 'bool') type = 'boolean';
     if (input.type === 'uint256') {
-      definition.properties[input.name].format = 'uint256';
-      definition.properties[input.name].examples = ['0'];
+      definition.properties[inputName].format = 'uint256';
+      definition.properties[inputName].examples = ['0'];
     }
     if (input.type === 'int256') {
-      definition.properties[input.name].format = 'int256';
-      definition.properties[input.name].examples = ['0'];
+      definition.properties[inputName].format = 'int256';
+      definition.properties[inputName].examples = ['0'];
     }
     if (input.type === 'bytes') {
-      definition.properties[input.name].format = 'bytes';
-      definition.properties[input.name].examples = ['0x0000…'];
+      definition.properties[inputName].format = 'bytes';
+      definition.properties[inputName].examples = ['0x0000…'];
     }
     if (input.type === 'address') {
-      definition.properties[input.name].format = 'ens-or-address';
-      definition.properties[input.name].examples = ['0x0000…'];
+      definition.properties[inputName].format = 'ens-or-address';
+      definition.properties[inputName].examples = ['0x0000…'];
       if (chainId) {
-        definition.properties[input.name].chainId = chainId;
+        definition.properties[inputName].chainId = chainId;
       }
     }
     if (input.type.endsWith('[]')) {
-      definition.properties[input.name].format = input.type;
-      definition.properties[input.name].examples = ['0x0, 0x1'];
+      definition.properties[inputName].format = input.type;
+      definition.properties[inputName].examples = ['0x0, 0x1'];
     }
-    definition.properties[input.name].type = type;
-    definition.properties[input.name].title = `${input.name} (${input.type})`;
+    definition.properties[inputName].type = type;
+    definition.properties[inputName].title = `${inputName} (${input.type})`;
   });
   return definition;
 }


### PR DESCRIPTION
### Summary

Sometimes Etherscan returns ABI without method parameters. We need to create placeholders for those.

### How to test

1. Go there: http://localhost:8080/#/eth:0x77cA6535CfDF9f4BC911F2a02e76f898dF5c926A/
2. Click on Contract call execution.
3. Use this address: `0x72eD19788Bce2971A5ed6401662230ee57e254B7`.
4. It works, you can add execution.