### PR TITLE
feat: add spaces and proposals UI links

### DIFF
--- a/apps/api/src/common/utils.ts
+++ b/apps/api/src/common/utils.ts
@@ -6,8 +6,33 @@ import fetch from 'cross-fetch';
 import { poseidonHashMany } from 'micro-starknet';
 import { hash } from 'starknet';
 import { Network } from '../../.checkpoint/models';
+import { UI_URL } from '../config';
 
 type ExecutionType = Parameters<typeof getExecutionData>[0];
+
+export function getSpaceLink({
+  networkId,
+  spaceId
+}: {
+  networkId: string;
+  spaceId: string;
+}) {
+  return `${UI_URL}/#/${networkId}:${spaceId}`;
+}
+
+export function getProposalLink({
+  networkId,
+  spaceId,
+  proposalId
+}: {
+  networkId: string;
+  spaceId: string;
+  proposalId: number;
+}) {
+  const spaceLink = getSpaceLink({ networkId, spaceId });
+
+  return `${spaceLink}/proposal/${proposalId}`;
+}
 
 export async function updateCounter(
   indexerName: string,

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,3 +1,5 @@
+export const UI_URL = process.env.UI_URL || 'https://snapshot.box';
+
 export const MANA_URL = process.env.VITE_MANA_URL || 'https://mana.box';
 
 /**

--- a/apps/api/src/evm/config.ts
+++ b/apps/api/src/evm/config.ts
@@ -8,7 +8,7 @@ import ProxyFactory from './abis/ProxyFactory.json';
 import SimpleQuorumTimelockExecutionStrategy from './abis/SimpleQuorumTimelockExecutionStrategy.json';
 import Space from './abis/Space.json';
 
-type NetworkID =
+export type NetworkID =
   | 'eth'
   | 'sep'
   | 'oeth'

--- a/apps/api/src/evm/writers.ts
+++ b/apps/api/src/evm/writers.ts
@@ -32,7 +32,13 @@ import {
   handleStrategiesMetadata,
   handleVoteMetadata
 } from '../common/ipfs';
-import { dropIpfs, getCurrentTimestamp, updateCounter } from '../common/utils';
+import {
+  dropIpfs,
+  getCurrentTimestamp,
+  getProposalLink,
+  getSpaceLink,
+  updateCounter
+} from '../common/utils';
 
 /**
  * List of execution strategies type that are known and we expect them to be deployed via factory.
@@ -213,6 +219,10 @@ export function createWriters(config: FullConfig) {
     const id = getAddress(event.args.space);
 
     const space = new Space(id, config.indexerName);
+    space.link = getSpaceLink({
+      networkId: config.indexerName,
+      spaceId: id
+    });
     space.verified = false;
     space.turbo = false;
     space.metadata = null;
@@ -584,6 +594,11 @@ export function createWriters(config: FullConfig) {
       `${spaceId}/${proposalId}`,
       config.indexerName
     );
+    proposal.link = getProposalLink({
+      networkId: config.indexerName,
+      spaceId,
+      proposalId
+    });
     proposal.proposal_id = proposalId;
     proposal.space = spaceId;
     proposal.author = author;

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -5,6 +5,7 @@ scalar BigDecimalVP
 
 type Space {
   id: String!
+  link: String!
   verified: Boolean!
   turbo: Boolean!
   metadata: SpaceMetadataItem
@@ -106,6 +107,7 @@ type ExecutionHash {
 
 type Proposal {
   id: String!
+  link: String!
   proposal_id: Int!
   space: Space!
   author: User!

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -25,7 +25,13 @@ import {
   handleStrategiesMetadata,
   handleVoteMetadata
 } from '../common/ipfs';
-import { dropIpfs, getCurrentTimestamp, updateCounter } from '../common/utils';
+import {
+  dropIpfs,
+  getCurrentTimestamp,
+  getProposalLink,
+  getSpaceLink,
+  updateCounter
+} from '../common/utils';
 
 type Strategy = {
   address: string;
@@ -72,6 +78,10 @@ export function createWriters(config: FullConfig) {
     const id = validateAndParseAddress(event.space);
 
     const space = new Space(id, config.indexerName);
+    space.link = getSpaceLink({
+      networkId: config.indexerName,
+      spaceId: id
+    });
     space.verified = config.overrides.verifiedSpaces.includes(id);
     space.turbo = false;
     space.metadata = null;
@@ -428,6 +438,11 @@ export function createWriters(config: FullConfig) {
       `${spaceId}/${proposalId}`,
       config.indexerName
     );
+    proposal.link = getProposalLink({
+      networkId: config.indexerName,
+      spaceId,
+      proposalId
+    });
     proposal.proposal_id = proposalId;
     proposal.space = spaceId;
     proposal.author = author.address;

--- a/scripts/dev-interactive.ts
+++ b/scripts/dev-interactive.ts
@@ -13,6 +13,7 @@ const SERVICES: Record<ServiceType, Service> = {
   },
   api: {
     env: {
+      UI_URL: 'http://localhost:8080',
       ENABLED_NETWORKS: 'sep,sn-sep',
       VITE_ENABLED_NETWORKS: 's-tn,sep,sn-sep',
       VITE_METADATA_NETWORK: 's-tn',

--- a/turbo.json
+++ b/turbo.json
@@ -21,7 +21,7 @@
       "cache": false,
       "persistent": true,
       "dependsOn": ["codegen", "^build"],
-      "passThroughEnv": ["ENABLED_NETWORKS", "INFURA_API_KEY", "VITE_MANA_URL"]
+      "passThroughEnv": ["UI_URL", "ENABLED_NETWORKS", "INFURA_API_KEY", "VITE_MANA_URL"]
     },
     "codegen": {
       "outputs": [".checkpoint/**", "src/networks/common/graphqlApi/gql/**"],


### PR DESCRIPTION
### Summary

This way we can reference entity URI directly form API.

Closes: https://github.com/snapshot-labs/workflow/issues/575

### How to test

1. Run `yarn dev:interactive` with UI and API.
2. Let it run for 15 seconds.
3. Run following query.
4. You can access spaces/proposals via provided link.

```gql
{
  spaces {
    id
    _indexer
    link
  }
  proposals {
    id
    _indexer
    link
  }
}
```
