### PR TITLE
fix: fix empty space

### DIFF
--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -185,9 +185,8 @@ watch(
           >
             <template #item="{ element: tx, index: i }">
               <TransactionsListItem :tx="tx" :chain-id="treasury.network">
-                <template #left>
+                <template v-if="model.length > 1" #left>
                   <div
-                    v-if="model.length > 1"
                     class="handle text-skin-link cursor-pointer opacity-50 hover:opacity-100"
                   >
                     <IH-switch-vertical />

--- a/apps/ui/src/components/TransactionsListItem.vue
+++ b/apps/ui/src/components/TransactionsListItem.vue
@@ -154,7 +154,7 @@ const parsedTitle = computedAsync(
 <template>
   <div class="w-full border-b last:border-b-0">
     <div class="w-full px-4 py-3 gap-2 flex items-center">
-      <div class="shrink-0">
+      <div v-if="$slots.left" class="shrink-0">
         <slot name="left" />
       </div>
       <button


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fix left gap in the transaction list, when the sort icon is hidden 

![Screenshot 2025-04-22 at 17 42 01](https://github.com/user-attachments/assets/66aa91e7-78d9-4724-9d32-56b999376838)

### How to test

1. Go to http://localhost:8080/#/s:paraswap-dao.eth/create/yrbww
2. Create an execution
3. There should be no left gap anymore
