### PR TITLE
fix: show error about max file size when uploading an image

### DIFF
--- a/apps/ui/src/components/Ui/InputStamp.vue
+++ b/apps/ui/src/components/Ui/InputStamp.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
-import { getUrl, imageUpload } from '@/helpers/utils';
+import {
+  getUrl,
+  getUserFacingErrorMessage,
+  imageUpload
+} from '@/helpers/utils';
 
 const model = defineModel<string>();
 
@@ -40,24 +44,16 @@ function openFilePicker() {
 async function handleFileChange(e: Event) {
   try {
     const file = (e.target as HTMLInputElement).files?.[0];
-    if (!file) throw new Error('File not found');
-
-    if (file.size > 1048576) {
-      throw new Error('File size must be less than 1 MB');
-    }
 
     isUploadingImage.value = true;
 
-    const image = await imageUpload(file);
-    if (!image) throw new Error('Image not uploaded');
+    const image = await imageUpload(file as File);
+    if (!image) throw new Error('Failed to upload image.');
 
     model.value = image.url;
     isUploadingImage.value = false;
   } catch (e) {
-    uiStore.addNotification(
-      'error',
-      e instanceof Error ? e.message : 'Failed to upload image.'
-    );
+    uiStore.addNotification('error', getUserFacingErrorMessage(e));
 
     console.error('Failed to upload image', e);
 
@@ -85,6 +81,7 @@ async function handleFileChange(e: Event) {
     <img
       v-if="imgUrl"
       :src="imgUrl"
+      alt="Uploaded avatar"
       :class="[
         `object-cover group-hover:opacity-80`,
         {

--- a/apps/ui/src/components/Ui/InputStamp.vue
+++ b/apps/ui/src/components/Ui/InputStamp.vue
@@ -41,6 +41,11 @@ async function handleFileChange(e: Event) {
   try {
     const file = (e.target as HTMLInputElement).files?.[0];
     if (!file) throw new Error('File not found');
+
+    if (file.size > 1048576) {
+      throw new Error('File size must be less than 1 MB');
+    }
+
     isUploadingImage.value = true;
 
     const image = await imageUpload(file);
@@ -49,9 +54,16 @@ async function handleFileChange(e: Event) {
     model.value = image.url;
     isUploadingImage.value = false;
   } catch (e) {
-    uiStore.addNotification('error', 'Failed to upload image.');
+    uiStore.addNotification(
+      'error',
+      e instanceof Error ? e.message : 'Failed to upload image.'
+    );
 
     console.error('Failed to upload image', e);
+
+    if (fileInput.value) {
+      fileInput.value.value = '';
+    }
     isUploadingImage.value = false;
   }
 }

--- a/apps/ui/src/components/Ui/InputStampCover.vue
+++ b/apps/ui/src/components/Ui/InputStampCover.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
-import { getUrl, imageUpload } from '@/helpers/utils';
+import {
+  getUrl,
+  getUserFacingErrorMessage,
+  imageUpload
+} from '@/helpers/utils';
 import { NetworkID } from '@/types';
 
 const model = defineModel<string | null>();
@@ -38,31 +42,22 @@ function openFilePicker() {
 async function handleFileChange(e: Event) {
   try {
     const file = (e.target as HTMLInputElement).files?.[0];
-    if (!file) throw new Error('File not found');
-
-    if (file.size > 1048576) {
-      throw new Error('File size must be less than 1 MB');
-    }
 
     isUploadingImage.value = true;
 
-    const image = await imageUpload(file);
-    if (!image) throw new Error('Image not uploaded');
+    const image = await imageUpload(file as File);
+    if (!image) throw new Error('Failed to upload image.');
 
     model.value = image.url;
     isUploadingImage.value = false;
   } catch (e) {
-    uiStore.addNotification(
-      'error',
-      e instanceof Error ? e.message : 'Failed to upload image.'
-    );
+    uiStore.addNotification('error', getUserFacingErrorMessage(e));
 
     console.error('Failed to upload image', e);
 
     if (fileInput.value) {
       fileInput.value.value = '';
     }
-    console.error('Failed to upload image', e);
     isUploadingImage.value = false;
   }
 }

--- a/apps/ui/src/components/Ui/InputStampCover.vue
+++ b/apps/ui/src/components/Ui/InputStampCover.vue
@@ -39,6 +39,11 @@ async function handleFileChange(e: Event) {
   try {
     const file = (e.target as HTMLInputElement).files?.[0];
     if (!file) throw new Error('File not found');
+
+    if (file.size > 1048576) {
+      throw new Error('File size must be less than 1 MB');
+    }
+
     isUploadingImage.value = true;
 
     const image = await imageUpload(file);
@@ -47,8 +52,16 @@ async function handleFileChange(e: Event) {
     model.value = image.url;
     isUploadingImage.value = false;
   } catch (e) {
-    uiStore.addNotification('error', 'Failed to upload image.');
+    uiStore.addNotification(
+      'error',
+      e instanceof Error ? e.message : 'Failed to upload image.'
+    );
 
+    console.error('Failed to upload image', e);
+
+    if (fileInput.value) {
+      fileInput.value.value = '';
+    }
     console.error('Failed to upload image', e);
     isUploadingImage.value = false;
   }

--- a/apps/ui/src/composables/useMarkdownEditor.ts
+++ b/apps/ui/src/composables/useMarkdownEditor.ts
@@ -1,4 +1,4 @@
-import { imageUpload } from '@/helpers/utils';
+import { getUserFacingErrorMessage, imageUpload } from '@/helpers/utils';
 
 type Formatting = {
   prefix: string;
@@ -124,13 +124,11 @@ export function useMarkdownEditor(
   }
 
   async function uploadFile(file: File) {
-    if (!file.type.startsWith('image/')) return;
-
     uploading.value = true;
 
     try {
       const image = await imageUpload(file);
-      if (!image) throw new Error('Image not uploaded');
+      if (!image) throw new Error('Failed to upload image.');
 
       insertFormatting({
         prefix: `![${file.name}](${image.url})`,
@@ -139,7 +137,7 @@ export function useMarkdownEditor(
 
       editorRef.value?.focus();
     } catch (e) {
-      uiStore.addNotification('error', 'Failed to upload image.');
+      uiStore.addNotification('error', getUserFacingErrorMessage(e));
 
       console.error('Failed to upload image', e);
     } finally {

--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -91,6 +91,7 @@ export const APE_GAS_CONFIGS: Record<number, ApeGasConfig> = {
 };
 
 export const MAX_SYMBOL_LENGTH = 12;
+export const MAX_FILE_SIZE_BYTES = 1024 * 1024; // 1 MB should be same as https://github.com/snapshot-labs/pineapple/blob/4023c623585e4cde2296922572d35c85d45cf940/src/upload.ts#L10
 
 export const SPACE_CATEGORIES = [
   { id: 'protocol', name: 'Protocol' },

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -17,7 +17,11 @@ import { RouteParamsRaw } from 'vue-router';
 import { getSpaceController as getEnsSpaceController } from '@/helpers/ens';
 import { VotingPowerItem } from '@/queries/votingPower';
 import { ChainId, Choice, NetworkID, Proposal, SpaceMetadata } from '@/types';
-import { EVM_EMPTY_ADDRESS, MAX_SYMBOL_LENGTH } from './constants';
+import {
+  EVM_EMPTY_ADDRESS,
+  MAX_FILE_SIZE_BYTES,
+  MAX_SYMBOL_LENGTH
+} from './constants';
 import { getOwner } from './stamp';
 import pkg from '@/../package.json';
 import ICCoingecko from '~icons/c/coingecko';
@@ -528,9 +532,19 @@ export function getStampUrl(
 
 export async function imageUpload(file: File) {
   if (!file) return;
-  // TODO: Additional Validations - File Size, File Type, Empty File, Hidden File
+
   if (!['image/jpeg', 'image/jpg', 'image/png'].includes(file.type)) {
-    return;
+    throw new Error('Invalid file type. Only JPEG and PNG images are allowed.');
+  }
+
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    throw new Error(
+      `File size must be less than ${(
+        MAX_FILE_SIZE_BYTES /
+        1024 /
+        1024
+      ).toFixed(0)} MB`
+    );
   }
 
   const formData = new FormData();
@@ -696,11 +710,11 @@ export function isUserAbortError(e: any) {
   );
 }
 
-export function getUserFacingErrorMessage(e: unknown): string {
-  return (
-    (e instanceof Error && e.message) ||
-    'Something went wrong. Please try again later.'
-  );
+export function getUserFacingErrorMessage(
+  e: unknown,
+  fallback: string = 'Something went wrong. Please try again later.'
+): string {
+  return (e instanceof Error && e.message) || fallback;
 }
 
 export async function getSpaceController(id: string, network: NetworkID) {


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/workflow/issues/577

### Summary
- added file size check to ensure uploads are less than 1 MB
- improved error handling to provide specific feedback on upload failures

### How to test
- Go to your space settings
- Try to upload images that are larger than 1MB to avatar and cover
- Should throw new error instead of "failed to upload image."

