### PR TITLE
feat: index farcaster in space metadata

### DIFF
--- a/apps/api/src/evm/ipfs.ts
+++ b/apps/api/src/evm/ipfs.ts
@@ -26,6 +26,7 @@ export async function handleSpaceMetadata(
   spaceMetadataItem.github = '';
   spaceMetadataItem.twitter = '';
   spaceMetadataItem.discord = '';
+  spaceMetadataItem.farcaster = '';
   spaceMetadataItem.voting_power_symbol = '';
   spaceMetadataItem.wallet = '';
   spaceMetadataItem.executors = [];
@@ -69,6 +70,8 @@ export async function handleSpaceMetadata(
       spaceMetadataItem.twitter = metadata.properties.twitter;
     if (metadata.properties.discord)
       spaceMetadataItem.discord = metadata.properties.discord;
+    if (metadata.properties.farcaster)
+      spaceMetadataItem.farcaster = metadata.properties.farcaster;
     if (metadata.properties.voting_power_symbol) {
       spaceMetadataItem.voting_power_symbol =
         metadata.properties.voting_power_symbol;

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -52,6 +52,7 @@ type SpaceMetadataItem {
   github: String!
   twitter: String!
   discord: String!
+  farcaster: String!
   voting_power_symbol: String!
   wallet: String!
   executors: [String!]!

--- a/apps/api/src/starknet/ipfs.ts
+++ b/apps/api/src/starknet/ipfs.ts
@@ -34,6 +34,7 @@ export async function handleSpaceMetadata(
   spaceMetadataItem.github = '';
   spaceMetadataItem.twitter = '';
   spaceMetadataItem.discord = '';
+  spaceMetadataItem.farcaster = '';
   spaceMetadataItem.voting_power_symbol = '';
   spaceMetadataItem.wallet = '';
   spaceMetadataItem.executors = [];
@@ -77,6 +78,8 @@ export async function handleSpaceMetadata(
       spaceMetadataItem.twitter = metadata.properties.twitter;
     if (metadata.properties.discord)
       spaceMetadataItem.discord = metadata.properties.discord;
+    if (metadata.properties.farcaster)
+      spaceMetadataItem.farcaster = metadata.properties.farcaster;
     if (metadata.properties.voting_power_symbol) {
       spaceMetadataItem.voting_power_symbol =
         metadata.properties.voting_power_symbol;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

From https://github.com/snapshot-labs/sx-monorepo/pull/1402#pullrequestreview-2921204670

This PR will index the `farcaster` field from space metadata, without introducing this new field into the UI, to warm up the sync
