### PR TITLE
fix: show only the user's delegated voting power in split-delegation

### DIFF
--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -13,6 +13,8 @@ type Delegatee = {
   name?: string;
 };
 
+const PERCENT_DIVISOR = 10000;
+
 const FETCH_DELEGATEES_FN = {
   'governor-subgraph': fetchGovernorSubgraphDelegatees,
   'delegate-registry': fetchDelegateRegistryDelegatees,
@@ -196,11 +198,12 @@ async function fetchSplitDelegationDelegatees(
   ]);
 
   return body.delegateTree.map(({ delegate, delegatedPower, weight }, i) => {
-    // simple cross multiplication to get the absolute VP percentage of the delegated VP
+    // Calculate what percentage of the delegatee's total voting power 
+    // comes from the current user's delegation using cross-multiplication
     const delegatedVpPercentage = delegatees[i].votingPower
       ? (delegatedPower * delegatees[i].percentOfVotingPower) /
         delegatees[i].votingPower /
-        10000
+        PERCENT_DIVISOR
       : 0;
 
     return {

--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -196,13 +196,14 @@ async function fetchSplitDelegationDelegatees(
   ]);
 
   return body.delegateTree.map(({ delegate, delegatedPower, weight }, i) => {
-    // delegatee's voting power ratio coming from the current account
-    const vpPercentFromDelegator = delegatedPower / delegatees[i].votingPower;
     return {
       id: delegate,
-      balance: delegatees[i].votingPower,
-      delegatedVotePercentage:
-        vpPercentFromDelegator * (delegatees[i].percentOfVotingPower / 10000),
+      balance: delegatedPower,
+      delegatedVotePercentage: delegatees[i].votingPower
+        ? (delegatedPower * delegatees[i].percentOfVotingPower) /
+          delegatees[i].votingPower /
+          10000
+        : 0,
       name: names[delegate],
       share: weight / 100
     };

--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -198,7 +198,7 @@ async function fetchSplitDelegationDelegatees(
   ]);
 
   return body.delegateTree.map(({ delegate, delegatedPower, weight }, i) => {
-    // Calculate what percentage of the delegatee's total voting power 
+    // Calculate what percentage of the delegatee's total voting power
     // comes from the current user's delegation using cross-multiplication
     const delegatedVpPercentage = delegatees[i].votingPower
       ? (delegatedPower * delegatees[i].percentOfVotingPower) /

--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -196,14 +196,17 @@ async function fetchSplitDelegationDelegatees(
   ]);
 
   return body.delegateTree.map(({ delegate, delegatedPower, weight }, i) => {
+    // simple cross multiplication to get the absolute VP percentage of the delegated VP
+    const delegatedVpPercentage = delegatees[i].votingPower
+      ? (delegatedPower * delegatees[i].percentOfVotingPower) /
+        delegatees[i].votingPower /
+        10000
+      : 0;
+
     return {
       id: delegate,
       balance: delegatedPower,
-      delegatedVotePercentage: delegatees[i].votingPower
-        ? (delegatedPower * delegatees[i].percentOfVotingPower) /
-          delegatees[i].votingPower /
-          10000
-        : 0,
+      delegatedVotePercentage: delegatedVpPercentage,
       name: names[delegate],
       share: weight / 100
     };


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an issue where the amount in the VP column in the delegatees section of the split delegation is not correct.

It was showing the delegatee full VP, instead of just the VP the delegatee get from the current user

### How to test

1. Go to http://localhost:8080/#/s:paraswap-dao.eth/delegates?as=0x9DC3E0fC228c2455773E70ee9E987aE2a6FBc07D
2. In the "delegatees" section, the vp for the delegatee "enerow" should be "1.1M psp" (the amount the current user has delegated)
3. Go to http://localhost:8080/#/s:paraswap-dao.eth/delegates?as=0x17F26c67fD5074d859ae63e00CF5b3Fd793c0786
4. The amount should be different
