### PR TITLE
fix: limit notification click area to notification itself

### DIFF
--- a/apps/ui/src/components/App/Notifications.vue
+++ b/apps/ui/src/components/App/Notifications.vue
@@ -3,13 +3,13 @@ const uiStore = useUiStore();
 </script>
 
 <template>
-  <div class="fixed bottom-4 inset-x-0 z-[52]">
+  <div class="fixed bottom-4 inset-x-0 z-[52] pointer-events-none">
     <UiAlert
       v-for="notification in uiStore.notifications"
       :key="notification.id"
       dismissible
       :type="notification.type"
-      class="!w-fit max-w-[90%] mx-auto mb-2 last:mb-0"
+      class="!w-fit max-w-[90%] mx-auto mb-2 last:mb-0 pointer-events-auto"
       @close="uiStore.dismissNotification(notification.id)"
     >
       {{ notification.message }}


### PR DESCRIPTION
### Summary

Previously entire horizontal section of screen would become occupied by notification click area.

Now it's limited only to the notification itself.

Closes: https://github.com/snapshot-labs/workflow/issues/559

### How to test

1. Apply patch from below to simulate notifications.
2. Go to http://localhost:8080/#/
3. You can click links at the same height as notifications.
4. You can dismiss notification by button.

```diff
diff --git a/apps/ui/src/App.vue b/apps/ui/src/App.vue
index af992a888..ef2cb7964 100644
--- a/apps/ui/src/App.vue
+++ b/apps/ui/src/App.vue
@@ -5,6 +5,7 @@ import whiteLabelRoutes from '@/routes/whiteLabel';
 const route = useRoute();
 const router = useRouter();
 const { app } = useApp();
+const { addNotification } = useUiStore();
 const {
   init: initWhiteLabel,
   isWhiteLabel,
@@ -37,7 +38,18 @@ watch(
   { immediate: true }
 );
 
-onMounted(() => initWhiteLabel());
+onMounted(() => {
+  initWhiteLabel();
+
+  addNotification(
+    'success',
+    'This is a demo version of the app. Some features may be limited.'
+  );
+  addNotification(
+    'error',
+    'Please note that this is a demo version of the app. Some features may be limited.'
+  );
+});
 </script>
 
 <template>
```

