### PR TITLE
chore: use brovider for Starknet L1 nodes

### DIFF
--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -32,7 +32,7 @@ export const METADATA: Partial<Record<NetworkID, Metadata>> = {
     baseChainId: 1,
     baseNetworkId: 'eth',
     rpcUrl: `https://starknet-mainnet.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
-    ethRpcUrl: `https://mainnet.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
+    ethRpcUrl: 'https://rpc.snapshot.org/1',
     apiUrl: UNIFIED_API_URL,
     explorerUrl: 'https://starkscan.co',
     avatar: 'ipfs://bafkreihbjafyh7eud7r6e5743esaamifcttsvbspfwcrfoc5ykodjdi67m'
@@ -43,7 +43,7 @@ export const METADATA: Partial<Record<NetworkID, Metadata>> = {
     baseChainId: 11155111,
     baseNetworkId: 'sep',
     rpcUrl: `https://starknet-sepolia.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
-    ethRpcUrl: `https://sepolia.infura.io/v3/${import.meta.env.VITE_INFURA_API_KEY}`,
+    ethRpcUrl: 'https://rpc.snapshot.org/11155111',
     apiUrl: UNIFIED_API_TESTNET_URL,
     explorerUrl: 'https://sepolia.starkscan.co',
     avatar: 'ipfs://bafkreihbjafyh7eud7r6e5743esaamifcttsvbspfwcrfoc5ykodjdi67m'


### PR DESCRIPTION
### Summary

Using brovider instead of hardcoded Infura URLs for Starknet L1 nodes.

### How to test

1. Go to http://localhost:8080/#/sn:0x05702362b68a350c1cae8f2a529d74fdbb502369ddcebfadac7e91da37636947/proposal/37
2. VP loads.

