### PR TITLE
feat: make ApeGas proposals show up as pending for 2 hours.

### DIFF
--- a/apps/api/src/evm/config.ts
+++ b/apps/api/src/evm/config.ts
@@ -42,6 +42,7 @@ export type FullConfig = {
     masterAxiom: string | null;
     propositionPowerValidationStrategyAddress: string;
     apeGasStrategy: string | null;
+    apeGasStrategyDelay: number;
   };
 } & CheckpointConfig;
 
@@ -88,7 +89,8 @@ export function createConfig(indexerName: NetworkID): FullConfig {
       masterAxiom: network.ExecutionStrategies.Axiom,
       propositionPowerValidationStrategyAddress:
         network.ProposalValidations.VotingPower,
-      apeGasStrategy: network.Strategies.ApeGas ?? null
+      apeGasStrategy: network.Strategies.ApeGas ?? null,
+      apeGasStrategyDelay: 2 * 60 * 5 // 2 hours, with 5 blocks per minute
     },
     network_node_url: `https://rpc.snapshot.org/${network.Meta.eip712ChainId}`,
     sources,

--- a/apps/api/src/evm/writers.ts
+++ b/apps/api/src/evm/writers.ts
@@ -714,6 +714,11 @@ export function createWriters(config: FullConfig) {
           )
       : [];
 
+    if (apeGasStrategiesIndices.length) {
+      proposal.start += config.overrides.apeGasStrategyDelay;
+      proposal.min_end = Math.max(proposal.start, proposal.max_end);
+    }
+
     for (const [, i] of apeGasStrategiesIndices) {
       const params = space.strategies_params[i];
       if (!params) continue;

--- a/apps/mana/src/db.ts
+++ b/apps/mana/src/db.ts
@@ -144,6 +144,15 @@ export async function updateApeGasProposal(
     .where({ id });
 }
 
-export async function getApeGasProposalsToProcess() {
-  return knex(APEGAS_PROPOSALS).select('*').where({ processed: false });
+export async function getApeGasProposalsToProcess({
+  chainId,
+  maxSnapshot
+}: {
+  chainId: number;
+  maxSnapshot: number;
+}) {
+  return knex(APEGAS_PROPOSALS)
+    .select('*')
+    .where({ chainId, processed: false })
+    .andWhere('snapshot', '<=', maxSnapshot);
 }

--- a/apps/mana/src/eth/registered.ts
+++ b/apps/mana/src/eth/registered.ts
@@ -1,6 +1,10 @@
+import { Contract } from '@ethersproject/contracts';
 import * as db from '../db';
 import { sleep } from '../utils';
+import { createWalletProxy } from './dependencies';
 
+const APE_GAS_CHAIN_IDS = [33111];
+const MULTICALL3_ADDRESS = '0xcA11bde05977b3631167028862bE2a173976CA11';
 const HERODOTUS_API_URL = 'https://apevote.api.herodotus.cloud/votes';
 const INTERVAL = 15_000;
 
@@ -33,9 +37,28 @@ async function processApeGasProposal(
   });
 }
 
-export async function registeredApeGasProposalsLoop() {
+export async function processApeGasProposals(chainId: number) {
+  const { provider } = createWalletProxy(chainId);
+
+  const multicallContract = new Contract(
+    MULTICALL3_ADDRESS,
+    ['function getBlockNumber() view returns (uint256 blockNumber)'],
+    provider
+  );
+
+  const currentL1BlockNumber = (
+    await multicallContract.getBlockNumber()
+  ).toNumber();
+
+  console.log(
+    `Processing ape gas proposals for chain ${chainId} at block ${currentL1BlockNumber}`
+  );
+
   while (true) {
-    const proposals = await db.getApeGasProposalsToProcess();
+    const proposals = await db.getApeGasProposalsToProcess({
+      chainId,
+      maxSnapshot: currentL1BlockNumber
+    });
 
     console.log('processing', proposals.length, 'ape gas proposals');
 
@@ -44,6 +67,20 @@ export async function registeredApeGasProposalsLoop() {
         await processApeGasProposal(proposal);
       } catch (e) {
         console.log('error', e);
+      }
+    }
+
+    await sleep(INTERVAL);
+  }
+}
+
+export async function registeredApeGasProposalsLoop() {
+  while (true) {
+    for (const chainId of APE_GAS_CHAIN_IDS) {
+      try {
+        await processApeGasProposals(chainId);
+      } catch (e) {
+        console.error(`Error processing ape gas on ${chainId} proposals:`, e);
       }
     }
 


### PR DESCRIPTION
### Summary

This PR adds two changes related to ApeGas proposals:
1. If proposal has actual voting delay Mana will only try to process it once snapshot is not in the future, without it Herodotus requests will keep failing.
2. If ApeGas strategy is used proposal will have additional 2 hour of enforced voting delay (this is on top of existing voting delay). This is buffer for all proof related computations.

### How to test

1. Apply patch below.
2. Run `yarn dev:interactive` and run UI, Mana, API.
3. Wait for API to sync up.
4. Create new proposal on Curtis on space with ApeGas voting strategy.
5. Proposal is pending.


```diff
diff --git a/scripts/dev-interactive.ts b/scripts/dev-interactive.ts
index 8596281f..320e5f20 100644
--- a/scripts/dev-interactive.ts
+++ b/scripts/dev-interactive.ts
@@ -13,8 +13,8 @@ const SERVICES: Record<ServiceType, Service> = {
   },
   api: {
     env: {
-      ENABLED_NETWORKS: 'sep,sn-sep',
-      VITE_ENABLED_NETWORKS: 's-tn,sep,sn-sep',
+      ENABLED_NETWORKS: 'curtis',
+      VITE_ENABLED_NETWORKS: 's-tn,curtis',
       VITE_METADATA_NETWORK: 's-tn',
       VITE_UNIFIED_API_TESTNET_URL: 'http://localhost:3000'
     }

```