### PR TITLE
feat: link topics and roles to specific space

### DIFF
--- a/apps/highlight/src/agents/townhall.ts
+++ b/apps/highlight/src/agents/townhall.ts
@@ -26,28 +26,31 @@ export default class Townhall extends Agent {
 
   async topic(
     {
+      space,
       title,
       body,
       discussionUrl
-    }: { title: string; body: string; discussionUrl: string },
+    }: { space: string; title: string; body: string; discussionUrl: string },
     { signer }: { signer: string }
   ) {
-    const id: number = (await this.get('topics:id')) || 1;
+    const id: number = (await this.get(`space:${space}:topics:id`)) || 1;
 
     const author = await this.getSigner(signer);
-    this.write('topics:id', id + 1);
-    this.emit('new_topic', [id, author, title, body, discussionUrl]);
+    this.write(`space:${space}:topics:id`, id + 1);
+    this.emit('new_topic', [space, id, author, title, body, discussionUrl]);
   }
 
-  async closeTopic({ topic }: { topic: number }) {
-    this.emit('close_topic', [topic]);
+  async closeTopic({ space, topic }: { space: string; topic: number }) {
+    this.emit('close_topic', [space, topic]);
   }
 
   async post(
     {
+      space,
       topic,
       body
     }: {
+      space: string;
       topic: number;
       body: string;
     },
@@ -55,38 +58,65 @@ export default class Townhall extends Agent {
   ) {
     // @TODO: reject the post if it was already proposed
 
-    const id: number = (await this.get(`topic:${topic}:posts:id`)) || 1;
+    const id: number =
+      (await this.get(`space:${space}:topic:${topic}:posts:id`)) || 1;
 
     const author = await this.getSigner(signer);
 
-    this.write(`topic:${topic}:posts:id`, id + 1);
-    this.emit('new_post', [id, author, topic, body]);
+    this.write(`space:${space}:topic:${topic}:posts:id`, id + 1);
+    this.emit('new_post', [space, topic, id, author, body]);
   }
 
-  async hidePost({ topic, post }: { topic: number; post: number }) {
+  async hidePost({
+    space,
+    topic,
+    post
+  }: {
+    space: string;
+    topic: number;
+    post: number;
+  }) {
     // @TODO: reject if not the author of the topic
 
-    this.emit('hide_post', [topic, post]);
+    this.emit('hide_post', [space, topic, post]);
   }
 
-  async pinPost({ topic, post }: { topic: number; post: number }) {
+  async pinPost({
+    space,
+    topic,
+    post
+  }: {
+    space: string;
+    topic: number;
+    post: number;
+  }) {
     // @TODO: reject if not the author of the topic
 
-    this.emit('pin_post', [topic, post]);
+    this.emit('pin_post', [space, topic, post]);
   }
 
-  async unpinPost({ topic, post }: { topic: number; post: number }) {
+  async unpinPost({
+    space,
+    topic,
+    post
+  }: {
+    space: string;
+    topic: number;
+    post: number;
+  }) {
     // @TODO: reject if not the author of the topic
 
-    this.emit('unpin_post', [topic, post]);
+    this.emit('unpin_post', [space, topic, post]);
   }
 
   async vote(
     {
+      space,
       topic,
       post,
       choice
     }: {
+      space: string;
       topic: number;
       post: number;
       choice: number;
@@ -96,13 +126,13 @@ export default class Townhall extends Agent {
     const author = await this.getSigner(signer);
 
     const votes: number[] =
-      (await this.get(`topic:${topic}:voter:${author}`)) || [];
+      (await this.get(`space:${space}:topic:${topic}:voter:${author}`)) || [];
 
     this.assert(!votes.includes(post), 'already voted');
     votes.push(post);
 
-    this.write(`topic:${topic}:voter:${author}`, votes);
-    this.emit('new_vote', [author, topic, post, choice]);
+    this.write(`space:${space}:topic:${topic}:voter:${author}`, votes);
+    this.emit('new_vote', [space, topic, post, author, choice]);
   }
 
   async createRole({

--- a/apps/highlight/src/agents/townhall.ts
+++ b/apps/highlight/src/agents/townhall.ts
@@ -40,7 +40,7 @@ export default class Townhall extends Agent {
     this.emit('new_topic', [space, id, author, title, body, discussionUrl]);
   }
 
-  async closeTopic({ space, topic }: { space: string; topic: number }) {
+  async closeTopic({ space, topic }: { space: number; topic: number }) {
     this.emit('close_topic', [space, topic]);
   }
 

--- a/apps/highlight/src/agents/townhall.ts
+++ b/apps/highlight/src/agents/townhall.ts
@@ -30,7 +30,7 @@ export default class Townhall extends Agent {
       title,
       body,
       discussionUrl
-    }: { space: string; title: string; body: string; discussionUrl: string },
+    }: { space: number; title: string; body: string; discussionUrl: string },
     { signer }: { signer: string }
   ) {
     const id: number = (await this.get(`space:${space}:topics:id`)) || 1;
@@ -50,7 +50,7 @@ export default class Townhall extends Agent {
       topic,
       body
     }: {
-      space: string;
+      space: number;
       topic: number;
       body: string;
     },
@@ -72,7 +72,7 @@ export default class Townhall extends Agent {
     topic,
     post
   }: {
-    space: string;
+    space: number;
     topic: number;
     post: number;
   }) {
@@ -86,7 +86,7 @@ export default class Townhall extends Agent {
     topic,
     post
   }: {
-    space: string;
+    space: number;
     topic: number;
     post: number;
   }) {
@@ -100,7 +100,7 @@ export default class Townhall extends Agent {
     topic,
     post
   }: {
-    space: string;
+    space: number;
     topic: number;
     post: number;
   }) {
@@ -116,7 +116,7 @@ export default class Townhall extends Agent {
       post,
       choice
     }: {
-      space: string;
+      space: number;
       topic: number;
       post: number;
       choice: number;
@@ -141,7 +141,7 @@ export default class Townhall extends Agent {
     description,
     color
   }: {
-    space: string;
+    space: number;
     name: string;
     description: string;
     color: string;
@@ -159,7 +159,7 @@ export default class Townhall extends Agent {
     description,
     color
   }: {
-    space: string;
+    space: number;
     id: string;
     name: string;
     description: string;
@@ -168,12 +168,12 @@ export default class Townhall extends Agent {
     this.emit('edit_role', [space, id, name, description, color]);
   }
 
-  async deleteRole({ space, id }: { space: string; id: string }) {
+  async deleteRole({ space, id }: { space: number; id: string }) {
     this.emit('delete_role', [space, id]);
   }
 
   async claimRole(
-    { space, id }: { space: string; id: string },
+    { space, id }: { space: number; id: string },
     { signer }: { signer: string }
   ) {
     const user = await this.getSigner(signer);
@@ -182,7 +182,7 @@ export default class Townhall extends Agent {
   }
 
   async revokeRole(
-    { space, id }: { space: string; id: string },
+    { space, id }: { space: number; id: string },
     { signer }: { signer: string }
   ) {
     const user = await this.getSigner(signer);

--- a/apps/highlight/src/api/index.ts
+++ b/apps/highlight/src/api/index.ts
@@ -5,6 +5,7 @@ import config from './config.json';
 import { HighlightIndexer } from './indexer';
 import overrides from './overrides.json';
 import { createWriters } from './writers';
+import { Space } from '../../.checkpoint/models';
 import Highlight from '../highlight/highlight';
 import { sleep } from '../utils';
 
@@ -44,6 +45,14 @@ export default async function createCheckpoint(highlight: Highlight) {
   console.log('Checkpoint ready');
 
   checkpoint.start();
+
+  let space = await Space.loadEntity('1', 'highlight');
+  if (!space) {
+    console.log('Space not found, creating a new one');
+    space = new Space('1', 'highlight');
+    space.space_id = 1;
+    await space.save();
+  }
 
   return checkpoint;
 }

--- a/apps/highlight/src/api/schema.gql
+++ b/apps/highlight/src/api/schema.gql
@@ -24,6 +24,7 @@ type Topic {
   created: Int!
   closed: Boolean!
   space: Space!
+  topic_id: Int!
   posts: [Post!]! @derivedFrom(field: "topic")
   votes: [Vote!]! @derivedFrom(field: "topic")
 }
@@ -41,6 +42,7 @@ type Post {
   created: Int!
   topic_id: Int!
   post_id: Int!
+  space: Space!
   topic: Topic!
   votes: [Vote!]! @derivedFrom(field: "post")
 }
@@ -52,6 +54,7 @@ type Vote {
   created: Int!
   topic_id: Int!
   post_id: Int!
+  space: Space!
   topic: Topic!
   post: Post!
 }

--- a/apps/highlight/src/api/schema.gql
+++ b/apps/highlight/src/api/schema.gql
@@ -2,6 +2,7 @@ scalar Text
 
 type Space {
   id: String!
+  space_id: Int!
   topic_count: Int!
   vote_count: Int!
 }

--- a/apps/highlight/src/api/writers.ts
+++ b/apps/highlight/src/api/writers.ts
@@ -18,7 +18,7 @@ const SetAliasEventData = z.tuple([
 ]);
 
 const NewTopicEventData = z.tuple([
-  z.string(), // spaceId
+  z.number(), // spaceId
   z.number(), // id
   z.string(), // author
   z.string(), // title
@@ -27,12 +27,12 @@ const NewTopicEventData = z.tuple([
 ]);
 
 const CloseTopicEventData = z.tuple([
-  z.string(), // spaceId
+  z.number(), // spaceId
   z.number() // id
 ]);
 
 const NewPostEventData = z.tuple([
-  z.string(), // spaceId
+  z.number(), // spaceId
   z.number(), // topicId
   z.number(), // id
   z.string(), // author
@@ -40,7 +40,7 @@ const NewPostEventData = z.tuple([
 ]);
 
 const PinPostEventData = z.tuple([
-  z.string(), // spaceId
+  z.number(), // spaceId
   z.number(), // topicId
   z.number() // postId
 ]);
@@ -48,7 +48,7 @@ const UnpinPostEventData = PinPostEventData;
 const HidePostEventData = PinPostEventData;
 
 const NewVoteEventData = z.tuple([
-  z.string(), // spaceId
+  z.number(), // spaceId
   z.number(), // topicId
   z.number(), // postId
   z.string(), // voter
@@ -56,7 +56,7 @@ const NewVoteEventData = z.tuple([
 ]);
 
 const NewRoleEventData = z.tuple([
-  z.string(), // spaceId
+  z.number(), // spaceId
   z.string(), // id
   z.string(), // name
   z.string(), // description
@@ -65,12 +65,12 @@ const NewRoleEventData = z.tuple([
 const EditRoleEventData = NewRoleEventData;
 
 const DeleteRoleEventData = z.tuple([
-  z.string(), // spaceId
+  z.number(), // spaceId
   z.string() // id
 ]);
 
 const ClaimRoleEventData = z.tuple([
-  z.string(), // spaceId
+  z.number(), // spaceId
   z.string(), // id
   z.string() // address
 ]);
@@ -94,9 +94,10 @@ export function createWriters(indexerName: string) {
 
     console.log('Handle new topic', spaceId, id, author, title, body);
 
+    const spaceEntityId = spaceId.toString();
     const topic = new Topic(`${spaceId}/${id}`, indexerName);
     topic.topic_id = id;
-    topic.space = spaceId;
+    topic.space = spaceEntityId;
     topic.author = author;
     topic.title = title;
     topic.body = body;
@@ -105,9 +106,9 @@ export function createWriters(indexerName: string) {
     topic.vote_count = 0;
     topic.created = unit.timestamp;
 
-    let space = await Space.loadEntity(spaceId, indexerName);
+    let space = await Space.loadEntity(spaceEntityId, indexerName);
     if (!space) {
-      space = new Space(spaceId, indexerName);
+      space = new Space(spaceEntityId, indexerName);
     }
     space.topic_count += 1;
 
@@ -145,7 +146,7 @@ export function createWriters(indexerName: string) {
     post.created = unit.timestamp;
     post.post_id = id;
     post.topic_id = topicId;
-    post.space = spaceId;
+    post.space = spaceId.toString();
     post.topic = `${spaceId}/${topicId}`;
 
     await post.save();
@@ -217,6 +218,7 @@ export function createWriters(indexerName: string) {
 
     console.log('Handle new vote', spaceId, voter, topicId, postId, choice);
 
+    const spaceEntityId = spaceId.toString();
     const id = `${spaceId}/${topicId}/${postId}/${voter}`;
     const vote = new Vote(id, indexerName);
     vote.voter = voter;
@@ -224,7 +226,7 @@ export function createWriters(indexerName: string) {
     vote.created = unit.timestamp;
     vote.topic_id = topicId;
     vote.post_id = postId;
-    vote.space = spaceId;
+    vote.space = spaceEntityId;
     vote.topic = `${spaceId}/${topicId}`;
     vote.post = `${spaceId}/${topicId}/${postId}`;
 
@@ -245,9 +247,9 @@ export function createWriters(indexerName: string) {
       await post.save();
     }
 
-    let space = await Space.loadEntity(spaceId, indexerName);
+    let space = await Space.loadEntity(spaceEntityId, indexerName);
     if (!space) {
-      space = new Space(spaceId, indexerName);
+      space = new Space(spaceEntityId, indexerName);
     }
     space.vote_count += 1;
 
@@ -262,7 +264,7 @@ export function createWriters(indexerName: string) {
     console.log('Handle new role', spaceId, id, name, description, color);
 
     const role = new Role(id.toString(), indexerName);
-    role.space = spaceId;
+    role.space = spaceId.toString();
     role.name = name;
     role.description = description;
     role.color = color;
@@ -280,7 +282,7 @@ export function createWriters(indexerName: string) {
     const role = await Role.loadEntity(id.toString(), indexerName);
     if (!role) return;
 
-    role.space = spaceId;
+    role.space = spaceId.toString();
     role.name = name;
     role.description = description;
     role.color = color;

--- a/apps/highlight/src/api/writers.ts
+++ b/apps/highlight/src/api/writers.ts
@@ -11,10 +11,6 @@ import {
   Vote
 } from '../../.checkpoint/models';
 
-// NOTE: Right now we are do not have notion of spaces in Highlight
-// We just create a default space for entities
-const DEFAULT_SPACE_ID = '1';
-
 const SetAliasEventData = z.tuple([
   z.string(), // from
   z.string(), // to
@@ -22,6 +18,7 @@ const SetAliasEventData = z.tuple([
 ]);
 
 const NewTopicEventData = z.tuple([
+  z.string(), // spaceId
   z.number(), // id
   z.string(), // author
   z.string(), // title
@@ -30,17 +27,20 @@ const NewTopicEventData = z.tuple([
 ]);
 
 const CloseTopicEventData = z.tuple([
+  z.string(), // spaceId
   z.number() // id
 ]);
 
 const NewPostEventData = z.tuple([
+  z.string(), // spaceId
+  z.number(), // topicId
   z.number(), // id
   z.string(), // author
-  z.number(), // topicId
   z.string() // body
 ]);
 
 const PinPostEventData = z.tuple([
+  z.string(), // spaceId
   z.number(), // topicId
   z.number() // postId
 ]);
@@ -48,9 +48,10 @@ const UnpinPostEventData = PinPostEventData;
 const HidePostEventData = PinPostEventData;
 
 const NewVoteEventData = z.tuple([
-  z.string(), // voter
+  z.string(), // spaceId
   z.number(), // topicId
   z.number(), // postId
+  z.string(), // voter
   z.union([z.literal(1), z.literal(2), z.literal(3)]) // choice
 ]);
 
@@ -79,7 +80,7 @@ export function createWriters(indexerName: string) {
   const handleSetAlias: Writer = async ({ unit, payload }) => {
     const [from, to] = SetAliasEventData.parse(payload.data);
 
-    const alias = new Alias(`${from}:${to}`, indexerName);
+    const alias = new Alias(`${from}/${to}`, indexerName);
     alias.address = from;
     alias.alias = to;
     alias.created = unit.timestamp;
@@ -88,14 +89,14 @@ export function createWriters(indexerName: string) {
   };
 
   const handleNewTopic: Writer = async ({ unit, payload }) => {
-    const [id, author, title, body, discussionUrl] = NewTopicEventData.parse(
-      payload.data
-    );
+    const [spaceId, id, author, title, body, discussionUrl] =
+      NewTopicEventData.parse(payload.data);
 
-    console.log('Handle new topic', id, author, title, body);
+    console.log('Handle new topic', spaceId, id, author, title, body);
 
-    const topic = new Topic(id.toString(), indexerName);
-    topic.space = DEFAULT_SPACE_ID;
+    const topic = new Topic(`${spaceId}/${id}`, indexerName);
+    topic.topic_id = id;
+    topic.space = spaceId;
     topic.author = author;
     topic.title = title;
     topic.body = body;
@@ -104,9 +105,9 @@ export function createWriters(indexerName: string) {
     topic.vote_count = 0;
     topic.created = unit.timestamp;
 
-    let space = await Space.loadEntity(DEFAULT_SPACE_ID, indexerName);
+    let space = await Space.loadEntity(spaceId, indexerName);
     if (!space) {
-      space = new Space(DEFAULT_SPACE_ID, indexerName);
+      space = new Space(spaceId, indexerName);
     }
     space.topic_count += 1;
 
@@ -114,11 +115,11 @@ export function createWriters(indexerName: string) {
   };
 
   const handleCloseTopic: Writer = async ({ payload }) => {
-    const [topicId] = CloseTopicEventData.parse(payload.data);
+    const [spaceId, topicId] = CloseTopicEventData.parse(payload.data);
 
-    console.log('Handle close topic', topicId);
+    console.log('Handle close topic', spaceId, topicId);
 
-    const topic = await Topic.loadEntity(topicId.toString(), indexerName);
+    const topic = await Topic.loadEntity(`${spaceId}/${topicId}`, indexerName);
 
     if (topic) {
       topic.closed = true;
@@ -128,11 +129,13 @@ export function createWriters(indexerName: string) {
   };
 
   const handleNewPost: Writer = async ({ unit, payload }) => {
-    const [id, author, topicId, body] = NewPostEventData.parse(payload.data);
+    const [spaceId, topicId, id, author, body] = NewPostEventData.parse(
+      payload.data
+    );
 
-    console.log('Handle new post', id, author, topicId, body);
+    console.log('Handle new post', spaceId, id, author, topicId, body);
 
-    const post = new Post(`${topicId}/${id}`, indexerName);
+    const post = new Post(`${spaceId}/${topicId}/${id}`, indexerName);
     post.author = author;
     post.body = body;
     post.vote_count = 0;
@@ -142,11 +145,12 @@ export function createWriters(indexerName: string) {
     post.created = unit.timestamp;
     post.post_id = id;
     post.topic_id = topicId;
-    post.topic = topicId.toString();
+    post.space = spaceId;
+    post.topic = `${spaceId}/${topicId}`;
 
     await post.save();
 
-    const topic = await Topic.loadEntity(topicId.toString(), indexerName);
+    const topic = await Topic.loadEntity(`${spaceId}/${topicId}`, indexerName);
 
     if (topic) {
       topic.post_count += 1;
@@ -156,11 +160,14 @@ export function createWriters(indexerName: string) {
   };
 
   const handlePinPost: Writer = async ({ payload }) => {
-    const [topicId, postId] = PinPostEventData.parse(payload.data);
+    const [spaceId, topicId, postId] = PinPostEventData.parse(payload.data);
 
-    console.log('Handle pin post vote', topicId, postId);
+    console.log('Handle pin post', spaceId, topicId, postId);
 
-    const post = await Post.loadEntity(`${topicId}/${postId}`, indexerName);
+    const post = await Post.loadEntity(
+      `${spaceId}/${topicId}/${postId}`,
+      indexerName
+    );
 
     if (post) {
       post.pinned = true;
@@ -170,11 +177,14 @@ export function createWriters(indexerName: string) {
   };
 
   const handleUnpinPost: Writer = async ({ payload }) => {
-    const [topicId, postId] = UnpinPostEventData.parse(payload.data);
+    const [spaceId, topicId, postId] = UnpinPostEventData.parse(payload.data);
 
-    console.log('Handle unpin post', topicId, postId);
+    console.log('Handle unpin post', spaceId, topicId, postId);
 
-    const post = await Post.loadEntity(`${topicId}/${postId}`, indexerName);
+    const post = await Post.loadEntity(
+      `${spaceId}/${topicId}/${postId}`,
+      indexerName
+    );
 
     if (post) {
       post.pinned = false;
@@ -184,11 +194,14 @@ export function createWriters(indexerName: string) {
   };
 
   const handleHidePost: Writer = async ({ payload }) => {
-    const [topicId, postId] = HidePostEventData.parse(payload.data);
+    const [spaceId, topicId, postId] = HidePostEventData.parse(payload.data);
 
-    console.log('Handle hide post vote', topicId, postId);
+    console.log('Handle hide post', spaceId, topicId, postId);
 
-    const post = await Post.loadEntity(`${topicId}/${postId}`, indexerName);
+    const post = await Post.loadEntity(
+      `${spaceId}/${topicId}/${postId}`,
+      indexerName
+    );
 
     if (post) {
       post.hidden = true;
@@ -198,26 +211,30 @@ export function createWriters(indexerName: string) {
   };
 
   const handleNewVote: Writer = async ({ unit, payload }) => {
-    const [voter, topicId, postId, choice] = NewVoteEventData.parse(
+    const [spaceId, topicId, postId, voter, choice] = NewVoteEventData.parse(
       payload.data
     );
 
-    console.log('Handle new vote', voter, topicId, postId, choice);
+    console.log('Handle new vote', spaceId, voter, topicId, postId, choice);
 
-    const id = `${topicId}/${postId}/${voter}`;
+    const id = `${spaceId}/${topicId}/${postId}/${voter}`;
     const vote = new Vote(id, indexerName);
     vote.voter = voter;
     vote.choice = choice;
     vote.created = unit.timestamp;
     vote.topic_id = topicId;
     vote.post_id = postId;
-    vote.topic = topicId.toString();
-    vote.post = postId.toString();
+    vote.space = spaceId;
+    vote.topic = `${spaceId}/${topicId}`;
+    vote.post = `${spaceId}/${topicId}/${postId}`;
 
     await vote.save();
 
-    const topic = await Topic.loadEntity(topicId.toString(), indexerName);
-    const post = await Post.loadEntity(`${topicId}/${postId}`, indexerName);
+    const topic = await Topic.loadEntity(`${spaceId}/${topicId}`, indexerName);
+    const post = await Post.loadEntity(
+      `${spaceId}/${topicId}/${postId}`,
+      indexerName
+    );
 
     if (topic && post) {
       topic.vote_count += 1;
@@ -228,9 +245,9 @@ export function createWriters(indexerName: string) {
       await post.save();
     }
 
-    let space = await Space.loadEntity(DEFAULT_SPACE_ID, indexerName);
+    let space = await Space.loadEntity(spaceId, indexerName);
     if (!space) {
-      space = new Space(DEFAULT_SPACE_ID, indexerName);
+      space = new Space(spaceId, indexerName);
     }
     space.vote_count += 1;
 
@@ -288,18 +305,15 @@ export function createWriters(indexerName: string) {
 
     console.log('Handle claim role', spaceId, id, userAddress);
 
-    let user = await User.loadEntity(userAddress, indexerName);
-    if (!user) user = new User(userAddress, indexerName);
+    const userId = `${spaceId}/${userAddress}`;
+    let user = await User.loadEntity(userId, indexerName);
+    if (!user) user = new User(userId, indexerName);
     await user.save();
 
-    let userRole = await UserRole.loadEntity(
-      `${spaceId}:${id}:${userAddress}`,
-      indexerName
-    );
-
+    let userRole = await UserRole.loadEntity(`${userId}/${id}`, indexerName);
     if (!userRole) {
-      userRole = new UserRole(`${spaceId}:${id}:${userAddress}`, indexerName);
-      userRole.user = userAddress;
+      userRole = new UserRole(`${userId}/${id}`, indexerName);
+      userRole.user = userId;
       userRole.role = id;
       await userRole.save();
     }
@@ -310,15 +324,12 @@ export function createWriters(indexerName: string) {
 
     console.log('Handle revoke role', spaceId, id, userAddress);
 
-    let user = await User.loadEntity(userAddress, indexerName);
-    if (!user) user = new User(userAddress, indexerName);
+    const userId = `${spaceId}/${userAddress}`;
+    let user = await User.loadEntity(userId, indexerName);
+    if (!user) user = new User(userId, indexerName);
     await user.save();
 
-    const userRole = await UserRole.loadEntity(
-      `${spaceId}:${id}:${userAddress}`,
-      indexerName
-    );
-
+    const userRole = await UserRole.loadEntity(`${userId}/${id}`, indexerName);
     if (userRole) {
       await userRole.delete();
     }

--- a/apps/ui/src/components/App/Nav.vue
+++ b/apps/ui/src/components/App/Nav.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import { FunctionalComponent } from 'vue';
-import { useSpaceController } from '@/composables/useSpaceController';
 import { SPACES_DISCUSSIONS } from '@/helpers/discourse';
 import { useSpaceQuery } from '@/queries/spaces';
 import IHAnnotation from '~icons/heroicons-outline/annotation';
@@ -32,7 +31,7 @@ const { isWhiteLabel } = useWhiteLabel();
 
 const { param } = useRouteParser('space');
 const { resolved, address, networkId } = useResolve(param);
-const spaceType = useSpaceType(param);
+const { spaceType } = useTownhallSpace(param);
 const { data: spaceData } = useSpaceQuery({
   networkId: networkId,
   spaceId: address

--- a/apps/ui/src/components/Townhall/PostItem.vue
+++ b/apps/ui/src/components/Townhall/PostItem.vue
@@ -5,7 +5,7 @@ import { _n, _p, _rt, shortenAddress } from '@/helpers/utils';
 import { useSetPostVisibilityMutation } from '@/queries/townhall';
 
 const props = defineProps<{
-  spaceId: string;
+  spaceId: number;
   topicId: number;
   topic: Topic;
   post: Post;

--- a/apps/ui/src/components/Townhall/Posts.vue
+++ b/apps/ui/src/components/Townhall/Posts.vue
@@ -7,7 +7,7 @@ import {
 } from '@/queries/townhall';
 
 const props = defineProps<{
-  spaceId: string;
+  spaceId: number;
   topicId: number;
   topic: Topic;
   posts: Post[];

--- a/apps/ui/src/components/Townhall/Posts.vue
+++ b/apps/ui/src/components/Townhall/Posts.vue
@@ -15,7 +15,10 @@ const props = defineProps<{
 
 const { web3 } = useWeb3();
 
-const { data: userRoles } = useUserRolesQuery(toRef(() => web3.value.account));
+const { data: userRoles } = useUserRolesQuery({
+  spaceId: toRef(props, 'spaceId'),
+  user: toRef(() => web3.value.account)
+});
 const { mutate: vote, isPending: isVotePending } = useVoteMutation({
   spaceId: toRef(props, 'spaceId'),
   topicId: toRef(props, 'topicId'),

--- a/apps/ui/src/components/TownhallTopicsList.vue
+++ b/apps/ui/src/components/TownhallTopicsList.vue
@@ -48,7 +48,7 @@ const currentLimit = computed(() => {
           :to="{
             name: 'space-townhall-topic',
             params: {
-              id: topic.id
+              id: topic.topic_id
             }
           }"
           class="py-3 mx-4 block border-b"

--- a/apps/ui/src/composables/useTownhall.ts
+++ b/apps/ui/src/composables/useTownhall.ts
@@ -98,7 +98,7 @@ export function useTownhall() {
   }
 
   async function sendTopic(
-    space: string,
+    space: number,
     title: string,
     body: string,
     discussionUrl: string
@@ -119,7 +119,7 @@ export function useTownhall() {
     );
   }
 
-  async function sendCloseTopic(space: string, topic: number) {
+  async function sendCloseTopic(space: number, topic: number) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -136,7 +136,7 @@ export function useTownhall() {
     );
   }
 
-  async function sendPost(space: string, topic: number, body: string) {
+  async function sendPost(space: number, topic: number, body: string) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -153,7 +153,7 @@ export function useTownhall() {
     );
   }
 
-  async function sendHidePost(space: string, topic: number, post: number) {
+  async function sendHidePost(space: number, topic: number, post: number) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -170,7 +170,7 @@ export function useTownhall() {
     );
   }
 
-  async function sendPinPost(space: string, topic: number, post: number) {
+  async function sendPinPost(space: number, topic: number, post: number) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -187,7 +187,7 @@ export function useTownhall() {
     );
   }
 
-  async function sendUnpinPost(space: string, topic: number, post: number) {
+  async function sendUnpinPost(space: number, topic: number, post: number) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -205,7 +205,7 @@ export function useTownhall() {
   }
 
   async function sendVote(
-    space: string,
+    space: number,
     topic: number,
     post: number,
     choice: 1 | 2 | 3
@@ -227,7 +227,7 @@ export function useTownhall() {
   }
 
   async function sendCreateRole(
-    space: string,
+    space: number,
     name: string,
     description: string,
     color: string
@@ -249,7 +249,7 @@ export function useTownhall() {
   }
 
   async function sendEditRole(
-    space: string,
+    space: number,
     id: string,
     name: string,
     description: string,
@@ -271,7 +271,7 @@ export function useTownhall() {
     );
   }
 
-  async function sendDeleteRole(space: string, id: string) {
+  async function sendDeleteRole(space: number, id: string) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -288,7 +288,7 @@ export function useTownhall() {
     );
   }
 
-  async function sendClaimRole(space: string, id: string) {
+  async function sendClaimRole(space: number, id: string) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -305,7 +305,7 @@ export function useTownhall() {
     );
   }
 
-  async function sendRevokeRole(space: string, id: string) {
+  async function sendRevokeRole(space: number, id: string) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;

--- a/apps/ui/src/composables/useTownhall.ts
+++ b/apps/ui/src/composables/useTownhall.ts
@@ -97,7 +97,12 @@ export function useTownhall() {
     );
   }
 
-  async function sendTopic(title: string, body: string, discussionUrl: string) {
+  async function sendTopic(
+    space: string,
+    title: string,
+    body: string,
+    discussionUrl: string
+  ) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -108,13 +113,13 @@ export function useTownhall() {
     return wrapPromise(
       highlightClient.createTopic({
         signer,
-        data: { title, body, discussionUrl },
+        data: { space, title, body, discussionUrl },
         salt: getSalt()
       })
     );
   }
 
-  async function sendCloseTopic(topic: number) {
+  async function sendCloseTopic(space: string, topic: number) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -125,13 +130,13 @@ export function useTownhall() {
     return wrapPromise(
       highlightClient.closeTopic({
         signer,
-        data: { topic },
+        data: { space, topic },
         salt: getSalt()
       })
     );
   }
 
-  async function sendPost(topic: number, body: string) {
+  async function sendPost(space: string, topic: number, body: string) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -142,13 +147,13 @@ export function useTownhall() {
     return wrapPromise(
       highlightClient.createPost({
         signer,
-        data: { topic, body },
+        data: { space, topic, body },
         salt: getSalt()
       })
     );
   }
 
-  async function sendHidePost(topic: number, post: number) {
+  async function sendHidePost(space: string, topic: number, post: number) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -159,13 +164,13 @@ export function useTownhall() {
     return wrapPromise(
       highlightClient.hidePost({
         signer,
-        data: { topic, post },
+        data: { space, topic, post },
         salt: getSalt()
       })
     );
   }
 
-  async function sendPinPost(topic: number, post: number) {
+  async function sendPinPost(space: string, topic: number, post: number) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -176,13 +181,13 @@ export function useTownhall() {
     return wrapPromise(
       highlightClient.pinPost({
         signer,
-        data: { topic, post },
+        data: { space, topic, post },
         salt: getSalt()
       })
     );
   }
 
-  async function sendUnpinPost(topic: number, post: number) {
+  async function sendUnpinPost(space: string, topic: number, post: number) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -193,13 +198,18 @@ export function useTownhall() {
     return wrapPromise(
       highlightClient.unpinPost({
         signer,
-        data: { topic, post },
+        data: { space, topic, post },
         salt: getSalt()
       })
     );
   }
 
-  async function sendVote(topic: number, post: number, choice: 1 | 2 | 3) {
+  async function sendVote(
+    space: string,
+    topic: number,
+    post: number,
+    choice: 1 | 2 | 3
+  ) {
     if (!auth.value) {
       modalAccountOpen.value = true;
       return null;
@@ -210,7 +220,7 @@ export function useTownhall() {
     return wrapPromise(
       highlightClient.vote({
         signer,
-        data: { topic, post, choice },
+        data: { space, topic, post, choice },
         salt: getSalt()
       })
     );

--- a/apps/ui/src/composables/useTownhallSpace.ts
+++ b/apps/ui/src/composables/useTownhallSpace.ts
@@ -2,19 +2,33 @@ import { MaybeRefOrGetter } from 'vue';
 
 export type SpaceType = 'proposalsSpace' | 'discussionsSpace';
 
-export function useSpaceType(spaceParam: MaybeRefOrGetter<string>) {
+export function useTownhallSpace(spaceParam: MaybeRefOrGetter<string>) {
   const { isWhiteLabel, space: whitelabelSpace } = useWhiteLabel();
 
-  return computed<SpaceType>(() => {
-    if (
+  const isOpenAgora = computed(() => {
+    return (
       toValue(spaceParam) === 's:openagora.eth' ||
       (isWhiteLabel.value &&
         whitelabelSpace.value?.id === 'openagora.eth' &&
         whitelabelSpace.value?.network === 's')
-    ) {
+    );
+  });
+
+  const townhallSpaceId = computed(() => {
+    if (isOpenAgora.value) {
+      return 1;
+    }
+
+    return null;
+  });
+
+  const spaceType = computed<SpaceType>(() => {
+    if (isOpenAgora.value) {
       return 'discussionsSpace';
     }
 
     return 'proposalsSpace';
   });
+
+  return { spaceType, townhallSpaceId };
 }

--- a/apps/ui/src/helpers/townhall/api.ts
+++ b/apps/ui/src/helpers/townhall/api.ts
@@ -25,6 +25,7 @@ const client = new ApolloClient({
 gql(`
   fragment spaceFields on Space {
     id
+    space_id
     vote_count
     topic_count
   }
@@ -82,6 +83,7 @@ gql(`
     id
     space {
       id
+      space_id
     }
     name
     description
@@ -141,10 +143,10 @@ const USER_ROLES_QUERY = gql(`
   }
 `);
 
-export async function getSpace(spaceId: string) {
+export async function getSpace(spaceId: number) {
   const { data } = await client.query({
     query: SPACE_QUERY,
-    variables: { id: spaceId }
+    variables: { id: spaceId.toString() }
   });
 
   return data.space;
@@ -155,19 +157,19 @@ export async function getTopics({
   limit,
   skip
 }: {
-  spaceId: string;
+  spaceId: number;
   limit: number;
   skip: number;
 }) {
   const { data } = await client.query({
     query: TOPICS_QUERY,
-    variables: { spaceId, limit, skip }
+    variables: { spaceId: spaceId.toString(), limit, skip }
   });
 
   return data.topics;
 }
 
-export async function getTopic(spaceId: string, topicId: number) {
+export async function getTopic(spaceId: number, topicId: number) {
   const { data } = await client.query({
     query: TOPIC_QUERY,
     variables: { id: `${spaceId}/${topicId}` }
@@ -177,7 +179,7 @@ export async function getTopic(spaceId: string, topicId: number) {
 }
 
 export async function getVotes(
-  spaceId: string,
+  spaceId: number,
   topicId: number,
   voter: string
 ) {
@@ -189,16 +191,16 @@ export async function getVotes(
   return data.votes;
 }
 
-export async function getRoles(spaceId: string) {
+export async function getRoles(spaceId: number) {
   const { data } = await client.query({
     query: ROLES_QUERY,
-    variables: { space: spaceId }
+    variables: { space: spaceId.toString() }
   });
 
   return data.roles;
 }
 
-export async function getUserRoles(spaceId: string, user: string) {
+export async function getUserRoles(spaceId: number, user: string) {
   const { data } = await client.query({
     query: USER_ROLES_QUERY,
     variables: { user: `${spaceId}/${user}` }
@@ -208,7 +210,7 @@ export async function getUserRoles(spaceId: string, user: string) {
 }
 
 export async function getResultsByRole(
-  spaceId: string,
+  spaceId: number,
   topicId: number,
   roleId: string
 ): Promise<Result[]> {

--- a/apps/ui/src/helpers/townhall/api.ts
+++ b/apps/ui/src/helpers/townhall/api.ts
@@ -3,8 +3,8 @@ import { HIGHLIGHT_URL } from '@/helpers/highlight';
 import { Post, Vote } from '@/helpers/townhall/types';
 import { gql } from './gql';
 
-type NewPostEvent = [number, string, number, string];
-type NewVoteEvent = [string, number, number, number];
+type NewPostEvent = [string, number, number, string, string];
+type NewVoteEvent = [string, number, number, string, number];
 
 export type Result = {
   post_id: number;
@@ -57,6 +57,7 @@ gql(`
     vote_count
     created
     closed
+    topic_id
     posts {
       ...postFields
     }
@@ -97,8 +98,8 @@ const SPACE_QUERY = gql(`
 `);
 
 const TOPICS_QUERY = gql(`
-  query Topics($limit: Int!, $skip: Int!) {
-    topics(first: $limit, skip: $skip, orderBy: created, orderDirection: desc) {
+  query Topics($spaceId: String!, $limit: Int!, $skip: Int!) {
+    topics(first: $limit, skip: $skip, orderBy: created, orderDirection: desc, where: { space: $spaceId }) {
       ...topicFields
     }
   }
@@ -150,33 +151,39 @@ export async function getSpace(spaceId: string) {
 }
 
 export async function getTopics({
+  spaceId,
   limit,
   skip
 }: {
+  spaceId: string;
   limit: number;
   skip: number;
 }) {
   const { data } = await client.query({
     query: TOPICS_QUERY,
-    variables: { limit, skip }
+    variables: { spaceId, limit, skip }
   });
 
   return data.topics;
 }
 
-export async function getTopic(id: string) {
+export async function getTopic(spaceId: string, topicId: number) {
   const { data } = await client.query({
     query: TOPIC_QUERY,
-    variables: { id }
+    variables: { id: `${spaceId}/${topicId}` }
   });
 
   return data.topic;
 }
 
-export async function getVotes(topic: string, voter: string) {
+export async function getVotes(
+  spaceId: string,
+  topicId: number,
+  voter: string
+) {
   const { data } = await client.query({
     query: VOTES_QUERY,
-    variables: { topic, voter }
+    variables: { topic: `${spaceId}/${topicId}`, voter }
   });
 
   return data.votes;
@@ -191,21 +198,22 @@ export async function getRoles(spaceId: string) {
   return data.roles;
 }
 
-export async function getUserRoles(user: string) {
+export async function getUserRoles(spaceId: string, user: string) {
   const { data } = await client.query({
     query: USER_ROLES_QUERY,
-    variables: { user }
+    variables: { user: `${spaceId}/${user}` }
   });
 
   return data.user?.roles.map(role => role.role) ?? [];
 }
 
 export async function getResultsByRole(
+  spaceId: string,
   topicId: number,
   roleId: string
 ): Promise<Result[]> {
   const res = await fetch(
-    `${HIGHLIGHT_URL}/townhall/topics/${topicId}/results_by_role/${roleId}`
+    `${HIGHLIGHT_URL}/townhall/spaces/${spaceId}/topics/${topicId}/results_by_role/${roleId}`
   );
 
   const { error, result } = await res.json();
@@ -218,7 +226,7 @@ export async function getResultsByRole(
 }
 
 export function newPostEventToEntry(event: NewPostEvent): Post {
-  const [id, author, topicId, body] = event;
+  const [, topicId, id, author, body] = event;
 
   return {
     id: `${topicId}/${id}`,
@@ -230,7 +238,7 @@ export function newPostEventToEntry(event: NewPostEvent): Post {
     scores_3: 0,
     pinned: false,
     hidden: false,
-    created: 0,
+    created: Math.floor(Date.now() / 1000),
     topic_id: topicId,
     post_id: id,
     topic: { id: String(topicId) }
@@ -238,11 +246,11 @@ export function newPostEventToEntry(event: NewPostEvent): Post {
 }
 
 export function newVoteEventToEntry(event: NewVoteEvent): Vote {
-  const [voter, topicId, postId, choice] = event;
+  const [, topicId, postId, voter, choice] = event;
 
   return {
     id: `${topicId}/${postId}/${voter}`,
-    created: 0,
+    created: Math.floor(Date.now() / 1000),
     topic_id: topicId,
     post_id: postId,
     topic: { id: String(topicId) },

--- a/apps/ui/src/queries/townhall.ts
+++ b/apps/ui/src/queries/townhall.ts
@@ -7,7 +7,7 @@ import {
   useQueryClient
 } from '@tanstack/vue-query';
 import { MaybeRefOrGetter } from 'vue';
-import { SpaceType } from '@/composables/useSpaceType';
+import { SpaceType } from '@/composables/useTownhallSpace';
 import {
   getResultsByRole,
   getRoles,
@@ -35,7 +35,7 @@ function addVoteToRoleResults({
   vote
 }: {
   queryClient: QueryClient;
-  spaceId: string;
+  spaceId: number;
   topicId: number;
   roleId: string;
   vote: Vote;
@@ -65,7 +65,7 @@ export function useSpaceQuery({
   spaceId,
   spaceType
 }: {
-  spaceId: MaybeRefOrGetter<string | null>;
+  spaceId: MaybeRefOrGetter<number | null>;
   spaceType: MaybeRefOrGetter<SpaceType>;
 }) {
   const queryFn = computed(() => {
@@ -96,7 +96,7 @@ export function useSpaceQuery({
 export function useTopicsQuery({
   spaceId
 }: {
-  spaceId: MaybeRefOrGetter<string>;
+  spaceId: MaybeRefOrGetter<number>;
 }) {
   return useInfiniteQuery({
     initialPageParam: 0,
@@ -121,7 +121,7 @@ export function useTopicsSummaryQuery({
   spaceId,
   enabled = true
 }: {
-  spaceId: MaybeRefOrGetter<string>;
+  spaceId: MaybeRefOrGetter<number>;
   enabled?: MaybeRefOrGetter<boolean>;
 }) {
   return useQuery({
@@ -142,7 +142,7 @@ export function useTopicQuery({
   spaceId,
   topicId
 }: {
-  spaceId: MaybeRefOrGetter<string>;
+  spaceId: MaybeRefOrGetter<number>;
   topicId: MaybeRefOrGetter<number>;
 }) {
   return useQuery({
@@ -167,7 +167,7 @@ export function useUserVotesQuery({
   topicId,
   user
 }: {
-  spaceId: MaybeRefOrGetter<string>;
+  spaceId: MaybeRefOrGetter<number>;
   topicId: MaybeRefOrGetter<number>;
   user: MaybeRefOrGetter<string>;
 }) {
@@ -181,7 +181,7 @@ export function useUserVotesQuery({
   });
 }
 
-export function useRolesQuery(spaceId: MaybeRefOrGetter<string>) {
+export function useRolesQuery(spaceId: MaybeRefOrGetter<number>) {
   return useQuery({
     queryKey: ['townhall', 'roles', spaceId, 'list'],
     queryFn: () => {
@@ -194,7 +194,7 @@ export function useUserRolesQuery({
   spaceId,
   user
 }: {
-  spaceId: MaybeRefOrGetter<string>;
+  spaceId: MaybeRefOrGetter<number>;
   user: MaybeRefOrGetter<string>;
 }) {
   return useQuery({
@@ -217,7 +217,7 @@ export function useResultsByRoleQuery({
   topicId,
   roleId
 }: {
-  spaceId: MaybeRefOrGetter<string>;
+  spaceId: MaybeRefOrGetter<number>;
   topicId: MaybeRefOrGetter<number>;
   roleId: MaybeRefOrGetter<string>;
 }) {
@@ -242,7 +242,7 @@ export function useResultsByRoleQuery({
 export function useRoleMutation({
   spaceId
 }: {
-  spaceId: MaybeRefOrGetter<string>;
+  spaceId: MaybeRefOrGetter<number>;
 }) {
   const { web3 } = useWeb3();
   const queryClient = useQueryClient();
@@ -252,8 +252,8 @@ export function useRoleMutation({
   return useMutation({
     mutationFn: ({ role, isRevoking }: { role: Role; isRevoking: boolean }) => {
       return isRevoking
-        ? sendRevokeRole(role.space.id, role.id)
-        : sendClaimRole(role.space.id, role.id);
+        ? sendRevokeRole(role.space.space_id, role.id)
+        : sendClaimRole(role.space.space_id, role.id);
     },
     onSuccess: (data, { role, isRevoking }) => {
       if (!data) return;
@@ -279,7 +279,7 @@ export function useCloseTopicMutation({
   spaceId,
   topicId
 }: {
-  spaceId: MaybeRefOrGetter<string>;
+  spaceId: MaybeRefOrGetter<number>;
   topicId: MaybeRefOrGetter<number>;
 }) {
   const queryClient = useQueryClient();
@@ -315,7 +315,7 @@ export function useCreatePostMutation({
   spaceId,
   topicId
 }: {
-  spaceId: MaybeRefOrGetter<string>;
+  spaceId: MaybeRefOrGetter<number>;
   topicId: MaybeRefOrGetter<number>;
 }) {
   const queryClient = useQueryClient();
@@ -359,7 +359,7 @@ export function useSetPostVisibilityMutation({
   spaceId,
   topicId
 }: {
-  spaceId: MaybeRefOrGetter<string>;
+  spaceId: MaybeRefOrGetter<number>;
   topicId: MaybeRefOrGetter<number>;
 }) {
   const queryClient = useQueryClient();
@@ -437,7 +437,7 @@ export function useVoteMutation({
   topicId,
   userRoles
 }: {
-  spaceId: MaybeRefOrGetter<string>;
+  spaceId: MaybeRefOrGetter<number>;
   topicId: MaybeRefOrGetter<number>;
   userRoles: MaybeRefOrGetter<Role[] | undefined>;
 }) {

--- a/apps/ui/src/views/Space.vue
+++ b/apps/ui/src/views/Space.vue
@@ -4,6 +4,7 @@ import { useSpaceQuery } from '@/queries/spaces';
 import { useSpaceQuery as useTownhallSpaceQuery } from '@/queries/townhall';
 
 const { setFavicon } = useFavicon();
+const route = useRoute();
 const { param } = useRouteParser('space');
 const { spaceType, townhallSpaceId } = useTownhallSpace(param);
 const { resolved, address, networkId } = useResolve(param);
@@ -21,6 +22,18 @@ const { data: townhallSpace, isPending: isTownhallSpacePending } =
     spaceId: townhallSpaceId,
     spaceType
   });
+
+const isTownhallRoute = computed(() => {
+  if (typeof route.name === 'string') {
+    return route.name.includes('townhall');
+  }
+
+  return false;
+});
+
+const isSpaceLoaded = computed(() =>
+  space.value && isTownhallRoute.value ? townhallSpace.value : true
+);
 
 watch(
   [resolved, networkId, address, () => web3.value.account],
@@ -63,5 +76,12 @@ onUnmounted(() => {
     "
     class="block p-4"
   />
+
+  <div v-else-if="!isSpaceLoaded">
+    <div class="px-4 py-3 flex items-center text-skin-link gap-2">
+      <IH-exclamation-circle />
+      <span>Failed to load space.</span>
+    </div>
+  </div>
   <router-view v-else :space="space" :townhall-space="townhallSpace" />
 </template>

--- a/apps/ui/src/views/Space.vue
+++ b/apps/ui/src/views/Space.vue
@@ -5,7 +5,7 @@ import { useSpaceQuery as useTownhallSpaceQuery } from '@/queries/townhall';
 
 const { setFavicon } = useFavicon();
 const { param } = useRouteParser('space');
-const spaceType = useSpaceType(param);
+const { spaceType, townhallSpaceId } = useTownhallSpace(param);
 const { resolved, address, networkId } = useResolve(param);
 const { loadVotes } = useAccount();
 const { isWhiteLabel } = useWhiteLabel();
@@ -18,7 +18,7 @@ const { data: space, isPending } = useSpaceQuery({
 
 const { data: townhallSpace, isPending: isTownhallSpacePending } =
   useTownhallSpaceQuery({
-    spaceId: address,
+    spaceId: townhallSpaceId,
     spaceType
   });
 

--- a/apps/ui/src/views/Space.vue
+++ b/apps/ui/src/views/Space.vue
@@ -18,7 +18,7 @@ const { data: space, isPending } = useSpaceQuery({
 
 const { data: townhallSpace, isPending: isTownhallSpacePending } =
   useTownhallSpaceQuery({
-    spaceId: '1',
+    spaceId: address,
     spaceType
   });
 

--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -15,7 +15,7 @@ import { Space } from '@/types';
 const props = defineProps<{ space: Space; townhallSpace?: TownhallSpace }>();
 
 const { param } = useRouteParser('space');
-const spaceType = useSpaceType(param);
+const { spaceType, townhallSpaceId } = useTownhallSpace(param);
 const { setTitle } = useTitle();
 const { isWhiteLabel } = useWhiteLabel();
 
@@ -35,7 +35,7 @@ const {
   isPending: isTopicsPending,
   isError: isTopicsError
 } = useTopicsSummaryQuery({
-  spaceId: toRef(() => props.space.id),
+  spaceId: toRef(() => townhallSpaceId.value!),
   enabled: computed(() => spaceType.value === 'discussionsSpace')
 });
 

--- a/apps/ui/src/views/Townhall/Create.vue
+++ b/apps/ui/src/views/Townhall/Create.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { getTopic } from '@/helpers/townhall/api';
+import { Space as TownhallSpace } from '@/helpers/townhall/types';
 import { sleep } from '@/helpers/utils';
 import { Space } from '@/types';
 
-const props = defineProps<{ space: Space }>();
+const props = defineProps<{ space: Space; townhallSpace: TownhallSpace }>();
 
 const route = useRoute();
 const router = useRouter();
@@ -45,7 +46,7 @@ async function handleSubmit() {
 
   try {
     const res = await sendTopic(
-      props.space.id,
+      props.townhallSpace.space_id,
       title.value,
       body.value,
       discussion.value

--- a/apps/ui/src/views/Townhall/Create.vue
+++ b/apps/ui/src/views/Townhall/Create.vue
@@ -44,15 +44,21 @@ async function handleSubmit() {
   submitLoading.value = true;
 
   try {
-    const res = await sendTopic(title.value, body.value, discussion.value);
+    const res = await sendTopic(
+      props.space.id,
+      title.value,
+      body.value,
+      discussion.value
+    );
     if (!res) return;
 
-    const id = res.result.events.find(event => event.key === 'new_topic')
-      .data[0];
+    const [spaceId, topicId] = res.result.events.find(
+      event => event.key === 'new_topic'
+    ).data;
 
     while (true) {
       try {
-        await getTopic(id.toString());
+        await getTopic(spaceId, topicId);
         break;
       } catch (e: unknown) {
         if (e instanceof Error && e.message.includes('Row not found')) {
@@ -64,7 +70,10 @@ async function handleSubmit() {
       }
     }
 
-    await router.push({ name: 'space-townhall-topic', params: { id } });
+    await router.push({
+      name: 'space-townhall-topic',
+      params: { id: topicId }
+    });
   } catch (e) {
     addNotification('error', e.message);
   } finally {

--- a/apps/ui/src/views/Townhall/Roles.vue
+++ b/apps/ui/src/views/Townhall/Roles.vue
@@ -18,17 +18,21 @@ const queryClient = useQueryClient();
 
 const modalOpen = ref(false);
 const activeLabelId = ref<string | null>(null);
-const spaceId = ref('1');
-const userSpaceRoles = computed(() => {
-  return userRoles.value?.filter(role => role.space.id === spaceId.value) ?? [];
-});
+const spaceId = computed(() => props.space.id);
 
 const { data: roles, isPending, isError } = useRolesQuery(spaceId);
-const { data: userRoles } = useUserRolesQuery(toRef(() => web3.value.account));
-const { isPending: isMutatingRole, variables, mutate } = useRoleMutation();
+const { data: userRoles } = useUserRolesQuery({
+  spaceId: spaceId,
+  user: toRef(() => web3.value.account)
+});
+const {
+  isPending: isMutatingRole,
+  variables,
+  mutate
+} = useRoleMutation({ spaceId: toRef(() => props.space.id) });
 
 function getIsRoleClaimed(roleId: string) {
-  return userSpaceRoles.value.some(role => role.id === roleId);
+  return (userRoles.value ?? []).some(role => role.id === roleId);
 }
 
 function setModalStatus(open: boolean = false, roleId: string | null = null) {

--- a/apps/ui/src/views/Townhall/Topic.vue
+++ b/apps/ui/src/views/Townhall/Topic.vue
@@ -19,7 +19,6 @@ const { setTitle } = useTitle();
 const { setContext, setVars, openChatbot } = useChatbot();
 
 const id = computed(() => Number(route.params.id));
-const spaceId = '1';
 
 const roleFilter: Ref<string> = ref('any');
 const sortBy: Ref<'agree' | 'disagree' | 'votes' | 'recent'> = ref('agree');
@@ -29,26 +28,32 @@ const {
   data: topic,
   isPending,
   isError
-} = useTopicQuery({ spaceId, topicId: id });
-const { data: roles, isError: isRolesError } = useRolesQuery(spaceId);
+} = useTopicQuery({ spaceId: toRef(() => props.space.id), topicId: id });
+const { data: roles, isError: isRolesError } = useRolesQuery(
+  toRef(() => props.space.id)
+);
 const {
   data: resultsByRole,
   isPending: isResultsPending,
   isError: isResultsError
-} = useResultsByRoleQuery({ topicId: id, roleId: roleFilter });
+} = useResultsByRoleQuery({
+  spaceId: toRef(() => props.space.id),
+  topicId: id,
+  roleId: roleFilter
+});
 const { data: userVotes, isError: isUserVotesError } = useUserVotesQuery({
-  spaceId,
+  spaceId: toRef(() => props.space.id),
   topicId: id,
   user: toRef(() => web3.value.account)
 });
 const { mutate: createPost, isPending: isCreatePostPending } =
   useCreatePostMutation({
-    spaceId,
+    spaceId: toRef(() => props.space.id),
     topicId: id
   });
 const { mutate: closeTopic, isPending: isCloseTopicPending } =
   useCloseTopicMutation({
-    spaceId,
+    spaceId: toRef(() => props.space.id),
     topicId: id
   });
 
@@ -203,7 +208,7 @@ watchEffect(() => {
             </span>
           </h4>
           <TownhallPosts
-            :space-id="spaceId"
+            :space-id="space.id"
             :topic-id="id"
             :topic="topic"
             :posts="pendingPosts"
@@ -303,7 +308,7 @@ watchEffect(() => {
             <TownhallPostItem
               v-for="(s, i) in results"
               :key="i"
-              :space-id="spaceId"
+              :space-id="space.id"
               :topic-id="id"
               :topic="topic"
               :post="s"

--- a/apps/ui/src/views/Townhall/Topics.vue
+++ b/apps/ui/src/views/Townhall/Topics.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
+import { Space as TownhallSpace } from '@/helpers/townhall/types';
 import { useTopicsQuery } from '@/queries/townhall';
 import { Space } from '@/types';
 
-const props = defineProps<{ space: Space }>();
+const props = defineProps<{ space: Space; townhallSpace: TownhallSpace }>();
 
 const { setTitle } = useTitle();
 
@@ -14,7 +15,7 @@ const {
   isError,
   isFetchingNextPage
 } = useTopicsQuery({
-  spaceId: toRef(() => props.space.id)
+  spaceId: toRef(() => props.townhallSpace.space_id)
 });
 
 async function handleEndReached() {

--- a/packages/sx.js/src/clients/highlight/ethereum-sig.ts
+++ b/packages/sx.js/src/clients/highlight/ethereum-sig.ts
@@ -145,8 +145,9 @@ export class HighlightEthereumSigClient {
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { title, body, discussionUrl } = data;
+    const { space, title, body, discussionUrl } = data;
     const message = {
+      space,
       title,
       body,
       discussionUrl
@@ -180,8 +181,9 @@ export class HighlightEthereumSigClient {
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { topic } = data;
+    const { space, topic } = data;
     const message = {
+      space,
       topic
     };
 
@@ -213,8 +215,9 @@ export class HighlightEthereumSigClient {
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { topic, body } = data;
+    const { space, topic, body } = data;
     const message = {
+      space,
       topic,
       body
     };
@@ -247,8 +250,9 @@ export class HighlightEthereumSigClient {
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { topic, post } = data;
+    const { space, topic, post } = data;
     const message = {
+      space,
       topic,
       post
     };
@@ -281,8 +285,9 @@ export class HighlightEthereumSigClient {
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { topic, post } = data;
+    const { space, topic, post } = data;
     const message = {
+      space,
       topic,
       post
     };
@@ -315,8 +320,9 @@ export class HighlightEthereumSigClient {
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { topic, post } = data;
+    const { space, topic, post } = data;
     const message = {
+      space,
       topic,
       post
     };
@@ -349,8 +355,9 @@ export class HighlightEthereumSigClient {
   }): Promise<Envelope> {
     const domain = await this.getDomain(signer, salt, TOWNHALL_CONFIG.address);
 
-    const { topic, post, choice } = data;
+    const { space, topic, post, choice } = data;
     const message = {
+      space,
       topic,
       post,
       choice

--- a/packages/sx.js/src/clients/highlight/types.ts
+++ b/packages/sx.js/src/clients/highlight/types.ts
@@ -15,21 +15,25 @@ export type SetAlias = {
 };
 
 export type CreateTopic = {
+  space: string;
   title: string;
   body: string;
   discussionUrl: string;
 };
 
 export type CloseTopic = {
+  space: string;
   topic: number;
 };
 
 export type CreatePost = {
+  space: string;
   topic: number;
   body: string;
 };
 
 export type HidePost = {
+  space: string;
   topic: number;
   post: number;
 };
@@ -37,6 +41,7 @@ export type PinPost = HidePost;
 export type UnpinPost = HidePost;
 
 export type Vote = {
+  space: string;
   topic: number;
   post: number;
   choice: number;

--- a/packages/sx.js/src/clients/highlight/types.ts
+++ b/packages/sx.js/src/clients/highlight/types.ts
@@ -15,25 +15,25 @@ export type SetAlias = {
 };
 
 export type CreateTopic = {
-  space: string;
+  space: number;
   title: string;
   body: string;
   discussionUrl: string;
 };
 
 export type CloseTopic = {
-  space: string;
+  space: number;
   topic: number;
 };
 
 export type CreatePost = {
-  space: string;
+  space: number;
   topic: number;
   body: string;
 };
 
 export type HidePost = {
-  space: string;
+  space: number;
   topic: number;
   post: number;
 };
@@ -41,14 +41,14 @@ export type PinPost = HidePost;
 export type UnpinPost = HidePost;
 
 export type Vote = {
-  space: string;
+  space: number;
   topic: number;
   post: number;
   choice: number;
 };
 
 export type CreateRole = {
-  space: string;
+  space: number;
   name: string;
   description: string;
   color: string;
@@ -57,7 +57,7 @@ export type CreateRole = {
 export type EditRole = CreateRole & { id: string };
 
 export type DeleteRole = {
-  space: string;
+  space: number;
   id: string;
 };
 export type ClaimRole = DeleteRole;

--- a/packages/sx.js/src/highlightConstants.ts
+++ b/packages/sx.js/src/highlightConstants.ts
@@ -20,7 +20,7 @@ export const TOWNHALL_CONFIG = {
   types: {
     createTopic: {
       Topic: [
-        { name: 'space', type: 'string' },
+        { name: 'space', type: 'uint64' },
         { name: 'title', type: 'string' },
         { name: 'body', type: 'string' },
         { name: 'discussionUrl', type: 'string' }
@@ -28,41 +28,41 @@ export const TOWNHALL_CONFIG = {
     },
     closeTopic: {
       CloseTopic: [
-        { name: 'space', type: 'string' },
+        { name: 'space', type: 'uint64' },
         { name: 'topic', type: 'uint64' }
       ]
     },
     createPost: {
       Post: [
-        { name: 'space', type: 'string' },
+        { name: 'space', type: 'uint64' },
         { name: 'topic', type: 'uint64' },
         { name: 'body', type: 'string' }
       ]
     },
     hidePost: {
       HidePost: [
-        { name: 'space', type: 'string' },
+        { name: 'space', type: 'uint64' },
         { name: 'topic', type: 'uint64' },
         { name: 'post', type: 'int' }
       ]
     },
     pinPost: {
       PinPost: [
-        { name: 'space', type: 'string' },
+        { name: 'space', type: 'uint64' },
         { name: 'topic', type: 'uint64' },
         { name: 'post', type: 'uint64' }
       ]
     },
     unpinPost: {
       UnpinPost: [
-        { name: 'space', type: 'string' },
+        { name: 'space', type: 'uint64' },
         { name: 'topic', type: 'uint64' },
         { name: 'post', type: 'uint64' }
       ]
     },
     vote: {
       Vote: [
-        { name: 'space', type: 'string' },
+        { name: 'space', type: 'uint64' },
         { name: 'topic', type: 'uint64' },
         { name: 'post', type: 'uint64' },
         { name: 'choice', type: 'uint64' }
@@ -70,7 +70,7 @@ export const TOWNHALL_CONFIG = {
     },
     createRole: {
       CreateRole: [
-        { name: 'space', type: 'string' },
+        { name: 'space', type: 'uint64' },
         { name: 'name', type: 'string' },
         { name: 'description', type: 'string' },
         { name: 'color', type: 'string' }
@@ -78,7 +78,7 @@ export const TOWNHALL_CONFIG = {
     },
     editRole: {
       EditRole: [
-        { name: 'space', type: 'string' },
+        { name: 'space', type: 'uint64' },
         { name: 'id', type: 'uint64' },
         { name: 'name', type: 'string' },
         { name: 'description', type: 'string' },
@@ -87,19 +87,19 @@ export const TOWNHALL_CONFIG = {
     },
     deleteRole: {
       DeleteRole: [
-        { name: 'space', type: 'string' },
+        { name: 'space', type: 'uint64' },
         { name: 'id', type: 'uint64' }
       ]
     },
     claimRole: {
       ClaimRole: [
-        { name: 'space', type: 'string' },
+        { name: 'space', type: 'uint64' },
         { name: 'id', type: 'uint64' }
       ]
     },
     revokeRole: {
       RevokeRole: [
-        { name: 'space', type: 'string' },
+        { name: 'space', type: 'uint64' },
         { name: 'id', type: 'uint64' }
       ]
     }

--- a/packages/sx.js/src/highlightConstants.ts
+++ b/packages/sx.js/src/highlightConstants.ts
@@ -20,40 +20,49 @@ export const TOWNHALL_CONFIG = {
   types: {
     createTopic: {
       Topic: [
+        { name: 'space', type: 'string' },
         { name: 'title', type: 'string' },
         { name: 'body', type: 'string' },
         { name: 'discussionUrl', type: 'string' }
       ]
     },
     closeTopic: {
-      CloseTopic: [{ name: 'topic', type: 'uint64' }]
+      CloseTopic: [
+        { name: 'space', type: 'string' },
+        { name: 'topic', type: 'uint64' }
+      ]
     },
     createPost: {
       Post: [
+        { name: 'space', type: 'string' },
         { name: 'topic', type: 'uint64' },
         { name: 'body', type: 'string' }
       ]
     },
     hidePost: {
       HidePost: [
+        { name: 'space', type: 'string' },
         { name: 'topic', type: 'uint64' },
         { name: 'post', type: 'int' }
       ]
     },
     pinPost: {
       PinPost: [
+        { name: 'space', type: 'string' },
         { name: 'topic', type: 'uint64' },
         { name: 'post', type: 'uint64' }
       ]
     },
     unpinPost: {
       UnpinPost: [
+        { name: 'space', type: 'string' },
         { name: 'topic', type: 'uint64' },
         { name: 'post', type: 'uint64' }
       ]
     },
     vote: {
       Vote: [
+        { name: 'space', type: 'string' },
         { name: 'topic', type: 'uint64' },
         { name: 'post', type: 'uint64' },
         { name: 'choice', type: 'uint64' }


### PR DESCRIPTION
### Summary

This PR now links all topics and roles to specific page, so topics and roles are not mixed up.

Closes: https://github.com/snapshot-labs/townhall/issues/13

### How to test

1. Go to http://localhost:8080/#/s:openagora.eth
2. Check roles, topics.
3. Create some role and claim it.
4. Create some topic and vote.
5. Check results.
6. All works as expected.
7. Go to http://localhost:8080/#/s:ethpoll.eth/townhall and http://localhost:8080/#/s:ethpoll.eth/townhall/roles
8. You don't see other space's topics and roles
9. You can create roles and topics there and they are not mixed up.
