### PR TITLE
feat: automatically process ApeGas proposals

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,3 +1,5 @@
+export const MANA_URL = process.env.VITE_MANA_URL || 'https://mana.box';
+
 /**
  * Array of enabled networks. Can be defined using ENABLED_NETWORKS environment variable
  * with comma-separated list of network names.

--- a/apps/api/src/evm/config.ts
+++ b/apps/api/src/evm/config.ts
@@ -1,5 +1,6 @@
 import { CheckpointConfig } from '@snapshot-labs/checkpoint';
 import { evmNetworks } from '@snapshot-labs/sx';
+import { MANA_URL } from '../config';
 import AxiomExecutionStrategy from './abis/AxiomExecutionStrategy.json';
 import L1AvatarExecutionStrategy from './abis/L1AvatarExecutionStrategy.json';
 import L1AvatarExecutionStrategyFactory from './abis/L1AvatarExecutionStrategyFactory.json';
@@ -34,11 +35,13 @@ export type FullConfig = {
   indexerName: NetworkID;
   chainId: number;
   overrides: {
+    manaRpcUrl: string;
     masterSpace: string;
     masterSimpleQuorumAvatar: string;
     masterSimpleQuorumTimelock: string;
     masterAxiom: string | null;
     propositionPowerValidationStrategyAddress: string;
+    apeGasStrategy: string | null;
   };
 } & CheckpointConfig;
 
@@ -77,13 +80,16 @@ export function createConfig(indexerName: NetworkID): FullConfig {
     indexerName,
     chainId: network.Meta.eip712ChainId,
     overrides: {
+      manaRpcUrl: `${MANA_URL}/eth_rpc/${network.Meta.eip712ChainId}`,
       masterSpace: network.Meta.masterSpace,
       masterSimpleQuorumAvatar: network.ExecutionStrategies.SimpleQuorumAvatar,
       masterSimpleQuorumTimelock:
         network.ExecutionStrategies.SimpleQuorumTimelock,
       masterAxiom: network.ExecutionStrategies.Axiom,
       propositionPowerValidationStrategyAddress:
-        network.ProposalValidations.VotingPower
+        network.ProposalValidations.VotingPower,
+      // TODO: replace with network property in PR that implements strategy
+      apeGasStrategy: '0x8E7083D3D0174Fe7f33821b2b4bDFE0fEE9C8e87'
     },
     network_node_url: `https://rpc.snapshot.org/${network.Meta.eip712ChainId}`,
     sources,

--- a/apps/api/src/evm/utils.ts
+++ b/apps/api/src/evm/utils.ts
@@ -104,3 +104,43 @@ export async function handleCustomExecutionStrategy(
 
   await executionStrategy.save();
 }
+
+export async function registerApeGasProposal(
+  {
+    viewId,
+    snapshot
+  }: {
+    viewId: string;
+    snapshot: number;
+  },
+  config: FullConfig
+) {
+  const res = await fetch(config.overrides.manaRpcUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'registerApeGasProposal',
+      params: {
+        viewId,
+        snapshot
+      }
+    })
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to register ApeGas proposal: ${res.status} ${res.statusText}`
+    );
+  }
+
+  const result = await res.json();
+  if (result.error) {
+    throw new Error(`Failed to register ApeGas proposal: ${result.error}`);
+  }
+
+  return result;
+}

--- a/apps/api/src/starknet/config.ts
+++ b/apps/api/src/starknet/config.ts
@@ -1,6 +1,7 @@
 import { CheckpointConfig } from '@snapshot-labs/checkpoint';
 import { starknetNetworks } from '@snapshot-labs/sx';
 import { validateAndParseAddress } from 'starknet';
+import { MANA_URL } from '../config';
 import spaceAbi from './abis/space.json';
 import spaceFactoryAbi from './abis/spaceFactory.json';
 
@@ -8,7 +9,6 @@ const snNetworkNodeUrl =
   process.env.NETWORK_NODE_URL_SN || 'https://rpc.snapshot.org/sn';
 const snSepNetworkNodeUrl =
   process.env.NETWORK_NODE_URL_SN_SEP || 'https://rpc.snapshot.org/sn-sep';
-const manaRpcUrl = process.env.VITE_MANA_URL || 'https://mana.box';
 
 export type FullConfig = {
   indexerName: 'sn' | 'sn-sep';
@@ -47,7 +47,7 @@ function createOverrides(networkId: keyof typeof CONFIG) {
   return {
     networkNodeUrl: CONFIG[networkId].networkNodeUrl,
     l1NetworkNodeUrl: CONFIG[networkId].l1NetworkNodeUrl,
-    manaRpcUrl: `${manaRpcUrl}/stark_rpc/${config.Meta.eip712ChainId}`,
+    manaRpcUrl: `${MANA_URL}/stark_rpc/${config.Meta.eip712ChainId}`,
     baseChainId: config.Meta.herodotusAccumulatesChainId,
     erc20VotesStrategy: config.Strategies.ERC20Votes,
     propositionPowerValidationStrategyAddress:

--- a/apps/mana/migrations/20250604134037_create_apegas_proposals_table.ts
+++ b/apps/mana/migrations/20250604134037_create_apegas_proposals_table.ts
@@ -1,0 +1,22 @@
+// This is a workaround for Node v23.
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import { type Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  const exists = await knex.schema.hasTable('apegas_proposals');
+  if (exists) return;
+
+  return knex.schema.createTable('apegas_proposals', t => {
+    t.uuid('id').primary().defaultTo(knex.fn.uuid());
+    t.timestamps(true, true);
+    t.integer('chainId');
+    t.string('viewId');
+    t.integer('snapshot');
+    t.string('herodotusId');
+    t.boolean('processed').defaultTo(false).index();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTable('apegas_proposals');
+}

--- a/apps/mana/src/db.ts
+++ b/apps/mana/src/db.ts
@@ -4,6 +4,15 @@ export const REGISTERED_TRANSACTIONS = 'registered_transactions';
 export const REGISTERED_PROPOSALS = 'registered_proposals';
 export const MERKLETREE_REQUESTS = 'merkletree_requests';
 export const MERKLETREES = 'merkletrees';
+export const APEGAS_PROPOSALS = 'apegas_proposals';
+
+export type ApeGasProposal = {
+  chainId: number;
+  viewId: number;
+  snapshot: number;
+  herodotusId?: string | null;
+  processed?: boolean;
+};
 
 export async function registerTransaction(
   network: string,
@@ -120,4 +129,21 @@ export async function getMerkleTreeRequest(id: string) {
 
 export async function getMerkleTree(id: string) {
   return knex(MERKLETREES).select('*').where({ id }).first();
+}
+
+export async function saveApeGasProposal(proposal: ApeGasProposal) {
+  return knex(APEGAS_PROPOSALS).insert(proposal).onConflict().ignore();
+}
+
+export async function updateApeGasProposal(
+  id: string,
+  proposal: Partial<ApeGasProposal>
+) {
+  return knex(APEGAS_PROPOSALS)
+    .update({ updated_at: knex.fn.now(), ...proposal })
+    .where({ id });
+}
+
+export async function getApeGasProposalsToProcess() {
+  return knex(APEGAS_PROPOSALS).select('*').where({ processed: false });
 }

--- a/apps/mana/src/eth/index.ts
+++ b/apps/mana/src/eth/index.ts
@@ -12,7 +12,8 @@ const jsonRpcRequestSchema = z.object({
     'finalizeProposal',
     'execute',
     'executeQueuedProposal',
-    'executeStarknetProposal'
+    'executeStarknetProposal',
+    'registerApeGasProposal'
   ]),
   params: z.any()
 });

--- a/apps/mana/src/eth/registered.ts
+++ b/apps/mana/src/eth/registered.ts
@@ -1,0 +1,52 @@
+import * as db from '../db';
+import { sleep } from '../utils';
+
+const HERODOTUS_API_URL = 'https://apevote.api.herodotus.cloud/votes';
+const INTERVAL = 15_000;
+
+async function processApeGasProposal(
+  proposal: db.ApeGasProposal & { id: string }
+) {
+  const response = await fetch(HERODOTUS_API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      view_id: proposal.viewId,
+      block_number: proposal.snapshot
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to process ape gas proposal');
+  }
+
+  const data = await response.json();
+  if (data.error) {
+    throw new Error(`Herodotus API error: ${data.error}`);
+  }
+
+  await db.updateApeGasProposal(proposal.id, {
+    processed: true,
+    herodotusId: data.id
+  });
+}
+
+export async function registeredApeGasProposalsLoop() {
+  while (true) {
+    const proposals = await db.getApeGasProposalsToProcess();
+
+    console.log('processing', proposals.length, 'ape gas proposals');
+
+    for (const proposal of proposals) {
+      try {
+        await processApeGasProposal(proposal);
+      } catch (e) {
+        console.log('error', e);
+      }
+    }
+
+    await sleep(INTERVAL);
+  }
+}

--- a/apps/mana/src/eth/rpc.ts
+++ b/apps/mana/src/eth/rpc.ts
@@ -15,6 +15,7 @@ import {
 import fetch from 'cross-fetch';
 import { Response } from 'express';
 import { createWalletProxy } from './dependencies';
+import * as db from '../db';
 import { rpcError, rpcSuccess } from '../utils';
 
 const NETWORKS = new Map<number, EvmNetworkConfig>([
@@ -191,11 +192,37 @@ export const createNetworkHandler = (chainId: number) => {
     }
   }
 
+  async function registerApeGasProposal(
+    id: number,
+    params: any,
+    res: Response
+  ) {
+    try {
+      const { viewId, snapshot } = params;
+
+      if (!viewId || !snapshot) {
+        return rpcError(res, 400, 'Missing viewId or snapshot', id);
+      }
+
+      await db.saveApeGasProposal({
+        chainId,
+        viewId,
+        snapshot
+      });
+
+      return rpcSuccess(res, 'success', id);
+    } catch (e) {
+      console.log('Error registering ApeGas proposal:', e);
+      return rpcError(res, 500, e, id);
+    }
+  }
+
   return {
     send,
     finalizeProposal,
     execute,
     executeQueuedProposal,
-    executeStarknetProposal
+    executeStarknetProposal,
+    registerApeGasProposal
   };
 };

--- a/apps/mana/src/index.ts
+++ b/apps/mana/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import express from 'express';
 import { PORT } from './constants';
 import ethRpc from './eth';
+import { registeredApeGasProposalsLoop } from './eth/registered';
 import starkRpc from './stark';
 import pkg from '../package.json';
 import {
@@ -37,6 +38,7 @@ app.get('/', (req, res) =>
 async function start() {
   registeredTransactionsLoop();
   registeredProposalsLoop();
+  registeredApeGasProposalsLoop();
 
   app.listen(PORT, () => console.log(`Listening at http://localhost:${PORT}`));
 }

--- a/turbo.json
+++ b/turbo.json
@@ -21,7 +21,7 @@
       "cache": false,
       "persistent": true,
       "dependsOn": ["codegen", "^build"],
-      "passThroughEnv": ["ENABLED_NETWORKS", "INFURA_API_KEY"]
+      "passThroughEnv": ["ENABLED_NETWORKS", "INFURA_API_KEY", "VITE_MANA_URL"]
     },
     "codegen": {
       "outputs": [".checkpoint/**", "src/networks/common/graphqlApi/gql/**"],


### PR DESCRIPTION
### Summary

This PR adds detection of ApeGas proposals in API and those proposals are saved in Mana via RPC.

Then Mana will try to process those proposals using Herodotus API.

### How to test

1. Apply patch below (it just changes local API to index curtis only).
2. Run `yarn dev:interactive`.
3. Create proposal on Space that uses ApeGas voting strategy (you can use this space http://localhost:8080/#/curtis:0xf6238F73A87D390CB00b2B380D2B777E13Fe2725 or create your own on [this PR](https://github.com/pulls)).
4. Inspect `SELECT * FROM public.apegas_proposals` on Mana database.
5. You see your request and Herodotus ID.
6. (optional) After around 1.5 hours you can vote on that proposal (if you have VP) on [this PR](https://github.com/pulls).

```diff
diff --git a/scripts/dev-interactive.ts b/scripts/dev-interactive.ts
index 8596281f..320e5f20 100644
--- a/scripts/dev-interactive.ts
+++ b/scripts/dev-interactive.ts
@@ -13,8 +13,8 @@ const SERVICES: Record<ServiceType, Service> = {
   },
   api: {
     env: {
-      ENABLED_NETWORKS: 'sep,sn-sep',
-      VITE_ENABLED_NETWORKS: 's-tn,sep,sn-sep',
+      ENABLED_NETWORKS: 'curtis',
+      VITE_ENABLED_NETWORKS: 's-tn,curtis',
       VITE_METADATA_NETWORK: 's-tn',
       VITE_UNIFIED_API_TESTNET_URL: 'http://localhost:3000'
     }
```