### PR TITLE
fix: always string network to score-api

### DIFF
--- a/packages/sx.js/src/strategies/offchain/remote-validate.ts
+++ b/packages/sx.js/src/strategies/offchain/remote-validate.ts
@@ -14,7 +14,7 @@ export default function createRemoteValidateStrategy(type: string): Strategy {
         validation: type,
         author: voterAddress,
         space: spaceId,
-        network: snapshotInfo.chainId,
+        network: snapshotInfo.chainId?.toString(),
         snapshot: snapshotInfo.at ?? 'latest',
         params: params[0]
       });

--- a/packages/sx.js/src/strategies/offchain/remote-validate.ts
+++ b/packages/sx.js/src/strategies/offchain/remote-validate.ts
@@ -16,7 +16,8 @@ export default function createRemoteValidateStrategy(type: string): Strategy {
         space: spaceId,
         network: snapshotInfo.chainId?.toString() || '',
         snapshot: snapshotInfo.at ?? 'latest',
-        params: params[0]
+        params: params[0],
+        delegation: false
       });
 
       return [isValid ? 1n : 0n];

--- a/packages/sx.js/src/strategies/offchain/remote-validate.ts
+++ b/packages/sx.js/src/strategies/offchain/remote-validate.ts
@@ -14,7 +14,7 @@ export default function createRemoteValidateStrategy(type: string): Strategy {
         validation: type,
         author: voterAddress,
         space: spaceId,
-        network: snapshotInfo.chainId?.toString(),
+        network: snapshotInfo.chainId?.toString() || '',
         snapshot: snapshotInfo.at ?? 'latest',
         params: params[0]
       });

--- a/packages/sx.js/src/strategies/offchain/remote-vp.ts
+++ b/packages/sx.js/src/strategies/offchain/remote-vp.ts
@@ -14,7 +14,7 @@ export default function createRemoteVpStrategy(): Strategy {
         address: voterAddress,
         space: spaceId,
         strategies: params,
-        network: snapshotInfo.chainId?.toString(),
+        network: snapshotInfo.chainId?.toString() || '',
         snapshot: snapshotInfo.at ?? 'latest'
       });
 

--- a/packages/sx.js/src/strategies/offchain/remote-vp.ts
+++ b/packages/sx.js/src/strategies/offchain/remote-vp.ts
@@ -15,7 +15,8 @@ export default function createRemoteVpStrategy(): Strategy {
         space: spaceId,
         strategies: params,
         network: snapshotInfo.chainId?.toString() || '',
-        snapshot: snapshotInfo.at ?? 'latest'
+        snapshot: snapshotInfo.at ?? 'latest',
+        delegation: false
       });
 
       return result.vp_by_strategy.map((vp: number, i: number) => {

--- a/packages/sx.js/src/strategies/offchain/remote-vp.ts
+++ b/packages/sx.js/src/strategies/offchain/remote-vp.ts
@@ -14,7 +14,7 @@ export default function createRemoteVpStrategy(): Strategy {
         address: voterAddress,
         space: spaceId,
         strategies: params,
-        network: snapshotInfo.chainId,
+        network: snapshotInfo.chainId?.toString(),
         snapshot: snapshotInfo.at ?? 'latest'
       });
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/553

This PR will always pass `network` as a string to score-api

### How to test

1. Go to the network tab in the dev console
2. in all requests to score-api, the `network` value in the body should now be string instead of a number
