### PR TITLE
fix: handle null in contract check

### DIFF
--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -257,7 +257,7 @@ function formatSpace(
       const { name, api_type, api_url, contract, chain_id } =
         JSON.parse(delegation);
 
-      if (contract.includes(':')) {
+      if (contract?.includes(':')) {
         // NOTE: Legacy format
         const [network, address] = contract.split(':');
 


### PR DESCRIPTION
### Summary
- added optional chaining to contract check to prevent errors when contract is null
```
TypeError: Cannot read properties of null (reading 'includes')
    at index.ts:260:20
    at Array.map (<anonymous>)
    at formatSpace (index.ts:256:45)
```

### How to test
1. Change env to 
```
VITE_ENABLED_NETWORKS=s-tn,curtis
VITE_METADATA_NETWORK=s-tn
```
2. Go to http://localhost:8080/#/explore?p=snapshot-x&n=curtis
3. You should see spaces instead of black page\
