### PR TITLE
feat: update relative time reactively

### DIFF
--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { formatQuorum, quorumLabel, quorumProgress } from '@/helpers/quorum';
-import { _n, _rt, getProposalId, shortenAddress } from '@/helpers/utils';
+import { _n, getProposalId, shortenAddress } from '@/helpers/utils';
 import { Proposal as ProposalType } from '@/types';
 
 const props = withDefaults(
@@ -132,12 +132,17 @@ const totalProgress = computed(() => quorumProgress(props.proposal));
         {{ quorumLabel(proposal.quorum_type) }}
       </span>
       ·
-      <button
-        type="button"
-        class="text-skin-text"
-        @click="modalOpenTimeline = true"
-        v-text="_rt(getTsFromCurrent(proposal.network, proposal.max_end))"
-      />
+      <TimeRelative
+        v-slot="{ relativeTime }"
+        :time="getTsFromCurrent(props.proposal.network, props.proposal.max_end)"
+      >
+        <button
+          type="button"
+          class="text-skin-text"
+          @click="modalOpenTimeline = true"
+          v-text="relativeTime"
+        />
+      </TimeRelative>
     </span>
   </div>
   <teleport to="#modal">

--- a/apps/ui/src/components/TimeRelative.vue
+++ b/apps/ui/src/components/TimeRelative.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const props = defineProps<{
+  time: number;
+}>();
+
+const relativeTime = useRelativeTime(() => props.time);
+</script>
+
+<template>
+  <slot :relative-time="relativeTime">{{ relativeTime }}</slot>
+</template>

--- a/apps/ui/src/components/TopicsListItem.vue
+++ b/apps/ui/src/components/TopicsListItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Topic } from '@/helpers/discourse';
-import { _n, _rt } from '@/helpers/utils';
+import { _n } from '@/helpers/utils';
 
 defineProps<{ topic: Topic }>();
 </script>
@@ -45,7 +45,9 @@ defineProps<{ topic: Topic }>();
             v-text="topic.latest_poster.name || topic.latest_poster.username"
           />
         </div>
-        <span> · {{ _rt(topic.updated) }}</span>
+        <TimeRelative v-slot="{ relativeTime }" :time="topic.updated">
+          <span> · {{ relativeTime }}</span>
+        </TimeRelative>
         <span> · {{ _n(topic.posts_count) }} replies</span>
       </div>
     </div>

--- a/apps/ui/src/composables/useRelativeTime.ts
+++ b/apps/ui/src/composables/useRelativeTime.ts
@@ -1,0 +1,12 @@
+import { MaybeRefOrGetter } from 'vue';
+import { _rt } from '@/helpers/utils';
+
+export function useRelativeTime(time: MaybeRefOrGetter<number>) {
+  const relativeTime = ref(_rt(toValue(time)));
+
+  useIntervalFn(() => {
+    relativeTime.value = _rt(toValue(time));
+  }, 1000);
+
+  return relativeTime;
+}

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -252,9 +252,9 @@ export function _t(number, format = 'MMM D, YYYY · h:mm A') {
   }
 }
 
-export function _rt(number) {
+export function _rt(time: number) {
   try {
-    return dayjs(number * 1000).fromNow(false);
+    return dayjs(time * 1000).fromNow(false);
   } catch (e) {
     console.log(e);
     return '';

--- a/apps/ui/src/views/My/Notifications.vue
+++ b/apps/ui/src/views/My/Notifications.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { _rt } from '@/helpers/utils';
-
 const notificationsStore = useNotificationsStore();
 const { modalAccountWithoutDismissOpen } = useModal();
 const { web3 } = useWeb3();
@@ -60,7 +58,7 @@ onUnmounted(() => notificationsStore.markAllAsRead());
               {{ notification.proposal.space.name }}
             </AppLink>
             proposal has {{ notification.type }}
-            {{ _rt(notification.timestamp) }}
+            <TimeRelative :time="notification.timestamp" />
             <AppLink
               :to="{
                 name: 'space-proposal-overview',

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -3,7 +3,6 @@ import { useQueryClient } from '@tanstack/vue-query';
 import { EMPTY_ADDRESS } from '@/helpers/constants';
 import {
   _n,
-  _rt,
   compareAddresses,
   getProposalId,
   getUrl,
@@ -109,19 +108,19 @@ const proposalMetadataUrl = computed(() => {
   return sanitizeUrl(url);
 });
 
+const endTime = useRelativeTime(() => {
+  return getTsFromCurrent(props.proposal.network, props.proposal.max_end);
+});
+
 const votingTime = computed(() => {
   if (!props.proposal) return null;
 
   const current = getCurrent(props.proposal.network);
   if (!current) return null;
 
-  const time = _rt(
-    getTsFromCurrent(props.proposal.network, props.proposal.max_end)
-  );
-
   const hasEnded = props.proposal.max_end <= current;
 
-  return hasEnded ? `Ended ${time}` : time;
+  return hasEnded ? `Ended ${endTime.value}` : endTime.value;
 });
 
 async function handleEditClick() {
@@ -360,7 +359,9 @@ onBeforeUnmount(() => destroyAudio());
               >
                 {{ proposal.space.name }}
               </AppLink>
-              <span> · {{ _rt(proposal.created) }}</span>
+              <TimeRelative v-slot="{ relativeTime }" :time="proposal.created">
+                <span> · {{ relativeTime }}</span>
+              </TimeRelative>
               <span> · {{ getProposalId(proposal) }}</span>
             </span>
           </div>

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { _n, _rt, _t, _vp, shortenAddress } from '@/helpers/utils';
+import { _n, _t, _vp, shortenAddress } from '@/helpers/utils';
 import { getNetwork, offchainNetworks } from '@/networks';
 import { useProposalVotesQuery } from '@/queries/votes';
 import { Proposal as ProposalType, Vote } from '@/types';
@@ -203,7 +203,9 @@ function handleScrollEvent(target: HTMLElement) {
           <div
             class="leading-[22px] max-w-[144px] w-[144px] flex flex-col justify-center truncate"
           >
-            <h4>{{ _rt(vote.created) }}</h4>
+            <TimeRelative v-slot="{ relativeTime }" :time="vote.created">
+              <h4>{{ relativeTime }}</h4>
+            </TimeRelative>
             <div class="text-[17px]">
               {{ _t(vote.created, 'MMM D, YYYY') }}
             </div>

--- a/apps/ui/src/views/Topic.vue
+++ b/apps/ui/src/views/Topic.vue
@@ -6,7 +6,7 @@ import {
   Topic
 } from '@/helpers/discourse';
 import turndownService from '@/helpers/turndownService';
-import { _rt, sanitizeUrl } from '@/helpers/utils';
+import { sanitizeUrl } from '@/helpers/utils';
 import { Proposal, Space } from '@/types';
 
 const props = defineProps<{ proposal?: Proposal; space?: Space }>();
@@ -106,10 +106,9 @@ onMounted(async () => {
           </a>
           <div class="flex flex-col leading-4 gap-1">
             <a :href="reply.user_url" target="_blank" v-text="reply.name" />
-            <span
-              class="text-skin-text text-sm"
-              v-text="_rt(reply.created_at)"
-            />
+            <TimeRelative v-slot="{ relativeTime }" :time="reply.created_at">
+              <span class="text-skin-text text-sm" v-text="relativeTime" />
+            </TimeRelative>
           </div>
         </div>
         <UiMarkdown


### PR DESCRIPTION
### Summary

Adding two helpers than can be used to reactively update relative time.
 - useRelativeTime - composable when time is needed in setup code
 - TimeRelative - component for rendering reactive relative time

Closes: https://github.com/snapshot-labs/workflow/issues/532

### How to test

1. Create proposal.
2. Open it.
3. Time it was created is updated on-the-fly.

