### PR TITLE
fix: show tooltip for truncated choices

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -190,10 +190,7 @@ onMounted(() => {
             class="text-white size-[14px] mt-0.5 ml-0.5"
           />
         </div>
-        <div
-          class="truncate grow"
-          v-text="proposal.choices[result.choice - 1]"
-        />
+        <UiTooltipOnTruncate :content="proposal.choices[result.choice - 1]" />
         <IH-lock-closed
           v-if="proposal.privacy !== 'none' && !proposal.completed"
           class="size-[16px] shrink-0"

--- a/apps/ui/src/components/ProposalVoteApproval.vue
+++ b/apps/ui/src/components/ProposalVoteApproval.vue
@@ -37,9 +37,7 @@ function toggleSelectedChoice(choice: number) {
         :class="{ 'border-skin-text': selectedChoices.includes(index + 1) }"
         @click="toggleSelectedChoice(index + 1)"
       >
-        <div class="grow truncate">
-          {{ choice }}
-        </div>
+        <UiTooltipOnTruncate :content="choice" />
         <IH-check v-if="selectedChoices.includes(index + 1)" class="shrink-0" />
       </UiButton>
     </div>

--- a/apps/ui/src/components/ProposalVoteRankedChoice.vue
+++ b/apps/ui/src/components/ProposalVoteRankedChoice.vue
@@ -36,10 +36,7 @@ const selectedChoices = ref<RankedChoice>(
           class="!h-[48px] text-left w-full flex items-center handle cursor-grab gap-2"
         >
           <IC-drag class="text-skin-text" />
-
-          <div class="grow truncate">
-            {{ proposal.choices[element - 1] }}
-          </div>
+          <UiTooltipOnTruncate :content="proposal.choices[element - 1]" />
           <div
             class="h-[18px] min-w-[18px] rounded-full leading-[18px] text-[13px] text-skin-link bg-skin-border px-2 text-center inline-block"
           >

--- a/apps/ui/src/components/ProposalVoteSingleChoice.vue
+++ b/apps/ui/src/components/ProposalVoteSingleChoice.vue
@@ -25,7 +25,7 @@ const selectedChoice = ref<number | null>(
         :class="{ 'border-skin-text': selectedChoice === index + 1 }"
         @click="selectedChoice = index + 1"
       >
-        <div class="grow truncate">{{ choice }}</div>
+        <UiTooltipOnTruncate :content="choice" />
         <IH-check v-if="selectedChoice === index + 1" class="shrink-0" />
       </UiButton>
     </div>

--- a/apps/ui/src/components/ProposalVoteWeighted.vue
+++ b/apps/ui/src/components/ProposalVoteWeighted.vue
@@ -57,10 +57,7 @@ watch(
           '!border-skin-link': selectedChoices[i + 1] > 0
         }"
       >
-        <div class="grow truncate text-skin-link">
-          {{ choice }}
-        </div>
-
+        <UiTooltipOnTruncate :content="choice" class="text-skin-link" />
         <div class="flex gap-1 items-center">
           <UiButton
             :disabled="!selectedChoices[i + 1]"

--- a/apps/ui/src/components/Ui/TooltipOnTruncate.vue
+++ b/apps/ui/src/components/Ui/TooltipOnTruncate.vue
@@ -3,50 +3,33 @@ const props = defineProps<{
   content?: string;
 }>();
 
-const wrapper = ref<HTMLElement | null>(null);
+const wrapperRef = ref<HTMLElement | null>(null);
 const isTruncated = ref(false);
 
 const tooltipContent = computed(() => {
-  return props.content || wrapper.value?.textContent || '';
+  return props.content || wrapperRef.value?.textContent || '';
 });
 
 const checkTruncation = () => {
-  if (!wrapper.value) return;
-  isTruncated.value = wrapper.value.scrollWidth > wrapper.value.clientWidth;
+  if (!wrapperRef.value) return;
+  isTruncated.value =
+    wrapperRef.value.scrollWidth > wrapperRef.value.clientWidth;
 };
 
-const debouncedCheckTruncation = useDebounceFn(checkTruncation, 300);
+const debouncedCheckTruncation = useDebounceFn(checkTruncation, 50);
 
-let resizeObserver: ResizeObserver | null = null;
-
-const setupResizeObserver = (element: HTMLElement) => {
-  if (resizeObserver) {
-    resizeObserver.disconnect();
-  }
-
-  if (window.ResizeObserver) {
-    resizeObserver = new ResizeObserver(debouncedCheckTruncation);
-    resizeObserver.observe(element);
-  }
-};
+useResizeObserver(wrapperRef, debouncedCheckTruncation);
 
 watchEffect(() => {
-  if (wrapper.value) {
+  if (wrapperRef.value) {
     checkTruncation();
-    setupResizeObserver(wrapper.value);
-  }
-});
-
-onBeforeUnmount(() => {
-  if (resizeObserver) {
-    resizeObserver.disconnect();
   }
 });
 </script>
 
 <template>
   <div
-    ref="wrapper"
+    ref="wrapperRef"
     v-tippy="{
       content: isTruncated ? tooltipContent : null
     }"

--- a/apps/ui/src/components/Ui/TooltipOnTruncate.vue
+++ b/apps/ui/src/components/Ui/TooltipOnTruncate.vue
@@ -15,16 +15,7 @@ const checkTruncation = () => {
   isTruncated.value = wrapper.value.scrollWidth > wrapper.value.clientWidth;
 };
 
-const debounce = (func: () => void, wait: number) => {
-  let timeout: NodeJS.Timeout;
-  return () => {
-    clearTimeout(timeout);
-    timeout = setTimeout(func, wait);
-  };
-};
-
-// Debounce with 16ms delay (~60fps) to prevent excessive calculations during animations/resizes
-const debouncedCheckTruncation = debounce(checkTruncation, 16);
+const debouncedCheckTruncation = useDebounceFn(checkTruncation, 300);
 
 let resizeObserver: ResizeObserver | null = null;
 

--- a/apps/ui/src/components/Ui/TooltipOnTruncate.vue
+++ b/apps/ui/src/components/Ui/TooltipOnTruncate.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+const props = defineProps<{
+  content?: string;
+}>();
+
+const wrapper = ref<HTMLElement | null>(null);
+const isTruncated = ref(false);
+
+const tooltipContent = computed(() => {
+  return props.content || wrapper.value?.textContent || '';
+});
+
+const checkTruncation = () => {
+  if (!wrapper.value) return;
+  isTruncated.value = wrapper.value.scrollWidth > wrapper.value.clientWidth;
+};
+
+const debounce = (func: () => void, wait: number) => {
+  let timeout: NodeJS.Timeout;
+  return () => {
+    clearTimeout(timeout);
+    timeout = setTimeout(func, wait);
+  };
+};
+
+// Debounce with 16ms delay (~60fps) to prevent excessive calculations during animations/resizes
+const debouncedCheckTruncation = debounce(checkTruncation, 16);
+
+let resizeObserver: ResizeObserver | null = null;
+
+const setupResizeObserver = (element: HTMLElement) => {
+  if (resizeObserver) {
+    resizeObserver.disconnect();
+  }
+
+  if (window.ResizeObserver) {
+    resizeObserver = new ResizeObserver(debouncedCheckTruncation);
+    resizeObserver.observe(element);
+  }
+};
+
+watchEffect(() => {
+  if (wrapper.value) {
+    checkTruncation();
+    setupResizeObserver(wrapper.value);
+  }
+});
+
+onBeforeUnmount(() => {
+  if (resizeObserver) {
+    resizeObserver.disconnect();
+  }
+});
+</script>
+
+<template>
+  <div
+    ref="wrapper"
+    v-tippy="{
+      content: isTruncated ? tooltipContent : null
+    }"
+    class="inline-block relative grow truncate"
+  >
+    <slot>{{ content }}</slot>
+  </div>
+</template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/573

Show a tooltip for long choice in results and vote, only when the choice is truncated

### How to test

Test with:

- http://127.0.0.1:8080/#/s:test.wa0x6e.eth/proposal/0xfe38f18680b255721c276013284cebccaed6d09b62164baf12e60436a9de5413
- http://127.0.0.1:8080/#/s:test.wa0x6e.eth/proposal/0x9d45d6cb75e93b582b35d4e27c960551c3dd3c2d071c3c7d8615639b37ab2af2

1. The vote form and result choice label should show a tooltip on mouse hover when truncated
2. There is no tooltip when not truncated
3. Resize the right sidebar
4. The tooltip status should react to the resize and new truncate status
