### PR TITLE
fix: wrong coingecko asset id passed for apechain

### DIFF
--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -52,7 +52,7 @@ export const COINGECKO_ASSET_PLATFORMS = {
   5000: 'mantle',
   8453: 'base',
   42161: 'arbitrum-one',
-  33139: 'ethereum',
+  33139: 'apechain',
   33111: 'apechain'
 };
 


### PR DESCRIPTION
### How to test:
- https://snapshot.box/#/ape:0xa1282429A4a34F9f91D50ecf3d8217Fc6654eF6e/treasury/1/tokens should not see price for WONG token
- http://localhost:8080/#/ape:0xa1282429A4a34F9f91D50ecf3d8217Fc6654eF6e/treasury/1/tokens should see price for WONG token