### PR TITLE
feat: add ability to claim roles

### DIFF
--- a/apps/highlight/src/agents/townhall.ts
+++ b/apps/highlight/src/agents/townhall.ts
@@ -16,6 +16,8 @@ export default class Townhall extends Agent {
     this.addEntrypoint(TOWNHALL_CONFIG.types.createRole);
     this.addEntrypoint(TOWNHALL_CONFIG.types.editRole);
     this.addEntrypoint(TOWNHALL_CONFIG.types.deleteRole);
+    this.addEntrypoint(TOWNHALL_CONFIG.types.claimRole);
+    this.addEntrypoint(TOWNHALL_CONFIG.types.revokeRole);
   }
 
   getAuthor(signer: string) {
@@ -157,5 +159,23 @@ export default class Townhall extends Agent {
 
   async deleteRole({ space, id }: { space: string; id: string }) {
     this.emit('delete_role', [space, id]);
+  }
+
+  async claimRole(
+    { space, id }: { space: string; id: string },
+    { signer }: { signer: string }
+  ) {
+    const user = await this.getAuthor(signer);
+
+    this.emit('claim_role', [space, id, user]);
+  }
+
+  async revokeRole(
+    { space, id }: { space: string; id: string },
+    { signer }: { signer: string }
+  ) {
+    const user = await this.getAuthor(signer);
+
+    this.emit('revoke_role', [space, id, user]);
   }
 }

--- a/apps/highlight/src/api/config.json
+++ b/apps/highlight/src/api/config.json
@@ -54,6 +54,14 @@
         {
           "name": "delete_role",
           "fn": "handleDeleteRole"
+        },
+        {
+          "name": "claim_role",
+          "fn": "handleClaimRole"
+        },
+        {
+          "name": "revoke_role",
+          "fn": "handleRevokeRole"
         }
       ]
     }

--- a/apps/highlight/src/api/schema.gql
+++ b/apps/highlight/src/api/schema.gql
@@ -55,5 +55,23 @@ type Role {
   name: String!
   description: String!
   color: String!
+  # Workaround as we can't cascade delete yet
+  deleted: Boolean!
   created: Int!
+}
+
+type User {
+  id: String!
+  roles: [UserRole!]! @derivedFrom(field: "user")
+}
+
+# Would be good to drop those entities if role is deleted in automated way.
+# This would require change in Checkpoint
+# For now we use soft-deletes to workaround it.
+# Ultimate solution would be to add annotation like cascadeDelete
+# eg. role: Role! @cascadeDelete
+type UserRole {
+  id: String!
+  user: User!
+  role: Role!
 }

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -68,7 +68,9 @@ const hasPlaceHolderSidebar = computed(
       'townhall',
       'townhall-space',
       'townhall-create',
-      'townhall-discussion'
+      'townhall-discussion',
+      'townhall-settings',
+      'townhall-roles'
     ].includes(String(route.matched[0]?.name)) &&
     !['space-editor', 'space-proposal'].includes(String(route.matched[1]?.name))
 );

--- a/apps/ui/src/composables/useTownhall.ts
+++ b/apps/ui/src/composables/useTownhall.ts
@@ -259,6 +259,38 @@ export function useTownhall() {
     );
   }
 
+  async function sendClaimRole(space: string, id: string) {
+    if (!auth.value) {
+      throw new Error('Not authenticated');
+    }
+
+    const signer = await getAliasSigner(auth.value.provider);
+
+    return wrapPromise(
+      highlightClient.claimRole({
+        signer,
+        data: { space, id },
+        salt: getSalt()
+      })
+    );
+  }
+
+  async function sendRevokeRole(space: string, id: string) {
+    if (!auth.value) {
+      throw new Error('Not authenticated');
+    }
+
+    const signer = await getAliasSigner(auth.value.provider);
+
+    return wrapPromise(
+      highlightClient.revokeRole({
+        signer,
+        data: { space, id },
+        salt: getSalt()
+      })
+    );
+  }
+
   return {
     sendDiscussion,
     sendCloseDiscussion,
@@ -268,6 +300,8 @@ export function useTownhall() {
     sendVote,
     sendCreateRole,
     sendEditRole,
-    sendDeleteRole
+    sendDeleteRole,
+    sendClaimRole,
+    sendRevokeRole
   };
 }

--- a/apps/ui/src/helpers/townhall/api.ts
+++ b/apps/ui/src/helpers/townhall/api.ts
@@ -107,8 +107,20 @@ const VOTES_QUERY = gql(`
 
 const ROLES_QUERY = gql(`
   query Roles($space: String!) {
-    roles(where: { space: $space }) {
+    roles(where: { space: $space, deleted: false }, orderBy: id, orderDirection: asc) {
       ...roleFields
+    }
+  }
+`);
+
+const USER_ROLES_QUERY = gql(`
+  query UserRoles($user: String!) {
+    user(id: $user) {
+      roles {
+        role {
+          ...roleFields
+        }
+      }
     }
   }
 `);
@@ -146,6 +158,15 @@ export async function getRoles(spaceId: string) {
   });
 
   return data.roles;
+}
+
+export async function getUserRoles(user: string) {
+  const { data } = await client.query({
+    query: USER_ROLES_QUERY,
+    variables: { user }
+  });
+
+  return data.user?.roles.map(role => role.role) ?? [];
 }
 
 export function newStatementEventToEntry(event: NewStatementEvent): Statement {

--- a/apps/ui/src/queries/townhall.ts
+++ b/apps/ui/src/queries/townhall.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query';
+import { MaybeRefOrGetter } from 'vue';
+import { getRoles, getUserRoles } from '@/helpers/townhall/api';
+import { Role } from '@/helpers/townhall/types';
+
+export function useRolesQuery(spaceId: MaybeRefOrGetter<string>) {
+  return useQuery({
+    queryKey: ['townhall', 'roles', spaceId, 'list'],
+    queryFn: () => {
+      return getRoles(toValue(spaceId));
+    }
+  });
+}
+
+export function useUserRolesQuery(user: MaybeRefOrGetter<string>) {
+  return useQuery({
+    queryKey: ['townhall', 'userRoles', user, 'list'],
+    queryFn: () => {
+      return getUserRoles(toValue(user));
+    },
+    enabled: () => !!toValue(user)
+  });
+}
+
+export function useRoleMutation(user: MaybeRefOrGetter<string>) {
+  const queryClient = useQueryClient();
+  const { addNotification } = useUiStore();
+  const { sendClaimRole, sendRevokeRole } = useTownhall();
+
+  return useMutation({
+    mutationFn: ({ role, isRevoking }: { role: Role; isRevoking: boolean }) => {
+      return isRevoking
+        ? sendRevokeRole(role.space, role.id)
+        : sendClaimRole(role.space, role.id);
+    },
+    onSuccess: async (_, { role, isRevoking }) => {
+      queryClient.setQueryData<Role[]>(
+        ['townhall', 'userRoles', user, 'list'],
+        (old = []) =>
+          isRevoking ? old.filter(r => r.id !== role.id) : [...old, role]
+      );
+    },
+    onError: error => {
+      addNotification('error', error.message);
+    }
+  });
+}

--- a/apps/ui/src/routes/default.ts
+++ b/apps/ui/src/routes/default.ts
@@ -17,6 +17,7 @@ import Space from '@/views/Space.vue';
 import Terms from '@/views/Terms.vue';
 import TownhallCreate from '@/views/Townhall/Create.vue';
 import TownhallDiscussion from '@/views/Townhall/Discussion.vue';
+import TownhallRoles from '@/views/Townhall/Roles.vue';
 import TownhallSettings from '@/views/Townhall/Settings.vue';
 import TownhallSpace from '@/views/Townhall/Space.vue';
 import Townhall from '@/views/Townhall/Townhall.vue';
@@ -62,6 +63,11 @@ export default [
     path: '/townhall/:space/settings',
     name: 'townhall-settings',
     component: TownhallSettings
+  },
+  {
+    path: '/townhall/:space/roles',
+    name: 'townhall-roles',
+    component: TownhallRoles
   },
   {
     path: '/townhall/:space/:id',

--- a/apps/ui/src/views/Townhall/Roles.vue
+++ b/apps/ui/src/views/Townhall/Roles.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import {
+  useRoleMutation,
+  useRolesQuery,
+  useUserRolesQuery
+} from '@/queries/townhall';
+
+const { setTitle } = useTitle();
+const route = useRoute();
+const { web3 } = useWeb3();
+
+const spaceId = computed(() => route.params.space as string);
+const userSpaceRoles = computed(() => {
+  return userRoles.value?.filter(role => role.space === spaceId.value) ?? [];
+});
+
+const { data: roles, isPending, isError } = useRolesQuery(spaceId);
+const { data: userRoles } = useUserRolesQuery(toRef(() => web3.value.account));
+const {
+  isPending: isMutatingRole,
+  variables,
+  mutate
+} = useRoleMutation(toRef(() => web3.value.account));
+
+function getIsRoleClaimed(roleId: string) {
+  return userSpaceRoles.value.some(role => role.id === roleId);
+}
+
+setTitle('Ethereum Open Agora');
+</script>
+
+<template>
+  <div>
+    <UiContainer class="!max-w-[960px] py-4">
+      <div class="eyebrow mb-2.5 text-skin-link">Roles</div>
+      <div class="md:border-x border-y md:rounded-lg md:mx-0 -mx-4">
+        <div v-if="isPending" class="my-3 mx-4">
+          <UiLoading />
+        </div>
+        <div v-else>
+          <div
+            v-if="isError"
+            class="px-4 py-3 flex items-center text-skin-link gap-2"
+          >
+            <IH-exclamation-circle />
+            <span v-text="'Failed to load roles.'" />
+          </div>
+          <div
+            v-if="roles?.length === 0"
+            class="px-4 py-3 flex items-center text-skin-link gap-2"
+          >
+            <IH-exclamation-circle />
+            <span v-text="'There are no roles here.'" />
+          </div>
+          <div
+            v-for="role in roles"
+            :key="role.id"
+            class="py-3 mx-4 block border-b last:border-b-0"
+          >
+            <div
+              class="flex flex-wrap md:flex-nowrap items-center justify-between gap-x-3 gap-y-1 truncate"
+            >
+              <div class="md:min-w-max min-w-0">
+                <UiProposalLabel
+                  :label="role.name || 'label preview'"
+                  :color="role.color"
+                  class="w-full"
+                />
+              </div>
+              <div v-if="role.description" class="w-full">
+                <div class="truncate" v-text="role.description" />
+              </div>
+              <div class="flex gap-3 items-center">
+                <UiButton
+                  :loading="variables?.role.id === role.id && isMutatingRole"
+                  @click="
+                    mutate({
+                      role,
+                      isRevoking: getIsRoleClaimed(role.id)
+                    })
+                  "
+                >
+                  {{ getIsRoleClaimed(role.id) ? 'Revoke' : 'Claim' }}
+                </UiButton>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </UiContainer>
+  </div>
+</template>

--- a/apps/ui/src/views/Townhall/Settings.vue
+++ b/apps/ui/src/views/Townhall/Settings.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { useQuery, useQueryClient } from '@tanstack/vue-query';
-import { getRoles } from '@/helpers/townhall/api';
+import { useQueryClient } from '@tanstack/vue-query';
 import { Role } from '@/helpers/townhall/types';
+import { useRolesQuery } from '@/queries/townhall';
 import { SpaceMetadataLabel } from '@/types';
 
 const { setTitle } = useTitle();
@@ -14,16 +14,7 @@ const modalOpen = ref(false);
 const activeLabelId = ref<string | null>(null);
 const spaceId = computed(() => route.params.space as string);
 
-const {
-  data: roles,
-  isPending,
-  isError
-} = useQuery({
-  queryKey: ['townhall', 'roles', spaceId, 'list'],
-  queryFn: () => {
-    return getRoles(spaceId.value);
-  }
-});
+const { data: roles, isPending, isError } = useRolesQuery(spaceId);
 
 function setModalStatus(open: boolean = false, roleId: string | null = null) {
   modalOpen.value = open;

--- a/packages/sx.js/src/clients/highlight/ethereum-sig.ts
+++ b/packages/sx.js/src/clients/highlight/ethereum-sig.ts
@@ -5,6 +5,7 @@ import {
   TypedDataSigner
 } from '@ethersproject/abstract-signer';
 import {
+  ClaimRole,
   CloseDiscussion,
   CreateDiscussion,
   CreateRole,
@@ -14,6 +15,7 @@ import {
   Envelope,
   HideStatement,
   PinStatement,
+  RevokeRole,
   SetAlias,
   UnpinStatement,
   Vote
@@ -473,6 +475,74 @@ export class HighlightEthereumSigClient {
       domain,
       message,
       primaryType: 'DeleteRole',
+      signer: await signer.getAddress(),
+      signature
+    };
+  }
+
+  public async claimRole({
+    signer,
+    data,
+    salt
+  }: {
+    signer: Signer & TypedDataSigner;
+    data: ClaimRole;
+    salt: bigint;
+  }): Promise<Envelope> {
+    const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
+
+    const { space, id } = data;
+    const message = {
+      space,
+      id
+    };
+
+    const signature = await this.sign(
+      signer,
+      domain,
+      TOWNHALL_CONFIG.types.claimRole,
+      message
+    );
+
+    return {
+      type: 'HIGHLIGHT_ENVELOPE',
+      domain,
+      message,
+      primaryType: 'ClaimRole',
+      signer: await signer.getAddress(),
+      signature
+    };
+  }
+
+  public async revokeRole({
+    signer,
+    data,
+    salt
+  }: {
+    signer: Signer & TypedDataSigner;
+    data: RevokeRole;
+    salt: bigint;
+  }): Promise<Envelope> {
+    const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
+
+    const { space, id } = data;
+    const message = {
+      space,
+      id
+    };
+
+    const signature = await this.sign(
+      signer,
+      domain,
+      TOWNHALL_CONFIG.types.revokeRole,
+      message
+    );
+
+    return {
+      type: 'HIGHLIGHT_ENVELOPE',
+      domain,
+      message,
+      primaryType: 'RevokeRole',
       signer: await signer.getAddress(),
       signature
     };

--- a/packages/sx.js/src/clients/highlight/types.ts
+++ b/packages/sx.js/src/clients/highlight/types.ts
@@ -55,3 +55,5 @@ export type DeleteRole = {
   space: string;
   id: string;
 };
+export type ClaimRole = DeleteRole;
+export type RevokeRole = ClaimRole;

--- a/packages/sx.js/src/highlightConstants.ts
+++ b/packages/sx.js/src/highlightConstants.ts
@@ -81,6 +81,18 @@ export const TOWNHALL_CONFIG = {
         { name: 'space', type: 'string' },
         { name: 'id', type: 'uint64' }
       ]
+    },
+    claimRole: {
+      ClaimRole: [
+        { name: 'space', type: 'string' },
+        { name: 'id', type: 'uint64' }
+      ]
+    },
+    revokeRole: {
+      RevokeRole: [
+        { name: 'space', type: 'string' },
+        { name: 'id', type: 'uint64' }
+      ]
     }
   }
 };


### PR DESCRIPTION
### Summary

This PR adds support for claiming roles. Users can now claim available roles by visiting http://localhost:8080/#/townhall/ethereum/roles

Towards: https://github.com/snapshot-labs/workflow/issues/549

I had to change how deleting role works to now be soft-delete - as we use many-to-many relationship we should delete `UserRole` entities when underlying role is deleted, but it's not currently possible with Checkpoint, so we use a workaround.

As of now nothing happens with claimed roles, it's not used when counting votes etc. It will be part of upcoming PR when we figure out good way of counting votes per-role.

### How to test

1. Go to http://localhost:8080/#/townhall/ethereum/settings
2. Create some roles.
3. Go to http://localhost:8080/#/townhall/ethereum/roles
4. You can claim/revoke roles.
5. Refresh page, you see your roles.
6. Change wallet, everything works as expected.

### Screenshots

<img width="1114" alt="image" src="https://github.com/user-attachments/assets/8caddbae-0a4e-4c31-a5ba-23e70f124614" />
