### PR TITLE
feat: add zappier proposals polling

### DIFF
--- a/apps/api/src/api.ts
+++ b/apps/api/src/api.ts
@@ -14,9 +14,8 @@ const PORT = process.env.PORT ? parseInt(process.env.PORT) : 3000;
 export async function startApiServer(checkpoint: Checkpoint) {
   const app = express();
   const httpServer = http.createServer(app);
-  console.log('--- STARTING ---\n\n');
 
-  app.get('/api/latest-proposals', async (req, res) => {
+  app.get('/latest-proposals', async (req, res) => {
     console.log('Fetching latest proposals');
     try {
       const space = req.query.space as string | undefined;
@@ -24,7 +23,7 @@ export async function startApiServer(checkpoint: Checkpoint) {
 
       const graphqlQuery = {
         query: `
-          query Proposals($where: ProposalWhere, $orderBy: String, $orderDirection: String, $first: Int) {
+          query Proposals($where: Proposal_filter, $orderBy: Proposal_orderBy, $orderDirection: OrderDirection, $first: Int) {
             proposals(
               where: $where
               orderBy: $orderBy
@@ -32,7 +31,12 @@ export async function startApiServer(checkpoint: Checkpoint) {
               first: $first
             ) {
               id
-              space
+              space {
+                id
+                metadata {
+                  name
+                }
+              }
               proposal_id
               created
             }
@@ -41,7 +45,7 @@ export async function startApiServer(checkpoint: Checkpoint) {
         variables: {
           where: {
             created_gte: thirtyMinutesAgo,
-            ...(space ? { space } : {})
+            ...(space ? { space: space } : {})
           },
           orderBy: 'created',
           orderDirection: 'desc',


### PR DESCRIPTION
### Summary

See: https://github.com/snapshot-labs/workflow/issues/519#issue-2950313742

Closes: https://github.com/snapshot-labs/workflow/issues/519#issue-2950313742

### Implementation

We create a new endpoint called `/api/latest-proposals`, with an optional `space` parameter.
This endpoint will return the proposals that were created during the last 30 minutes, by using the existing Checkpoint api.
Zappier will poll us every 15 minutes max, so by using 30 minutes, we are safe.
De-duplication happens on Zappier's side. As long as we return stable IDs for the `proposals`, returning duplicates will not be an issue.



### How to test

Run locally and run this command (this is what Zapier will send, every 15 minutes max):

TODO
