### PR TITLE
refactor: support null current on EVM

### DIFF
--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -846,9 +846,6 @@ export function createActions(
       voterAddress: string,
       snapshotInfo: SnapshotInfo
     ): Promise<VotingPower[]> => {
-      if (snapshotInfo.at === null)
-        throw new Error('EVM requires block number to be defined');
-
       const cumulativeDecimals = Math.max(
         ...strategiesMetadata.map(metadata => metadata.decimals ?? 0)
       );

--- a/apps/ui/src/networks/index.ts
+++ b/apps/ui/src/networks/index.ts
@@ -86,15 +86,6 @@ export const enabledReadWriteNetworks: NetworkID[] = enabledNetworks.filter(
   id => !getNetwork(id).readOnly
 );
 
-/**
- * supportsNullCurrent return true if the network supports null current to be used for computing current voting power
- * @param networkId Network ID
- * @returns boolean true if the network supports null current
- */
-export const supportsNullCurrent = (networkID: NetworkID) => {
-  return !evmNetworks.includes(networkID);
-};
-
 export const explorePageProtocols: Record<ExplorePageProtocol, ProtocolConfig> =
   {
     snapshot: {

--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -2,7 +2,7 @@ import { getAddress } from '@ethersproject/address';
 import { useQuery } from '@tanstack/vue-query';
 import { MaybeRefOrGetter } from 'vue';
 import { getNames } from '@/helpers/stamp';
-import { getNetwork, supportsNullCurrent } from '@/networks';
+import { getNetwork } from '@/networks';
 import { RequiredProperty, Space, SpaceMetadataDelegation } from '@/types';
 
 type Delegatee = {
@@ -72,7 +72,6 @@ async function fetchDelegateRegistryDelegatees(
     delegation as RequiredProperty<typeof delegation>,
     space
   );
-  const { getCurrent } = useMetaStore();
 
   const accountDelegation = await getDelegation(account);
 
@@ -87,9 +86,7 @@ async function fetchDelegateRegistryDelegatees(
       space.strategies_parsed_metadata,
       account,
       {
-        at: supportsNullCurrent(space.network)
-          ? null
-          : getCurrent(space.network) || 0,
+        at: null,
         chainId: space.snapshot_chain_id
       }
     ),

--- a/apps/ui/src/queries/propositionPower.ts
+++ b/apps/ui/src/queries/propositionPower.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/vue-query';
 import { MaybeRefOrGetter } from 'vue';
 import { compareAddresses } from '@/helpers/utils';
-import { getNetwork, supportsNullCurrent } from '@/networks';
+import { getNetwork } from '@/networks';
 import { VotingPower } from '@/networks/types';
-import { NetworkID, Space } from '@/types';
+import { Space } from '@/types';
 
 type Strategy = {
   name: string;
@@ -19,11 +19,6 @@ export type PropositionPowerItem = {
 };
 
 const { web3 } = useWeb3();
-
-function getLatestBlock(network: NetworkID): number | null {
-  const { getCurrent } = useMetaStore();
-  return supportsNullCurrent(network) ? null : getCurrent(network) ?? 0;
-}
 
 function getIsSpaceMember(space: Space, account: string): boolean {
   return [
@@ -89,16 +84,14 @@ async function getPropositionPower(space: Space, block: number | null) {
 }
 
 export function usePropositionPowerQuery(space: MaybeRefOrGetter<Space>) {
-  const block = computed(() => getLatestBlock(toValue(space).network));
-
   return useQuery({
     queryKey: [
       'propositionPower',
       () => web3.value.account,
       () => toValue(space).id,
-      block
+      null
     ],
-    queryFn: async () => getPropositionPower(toValue(space), block.value),
+    queryFn: async () => getPropositionPower(toValue(space), null),
     enabled: () => !!web3.value.account && !web3.value.authLoading,
     staleTime: 60 * 1000
   });

--- a/apps/ui/src/queries/votingPower.ts
+++ b/apps/ui/src/queries/votingPower.ts
@@ -1,9 +1,9 @@
 import { utils } from '@snapshot-labs/sx';
 import { useQuery } from '@tanstack/vue-query';
 import { MaybeRefOrGetter } from 'vue';
-import { getNetwork, offchainNetworks, supportsNullCurrent } from '@/networks';
+import { getNetwork, offchainNetworks } from '@/networks';
 import { VotingPower } from '@/networks/types';
-import { NetworkID, Proposal, Space } from '@/types';
+import { Proposal, Space } from '@/types';
 
 export type VotingPowerItem = {
   votingPowers: VotingPower[];
@@ -50,13 +50,7 @@ function getProposalSnapshot(proposal?: Proposal | null): Snapshot {
     ? null
     : proposal.snapshot;
 
-  return snapshot || getLatestBlock(proposal.network);
-}
-
-function getLatestBlock(network: NetworkID): Snapshot {
-  const { getCurrent } = useMetaStore();
-
-  return supportsNullCurrent(network) ? null : getCurrent(network) || 0;
+  return snapshot || null;
 }
 
 async function getVotingPower(
@@ -104,13 +98,13 @@ export function useSpaceVotingPowerQuery(
   return useQuery({
     queryKey: VOTING_POWER_KEYS.space(
       toRef(() => toValue(account)),
-      toRef(() => getLatestBlock(toValue(space).network)),
+      null,
       toRef(() => toValue(space).id)
     ),
     queryFn: async () => {
       const spaceValue = toValue(space);
 
-      return getVotingPower(getLatestBlock(spaceValue.network), spaceValue, [
+      return getVotingPower(null, spaceValue, [
         spaceValue.strategies,
         spaceValue.strategies_params,
         spaceValue.strategies_parsed_metadata

--- a/apps/ui/src/queries/votingPower.ts
+++ b/apps/ui/src/queries/votingPower.ts
@@ -46,11 +46,7 @@ function isOnchainPendingProposal(proposal: Proposal): boolean {
 function getProposalSnapshot(proposal?: Proposal | null): Snapshot {
   if (!proposal) return null;
 
-  const snapshot = isOnchainPendingProposal(proposal)
-    ? null
-    : proposal.snapshot;
-
-  return snapshot || null;
+  return isOnchainPendingProposal(proposal) ? null : proposal.snapshot;
 }
 
 async function getVotingPower(

--- a/apps/ui/src/views/SpaceUser.vue
+++ b/apps/ui/src/views/SpaceUser.vue
@@ -7,7 +7,7 @@ import {
   shortenAddress
 } from '@/helpers/utils';
 import { addressValidator as isValidAddress } from '@/helpers/validation';
-import { getNetwork, supportsNullCurrent } from '@/networks';
+import { getNetwork } from '@/networks';
 import { VotingPower, VotingPowerStatus } from '@/networks/types';
 import { Space, UserActivity } from '@/types';
 
@@ -15,7 +15,6 @@ const props = defineProps<{ space: Space }>();
 
 const route = useRoute();
 const usersStore = useUsersStore();
-const { getCurrent } = useMetaStore();
 const { isWhiteLabel } = useWhiteLabel();
 
 const userActivity = ref<UserActivity>({
@@ -148,9 +147,7 @@ async function getVotingPower() {
       props.space.strategies_parsed_metadata,
       userId.value,
       {
-        at: supportsNullCurrent(props.space.network)
-          ? null
-          : getCurrent(props.space.network) || 0,
+        at: null,
         chainId: props.space.snapshot_chain_id
       }
     );

--- a/packages/sx.js/src/clients/evm/types.ts
+++ b/packages/sx.js/src/clients/evm/types.ts
@@ -92,7 +92,7 @@ export type Strategy = {
     strategyAddress: string,
     voterAddress: string,
     metadata: Record<string, any> | null,
-    block: number,
+    block: number | null,
     params: string,
     provider: Provider
   ): Promise<bigint>;

--- a/packages/sx.js/src/strategies/evm/comp.ts
+++ b/packages/sx.js/src/strategies/evm/comp.ts
@@ -13,14 +13,14 @@ export default function createCompStrategy(): Strategy {
       strategyAddress: string,
       voterAddress: string,
       metadata: Record<string, any> | null,
-      block: number,
+      block: number | null,
       params: string,
       provider: Provider
     ): Promise<bigint> {
       const compContract = new Contract(params, ICompAbi, provider);
 
       const votingPower = await compContract.getCurrentVotes(voterAddress, {
-        blockTag: block
+        blockTag: block ?? 'latest'
       });
 
       return BigInt(votingPower.toString());

--- a/packages/sx.js/src/strategies/evm/ozVotes.ts
+++ b/packages/sx.js/src/strategies/evm/ozVotes.ts
@@ -13,14 +13,14 @@ export default function createOzVotesStrategy(): Strategy {
       strategyAddress: string,
       voterAddress: string,
       metadata: Record<string, any> | null,
-      block: number,
+      block: number | null,
       params: string,
       provider: Provider
     ): Promise<bigint> {
       const votesContract = new Contract(params, IVotes, provider);
 
       const votingPower = await votesContract.getVotes(voterAddress, {
-        blockTag: block
+        blockTag: block ?? 'latest'
       });
 
       return BigInt(votingPower.toString());

--- a/packages/sx.js/test/unit/strategies/evm/comp.test.ts
+++ b/packages/sx.js/test/unit/strategies/evm/comp.test.ts
@@ -11,9 +11,29 @@ describe('compStrategy', () => {
   beforeAll(() => {
     vi.mock('@ethersproject/contracts', () => ({
       Contract: class {
-        async getCurrentVotes(voterAddress: string) {
-          if (voterAddress === '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70') {
-            return '440540570656796043262';
+        async getCurrentVotes(
+          voterAddress: string,
+          { blockTag }: { blockTag: number | string }
+        ) {
+          if (
+            voterAddress === '0xa40839f84cf98ee6f4fdb84c1bb1a448e7835efe' &&
+            blockTag === 8388714
+          ) {
+            return '150000000';
+          }
+
+          if (
+            voterAddress === '0x000000000000000000000000000000000000dead' &&
+            blockTag === 8388714
+          ) {
+            return '0';
+          }
+
+          if (
+            voterAddress === '0xa40839f84cf98ee6f4fdb84c1bb1a448e7835efe' &&
+            blockTag === 'latest'
+          ) {
+            return '300000000';
           }
 
           return '0';
@@ -34,14 +54,14 @@ describe('compStrategy', () => {
     it('should compute voting power for user with delegated tokens at specific timestamp', async () => {
       const votingPower = await compStrategy.getVotingPower(
         '0x0c2De612982Efd102803161fc7C74CcA15Db932c',
-        '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
+        '0xa40839f84cf98ee6f4fdb84c1bb1a448e7835efe',
         null,
-        9343895,
+        8388714,
         params,
         provider
       );
 
-      expect(votingPower.toString()).toEqual('440540570656796043262');
+      expect(votingPower.toString()).toEqual('150000000');
     });
 
     it('should compute voting power for user without delegated tokens', async () => {
@@ -49,12 +69,25 @@ describe('compStrategy', () => {
         '0x0c2De612982Efd102803161fc7C74CcA15Db932c',
         '0x000000000000000000000000000000000000dead',
         null,
-        9343895,
+        8388714,
         params,
         provider
       );
 
       expect(votingPower.toString()).toEqual('0');
+    });
+
+    it('should compute voting power for user with delegated tokens at null block', async () => {
+      const votingPower = await compStrategy.getVotingPower(
+        '0x0c2De612982Efd102803161fc7C74CcA15Db932c',
+        '0xa40839f84cf98ee6f4fdb84c1bb1a448e7835efe',
+        null,
+        null,
+        params,
+        provider
+      );
+
+      expect(votingPower.toString()).toEqual('300000000');
     });
   });
 });

--- a/packages/sx.js/test/unit/strategies/evm/ozVotes.test.ts
+++ b/packages/sx.js/test/unit/strategies/evm/ozVotes.test.ts
@@ -11,9 +11,31 @@ describe('ozVotes', () => {
   beforeAll(() => {
     vi.mock('@ethersproject/contracts', () => ({
       Contract: class {
-        async getVotes(voterAddress: string) {
-          if (voterAddress === '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70')
-            return '10000021';
+        async getVotes(
+          voterAddress: string,
+          { blockTag }: { blockTag: number | string }
+        ) {
+          if (
+            voterAddress === '0xa40839f84cf98ee6f4fdb84c1bb1a448e7835efe' &&
+            blockTag === 8388733
+          ) {
+            return '1000000000000000000';
+          }
+
+          if (
+            voterAddress === '0x000000000000000000000000000000000000dead' &&
+            blockTag === 8388733
+          ) {
+            return '0';
+          }
+
+          if (
+            voterAddress === '0xa40839f84cf98ee6f4fdb84c1bb1a448e7835efe' &&
+            blockTag === 'latest'
+          ) {
+            return '3000000000000000000';
+          }
+
           return '0';
         }
       }
@@ -32,14 +54,14 @@ describe('ozVotes', () => {
     it('should compute voting power for user with delegated tokens at specific timestamp', async () => {
       const votingPower = await ozVotesStrategy.getVotingPower(
         '0x2c8631584474E750CEdF2Fb6A904f2e84777Aefe',
-        '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',
+        '0xa40839f84cf98ee6f4fdb84c1bb1a448e7835efe',
         null,
-        9343895,
+        8388733,
         params,
         provider
       );
 
-      expect(votingPower.toString()).toEqual('10000021');
+      expect(votingPower.toString()).toEqual('1000000000000000000');
     });
 
     it('should compute voting power for user without delegated tokens', async () => {
@@ -47,12 +69,25 @@ describe('ozVotes', () => {
         '0x2c8631584474E750CEdF2Fb6A904f2e84777Aefe',
         '0x000000000000000000000000000000000000dead',
         null,
-        9343895,
+        8388733,
         params,
         provider
       );
 
       expect(votingPower.toString()).toEqual('0');
+    });
+
+    it('should compute voting power for user with delegated tokens at null block', async () => {
+      const votingPower = await ozVotesStrategy.getVotingPower(
+        '0x2c8631584474E750CEdF2Fb6A904f2e84777Aefe',
+        '0xa40839f84cf98ee6f4fdb84c1bb1a448e7835efe',
+        null,
+        null,
+        params,
+        provider
+      );
+
+      expect(votingPower.toString()).toEqual('3000000000000000000');
     });
   });
 });


### PR DESCRIPTION
### Summary

For some reason we didn't support null current on EVM, but revisting it I don't see reason why that would be the case.

This is needed however to implement apeGas voting strategy.

All strategies we use on EVM use block number just as blockTag so null current can be replaced with "latest" blockTag.

This is likely very old limitation that we had initially that we kept instead of normalizing.

To make sure it works I added tests that test null block number for all strategies. Those tests are mocked now (because latest block can change if balance changes), but as of now they should also work without mocks.

### How to test

1. Add ERC20 votes and ERC20 Comp strategy to your Sepolia space.
2. Go to proposals page, VP loads properly.
3. Create proposal with voting delay.
4. While proposal is pending VP loads properly.
5. Once proposal started VP loads properly.
6. You can vote and your VP is correct.
