### PR TITLE
fix: ignore duplicate execution hashes

### DIFF
--- a/apps/api/src/evm/writers.ts
+++ b/apps/api/src/evm/writers.ts
@@ -649,12 +649,19 @@ export function createWriters(config: FullConfig) {
     proposal.execution_ready = proposal.execution_strategy_type != 'Axiom';
 
     if (proposal.execution_hash !== EMPTY_EXECUTION_HASH) {
-      const executionHash = new ExecutionHash(
+      let executionHash = await ExecutionHash.loadEntity(
         proposal.execution_hash,
         config.indexerName
       );
-      executionHash.proposal_id = `${spaceId}/${proposalId}`;
-      await executionHash.save();
+
+      if (!executionHash) {
+        executionHash = new ExecutionHash(
+          proposal.execution_hash,
+          config.indexerName
+        );
+        executionHash.proposal_id = `${spaceId}/${proposalId}`;
+        await executionHash.save();
+      }
     }
 
     try {


### PR DESCRIPTION
### Summary

In normal operation this shouldn't be duplicate (execution hash is salted), but if someone tries to reuse it anyway we can just ignore it.
