### PR TITLE
feat: quorum update handling

### DIFF
--- a/apps/api/src/evm/config.ts
+++ b/apps/api/src/evm/config.ts
@@ -5,6 +5,7 @@ import AxiomExecutionStrategy from './abis/AxiomExecutionStrategy.json';
 import L1AvatarExecutionStrategy from './abis/L1AvatarExecutionStrategy.json';
 import L1AvatarExecutionStrategyFactory from './abis/L1AvatarExecutionStrategyFactory.json';
 import ProxyFactory from './abis/ProxyFactory.json';
+import SimpleQuorumAvatarExecutionStrategy from './abis/SimpleQuorumAvatarExecutionStrategy.json';
 import SimpleQuorumTimelockExecutionStrategy from './abis/SimpleQuorumTimelockExecutionStrategy.json';
 import Space from './abis/Space.json';
 
@@ -181,6 +182,15 @@ export function createConfig(indexerName: NetworkID): FullConfig {
           }
         ]
       },
+      SimpleQuorumAvatarExecutionStrategy: {
+        abi: 'SimpleQuorumAvatarExecutionStrategy',
+        events: [
+          {
+            name: 'QuorumUpdated(uint256)',
+            fn: 'handleQuorumUpdated'
+          }
+        ]
+      },
       AxiomExecutionStrategy: {
         abi: 'AxiomExecutionStrategy',
         events: [
@@ -203,6 +213,7 @@ export function createConfig(indexerName: NetworkID): FullConfig {
     abis: {
       ProxyFactory,
       Space,
+      SimpleQuorumAvatarExecutionStrategy,
       SimpleQuorumTimelockExecutionStrategy,
       AxiomExecutionStrategy,
       L1AvatarExecutionStrategy,

--- a/apps/api/src/evm/config.ts
+++ b/apps/api/src/evm/config.ts
@@ -179,6 +179,10 @@ export function createConfig(indexerName: NetworkID): FullConfig {
           {
             name: 'ProposalVetoed(bytes32)',
             fn: 'handleTimelockProposalVetoed'
+          },
+          {
+            name: 'QuorumUpdated(uint256)',
+            fn: 'handleQuorumUpdated'
           }
         ]
       },

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -138,7 +138,7 @@ type Proposal {
   scores_2: BigDecimalVP!
   scores_3: BigDecimalVP!
   scores_total: BigDecimalVP!
-  quorum: BigInt!
+  quorum: BigDecimalVP!
   created: Int!
   edited: Int
   tx: String!

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -142,7 +142,6 @@ type Proposal {
   scores_total: BigDecimalVP!
   quorum: BigDecimalVP!
   scores_total_parsed: Float!
-  quorum: BigInt!
   created: Int!
   edited: Int
   tx: String!

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -466,7 +466,7 @@ export function createWriters(config: FullConfig) {
     proposal.scores_2 = '0';
     proposal.scores_3 = '0';
     proposal.scores_total = '0';
-    proposal.quorum = 0n;
+    proposal.quorum = '0';
     proposal.strategies_indices = space.strategies_indices;
     // NOTE: deprecated
     proposal.strategies_indicies = proposal.strategies_indices;
@@ -492,7 +492,7 @@ export function createWriters(config: FullConfig) {
       proposal.execution_strategy_type =
         executionStrategy.executionStrategyType;
       proposal.execution_destination = executionStrategy.destinationAddress;
-      proposal.quorum = executionStrategy.quorum;
+      proposal.quorum = executionStrategy.quorum.toString();
 
       // Find matching strategy and persist it on space object
       // We use this on UI to properly display execution with treasury
@@ -670,7 +670,7 @@ export function createWriters(config: FullConfig) {
     if (executionStrategy) {
       proposal.execution_strategy_type =
         executionStrategy.executionStrategyType;
-      proposal.quorum = executionStrategy.quorum;
+      proposal.quorum = executionStrategy.quorum.toString();
 
       // Find matching strategy and persist it on space object
       // We use this on UI to properly display execution with treasury

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -482,7 +482,6 @@ export function createWriters(config: FullConfig) {
     proposal.scores_total = '0';
     proposal.quorum = '0';
     proposal.scores_total_parsed = 0;
-    proposal.quorum = 0n;
     proposal.strategies_indices = space.strategies_indices;
     proposal.strategies = space.strategies;
     proposal.strategies_params = space.strategies_params;

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -370,7 +370,7 @@ function formatProposal(
     state,
     network: networkId,
     privacy: 'none',
-    quorum: +proposal.quorum,
+    quorum: Number(proposal.execution_strategy_details?.quorum || 0),
     flagged: false,
     flag_code: 0,
     completed: ['passed', 'executed', 'rejected'].includes(state)

--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -130,6 +130,7 @@ gql(`
       type
       treasury_chain
       treasury
+      quorum
     }
     execution_strategy_type
     execution_destination


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/workflow/issues/581

### Summary
- introduced handleQuorumUpdated for quorum updates
- changed proposal quorum type from BigInt to BigDecimalVP
- ensured quorum values are strings for consistency

### How to test
- apply this patch
```bash
diff --git a/apps/api/src/evm/config.ts b/apps/api/src/evm/config.ts
index 704698ef..209afd5f 100644
--- a/apps/api/src/evm/config.ts
+++ b/apps/api/src/evm/config.ts
@@ -28,7 +28,7 @@ const START_BLOCKS: Record<NetworkID, number> = {
   arb1: 157825417,
   base: 23524251,
   mnt: 75662182,
-  ape: 12100384,
+  ape: 18217450,
   curtis: 16682282
 };
 
diff --git a/scripts/dev-interactive.ts b/scripts/dev-interactive.ts
index 5a60152e..e57d023e 100644
--- a/scripts/dev-interactive.ts
+++ b/scripts/dev-interactive.ts
@@ -14,9 +14,9 @@ const SERVICES: Record<ServiceType, Service> = {
   api: {
     env: {
       UI_URL: 'http://localhost:8080',
-      ENABLED_NETWORKS: 'sep,sn-sep',
-      VITE_ENABLED_NETWORKS: 's-tn,sep,sn-sep',
-      VITE_METADATA_NETWORK: 's-tn',
+      ENABLED_NETWORKS: 's,ape',
+      VITE_ENABLED_NETWORKS: 's,ape',
+      VITE_METADATA_NETWORK: 's',
       VITE_UNIFIED_API_TESTNET_URL: 'http://localhost:3000'
     }
   },

```
- Run `yarn dev:interactive`
- Go to 
- Run below query: 
```GraphQL
query Space {
  space(indexer: "ape", id: "0xa1282429A4a34F9f91D50ecf3d8217Fc6654eF6e") {
    id
  _indexer
  metadata {
    executors_strategies {
      id
      address
      quorum
    }
  }
  }
}

{
  proposals (first: 100, where:  {
     space: "0xa1282429A4a34F9f91D50ecf3d8217Fc6654eF6e"
  }) {
    id
    link
    space {
      id
    }
    quorum
  }
}
```
- Make sure new quorum is updated in space and new proposals, but old quorum should be used in old proposals