### PR TITLE
fix(townhall): remove randomness when ordering post

### DIFF
--- a/apps/ui/src/queries/townhall.ts
+++ b/apps/ui/src/queries/townhall.ts
@@ -135,7 +135,6 @@ export function useTopicQuery({
 
       topic.posts = topic.posts
         .filter(s => !s.hidden)
-        .sort(() => 0.5 - Math.random())
         .sort((a, b) => Number(b.pinned) - Number(a.pinned));
 
       return topic;

--- a/apps/ui/src/views/Townhall/Topic.vue
+++ b/apps/ui/src/views/Townhall/Topic.vue
@@ -53,9 +53,9 @@ const { mutate: closeTopic, isPending: isCloseTopicPending } =
   });
 
 const pendingPosts: ComputedRef<Post[]> = computed(() =>
-  (topic.value?.posts ?? []).filter(
-    s => !(userVotes.value ?? []).find(v => v.post_id === s.post_id)
-  )
+  (topic.value?.posts ?? [])
+    .filter(s => !(userVotes.value ?? []).find(v => v.post_id === s.post_id))
+    .sort(() => 0.5 - Math.random())
 );
 
 const results: ComputedRef<Post[]> = computed(() =>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fix an issue with townhall post, where post ordering is not consistent, due to the random factor introduced for pending posts.

Post ordering is now consistent, and pending post still keep the random ordering

### How to test

1. Go to a topic with many post
2. Post having the same ordering weight (e.g. same number of votes when sorted by number of votes), will always be shown in the same order, on each page refresh
3. Pending post still show in random order
