### PR TITLE
feat: use brovider for Starknet in API

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -5,7 +5,3 @@
 export const ENABLED_NETWORKS = process.env.ENABLED_NETWORKS
   ? process.env.ENABLED_NETWORKS.split(',')
   : null;
-
-/** Infura API key used by default for network nodes. */
-export const DEFAULT_INFURA_API_KEY =
-  process.env.INFURA_API_KEY || '46a5dd9727bf48d4a132672d3f376146';

--- a/apps/api/src/starknet/config.ts
+++ b/apps/api/src/starknet/config.ts
@@ -1,16 +1,13 @@
 import { CheckpointConfig } from '@snapshot-labs/checkpoint';
 import { starknetNetworks } from '@snapshot-labs/sx';
 import { validateAndParseAddress } from 'starknet';
-import { DEFAULT_INFURA_API_KEY } from '../config';
 import spaceAbi from './abis/space.json';
 import spaceFactoryAbi from './abis/spaceFactory.json';
 
 const snNetworkNodeUrl =
-  process.env.NETWORK_NODE_URL_SN ||
-  `https://starknet-mainnet.infura.io/v3/${DEFAULT_INFURA_API_KEY}`;
+  process.env.NETWORK_NODE_URL_SN || 'https://rpc.snapshot.org/sn';
 const snSepNetworkNodeUrl =
-  process.env.NETWORK_NODE_URL_SN_SEP ||
-  `https://starknet-sepolia.infura.io/v3/${DEFAULT_INFURA_API_KEY}`;
+  process.env.NETWORK_NODE_URL_SN_SEP || 'https://rpc.snapshot.org/sn-sep';
 const manaRpcUrl = process.env.VITE_MANA_URL || 'https://mana.box';
 
 export type FullConfig = {


### PR DESCRIPTION
### Summary

Instead of using Infura for Starknet we now use Brovider everywhere.