### PR TITLE
feat(townhall): add discussion URL input to discussions

### DIFF
--- a/apps/highlight/src/agents/townhall.ts
+++ b/apps/highlight/src/agents/townhall.ts
@@ -20,14 +20,18 @@ export default class Townhall extends Agent {
   }
 
   async discussion(
-    { title, body }: { title: string; body: string },
+    {
+      title,
+      body,
+      discussionUrl
+    }: { title: string; body: string; discussionUrl: string },
     { signer }: { signer: string }
   ) {
     const id: number = (await this.get('discussions:id')) || 1;
 
     const author = await this.getAuthor(signer);
     this.write('discussions:id', id + 1);
-    this.emit('new_discussion', [id, author, title, body]);
+    this.emit('new_discussion', [id, author, title, body, discussionUrl]);
   }
 
   async closeDiscussion({ discussion }: { discussion: number }) {

--- a/apps/highlight/src/api/schema.gql
+++ b/apps/highlight/src/api/schema.gql
@@ -10,7 +10,8 @@ type Alias {
 type Discussion {
   id: String!
   title: String!
-  body: Text
+  body: Text!
+  discussion_url: String!
   author: String!
   statement_count: Int!
   vote_count: Int!

--- a/apps/highlight/src/api/writers.ts
+++ b/apps/highlight/src/api/writers.ts
@@ -12,7 +12,8 @@ const NewDiscussionEventData = z.tuple([
   z.number(), // id
   z.string(), // author
   z.string(), // title
-  z.string() // body
+  z.string(), // body
+  z.string() // discussionUrl
 ]);
 
 const CloseDiscussionEventData = z.tuple([
@@ -53,9 +54,8 @@ export function createWriters(indexerName: string) {
   };
 
   const handleNewDiscussion: Writer = async ({ unit, payload }) => {
-    const [id, author, title, body] = NewDiscussionEventData.parse(
-      payload.data
-    );
+    const [id, author, title, body, discussionUrl] =
+      NewDiscussionEventData.parse(payload.data);
 
     console.log('Handle new discussion', id, author, title, body);
 
@@ -63,6 +63,7 @@ export function createWriters(indexerName: string) {
     discussion.author = author;
     discussion.title = title;
     discussion.body = body;
+    discussion.discussion_url = discussionUrl;
     discussion.statement_count = 0;
     discussion.vote_count = 0;
     discussion.created = unit.timestamp;

--- a/apps/ui/src/composables/useTownhall.ts
+++ b/apps/ui/src/composables/useTownhall.ts
@@ -96,7 +96,11 @@ export function useTownhall() {
     );
   }
 
-  async function sendDiscussion(title: string, body: string) {
+  async function sendDiscussion(
+    title: string,
+    body: string,
+    discussionUrl: string
+  ) {
     if (!auth.value) {
       throw new Error('Not authenticated');
     }
@@ -106,7 +110,7 @@ export function useTownhall() {
     return wrapPromise(
       highlightClient.createDiscussion({
         signer,
-        data: { title, body },
+        data: { title, body, discussionUrl },
         salt: getSalt()
       })
     );

--- a/apps/ui/src/helpers/townhall/api.ts
+++ b/apps/ui/src/helpers/townhall/api.ts
@@ -39,6 +39,7 @@ gql(`
     id
     title
     body
+    discussion_url
     author
     statement_count
     vote_count

--- a/apps/ui/src/views/Townhall/Create.vue
+++ b/apps/ui/src/views/Townhall/Create.vue
@@ -9,6 +9,7 @@ const { addNotification } = useUiStore();
 
 const title = ref(route.query.title as string);
 const body = ref('');
+const discussion = ref('');
 const strategy = ref('anyone');
 const submitLoading = ref(false);
 
@@ -25,6 +26,14 @@ const BODY_DEFINITION = {
   title: 'Context',
   maxLength: 10e3,
   examples: ['Add more context…']
+};
+
+const DISCUSSION_DEFINITION = {
+  type: 'string',
+  format: 'uri',
+  title: 'Discussion',
+  maxLength: 256,
+  examples: ['e.g. https://forum.balancer.fi/t/proposal…']
 };
 
 const STRATEGY_DEFINITION = {
@@ -44,7 +53,7 @@ async function handleSubmit() {
   submitLoading.value = true;
 
   try {
-    const res = await sendDiscussion(title.value, body.value);
+    const res = await sendDiscussion(title.value, body.value, discussion.value);
 
     const id = res.result.events.find(event => event.key === 'new_discussion')
       .data[0];
@@ -95,6 +104,8 @@ async function handleSubmit() {
       <div class="s-base">
         <UiComposer v-model="body" :definition="BODY_DEFINITION" />
       </div>
+      <UiInputString v-model="discussion" :definition="DISCUSSION_DEFINITION" />
+      <UiLinkPreview :url="discussion" />
       <div>
         <UiSelect
           v-model="strategy"

--- a/apps/ui/src/views/Townhall/Discussion.vue
+++ b/apps/ui/src/views/Townhall/Discussion.vue
@@ -267,6 +267,23 @@ function toggleAdminView() {
             class="pb-4"
           />
 
+          <div v-if="discussion.discussion_url">
+            <h4 class="mb-3 eyebrow flex items-center gap-2">
+              <IH-chat-alt />
+              <span>Discussion</span>
+            </h4>
+            <a
+              :href="discussion.discussion_url"
+              target="_blank"
+              class="block mb-5"
+            >
+              <UiLinkPreview
+                :url="discussion.discussion_url"
+                :show-default="true"
+              />
+            </a>
+          </div>
+
           <div v-if="!discussion.closed && pendingStatements.length > 0">
             <h4 class="mb-3 eyebrow flex items-center gap-2">
               <IH-eye />

--- a/packages/sx.js/src/clients/highlight/ethereum-sig.ts
+++ b/packages/sx.js/src/clients/highlight/ethereum-sig.ts
@@ -140,10 +140,11 @@ export class HighlightEthereumSigClient {
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { title, body } = data;
+    const { title, body, discussionUrl } = data;
     const message = {
       title,
-      body
+      body,
+      discussionUrl
     };
 
     const signature = await this.sign(

--- a/packages/sx.js/src/clients/highlight/types.ts
+++ b/packages/sx.js/src/clients/highlight/types.ts
@@ -17,6 +17,7 @@ export type SetAlias = {
 export type CreateDiscussion = {
   title: string;
   body: string;
+  discussionUrl: string;
 };
 
 export type CloseDiscussion = {

--- a/packages/sx.js/src/highlightConstants.ts
+++ b/packages/sx.js/src/highlightConstants.ts
@@ -21,7 +21,8 @@ export const TOWNHALL_CONFIG = {
     createDiscussion: {
       Discussion: [
         { name: 'title', type: 'string' },
-        { name: 'body', type: 'string' }
+        { name: 'body', type: 'string' },
+        { name: 'discussionUrl', type: 'string' }
       ]
     },
     closeDiscussion: {

--- a/turbo.json
+++ b/turbo.json
@@ -24,11 +24,16 @@
       "passThroughEnv": ["ENABLED_NETWORKS", "INFURA_API_KEY"]
     },
     "codegen": {
-      "outputs": [".checkpoint/**", "src/networks/common/graphqlApi/gql/**"],
+      "outputs": [
+        ".checkpoint/**",
+        "src/networks/common/graphqlApi/gql/**",
+        "src/helpers/townhall/gql/**"
+      ],
       "inputs": [
         "**/*.gql",
         "codegen.ts",
-        "src/networks/common/graphqlApi/queries.ts"
+        "src/networks/common/graphqlApi/queries.ts",
+        "src/helpers/townhall/api.ts"
       ]
     }
   }


### PR DESCRIPTION
### Summary

For now just adding it as additional argument in entrypoint/event. In the future we might want to replace it with IPFS/Swarm, but for now keeping it as simple as possible.

Towards: https://github.com/snapshot-labs/workflow/issues/549

### How to test

1. Go to http://localhost:8080/#/townhall/ethereum/create
2. Fill in form.
3. Use `https://forum.balancer.fi/t/bip-xxx-grant-maxis-stablesurge-v2-parameter-change-permissions/6492` for Discussion URL.
4. Submit, you can see discussion URL in the final discussion.

### Screenshots

<img width="767" alt="image" src="https://github.com/user-attachments/assets/5a169094-5755-4889-8898-7b4f382462f7" />

