### PR TITLE
fix: delegation page delegatee loading

### DIFF
--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -197,7 +197,7 @@ watchEffect(() => setTitle(`Delegates - ${props.space.name}`));
       </UiTooltip>
     </div>
 
-    <div class="mb-3">
+    <div v-if="web3.account" class="mb-3">
       <UiLabel label="Delegating to" />
       <UiLoading v-if="isPendingDelegatees" class="px-4 py-3 block" />
       <div v-else-if="delegatees?.length" class="w-full truncate px-4">

--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -1,4 +1,4 @@
-import { getAddress } from '@ethersproject/address';
+import { getAddress, isAddress } from '@ethersproject/address';
 import { useQuery } from '@tanstack/vue-query';
 import { MaybeRefOrGetter } from 'vue';
 import { getNames } from '@/helpers/stamp';
@@ -162,6 +162,10 @@ async function fetchSplitDelegationDelegatees(
   delegation: SpaceMetadataDelegation,
   space: Space
 ): Promise<Delegatee[]> {
+  if (!isAddress(account)) {
+    return [];
+  }
+
   const splitDelegationStrategy = getSplitDelegationStrategy(space);
 
   if (!splitDelegationStrategy) {

--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -228,7 +228,7 @@ export function useDelegateesQuery(
       FETCH_DELEGATEES_FN[
         toValue(delegation)!.apiType as keyof typeof FETCH_DELEGATEES_FN
       ](toValue(account), toValue(delegation)!, toValue(space)),
-    enabled:
+    enabled: () =>
       !!toValue(account) &&
       !!toValue(delegation)?.chainId &&
       !!toValue(delegation)?.apiType &&


### PR DESCRIPTION
### Summary

This PR fixes couple issue with delegatees loading:
1. Fixes reactivity for enabled flag in (#1359), regression from #1345
2. Only shows section "Delegating to" if user is logged in (otherwise it was showing empty section that loaded forever), regression from #1344
3. Updated `fetchSplitDelegationDelegatees` to make API call only for Ethereum addresses, otherwise when signed with Starknet wallet it will end up trying to load it from API and retry 3 times so it was loading for ~10 seconds.

Closes: #1359

### How to test

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth/delegates unlogged.
2. No "Delegating to" section.
3. Sign in with Metamask, it works as expected.
4. Switch to Argent, it works as expected (not delegating message).

