### PR TITLE
fix: remove hide abstain switcher from space settings

### DIFF
--- a/apps/ui/src/components/FormSpaceVoting.vue
+++ b/apps/ui/src/components/FormSpaceVoting.vue
@@ -34,9 +34,6 @@ const privacy = defineModel<SpacePrivacy>('privacy', {
 const voteValidation = defineModel<Validation>('voteValidation', {
   required: true
 });
-const ignoreAbstainVotes = defineModel<boolean>('ignoreAbstainVotes', {
-  required: true
-});
 
 const props = defineProps<{
   snapshotChainId: ChainId;
@@ -286,10 +283,6 @@ watchEffect(() => {
           <IH-chevron-down />
         </button>
       </UiWrapperInput>
-      <UiSwitch
-        v-model="ignoreAbstainVotes"
-        title="Ignore abstain votes in basic voting results"
-      />
     </div>
   </div>
   <teleport to="#modal">


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/555

Remove the 'ignore abstain votes' option in the space settings

### How to test

1. Go to a space settings, the vote tab
2. The 'hide abstain votes' option is gone
3. If the space has enabled it already, saving the setting should keep it to `true`:

```
    "hideAbstain": true
```