### PR TITLE
feat: add ability to filter results by role

### DIFF
--- a/apps/ui/src/helpers/townhall/api.ts
+++ b/apps/ui/src/helpers/townhall/api.ts
@@ -6,6 +6,12 @@ import { gql } from './gql';
 type NewStatementEvent = [number, string, number, string];
 type NewVoteEvent = [string, number, number, number];
 
+export type Result = {
+  statement_id: number;
+  choice: number;
+  vote_count: number;
+};
+
 const client = new ApolloClient({
   uri: HIGHLIGHT_URL,
   cache: new InMemoryCache({ addTypename: false }),
@@ -167,6 +173,23 @@ export async function getUserRoles(user: string) {
   });
 
   return data.user?.roles.map(role => role.role) ?? [];
+}
+
+export async function getResultsByRole(
+  discussionId: number,
+  roleId: string
+): Promise<Result[]> {
+  const res = await fetch(
+    `${HIGHLIGHT_URL}/townhall/discussions/${discussionId}/results_by_role/${roleId}`
+  );
+
+  const { error, result } = await res.json();
+  if (error) throw new Error('RPC call failed');
+
+  return result.map(r => ({
+    ...r,
+    vote_count: Number(r.vote_count)
+  }));
 }
 
 export function newStatementEventToEntry(event: NewStatementEvent): Statement {

--- a/apps/ui/src/queries/townhall.ts
+++ b/apps/ui/src/queries/townhall.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query';
 import { MaybeRefOrGetter } from 'vue';
-import { getRoles, getUserRoles } from '@/helpers/townhall/api';
+import {
+  getResultsByRole,
+  getRoles,
+  getUserRoles
+} from '@/helpers/townhall/api';
 import { Role } from '@/helpers/townhall/types';
 
 export function useRolesQuery(spaceId: MaybeRefOrGetter<string>) {
@@ -19,6 +23,21 @@ export function useUserRolesQuery(user: MaybeRefOrGetter<string>) {
       return getUserRoles(toValue(user));
     },
     enabled: () => !!toValue(user)
+  });
+}
+
+export function useResultsByRoleQuery({
+  discussionId,
+  roleId
+}: {
+  discussionId: MaybeRefOrGetter<number>;
+  roleId: MaybeRefOrGetter<string>;
+}) {
+  return useQuery({
+    queryKey: ['townhall', 'discussionResults', discussionId, roleId, 'list'],
+    queryFn: () => {
+      return getResultsByRole(toValue(discussionId), toValue(roleId));
+    }
   });
 }
 

--- a/apps/ui/src/views/Townhall/Discussion.vue
+++ b/apps/ui/src/views/Townhall/Discussion.vue
@@ -7,7 +7,8 @@ import {
   newVoteEventToEntry
 } from '@/helpers/townhall/api';
 import { Discussion, Statement, Vote } from '@/helpers/townhall/types';
-import { _n, clone } from '@/helpers/utils';
+import { _n, clone, sleep } from '@/helpers/utils';
+import { useResultsByRoleQuery, useRolesQuery } from '@/queries/townhall';
 
 const route = useRoute();
 const { web3 } = useWeb3();
@@ -15,7 +16,9 @@ const { addNotification } = useUiStore();
 const { sendStatement, sendCloseDiscussion } = useTownhall();
 
 const id = parseInt(route.params.id as string);
+const spaceId = computed(() => route.params.space as string);
 
+const roleFilter = ref('any');
 const discussion = ref<Discussion | null>(null);
 const statements = ref<Statement[]>([]);
 const votes = ref<Vote[]>([]);
@@ -26,19 +29,36 @@ const closeDiscussionLoading = ref(false);
 const statementInput = ref('');
 const view = ref('');
 
+const {
+  data: roles,
+  isPending: isRolesPending,
+  isError: isRolesError
+} = useRolesQuery(spaceId);
+const {
+  data: resultsByRole,
+  isPending: isResultsPending,
+  isError: isResultsError,
+  refetch: refetchResults
+} = useResultsByRoleQuery({ discussionId: id, roleId: roleFilter });
+
 const pendingStatements: ComputedRef<Statement[]> = computed(() =>
   statements.value.filter(
     s => !votes.value.find(v => v.statement_id === s.statement_id)
   )
 );
+
 const results: ComputedRef<Statement[]> = computed(() =>
   clone(statements.value)
     .filter(s => !s.hidden)
-    .sort((a, b) => b.vote_count - a.vote_count)
+    .sort(
+      (a, b) =>
+        getStatementVoteCount(b.statement_id) -
+        getStatementVoteCount(a.statement_id)
+    )
     .sort((a, b) => Number(b.pinned) - Number(a.pinned))
 );
 
-client.subscribe(([subject, body]) => {
+client.subscribe(async ([subject, body]) => {
   if (subject === 'justsaying') {
     const event = body.body;
 
@@ -92,27 +112,32 @@ client.subscribe(([subject, body]) => {
       case 'new_vote':
         const vote = newVoteEventToEntry(event);
 
-        if (vote.discussion_id === id) {
-          if (vote.voter === web3.value.account) {
-            votes.value = [...votes.value, vote];
-          }
-
-          const statementIndex = statements.value.findIndex(
-            s => s.statement_id === vote.statement_id
-          );
-          const statement = clone(statements.value[statementIndex]);
-          statement.vote_count += 1;
-          statement[`scores_${vote.choice}`] += 1;
-
-          const statementsClone = clone(statements.value);
-          statementsClone[statementIndex] = statement;
-          statements.value = statementsClone;
+        if (vote.discussion_id !== id) {
+          return;
         }
+
+        if (vote.voter === web3.value.account) {
+          votes.value = [...votes.value, vote];
+        }
+
+        // NOTE: This is a temporary workaround, we wait for Checkpoint to index the vote.
+        // Right now we use WebSockets so we receive all votes (not only our own), but here we don't know
+        // roles of all voters so we can't update the resultsByRole.
+        // Once we remove WebSockets and use optimistic updates for our own actions we can optimistically update the resultsByRole as well.
+        await sleep(2500);
+        refetchResults();
 
         break;
     }
   }
 });
+
+function getStatementVoteCount(statementId: number) {
+  return (
+    resultsByRole.value?.find(r => r.statement_id === statementId)
+      ?.vote_count ?? 0
+  );
+}
 
 onMounted(async () => {
   loading.value = true;
@@ -182,8 +207,15 @@ function toggleAdminView() {
 
 <template>
   <div class="mb-6">
-    <div v-if="loading" class="my-4">
+    <div v-if="loading || isRolesPending || isResultsPending" class="my-4">
       <UiLoading class="p-4" />
+    </div>
+    <div
+      v-else-if="isRolesError || isResultsError"
+      class="px-4 py-3 flex items-center text-skin-link gap-2"
+    >
+      <IH-exclamation-circle />
+      <span v-text="'Failed to load discussion.'" />
     </div>
     <div v-else-if="loaded && discussion">
       <div class="border-b bg-skin-border/10 pb-3 pt-7 mb-6">
@@ -345,11 +377,19 @@ function toggleAdminView() {
                   {{ _n(results.length) }}
                 </div>
               </h4>
-              <div>
-                Sort by:
-                <span class="text-skin-link">newest</span>
-                <IH-arrow-sm-down class="inline-block ml-2" />
-              </div>
+              <UiSelectDropdown
+                v-model="roleFilter"
+                title="Role"
+                gap="12"
+                placement="start"
+                :items="[
+                  { key: 'any', label: 'Any role' },
+                  ...(roles || []).map(role => ({
+                    key: role.id,
+                    label: role.name
+                  }))
+                ]"
+              />
             </div>
             <div class="space-y-3">
               <TownhallStatementItem
@@ -357,6 +397,7 @@ function toggleAdminView() {
                 :key="i"
                 :discussion="discussion"
                 :statement="s"
+                :results="resultsByRole ?? []"
               />
             </div>
           </div>


### PR DESCRIPTION
### Summary

This PR adds ability to filter results by specific roles. This is done by addition of REST endpoint that computes those values from database.

Towards: https://github.com/snapshot-labs/workflow/issues/549

**Note:** There might be some bugs with WebSockets as `kbyte` doesn't support unsubscribing that means that if you change something in code and app is reloaded it might subscribe multiple times and we end up receiving events multiple times, that can result in vote counts increasing more than they should. I left it as-is as WebSockets will be removed.

### How to test

1. Go to http://localhost:8080/#/townhall/ethereum/settings
2. Create some roles
3. Claim some roles (on multiple accounts so you can then filter results).
4. Create discussion.
5. Vote on few accounts.
6. You see results from specific role as expected.

### Screenshots

https://github.com/user-attachments/assets/198b0e81-2c78-4df4-890b-8c3f3d14fe7e

