### PR TITLE
fix: remove redundant warning message

### DIFF
--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -542,7 +542,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
           the name's owner
         </UiMessage>
         <UiMessage
-          v-if="isOffchainNetwork && isController && !isOwner"
+          v-else-if="isOffchainNetwork && isController && !isOwner"
           type="danger"
           class="mb-3"
         >


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR removes the warning redundant message when editing a .shib offchain space controller

![Screenshot 2025-05-01 at 21 05 46](https://github.com/user-attachments/assets/c570eab1-9549-4ea5-9c4b-c6cfd77e08e2)

### How to test

1. Go to http://localhost:8080/#/s-tn:test-snapshot.shib/settings/controller
2. You should see only the warning message about .shib space
