### PR TITLE
fix: refresh the votes list after a vote

### DIFF
--- a/apps/ui/src/components/Modal/Vote.vue
+++ b/apps/ui/src/components/Modal/Vote.vue
@@ -133,6 +133,9 @@ async function handleConfirmed(tx?: string | null) {
         props.proposal.proposal_id.toString()
       )
     });
+    queryClient.invalidateQueries({
+      queryKey: ['votes', props.proposal.proposal_id.toString(), 'list']
+    });
     await loadVotes(props.proposal.network, [props.proposal.space.id]);
   }
 }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/603

After submitting an offchain vote, refresh the votes list

### How to test

1. Go to an offchain proposal page, then votes tab
2. vote using the right sidebar
3. after submitting the vote, the votes list should refresh and be updated to reflect your vote
