### PR TITLE
fix: delegation not working for spaces using other delegation strategies

### DIFF
--- a/apps/ui/src/components/Modal/Delegate.vue
+++ b/apps/ui/src/components/Modal/Delegate.vue
@@ -139,10 +139,10 @@ const chainIds = computed(() => {
     .flatMap(params => {
       return [
         params.network,
-        ...params.params?.strategies?.flatMap(p => [
+        ...(params.params?.strategies?.flatMap(p => [
           p.network,
           p.params?.network
-        ])
+        ]) || [])
       ];
     })
     .filter(Boolean)


### PR DESCRIPTION
### Summary
- Unlike delegation strategy, strategies like `erc20-balance-of-delegation` doesn't have `strategies` inside their params so return this error:

```
TypeError: (intermediate value) is not iterable
at Delegate.vue?t=1749738559111:1:1
at Array.flatMap (<anonymous>)
at Delegate.vue:140:3
```

### How to test:
- Go to http://localhost:8080/#/s:lido-snapshot.eth/profile/0x42E6DD8D517abB3E4f6611Ca53a8D1243C183fB0
- Click delegate
- before fix, it should throw error
- After fix, it should open the delegation modal
