### PR TITLE
fix: hide the execute actions on read-only execution

### DIFF
--- a/apps/ui/src/networks/offchain/index.ts
+++ b/apps/ui/src/networks/offchain/index.ts
@@ -35,13 +35,17 @@ export function createOffchainNetwork(networkId: NetworkID): Network {
     return false;
   };
 
+  const isExecutorActionsSupported = (executorType: string) => {
+    return executorType === 'oSnap';
+  };
+
   const helpers = {
     isAuthenticatorSupported: () => true,
     isAuthenticatorContractSupported: () => false,
     getRelayerAuthenticatorType: () => null,
     isStrategySupported: () => true,
     isExecutorSupported: isExecutorSupported,
-    isExecutorActionsSupported: isExecutorSupported,
+    isExecutorActionsSupported: isExecutorActionsSupported,
     pin: pinPineapple,
     getSpaceController: async (space: Space) =>
       getSpaceController(space.id, networkId),


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/550

### How to test

1. Go to http://localhost:8080/#/s-tn:chakrin.eth/proposal/0xf010d9269a273ba9329d4bbfbd33b6c36c856ddb99379daaa65467dfbf84e9dd
2. The execute button should not appear
