### PR TITLE
fix: bump checkpoint to 0.1.0-beta.59

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,7 +25,7 @@
     "@ethersproject/providers": "^5.7.2",
     "@ethersproject/units": "^5.6.1",
     "@faker-js/faker": "^7.4.0",
-    "@snapshot-labs/checkpoint": "^0.1.0-beta.57",
+    "@snapshot-labs/checkpoint": "^0.1.0-beta.59",
     "@snapshot-labs/sx": "^0.1.0",
     "@types/bn.js": "^5.1.0",
     "@types/mysql": "^2.15.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3912,10 +3912,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
-"@snapshot-labs/checkpoint@^0.1.0-beta.57":
-  version "0.1.0-beta.57"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/checkpoint/-/checkpoint-0.1.0-beta.57.tgz#1df638a628a4c8bccf1c86cb660567d51bffe9f6"
-  integrity sha512-zUqHRxSD4UBU0B2BG4Ajm8+W7vAEhs+S+OfBV/c4C1ID2SojQ+oaY05ZDnHr5VoDS5sk+XzHhOnb31xjCQO0+A==
+"@snapshot-labs/checkpoint@^0.1.0-beta.59":
+  version "0.1.0-beta.59"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/checkpoint/-/checkpoint-0.1.0-beta.59.tgz#e1ba3acf223a0875e32d0f88c01b311539f340e0"
+  integrity sha512-1Tdd4rZxxW4PiCE8x9iU9GJdT+W1Vjh6rmHtekzJO9nbQlJYfNpLiWM1f2uNVGmVB6VuqCjX35/Pg3wg63IZ6A==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/address" "^5.7.0"


### PR DESCRIPTION
### Summary

This will improve performance of our indexers, fixing issues with indexer falling behind.

I will deploy testnet first once it's merged.