### PR TITLE
refactor: rename Discussion -> Topic, Statement -> Post

### DIFF
--- a/apps/highlight/src/api/config.json
+++ b/apps/highlight/src/api/config.json
@@ -16,28 +16,28 @@
       "start": 1,
       "events": [
         {
-          "name": "new_discussion",
-          "fn": "handleNewDiscussion"
+          "name": "new_topic",
+          "fn": "handleNewTopic"
         },
         {
-          "name": "close_discussion",
-          "fn": "handleCloseDiscussion"
+          "name": "close_topic",
+          "fn": "handleCloseTopic"
         },
         {
-          "name": "new_statement",
-          "fn": "handleNewStatement"
+          "name": "new_post",
+          "fn": "handleNewPost"
         },
         {
-          "name": "pin_statement",
-          "fn": "handlePinStatement"
+          "name": "pin_post",
+          "fn": "handlePinPost"
         },
         {
-          "name": "unpin_statement",
-          "fn": "handleUnpinStatement"
+          "name": "unpin_post",
+          "fn": "handleUnpinPost"
         },
         {
-          "name": "hide_statement",
-          "fn": "handleHideStatement"
+          "name": "hide_post",
+          "fn": "handleHidePost"
         },
         {
           "name": "new_vote",

--- a/apps/highlight/src/api/schema.gql
+++ b/apps/highlight/src/api/schema.gql
@@ -2,7 +2,7 @@ scalar Text
 
 type Space {
   id: String!
-  discussion_count: Int!
+  topic_count: Int!
   vote_count: Int!
 }
 
@@ -13,22 +13,22 @@ type Alias {
   created: Int!
 }
 
-type Discussion {
+type Topic {
   id: String!
   title: String!
   body: Text!
   discussion_url: String!
   author: String!
-  statement_count: Int!
+  post_count: Int!
   vote_count: Int!
   created: Int!
   closed: Boolean!
   space: Space!
-  statements: [Statement!]! @derivedFrom(field: "discussion")
-  votes: [Vote!]! @derivedFrom(field: "discussion")
+  posts: [Post!]! @derivedFrom(field: "topic")
+  votes: [Vote!]! @derivedFrom(field: "topic")
 }
 
-type Statement {
+type Post {
   id: String!
   body: Text!
   author: String!
@@ -39,10 +39,10 @@ type Statement {
   pinned: Boolean!
   hidden: Boolean!
   created: Int!
-  discussion_id: Int!
-  statement_id: Int!
-  discussion: Discussion!
-  votes: [Vote!]! @derivedFrom(field: "statement")
+  topic_id: Int!
+  post_id: Int!
+  topic: Topic!
+  votes: [Vote!]! @derivedFrom(field: "post")
 }
 
 type Vote {
@@ -50,10 +50,10 @@ type Vote {
   voter: String!
   choice: Int!
   created: Int!
-  discussion_id: Int!
-  statement_id: Int!
-  discussion: Discussion!
-  statement: Statement!
+  topic_id: Int!
+  post_id: Int!
+  topic: Topic!
+  post: Post!
 }
 
 type Role {

--- a/apps/highlight/src/index.ts
+++ b/apps/highlight/src/index.ts
@@ -29,17 +29,17 @@ async function run() {
   app.use('/highlight', rpc);
 
   app.get(
-    '/townhall/discussions/:discussionId/results_by_role/:roleId',
+    '/townhall/topics/:topicId/results_by_role/:roleId',
     async (req, res) => {
       const { knex } = checkpoint.getBaseContext();
 
-      const { discussionId, roleId } = req.params;
+      const { topicId, roleId } = req.params;
 
       let query = knex('votes')
-        .select('votes.statement_id', 'choice')
+        .select('votes.post_id', 'choice')
         .countDistinct('votes.voter', { as: 'vote_count' })
         .whereRaw('upper_inf(votes.block_range)')
-        .where('discussion_id', discussionId);
+        .where('topic_id', topicId);
 
       if (roleId !== 'any') {
         query = query
@@ -49,7 +49,7 @@ async function run() {
           .where('roles.id', roleId);
       }
 
-      const result = await query.groupBy('votes.statement_id', 'choice');
+      const result = await query.groupBy('votes.post_id', 'choice');
 
       res.json({ result });
     }

--- a/apps/highlight/src/index.ts
+++ b/apps/highlight/src/index.ts
@@ -49,9 +49,14 @@ async function run() {
           .where('roles.id', roleId);
       }
 
-      const result = await query.groupBy('votes.post_id', 'choice');
+      try {
+        const result = await query.groupBy('votes.post_id', 'choice');
 
-      res.json({ result });
+        return res.json({ result });
+      } catch (e) {
+        console.error('Error fetching results by role:', e);
+        return res.status(500).json({ error: 'Internal Server Error' });
+      }
     }
   );
   app.use('/', checkpoint.graphql);

--- a/apps/ui/src/components/Townhall/PostItem.vue
+++ b/apps/ui/src/components/Townhall/PostItem.vue
@@ -1,31 +1,29 @@
 <script setup lang="ts">
 import { Result } from '@/helpers/townhall/api';
-import { Discussion, Statement } from '@/helpers/townhall/types';
+import { Post, Topic } from '@/helpers/townhall/types';
 import { _n, _p, _rt, shortenAddress } from '@/helpers/utils';
-import { useSetStatementVisibilityMutation } from '@/queries/townhall';
+import { useSetPostVisibilityMutation } from '@/queries/townhall';
 
 const props = defineProps<{
   spaceId: string;
-  discussionId: number;
-  discussion: Discussion;
-  statement: Statement;
+  topicId: number;
+  topic: Topic;
+  post: Post;
   results: Result[];
 }>();
 
 const { web3 } = useWeb3();
-const { mutate: setStatementVisibility } = useSetStatementVisibilityMutation({
+const { mutate: setPostVisibility } = useSetPostVisibilityMutation({
   spaceId: toRef(props, 'spaceId'),
-  discussionId: toRef(props, 'discussionId')
+  topicId: toRef(props, 'topicId')
 });
 
-const statementResults = computed(() => {
-  return props.results.filter(
-    result => result.statement_id === props.statement.statement_id
-  );
+const postResults = computed(() => {
+  return props.results.filter(result => result.post_id === props.post.post_id);
 });
 
 const voteCount = computed(() =>
-  statementResults.value.reduce((acc, result) => acc + result.vote_count, 0)
+  postResults.value.reduce((acc, result) => acc + result.vote_count, 0)
 );
 
 const choice = computed(() => {
@@ -36,8 +34,7 @@ const choice = computed(() => {
 
 function getChoiceResult(choice: 1 | 2 | 3) {
   return (
-    statementResults.value.find(result => result.choice === choice)
-      ?.vote_count ?? 0
+    postResults.value.find(result => result.choice === choice)?.vote_count ?? 0
   );
 }
 </script>
@@ -47,14 +44,14 @@ function getChoiceResult(choice: 1 | 2 | 3) {
     <div class="flex">
       <div class="flex-1">
         <div class="text-[17px] flex gap-2 items-center mb-3">
-          <UiStamp :id="statement.author" :size="20" />
-          {{ shortenAddress(statement.author) }}
+          <UiStamp :id="post.author" :size="20" />
+          {{ shortenAddress(post.author) }}
           <span>·</span>
-          {{ _rt(statement.created) }}
+          {{ _rt(post.created) }}
         </div>
-        <div class="text-skin-link mb-1">{{ statement.body }}</div>
+        <div class="text-skin-link mb-1">{{ post.body }}</div>
       </div>
-      <UiDropdown v-if="web3.account && discussion.author === web3.account">
+      <UiDropdown v-if="web3.account && topic.author === web3.account">
         <template #button>
           <UiButton class="!p-0 !border-0 !h-[auto] !bg-transparent">
             <IH-dots-horizontal class="text-skin-link" />
@@ -67,14 +64,14 @@ function getChoiceResult(choice: 1 | 2 | 3) {
               class="flex items-center gap-2"
               :class="{ 'opacity-80': active }"
               @click="
-                setStatementVisibility({
-                  statementId: statement.statement_id,
+                setPostVisibility({
+                  postId: post.post_id,
                   visibility: 'pin'
                 })
               "
             >
               <IC-pin class="w-[16px] h-[16px]" />
-              {{ statement.pinned ? 'Unpin' : 'Pin' }} statement
+              {{ post.pinned ? 'Unpin' : 'Pin' }} post
             </button>
           </UiDropdownItem>
           <UiDropdownItem v-slot="{ active }">
@@ -83,14 +80,14 @@ function getChoiceResult(choice: 1 | 2 | 3) {
               class="flex items-center gap-2"
               :class="{ 'opacity-80': active }"
               @click="
-                setStatementVisibility({
-                  statementId: statement.statement_id,
+                setPostVisibility({
+                  postId: post.post_id,
                   visibility: 'hide'
                 })
               "
             >
               <IH-flag :width="16" />
-              Hide statement
+              Hide post
             </button>
           </UiDropdownItem>
         </template>
@@ -98,7 +95,7 @@ function getChoiceResult(choice: 1 | 2 | 3) {
     </div>
     <div class="flex text-[17px] items-center gap-2.5">
       <div
-        v-if="statementResults.length > 0"
+        v-if="postResults.length > 0"
         :class="{
           'bg-skin-success/10 border-skin-success': choice === 1,
           'bg-skin-danger/10 border-skin-danger': choice === 2,
@@ -120,8 +117,8 @@ function getChoiceResult(choice: 1 | 2 | 3) {
         </div>
       </div>
       <div class="flex-1" v-text="`${_n(voteCount)} votes`" />
-      <div class="justify-end" v-text="`#${statement.statement_id}`" />
-      <IC-pin v-if="statement.pinned" class="w-[16px] h-[16px]" />
+      <div class="justify-end" v-text="`#${post.post_id}`" />
+      <IC-pin v-if="post.pinned" class="w-[16px] h-[16px]" />
     </div>
   </div>
 </template>

--- a/apps/ui/src/components/Townhall/PostItem.vue
+++ b/apps/ui/src/components/Townhall/PostItem.vue
@@ -66,7 +66,7 @@ function getChoiceResult(choice: 1 | 2 | 3) {
               @click="
                 setPostVisibility({
                   postId: post.post_id,
-                  visibility: 'pin'
+                  visibility: post.pinned ? 'unpin' : 'pin'
                 })
               "
             >

--- a/apps/ui/src/components/Townhall/Posts.vue
+++ b/apps/ui/src/components/Townhall/Posts.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
-import { Discussion, Statement } from '@/helpers/townhall/types';
+import { Post, Topic } from '@/helpers/townhall/types';
 import {
-  useSetStatementVisibilityMutation,
+  useSetPostVisibilityMutation,
   useUserRolesQuery,
   useVoteMutation
 } from '@/queries/townhall';
 
 const props = defineProps<{
   spaceId: string;
-  discussionId: number;
-  discussion: Discussion;
-  statements: Statement[];
+  topicId: number;
+  topic: Topic;
+  posts: Post[];
 }>();
 
 const { web3 } = useWeb3();
@@ -18,26 +18,24 @@ const { web3 } = useWeb3();
 const { data: userRoles } = useUserRolesQuery(toRef(() => web3.value.account));
 const { mutate: vote, isPending: isVotePending } = useVoteMutation({
   spaceId: toRef(props, 'spaceId'),
-  discussionId: toRef(props, 'discussionId'),
+  topicId: toRef(props, 'topicId'),
   userRoles
 });
-const {
-  mutate: setStatementVisibility,
-  isPending: isSetStatementVisibiltyPending
-} = useSetStatementVisibilityMutation({
-  spaceId: toRef(props, 'spaceId'),
-  discussionId: toRef(props, 'discussionId')
-});
+const { mutate: setPostVisibility, isPending: isSetPostVisibilityPending } =
+  useSetPostVisibilityMutation({
+    spaceId: toRef(props, 'spaceId'),
+    topicId: toRef(props, 'topicId')
+  });
 </script>
 
 <template>
-  <div v-if="statements[0]">
+  <div v-if="posts[0]">
     <div class="border rounded-md p-4 min-h-[220px] flex flex-col">
       <div class="text-lg text-skin-link flex-auto">
         <UiLoading v-if="isVotePending" />
         <div v-else class="flex">
-          <div class="flex-1 mr-3 mb-4" v-text="statements[0].body" />
-          <UiDropdown v-if="web3.account && discussion.author === web3.account">
+          <div class="flex-1 mr-3 mb-4" v-text="posts[0].body" />
+          <UiDropdown v-if="web3.account && topic.author === web3.account">
             <template #button>
               <UiButton class="!p-0 !border-0 !h-[auto] !bg-transparent">
                 <IH-dots-horizontal class="text-skin-link" />
@@ -50,14 +48,14 @@ const {
                   class="flex items-center gap-2"
                   :class="{ 'opacity-80': active }"
                   @click="
-                    setStatementVisibility({
-                      statementId: statements[0].statement_id,
+                    setPostVisibility({
+                      postId: posts[0].post_id,
                       visibility: 'pin'
                     })
                   "
                 >
                   <IC-pin class="w-[16px] h-[16px]" />
-                  {{ statements[0].pinned ? 'Unpin' : 'Pin' }} statement
+                  {{ posts[0].pinned ? 'Unpin' : 'Pin' }} statement
                 </button>
               </UiDropdownItem>
               <UiDropdownItem v-slot="{ active }">
@@ -65,10 +63,10 @@ const {
                   type="button"
                   class="flex items-center gap-2"
                   :class="{ 'opacity-80': active }"
-                  :disabled="isSetStatementVisibiltyPending"
+                  :disabled="isSetPostVisibilityPending"
                   @click="
-                    setStatementVisibility({
-                      statementId: statements[0].statement_id,
+                    setPostVisibility({
+                      postId: posts[0].post_id,
                       visibility: 'hide'
                     })
                   "
@@ -85,7 +83,7 @@ const {
         <UiButton
           :disabled="isVotePending"
           class="!border-skin-success !text-skin-success space-x-1"
-          @click="vote({ statementId: statements[0].statement_id, choice: 1 })"
+          @click="vote({ postId: posts[0].post_id, choice: 1 })"
         >
           <IH-check class="inline-block" />
           <span class="hidden sm:inline-block" v-text="'Agree'" />
@@ -93,7 +91,7 @@ const {
         <UiButton
           :disabled="isVotePending"
           class="!border-skin-danger !text-skin-danger space-x-1"
-          @click="vote({ statementId: statements[0].statement_id, choice: 2 })"
+          @click="vote({ postId: posts[0].post_id, choice: 2 })"
         >
           <IH-x class="inline-block" />
           <span class="hidden sm:inline-block" v-text="'Disagree'" />
@@ -101,7 +99,7 @@ const {
         <UiButton
           :disabled="isVotePending"
           class="!border-skin-text !text-skin-text space-x-1"
-          @click="vote({ statementId: statements[0].statement_id, choice: 3 })"
+          @click="vote({ postId: posts[0].post_id, choice: 3 })"
         >
           <IH-minus-sm class="inline-block" />
           <span class="hidden sm:inline-block" v-text="'Pass'" />
@@ -109,11 +107,11 @@ const {
       </div>
     </div>
     <div class="h-4">
-      <div v-if="statements[1]" class="mx-1">
+      <div v-if="posts[1]" class="mx-1">
         <div class="border border-t-0 rounded-b-md h-2" />
-        <div v-if="statements[2]" class="mx-1">
+        <div v-if="posts[2]" class="mx-1">
           <div class="border border-t-0 rounded-b-md h-2" />
-          <div v-if="statements[3]" class="mx-1">
+          <div v-if="posts[3]" class="mx-1">
             <div class="border border-t-0 rounded-b-md h-2" />
           </div>
         </div>

--- a/apps/ui/src/components/Townhall/Posts.vue
+++ b/apps/ui/src/components/Townhall/Posts.vue
@@ -50,7 +50,7 @@ const { mutate: setPostVisibility, isPending: isSetPostVisibilityPending } =
                   @click="
                     setPostVisibility({
                       postId: posts[0].post_id,
-                      visibility: 'pin'
+                      visibility: posts[0].pinned ? 'unpin' : 'pin'
                     })
                   "
                 >

--- a/apps/ui/src/components/TownhallTopicsList.vue
+++ b/apps/ui/src/components/TownhallTopicsList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Discussion } from '@/helpers/townhall/types';
+import { Topic } from '@/helpers/townhall/types';
 import { _n } from '@/helpers/utils';
 
 const props = defineProps<{
@@ -7,7 +7,7 @@ const props = defineProps<{
   isError?: boolean;
   isLoading?: boolean;
   isLoadingMore?: boolean;
-  topics: Discussion[];
+  topics: Topic[];
   limit?: number | 'off';
   route?: {
     name: string;
@@ -60,7 +60,7 @@ const currentLimit = computed(() => {
           <div class="text-skin-text">
             <UiStamp :id="topic.author" :size="20" class="mr-2.5" />
             <IH-annotation class="inline-block mr-0.5" />
-            {{ _n(topic.statement_count) }} replies
+            {{ _n(topic.post_count) }} replies
           </div>
         </router-link>
       </UiContainerInfiniteScroll>

--- a/apps/ui/src/composables/useTownhall.ts
+++ b/apps/ui/src/composables/useTownhall.ts
@@ -97,11 +97,7 @@ export function useTownhall() {
     );
   }
 
-  async function sendDiscussion(
-    title: string,
-    body: string,
-    discussionUrl: string
-  ) {
+  async function sendTopic(title: string, body: string, discussionUrl: string) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -110,7 +106,7 @@ export function useTownhall() {
     const signer = await getAliasSigner(auth.value.provider);
 
     return wrapPromise(
-      highlightClient.createDiscussion({
+      highlightClient.createTopic({
         signer,
         data: { title, body, discussionUrl },
         salt: getSalt()
@@ -118,7 +114,7 @@ export function useTownhall() {
     );
   }
 
-  async function sendCloseDiscussion(discussion: number) {
+  async function sendCloseTopic(topic: number) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -127,15 +123,15 @@ export function useTownhall() {
     const signer = await getAliasSigner(auth.value.provider);
 
     return wrapPromise(
-      highlightClient.closeDiscussion({
+      highlightClient.closeTopic({
         signer,
-        data: { discussion },
+        data: { topic },
         salt: getSalt()
       })
     );
   }
 
-  async function sendStatement(discussion: number, statement: string) {
+  async function sendPost(topic: number, body: string) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -144,15 +140,15 @@ export function useTownhall() {
     const signer = await getAliasSigner(auth.value.provider);
 
     return wrapPromise(
-      highlightClient.createStatement({
+      highlightClient.createPost({
         signer,
-        data: { discussion, statement },
+        data: { topic, body },
         salt: getSalt()
       })
     );
   }
 
-  async function sendHideStatement(discussion: number, statement: number) {
+  async function sendHidePost(topic: number, post: number) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -161,15 +157,15 @@ export function useTownhall() {
     const signer = await getAliasSigner(auth.value.provider);
 
     return wrapPromise(
-      highlightClient.hideStatement({
+      highlightClient.hidePost({
         signer,
-        data: { discussion, statement },
+        data: { topic, post },
         salt: getSalt()
       })
     );
   }
 
-  async function sendPinStatement(discussion: number, statement: number) {
+  async function sendPinPost(topic: number, post: number) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -178,19 +174,15 @@ export function useTownhall() {
     const signer = await getAliasSigner(auth.value.provider);
 
     return wrapPromise(
-      highlightClient.pinStatement({
+      highlightClient.pinPost({
         signer,
-        data: { discussion, statement },
+        data: { topic, post },
         salt: getSalt()
       })
     );
   }
 
-  async function sendVote(
-    discussion: number,
-    statement: number,
-    choice: 1 | 2 | 3
-  ) {
+  async function sendVote(topic: number, post: number, choice: 1 | 2 | 3) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -201,7 +193,7 @@ export function useTownhall() {
     return wrapPromise(
       highlightClient.vote({
         signer,
-        data: { discussion, statement, choice },
+        data: { topic, post, choice },
         salt: getSalt()
       })
     );
@@ -304,11 +296,11 @@ export function useTownhall() {
   }
 
   return {
-    sendDiscussion,
-    sendCloseDiscussion,
-    sendStatement,
-    sendHideStatement,
-    sendPinStatement,
+    sendTopic,
+    sendCloseTopic,
+    sendPost,
+    sendHidePost,
+    sendPinPost,
     sendVote,
     sendCreateRole,
     sendEditRole,

--- a/apps/ui/src/composables/useTownhall.ts
+++ b/apps/ui/src/composables/useTownhall.ts
@@ -182,6 +182,23 @@ export function useTownhall() {
     );
   }
 
+  async function sendUnpinPost(topic: number, post: number) {
+    if (!auth.value) {
+      modalAccountOpen.value = true;
+      return null;
+    }
+
+    const signer = await getAliasSigner(auth.value.provider);
+
+    return wrapPromise(
+      highlightClient.unpinPost({
+        signer,
+        data: { topic, post },
+        salt: getSalt()
+      })
+    );
+  }
+
   async function sendVote(topic: number, post: number, choice: 1 | 2 | 3) {
     if (!auth.value) {
       modalAccountOpen.value = true;
@@ -301,6 +318,7 @@ export function useTownhall() {
     sendPost,
     sendHidePost,
     sendPinPost,
+    sendUnpinPost,
     sendVote,
     sendCreateRole,
     sendEditRole,

--- a/apps/ui/src/helpers/townhall/types.ts
+++ b/apps/ui/src/helpers/townhall/types.ts
@@ -1,13 +1,13 @@
 import {
-  DiscussionFieldsFragment,
+  PostFieldsFragment,
   RoleFieldsFragment,
   SpaceFieldsFragment,
-  StatementFieldsFragment,
+  TopicFieldsFragment,
   VoteFieldsFragment
 } from './gql/graphql';
 
 export type Space = SpaceFieldsFragment;
-export type Discussion = DiscussionFieldsFragment;
-export type Statement = StatementFieldsFragment;
+export type Topic = TopicFieldsFragment;
+export type Post = PostFieldsFragment;
 export type Vote = VoteFieldsFragment;
 export type Role = RoleFieldsFragment;

--- a/apps/ui/src/queries/townhall.ts
+++ b/apps/ui/src/queries/townhall.ts
@@ -8,18 +8,18 @@ import {
 import { MaybeRefOrGetter } from 'vue';
 import { SpaceType } from '@/composables/useSpaceType';
 import {
-  getDiscussion,
-  getDiscussions,
   getResultsByRole,
   getRoles,
   getSpace,
+  getTopic,
+  getTopics,
   getUserRoles,
   getVotes,
-  newStatementEventToEntry,
+  newPostEventToEntry,
   newVoteEventToEntry,
   Result
 } from '@/helpers/townhall/api';
-import { Discussion, Role, Vote } from '@/helpers/townhall/types';
+import { Role, Topic, Vote } from '@/helpers/townhall/types';
 
 export const TOPICS_LIMIT = 20;
 export const TOPICS_SUMMARY_LIMIT = 6;
@@ -28,27 +28,27 @@ const DEFAULT_STALE_TIME = 1000 * 5;
 
 function addVoteToRoleResults({
   queryClient,
-  discussionId,
+  topicId,
   roleId,
   vote
 }: {
   queryClient: QueryClient;
-  discussionId: number;
+  topicId: number;
   roleId: string;
   vote: Vote;
 }) {
   queryClient.setQueryData<Result[]>(
-    ['townhall', 'discussionResults', { discussionId, roleId }, 'list'],
+    ['townhall', 'topicResults', { topicId, roleId }, 'list'],
     oldData => {
       const updatedData = structuredClone(oldData ?? []);
       const existingResult = updatedData.find(
-        r => r.statement_id === vote.statement_id && r.choice === vote.choice
+        r => r.post_id === vote.post_id && r.choice === vote.choice
       );
       if (existingResult) {
         existingResult.vote_count += 1;
       } else {
         updatedData.push({
-          statement_id: vote.statement_id,
+          post_id: vote.post_id,
           choice: vote.choice,
           vote_count: 1
         });
@@ -87,9 +87,9 @@ export function useTopicsQuery({
 }) {
   return useInfiniteQuery({
     initialPageParam: 0,
-    queryKey: ['townhall', 'discussions', 'list', { spaceId }],
+    queryKey: ['townhall', 'topics', 'list', { spaceId }],
     queryFn: async ({ pageParam = 0 }) => {
-      return getDiscussions({ limit: TOPICS_LIMIT, skip: pageParam });
+      return getTopics({ limit: TOPICS_LIMIT, skip: pageParam });
     },
     getNextPageParam: (lastPage, pages) => {
       if (lastPage.length < TOPICS_LIMIT) return null;
@@ -108,9 +108,9 @@ export function useTopicsSummaryQuery({
   enabled?: MaybeRefOrGetter<boolean>;
 }) {
   return useQuery({
-    queryKey: ['townhall', 'discussions', 'summary', { spaceId }],
+    queryKey: ['townhall', 'topics', 'summary', { spaceId }],
     queryFn: async () => {
-      return getDiscussions({
+      return getTopics({
         skip: 0,
         limit: TOPICS_SUMMARY_LIMIT
       });
@@ -120,25 +120,25 @@ export function useTopicsSummaryQuery({
   });
 }
 
-export function useDiscussionQuery({
+export function useTopicQuery({
   spaceId,
-  discussionId
+  topicId
 }: {
   spaceId: MaybeRefOrGetter<string>;
-  discussionId: MaybeRefOrGetter<number>;
+  topicId: MaybeRefOrGetter<number>;
 }) {
   return useQuery({
-    queryKey: ['townhall', 'discussions', 'detail', { spaceId, discussionId }],
+    queryKey: ['townhall', 'topics', 'detail', { spaceId, topicId }],
     queryFn: async () => {
-      const discussion = await getDiscussion(toValue(discussionId).toString());
-      if (!discussion) return null;
+      const topic = await getTopic(toValue(topicId).toString());
+      if (!topic) return null;
 
-      discussion.statements = discussion.statements
+      topic.posts = topic.posts
         .filter(s => !s.hidden)
         .sort(() => 0.5 - Math.random())
         .sort((a, b) => Number(b.pinned) - Number(a.pinned));
 
-      return discussion;
+      return topic;
     },
     staleTime: DEFAULT_STALE_TIME
   });
@@ -146,17 +146,17 @@ export function useDiscussionQuery({
 
 export function useUserVotesQuery({
   spaceId,
-  discussionId,
+  topicId,
   user
 }: {
   spaceId: MaybeRefOrGetter<string>;
-  discussionId: MaybeRefOrGetter<number>;
+  topicId: MaybeRefOrGetter<number>;
   user: MaybeRefOrGetter<string>;
 }) {
   return useQuery({
-    queryKey: ['townhall', 'votes', 'list', { spaceId, discussionId, user }],
+    queryKey: ['townhall', 'votes', 'list', { spaceId, topicId, user }],
     queryFn: async () => {
-      return getVotes(toValue(discussionId).toString(), toValue(user));
+      return getVotes(toValue(topicId).toString(), toValue(user));
     },
     enabled: () => !!toValue(user),
     staleTime: DEFAULT_STALE_TIME
@@ -189,21 +189,16 @@ export function useUserRolesQuery(user: MaybeRefOrGetter<string>) {
 }
 
 export function useResultsByRoleQuery({
-  discussionId,
+  topicId,
   roleId
 }: {
-  discussionId: MaybeRefOrGetter<number>;
+  topicId: MaybeRefOrGetter<number>;
   roleId: MaybeRefOrGetter<string>;
 }) {
   return useQuery({
-    queryKey: [
-      'townhall',
-      'discussionResults',
-      { discussionId, roleId },
-      'list'
-    ],
+    queryKey: ['townhall', 'topicResults', { topicId, roleId }, 'list'],
     queryFn: () => {
-      return getResultsByRole(toValue(discussionId), toValue(roleId));
+      return getResultsByRole(toValue(topicId), toValue(roleId));
     },
     staleTime: DEFAULT_STALE_TIME
   });
@@ -236,24 +231,24 @@ export function useRoleMutation() {
   });
 }
 
-export function useCloseDiscussionMutation({
+export function useCloseTopicMutation({
   spaceId,
-  discussionId
+  topicId
 }: {
   spaceId: MaybeRefOrGetter<string>;
-  discussionId: MaybeRefOrGetter<number>;
+  topicId: MaybeRefOrGetter<number>;
 }) {
   const queryClient = useQueryClient();
   const { addNotification } = useUiStore();
-  const { sendCloseDiscussion } = useTownhall();
+  const { sendCloseTopic } = useTownhall();
 
   return useMutation({
     mutationFn: () => {
-      return sendCloseDiscussion(toValue(discussionId));
+      return sendCloseTopic(toValue(topicId));
     },
     onSuccess: () => {
-      queryClient.setQueryData<Discussion>(
-        ['townhall', 'discussions', 'detail', { spaceId, discussionId }],
+      queryClient.setQueryData<Topic>(
+        ['townhall', 'topics', 'detail', { spaceId, topicId }],
         old => {
           if (!old) return old;
 
@@ -264,7 +259,7 @@ export function useCloseDiscussionMutation({
         }
       );
 
-      addNotification('success', 'Discussion closed successfully');
+      addNotification('success', 'Topic closed successfully');
     },
     onError: error => {
       addNotification('error', error.message);
@@ -272,43 +267,43 @@ export function useCloseDiscussionMutation({
   });
 }
 
-export function useCreateStatementMutation({
+export function useCreatePostMutation({
   spaceId,
-  discussionId
+  topicId
 }: {
   spaceId: MaybeRefOrGetter<string>;
-  discussionId: MaybeRefOrGetter<number>;
+  topicId: MaybeRefOrGetter<number>;
 }) {
   const queryClient = useQueryClient();
   const { addNotification } = useUiStore();
-  const { sendStatement } = useTownhall();
+  const { sendPost } = useTownhall();
 
   return useMutation({
-    mutationFn: (statement: string) => {
-      return sendStatement(toValue(discussionId), statement);
+    mutationFn: (body: string) => {
+      return sendPost(toValue(topicId), body);
     },
     onSuccess: async data => {
       if (!data) return;
 
       const { data: eventData } = data.result.events.find(
-        event => event.key === 'new_statement'
+        event => event.key === 'new_post'
       );
 
-      const statement = newStatementEventToEntry(eventData);
+      const post = newPostEventToEntry(eventData);
 
-      queryClient.setQueryData<Discussion>(
-        ['townhall', 'discussions', 'detail', { spaceId, discussionId }],
+      queryClient.setQueryData<Topic>(
+        ['townhall', 'topics', 'detail', { spaceId, topicId }],
         old => {
           if (!old) return old;
 
           return {
             ...old,
-            statements: [...old.statements, statement]
+            posts: [...old.posts, post]
           };
         }
       );
 
-      addNotification('success', 'Statement published successfully');
+      addNotification('success', 'Post published successfully');
     },
     onError: error => {
       addNotification('error', error.message);
@@ -316,61 +311,61 @@ export function useCreateStatementMutation({
   });
 }
 
-export function useSetStatementVisibilityMutation({
+export function useSetPostVisibilityMutation({
   spaceId,
-  discussionId
+  topicId
 }: {
   spaceId: MaybeRefOrGetter<string>;
-  discussionId: MaybeRefOrGetter<number>;
+  topicId: MaybeRefOrGetter<number>;
 }) {
   const queryClient = useQueryClient();
   const { addNotification } = useUiStore();
-  const { sendPinStatement, sendHideStatement } = useTownhall();
+  const { sendPinPost, sendHidePost } = useTownhall();
 
   return useMutation({
     mutationFn: ({
-      statementId,
+      postId,
       visibility
     }: {
-      statementId: number;
+      postId: number;
       visibility: 'pin' | 'hide';
     }) => {
       if (visibility === 'pin') {
-        return sendPinStatement(toValue(discussionId), statementId);
+        return sendPinPost(toValue(topicId), postId);
       }
 
       if (visibility === 'hide') {
-        return sendHideStatement(toValue(discussionId), statementId);
+        return sendHidePost(toValue(topicId), postId);
       }
 
       throw new Error('Invalid visibility type');
     },
-    onSuccess: async (_, { statementId, visibility }) => {
-      queryClient.setQueryData<Discussion>(
-        ['townhall', 'discussions', 'detail', { spaceId, discussionId }],
+    onSuccess: async (_, { postId, visibility }) => {
+      queryClient.setQueryData<Topic>(
+        ['townhall', 'topics', 'detail', { spaceId, topicId }],
         old => {
           if (!old) return old;
 
           return {
             ...old,
-            statements: old.statements.map(statement => {
-              if (statement.statement_id !== statementId) return statement;
+            posts: old.posts.map(post => {
+              if (post.post_id !== postId) return post;
 
               if (visibility === 'pin') {
                 return {
-                  ...statement,
+                  ...post,
                   pinned: true
                 };
               }
 
               if (visibility === 'hide') {
                 return {
-                  ...statement,
+                  ...post,
                   hidden: true
                 };
               }
 
-              return statement;
+              return post;
             })
           };
         }
@@ -384,11 +379,11 @@ export function useSetStatementVisibilityMutation({
 
 export function useVoteMutation({
   spaceId,
-  discussionId,
+  topicId,
   userRoles
 }: {
   spaceId: MaybeRefOrGetter<string>;
-  discussionId: MaybeRefOrGetter<number>;
+  topicId: MaybeRefOrGetter<number>;
   userRoles: MaybeRefOrGetter<Role[] | undefined>;
 }) {
   const { web3 } = useWeb3();
@@ -397,14 +392,8 @@ export function useVoteMutation({
   const { sendVote } = useTownhall();
 
   return useMutation({
-    mutationFn: ({
-      statementId,
-      choice
-    }: {
-      statementId: number;
-      choice: 1 | 2 | 3;
-    }) => {
-      return sendVote(toValue(discussionId), statementId, choice);
+    mutationFn: ({ postId, choice }: { postId: number; choice: 1 | 2 | 3 }) => {
+      return sendVote(toValue(topicId), postId, choice);
     },
     onSuccess: async data => {
       if (!data) return;
@@ -420,7 +409,7 @@ export function useVoteMutation({
           'townhall',
           'votes',
           'list',
-          { spaceId, discussionId, user: web3.value.account }
+          { spaceId, topicId, user: web3.value.account }
         ],
         (old = []) => [...old, vote]
       );
@@ -429,7 +418,7 @@ export function useVoteMutation({
       roles.forEach(role => {
         addVoteToRoleResults({
           queryClient,
-          discussionId: toValue(discussionId),
+          topicId: toValue(topicId),
           roleId: role,
           vote
         });

--- a/apps/ui/src/queries/townhall.ts
+++ b/apps/ui/src/queries/townhall.ts
@@ -320,7 +320,7 @@ export function useSetPostVisibilityMutation({
 }) {
   const queryClient = useQueryClient();
   const { addNotification } = useUiStore();
-  const { sendPinPost, sendHidePost } = useTownhall();
+  const { sendPinPost, sendUnpinPost, sendHidePost } = useTownhall();
 
   return useMutation({
     mutationFn: ({
@@ -328,10 +328,14 @@ export function useSetPostVisibilityMutation({
       visibility
     }: {
       postId: number;
-      visibility: 'pin' | 'hide';
+      visibility: 'pin' | 'unpin' | 'hide';
     }) => {
       if (visibility === 'pin') {
         return sendPinPost(toValue(topicId), postId);
+      }
+
+      if (visibility === 'unpin') {
+        return sendUnpinPost(toValue(topicId), postId);
       }
 
       if (visibility === 'hide') {
@@ -355,6 +359,13 @@ export function useSetPostVisibilityMutation({
                 return {
                   ...post,
                   pinned: true
+                };
+              }
+
+              if (visibility === 'unpin') {
+                return {
+                  ...post,
+                  pinned: false
                 };
               }
 

--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -107,7 +107,7 @@ watchEffect(() => setTitle(props.space.name));
           </template>
           <div v-if="spaceType === 'discussionsSpace'">
             <b class="text-skin-link">{{
-              _n(townhallSpace?.discussion_count || 0)
+              _n(townhallSpace?.topic_count || 0)
             }}</b>
             discussions
           </div>

--- a/apps/ui/src/views/Townhall/Create.vue
+++ b/apps/ui/src/views/Townhall/Create.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getDiscussion } from '@/helpers/townhall/api';
+import { getTopic } from '@/helpers/townhall/api';
 import { sleep } from '@/helpers/utils';
 import { Space } from '@/types';
 
@@ -7,7 +7,7 @@ const props = defineProps<{ space: Space }>();
 
 const route = useRoute();
 const router = useRouter();
-const { sendDiscussion } = useTownhall();
+const { sendTopic } = useTownhall();
 const { addNotification } = useUiStore();
 const { setTitle } = useTitle();
 const { setContext, setVars, openChatbot } = useChatbot();
@@ -44,15 +44,15 @@ async function handleSubmit() {
   submitLoading.value = true;
 
   try {
-    const res = await sendDiscussion(title.value, body.value, discussion.value);
+    const res = await sendTopic(title.value, body.value, discussion.value);
     if (!res) return;
 
-    const id = res.result.events.find(event => event.key === 'new_discussion')
+    const id = res.result.events.find(event => event.key === 'new_topic')
       .data[0];
 
     while (true) {
       try {
-        await getDiscussion(id.toString());
+        await getTopic(id.toString());
         break;
       } catch (e: unknown) {
         if (e instanceof Error && e.message.includes('Row not found')) {

--- a/apps/ui/src/views/Townhall/Roles.vue
+++ b/apps/ui/src/views/Townhall/Roles.vue
@@ -51,7 +51,7 @@ async function handleAddRole(config: SpaceMetadataLabel) {
     const newRoles: Role[] = res.result.events
       .filter(event => event.key === 'new_role')
       .map(event => ({
-        space: event.data[0],
+        space: { id: event.data[0] },
         id: event.data[1],
         name: event.data[2],
         description: event.data[3],

--- a/packages/sx.js/src/clients/highlight/ethereum-sig.ts
+++ b/packages/sx.js/src/clients/highlight/ethereum-sig.ts
@@ -6,18 +6,18 @@ import {
 } from '@ethersproject/abstract-signer';
 import {
   ClaimRole,
-  CloseDiscussion,
-  CreateDiscussion,
+  CloseTopic,
+  CreatePost,
   CreateRole,
-  CreateStatement,
+  CreateTopic,
   DeleteRole,
   EditRole,
   Envelope,
-  HideStatement,
-  PinStatement,
+  HidePost,
+  PinPost,
   RevokeRole,
   SetAlias,
-  UnpinStatement,
+  UnpinPost,
   Vote
 } from './types';
 import {
@@ -134,13 +134,13 @@ export class HighlightEthereumSigClient {
     };
   }
 
-  public async createDiscussion({
+  public async createTopic({
     signer,
     data,
     salt
   }: {
     signer: Signer & TypedDataSigner;
-    data: CreateDiscussion;
+    data: CreateTopic;
     salt: bigint;
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
@@ -155,7 +155,7 @@ export class HighlightEthereumSigClient {
     const signature = await this.sign(
       signer,
       domain,
-      TOWNHALL_CONFIG.types.createDiscussion,
+      TOWNHALL_CONFIG.types.createTopic,
       message
     );
 
@@ -163,32 +163,32 @@ export class HighlightEthereumSigClient {
       type: 'HIGHLIGHT_ENVELOPE',
       domain,
       message,
-      primaryType: 'Discussion',
+      primaryType: 'Topic',
       signer: await signer.getAddress(),
       signature
     };
   }
 
-  public async closeDiscussion({
+  public async closeTopic({
     signer,
     data,
     salt
   }: {
     signer: Signer & TypedDataSigner;
-    data: CloseDiscussion;
+    data: CloseTopic;
     salt: bigint;
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { discussion } = data;
+    const { topic } = data;
     const message = {
-      discussion
+      topic
     };
 
     const signature = await this.sign(
       signer,
       domain,
-      TOWNHALL_CONFIG.types.closeDiscussion,
+      TOWNHALL_CONFIG.types.closeTopic,
       message
     );
 
@@ -196,33 +196,33 @@ export class HighlightEthereumSigClient {
       type: 'HIGHLIGHT_ENVELOPE',
       domain,
       message,
-      primaryType: 'CloseDiscussion',
+      primaryType: 'CloseTopic',
       signer: await signer.getAddress(),
       signature
     };
   }
 
-  public async createStatement({
+  public async createPost({
     signer,
     data,
     salt
   }: {
     signer: Signer & TypedDataSigner;
-    data: CreateStatement;
+    data: CreatePost;
     salt: bigint;
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { discussion, statement } = data;
+    const { topic, body } = data;
     const message = {
-      discussion,
-      statement
+      topic,
+      body
     };
 
     const signature = await this.sign(
       signer,
       domain,
-      TOWNHALL_CONFIG.types.createStatement,
+      TOWNHALL_CONFIG.types.createPost,
       message
     );
 
@@ -230,33 +230,33 @@ export class HighlightEthereumSigClient {
       type: 'HIGHLIGHT_ENVELOPE',
       domain,
       message,
-      primaryType: 'Statement',
+      primaryType: 'Post',
       signer: await signer.getAddress(),
       signature
     };
   }
 
-  public async hideStatement({
+  public async hidePost({
     signer,
     data,
     salt
   }: {
     signer: Signer & TypedDataSigner;
-    data: HideStatement;
+    data: HidePost;
     salt: bigint;
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { discussion, statement } = data;
+    const { topic, post } = data;
     const message = {
-      discussion,
-      statement
+      topic,
+      post
     };
 
     const signature = await this.sign(
       signer,
       domain,
-      TOWNHALL_CONFIG.types.hideStatement,
+      TOWNHALL_CONFIG.types.hidePost,
       message
     );
 
@@ -264,33 +264,33 @@ export class HighlightEthereumSigClient {
       type: 'HIGHLIGHT_ENVELOPE',
       domain,
       message,
-      primaryType: 'HideStatement',
+      primaryType: 'HidePost',
       signer: await signer.getAddress(),
       signature
     };
   }
 
-  public async pinStatement({
+  public async pinPost({
     signer,
     data,
     salt
   }: {
     signer: Signer & TypedDataSigner;
-    data: PinStatement;
+    data: PinPost;
     salt: bigint;
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { discussion, statement } = data;
+    const { topic, post } = data;
     const message = {
-      discussion,
-      statement
+      topic,
+      post
     };
 
     const signature = await this.sign(
       signer,
       domain,
-      TOWNHALL_CONFIG.types.pinStatement,
+      TOWNHALL_CONFIG.types.pinPost,
       message
     );
 
@@ -298,33 +298,33 @@ export class HighlightEthereumSigClient {
       type: 'HIGHLIGHT_ENVELOPE',
       domain,
       message,
-      primaryType: 'PinStatement',
+      primaryType: 'PinPost',
       signer: await signer.getAddress(),
       signature
     };
   }
 
-  public async unpinStatement({
+  public async unpinPost({
     signer,
     data,
     salt
   }: {
     signer: Signer & TypedDataSigner;
-    data: UnpinStatement;
+    data: UnpinPost;
     salt: bigint;
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { discussion, statement } = data;
+    const { topic, post } = data;
     const message = {
-      discussion,
-      statement
+      topic,
+      post
     };
 
     const signature = await this.sign(
       signer,
       domain,
-      TOWNHALL_CONFIG.types.unpinStatement,
+      TOWNHALL_CONFIG.types.unpinPost,
       message
     );
 
@@ -332,7 +332,7 @@ export class HighlightEthereumSigClient {
       type: 'HIGHLIGHT_ENVELOPE',
       domain,
       message,
-      primaryType: 'UnpinStatement',
+      primaryType: 'UnpinPost',
       signer: await signer.getAddress(),
       signature
     };
@@ -349,10 +349,10 @@ export class HighlightEthereumSigClient {
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { discussion, statement, choice } = data;
+    const { topic, post, choice } = data;
     const message = {
-      discussion,
-      statement,
+      topic,
+      post,
       choice
     };
 

--- a/packages/sx.js/src/clients/highlight/types.ts
+++ b/packages/sx.js/src/clients/highlight/types.ts
@@ -14,31 +14,31 @@ export type SetAlias = {
   alias: string;
 };
 
-export type CreateDiscussion = {
+export type CreateTopic = {
   title: string;
   body: string;
   discussionUrl: string;
 };
 
-export type CloseDiscussion = {
-  discussion: number;
+export type CloseTopic = {
+  topic: number;
 };
 
-export type CreateStatement = {
-  discussion: number;
-  statement: string;
+export type CreatePost = {
+  topic: number;
+  body: string;
 };
 
-export type HideStatement = {
-  discussion: number;
-  statement: number;
+export type HidePost = {
+  topic: number;
+  post: number;
 };
-export type PinStatement = HideStatement;
-export type UnpinStatement = HideStatement;
+export type PinPost = HidePost;
+export type UnpinPost = HidePost;
 
 export type Vote = {
-  discussion: number;
-  statement: number;
+  topic: number;
+  post: number;
   choice: number;
 };
 

--- a/packages/sx.js/src/highlightConstants.ts
+++ b/packages/sx.js/src/highlightConstants.ts
@@ -18,44 +18,44 @@ export const ALIASES_CONFIG = {
 export const TOWNHALL_CONFIG = {
   address: '0x0000000000000000000000000000000000000002',
   types: {
-    createDiscussion: {
-      Discussion: [
+    createTopic: {
+      Topic: [
         { name: 'title', type: 'string' },
         { name: 'body', type: 'string' },
         { name: 'discussionUrl', type: 'string' }
       ]
     },
-    closeDiscussion: {
-      CloseDiscussion: [{ name: 'discussion', type: 'uint64' }]
+    closeTopic: {
+      CloseTopic: [{ name: 'topic', type: 'uint64' }]
     },
-    createStatement: {
-      Statement: [
-        { name: 'discussion', type: 'uint64' },
-        { name: 'statement', type: 'string' }
+    createPost: {
+      Post: [
+        { name: 'topic', type: 'uint64' },
+        { name: 'body', type: 'string' }
       ]
     },
-    hideStatement: {
-      HideStatement: [
-        { name: 'discussion', type: 'uint64' },
-        { name: 'statement', type: 'int' }
+    hidePost: {
+      HidePost: [
+        { name: 'topic', type: 'uint64' },
+        { name: 'post', type: 'int' }
       ]
     },
-    pinStatement: {
-      PinStatement: [
-        { name: 'discussion', type: 'uint64' },
-        { name: 'statement', type: 'uint64' }
+    pinPost: {
+      PinPost: [
+        { name: 'topic', type: 'uint64' },
+        { name: 'post', type: 'uint64' }
       ]
     },
-    unpinStatement: {
-      UnpinStatement: [
-        { name: 'discussion', type: 'uint64' },
-        { name: 'statement', type: 'uint64' }
+    unpinPost: {
+      UnpinPost: [
+        { name: 'topic', type: 'uint64' },
+        { name: 'post', type: 'uint64' }
       ]
     },
     vote: {
       Vote: [
-        { name: 'discussion', type: 'uint64' },
-        { name: 'statement', type: 'uint64' },
+        { name: 'topic', type: 'uint64' },
+        { name: 'post', type: 'uint64' },
         { name: 'choice', type: 'uint64' }
       ]
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4515,7 +4515,7 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
-"@snapshot-labs/checkpoint@^0.1.0-beta.59":
+"@snapshot-labs/checkpoint@^0.1.0-beta.58", "@snapshot-labs/checkpoint@^0.1.0-beta.59":
   version "0.1.0-beta.59"
   resolved "https://registry.yarnpkg.com/@snapshot-labs/checkpoint/-/checkpoint-0.1.0-beta.59.tgz#e1ba3acf223a0875e32d0f88c01b311539f340e0"
   integrity sha512-1Tdd4rZxxW4PiCE8x9iU9GJdT+W1Vjh6rmHtekzJO9nbQlJYfNpLiWM1f2uNVGmVB6VuqCjX35/Pg3wg63IZ6A==


### PR DESCRIPTION
### Summary

This PR renames Discussions to Topics and Statements to Posts.

I also included few fixes that make testing this PR easier (otherwise you will hit some minor bugs that might be confusing if they are coming from this PR or not):
1. New role's optimistic entry uses correct format.
2. Add unpin action (before always pin was used even if you saw "Unpin post").
3. Prevent crash of API on results endpoint.

Closes: https://github.com/snapshot-labs/townhall/issues/15

### How to test

1. Go to http://localhost:8080/#/s:ethpoll.eth/townhall
2. Create topic.
3. Create posts, vote on them, pin, unpin, hide.
4. Vote on posts.
5. Close topic.
6. Everything works as supposed, not mentions of legacy names (discussion, statement).
