### PR TITLE
fix: allow single choice for voting choice

### DIFF
--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -141,7 +141,7 @@ const bodyDefinition = computed(() => ({
 const choicesDefinition = computed(() => ({
   type: 'array',
   title: 'Choices',
-  minItems: offchainNetworks.includes(props.space.network) ? 2 : 3,
+  minItems: offchainNetworks.includes(props.space.network) ? 1 : 3,
   maxItems: limits.value[`space.${spaceType.value}.choices_limit`],
   items: [{ type: 'string', minLength: 1, maxLength: 32 }],
   additionalItems: { type: 'string', maxLength: 32 }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/547

This PR decrease the minimum required number of choices to 1 for offchain proposals, when not a basic voting proposal

### How to test

1.

### To-Do

- [ ]

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
