### PR TITLE
fix: update isContract checks to support EIP-7702

### DIFF
--- a/apps/ui/src/components/Modal/Transaction.vue
+++ b/apps/ui/src/components/Modal/Transaction.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Fragment, Interface, JsonFragment } from '@ethersproject/abi';
 import { isAddress } from '@ethersproject/address';
+import { getIsContract } from '@/helpers/contracts';
 import { getABI } from '@/helpers/etherscan';
 import { getProvider } from '@/helpers/provider';
 import { resolver } from '@/helpers/resolver';
@@ -169,8 +170,8 @@ async function handleToChange(to: string) {
   const provider = getProvider(props.network);
 
   try {
-    const code = await provider.getCode(contractAddress);
-    if (code === '0x') {
+    const isContract = await getIsContract(provider, contractAddress);
+    if (!isContract) {
       addressInvalid.value = true;
       return;
     }

--- a/apps/ui/src/composables/useSafeWallet.ts
+++ b/apps/ui/src/composables/useSafeWallet.ts
@@ -1,5 +1,6 @@
 import { Contract } from '@ethersproject/contracts';
 import { computedAsync, useMemoize } from '@vueuse/core';
+import { getIsContract } from '@/helpers/contracts';
 import { getProvider } from '@/helpers/provider';
 import { offchainNetworks } from '@/networks';
 import { NetworkID } from '@/types';
@@ -7,9 +8,9 @@ import { NetworkID } from '@/types';
 const getSafeVersion = useMemoize(
   async (networkKey: string, account: string) => {
     const provider = getProvider(Number(networkKey));
-    const code = await provider.getCode(account);
 
-    if (code === '0x') return undefined;
+    const isContract = await getIsContract(provider, account);
+    if (!isContract) return undefined;
 
     const abi = ['function VERSION() view returns (string)'];
     const contract = new Contract(account, abi, provider);

--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -23,6 +23,7 @@ export const VERIFIED_URL =
 
 export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 export const ETH_CONTRACT = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+export const EIP7702_DELEGATION_INDICATOR = '0xef0100';
 
 export const CHAIN_IDS: Record<Exclude<NetworkID, 's' | 's-tn'>, ChainId> = {
   // EVM

--- a/apps/ui/src/helpers/contracts.ts
+++ b/apps/ui/src/helpers/contracts.ts
@@ -1,6 +1,17 @@
+import { Provider } from '@ethersproject/providers';
 import { abis } from './abis';
+import { EIP7702_DELEGATION_INDICATOR } from './constants';
 import Multicaller from './multicaller';
 import { getProvider } from './provider';
+
+export async function getIsContract(provider: Provider, address: string) {
+  const code = await provider.getCode(address);
+
+  if (code === '0x') return false;
+  if (code.startsWith(EIP7702_DELEGATION_INDICATOR)) return false;
+
+  return true;
+}
 
 export async function getTokensMetadata(chainId: number, tokens: string[]) {
   const provider = getProvider(chainId);

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -17,6 +17,7 @@ import {
   evmSepolia,
   getEvmStrategy
 } from '@snapshot-labs/sx';
+import { getIsContract as _getIsContract } from '@/helpers/contracts';
 import { vote as highlightVote } from '@/helpers/highlight';
 import { getSwapLink } from '@/helpers/link';
 import { executionCall, getRelayerInfo, MANA_URL } from '@/helpers/mana';
@@ -102,8 +103,7 @@ export function createActions(
       return true;
     }
 
-    const code = await provider.getCode(address);
-    return code !== '0x';
+    return _getIsContract(provider, address);
   };
 
   /**

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -14,6 +14,7 @@ import {
   constants as starknetConstants,
   uint256
 } from 'starknet';
+import { getIsContract as _getIsContract } from '@/helpers/contracts';
 import { executionCall, getRelayerInfo, MANA_URL } from '@/helpers/mana';
 import { getProvider } from '@/helpers/provider';
 import { convertToMetaTransactions } from '@/helpers/transactions';
@@ -102,8 +103,7 @@ export function createActions(
     if (!EVM_CONNECTORS.includes(connectorType)) return false;
     if (connectorType === 'sequence') return true;
 
-    const code = await l1Provider.getCode(address);
-    return code !== '0x';
+    return _getIsContract(l1Provider, address);
   };
 
   const client = new clients.StarknetTx(clientConfig);


### PR DESCRIPTION
### Summary

After Pectra update EOA's getCode call can return non 0x responses. This links EOA to smart contract and it can be detected by 0xef0100 delegation indicator.

We need to check if code is not just EIP-7702 reference before assuming it's a contract.

### How to test

1. Upgrade your mainnet account to EIP-7702 (not sure how I did that anymore).
2. After that Snapshot works as it used to.
3. For example you can follow and unfollow spaces (before it would tell you that Safe wallets can't follow spaces).
