### PR TITLE
Add basic Townhall categories

### DIFF
--- a/apps/highlight/src/agents/townhall.ts
+++ b/apps/highlight/src/agents/townhall.ts
@@ -18,6 +18,7 @@ export default class Townhall extends Agent {
     this.addEntrypoint(TOWNHALL_CONFIG.types.deleteRole);
     this.addEntrypoint(TOWNHALL_CONFIG.types.claimRole);
     this.addEntrypoint(TOWNHALL_CONFIG.types.revokeRole);
+    this.addEntrypoint(TOWNHALL_CONFIG.types.addCategory);
   }
 
   getSigner(signer: string) {
@@ -28,15 +29,16 @@ export default class Townhall extends Agent {
     {
       title,
       body,
-      discussionUrl
-    }: { title: string; body: string; discussionUrl: string },
+      discussionUrl,
+      category
+    }: { title: string; body: string; discussionUrl: string; category: number },
     { signer }: { signer: string }
   ) {
     const id: number = (await this.get('discussions:id')) || 1;
 
     const author = await this.getSigner(signer);
     this.write('discussions:id', id + 1);
-    this.emit('new_discussion', [id, author, title, body, discussionUrl]);
+    this.emit('new_discussion', [id, author, title, body, discussionUrl, category]);
   }
 
   async closeDiscussion({ discussion }: { discussion: number }) {
@@ -177,5 +179,20 @@ export default class Townhall extends Agent {
     const user = await this.getSigner(signer);
 
     this.emit('revoke_role', [space, id, user]);
+  }
+
+  async addCategory({
+    parent,
+    name,
+    about
+  }: {
+    parent: number;
+    name: string;
+    about: string;
+  }) {
+    const id: number = (await this.get('categories:id')) ?? 0;
+    this.write('categories:id', id + 1);
+
+    this.emit('new_category', [parent, String(id), name, about]);
   }
 }

--- a/apps/highlight/src/api/config.json
+++ b/apps/highlight/src/api/config.json
@@ -62,6 +62,10 @@
         {
           "name": "revoke_role",
           "fn": "handleRevokeRole"
+        },
+        {
+          "name": "new_category",
+          "fn": "handleNewCategory"
         }
       ]
     }

--- a/apps/highlight/src/api/writers.ts
+++ b/apps/highlight/src/api/writers.ts
@@ -75,6 +75,13 @@ const ClaimRoleEventData = z.tuple([
 ]);
 const RevokeRoleEventData = ClaimRoleEventData;
 
+const NewCategoryEventData = z.tuple([
+  z.number(), // parent
+  z.string(), // id
+  z.string(), // name
+  z.string() // about
+]);
+
 export function createWriters(indexerName: string) {
   const handleSetAlias: Writer = async ({ unit, payload }) => {
     const [from, to] = SetAliasEventData.parse(payload.data);
@@ -352,6 +359,12 @@ export function createWriters(indexerName: string) {
     }
   };
 
+  const handleNewCategory: Writer = async ({ unit, payload }) => {
+    const [parent, id, name, about] = NewCategoryEventData.parse(payload.data);
+    console.log('Handle new category', parent, id, name, about);
+    // No persistent storage for categories yet
+  };
+
   return {
     // aliases
     handleSetAlias,
@@ -367,6 +380,7 @@ export function createWriters(indexerName: string) {
     handleEditRole,
     handleDeleteRole,
     handleClaimRole,
-    handleRevokeRole
+    handleRevokeRole,
+    handleNewCategory
   };
 }

--- a/apps/ui/src/components/Modal/CategoryConfig.vue
+++ b/apps/ui/src/components/Modal/CategoryConfig.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { clone } from '@/helpers/utils';
+import { getValidator } from '@/helpers/validation';
+
+const props = defineProps<{ open: boolean; initialState?: { name: string; description: string } }>();
+const emit = defineEmits<{ (e: 'add', config: { name: string; description: string }); (e: 'close'): void }>();
+
+const form = ref(props.initialState ? clone(props.initialState) : { name: '', description: '' });
+
+const definition = {
+  type: 'object',
+  title: 'Category',
+  additionalProperties: false,
+  required: ['name'],
+  properties: {
+    name: {
+      type: 'string',
+      title: 'Category name',
+      minLength: 1,
+      maxLength: 32,
+      examples: ['announcements']
+    },
+    description: {
+      type: 'string',
+      title: 'Description',
+      maxLength: 100,
+      examples: ['Explain about category']
+    }
+  }
+};
+
+const formErrors = computed(() => {
+  const validator = getValidator(definition);
+  return validator.validate(form.value, { skipEmptyOptionalFields: true });
+});
+
+const formValid = computed(() => Object.keys(formErrors.value).length === 0);
+
+function handleSubmit() {
+  emit('add', form.value);
+}
+
+watch(
+  () => props.open,
+  () => {
+    form.value = clone(props.initialState || { name: '', description: '' });
+  }
+);
+</script>
+<template>
+  <UiModal :open="open" @close="emit('close')">
+    <template #header>
+      <h3 v-text="initialState ? 'Edit category' : 'Add category'" />
+    </template>
+    <div class="s-box p-4">
+      <UiForm :model-value="form" :error="formErrors" :definition="definition" />
+    </div>
+    <template #footer>
+      <UiButton class="w-full" :disabled="!formValid" @click="handleSubmit">Confirm</UiButton>
+    </template>
+  </UiModal>
+</template>

--- a/apps/ui/src/composables/useTownhall.ts
+++ b/apps/ui/src/composables/useTownhall.ts
@@ -303,6 +303,23 @@ export function useTownhall() {
     );
   }
 
+  async function sendAddCategory(parent: number, name: string, about: string) {
+    if (!auth.value) {
+      modalAccountOpen.value = true;
+      return null;
+    }
+
+    const signer = await getAliasSigner(auth.value.provider);
+
+    return wrapPromise(
+      highlightClient.addCategory({
+        signer,
+        data: { parent, name, about },
+        salt: getSalt()
+      })
+    );
+  }
+
   return {
     sendDiscussion,
     sendCloseDiscussion,
@@ -314,6 +331,7 @@ export function useTownhall() {
     sendEditRole,
     sendDeleteRole,
     sendClaimRole,
-    sendRevokeRole
+    sendRevokeRole,
+    sendAddCategory
   };
 }

--- a/packages/sx.js/src/clients/highlight/ethereum-sig.ts
+++ b/packages/sx.js/src/clients/highlight/ethereum-sig.ts
@@ -18,7 +18,8 @@ import {
   RevokeRole,
   SetAlias,
   UnpinStatement,
-  Vote
+  Vote,
+  AddCategory
 } from './types';
 import {
   ALIASES_CONFIG,
@@ -145,11 +146,12 @@ export class HighlightEthereumSigClient {
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { title, body, discussionUrl } = data;
+    const { title, body, discussionUrl, category } = data;
     const message = {
       title,
       body,
-      discussionUrl
+      discussionUrl,
+      category
     };
 
     const signature = await this.sign(
@@ -543,6 +545,41 @@ export class HighlightEthereumSigClient {
       domain,
       message,
       primaryType: 'RevokeRole',
+      signer: await signer.getAddress(),
+      signature
+    };
+  }
+
+  public async addCategory({
+    signer,
+    data,
+    salt
+  }: {
+    signer: Signer & TypedDataSigner;
+    data: AddCategory;
+    salt: bigint;
+  }): Promise<Envelope> {
+    const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
+
+    const { parent, name, about } = data;
+    const message = {
+      parent,
+      name,
+      about
+    };
+
+    const signature = await this.sign(
+      signer,
+      domain,
+      TOWNHALL_CONFIG.types.addCategory,
+      message
+    );
+
+    return {
+      type: 'HIGHLIGHT_ENVELOPE',
+      domain,
+      message,
+      primaryType: 'AddCategory',
       signer: await signer.getAddress(),
       signature
     };

--- a/packages/sx.js/src/clients/highlight/types.ts
+++ b/packages/sx.js/src/clients/highlight/types.ts
@@ -18,6 +18,7 @@ export type CreateDiscussion = {
   title: string;
   body: string;
   discussionUrl: string;
+  category: number;
 };
 
 export type CloseDiscussion = {
@@ -57,3 +58,9 @@ export type DeleteRole = {
 };
 export type ClaimRole = DeleteRole;
 export type RevokeRole = ClaimRole;
+
+export type AddCategory = {
+  parent: number;
+  name: string;
+  about: string;
+};

--- a/packages/sx.js/src/highlightConstants.ts
+++ b/packages/sx.js/src/highlightConstants.ts
@@ -22,7 +22,8 @@ export const TOWNHALL_CONFIG = {
       Discussion: [
         { name: 'title', type: 'string' },
         { name: 'body', type: 'string' },
-        { name: 'discussionUrl', type: 'string' }
+        { name: 'discussionUrl', type: 'string' },
+        { name: 'category', type: 'uint64' }
       ]
     },
     closeDiscussion: {
@@ -92,6 +93,13 @@ export const TOWNHALL_CONFIG = {
       RevokeRole: [
         { name: 'space', type: 'string' },
         { name: 'id', type: 'uint64' }
+      ]
+    },
+    addCategory: {
+      AddCategory: [
+        { name: 'parent', type: 'uint64' },
+        { name: 'name', type: 'string' },
+        { name: 'about', type: 'string' }
       ]
     }
   }


### PR DESCRIPTION
## Summary
- support categories in Highlight constants and client
- add addCategory method to townhall agent and highlight client
- wire new category modal and dropdown on Townhall topics page

## Testing
- `yarn lint` *(fails: Error when performing the request to https://registry.yarnpkg.com)*
- `yarn typecheck` *(fails: connect EHOSTUNREACH 172.24.0.3:8080)*
- `yarn test` *(fails: connect EHOSTUNREACH 172.24.0.3:8080)*