### PR TITLE
feat: show message if connector is not supported for voting

### DIFF
--- a/apps/ui/src/networks/common/helpers.ts
+++ b/apps/ui/src/networks/common/helpers.ts
@@ -5,12 +5,12 @@ import {
 import { MetaTransaction } from '@snapshot-labs/sx/dist/utils/encoding/execution-hash';
 import { getUrl } from '@/helpers/utils';
 import {
+  AuthenticatorSupportInfo,
   ConnectorType,
   NetworkHelpers,
   StrategyConfig
 } from '@/networks/types';
 import { Choice, Space } from '@/types';
-import { EVM_CONNECTORS, STARKNET_CONNECTORS } from './constants';
 
 type SpaceExecutionData = Pick<Space, 'executors' | 'executors_types'>;
 type ExecutorType = Parameters<typeof _getExecutionData>[0];
@@ -67,15 +67,7 @@ export async function buildMetadata(
   return `ipfs://${pinned.cid}`;
 }
 
-export function createStrategyPicker({
-  helpers,
-  managerConnectors,
-  lowPriorityAuthenticators = []
-}: {
-  helpers: NetworkHelpers;
-  managerConnectors: ConnectorType[];
-  lowPriorityAuthenticators?: ('evm' | 'evm-tx' | 'starknet')[];
-}) {
+export function createStrategyPicker({ helpers }: { helpers: NetworkHelpers }) {
   return function pick({
     authenticators,
     strategies,
@@ -91,62 +83,41 @@ export function createStrategyPicker({
     connectorType: ConnectorType;
     ignoreRelayer?: boolean;
   }) {
+    type AuthenticatorWithSupportInfo = {
+      authenticator: string;
+      supportInfo: AuthenticatorSupportInfo;
+    };
+
+    const hasSupportInfo = (entry: {
+      supportInfo: AuthenticatorSupportInfo | null;
+    }): entry is AuthenticatorWithSupportInfo => {
+      if (!entry.supportInfo) return false;
+      return true;
+    };
+
     const authenticatorsInfo = [...authenticators]
-      .filter(authenticator =>
-        isContract
-          ? helpers.isAuthenticatorContractSupported(authenticator)
-          : helpers.isAuthenticatorSupported(authenticator)
-      )
+      .map(authenticator => ({
+        authenticator,
+        supportInfo: helpers.getAuthenticatorSupportInfo(authenticator)
+      }))
+      .filter(hasSupportInfo)
+      .filter(({ supportInfo }) => {
+        if (isContract && !supportInfo.isContractSupported) return false;
+        if (ignoreRelayer && supportInfo.relayerType) return false;
+
+        return supportInfo.isSupported;
+      })
       .sort((a, b) => {
-        const aRelayer = helpers.getRelayerAuthenticatorType(a);
-        const bRelayer = helpers.getRelayerAuthenticatorType(b);
-        const aLowPriority =
-          aRelayer && lowPriorityAuthenticators.includes(aRelayer);
-        const bLowPriority =
-          bRelayer && lowPriorityAuthenticators.includes(bRelayer);
+        const aRelayerPriority = a.supportInfo.priority ?? 0;
+        const bRelayerPriority = b.supportInfo.priority ?? 0;
 
-        if (aLowPriority && !bLowPriority) {
-          return 1;
-        }
-
-        if (!aLowPriority && bLowPriority) {
-          return -1;
-        }
-
-        if (aRelayer && bRelayer) {
-          return 0;
-        }
-
-        if (aRelayer) {
-          return -1;
-        }
-
-        if (bRelayer) {
-          return 1;
-        }
-
-        return 0;
+        return bRelayerPriority - aRelayerPriority;
       })
-      .map(authenticator => {
-        const relayerType = helpers.getRelayerAuthenticatorType(authenticator);
-
-        let connectors: ConnectorType[] = [];
-        if (relayerType && ['evm', 'evm-tx'].includes(relayerType))
-          connectors = EVM_CONNECTORS;
-        else if (relayerType === 'starknet') connectors = STARKNET_CONNECTORS;
-        else connectors = managerConnectors;
-
-        return {
-          authenticator,
-          relayerType,
-          connectors
-        };
-      })
-      .filter(authenticator =>
-        ignoreRelayer && authenticator.relayerType
-          ? !['evm', 'starknet'].includes(authenticator.relayerType)
-          : true
-      );
+      .map(({ authenticator, supportInfo }) => ({
+        authenticator,
+        relayerType: supportInfo.relayerType,
+        connectors: supportInfo.connectors
+      }));
 
     const authenticatorInfo = authenticatorsInfo.find(({ connectors }) =>
       connectors.includes(connectorType)

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -27,7 +27,6 @@ import { getProvider } from '@/helpers/provider';
 import { convertToMetaTransactions } from '@/helpers/transactions';
 import { createErc1155Metadata, verifyNetwork } from '@/helpers/utils';
 import { WHITELIST_SERVER_URL } from '@/helpers/whitelistServer';
-import { EVM_CONNECTORS } from '@/networks/common/constants';
 import {
   buildMetadata,
   createStrategyPicker,
@@ -79,8 +78,7 @@ export function createActions(
   const networkConfig = CONFIGS[chainId];
 
   const pickAuthenticatorAndStrategies = createStrategyPicker({
-    helpers,
-    managerConnectors: EVM_CONNECTORS
+    helpers
   });
 
   const clientOpts = {

--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -10,7 +10,8 @@ import { PinFunction } from '@/helpers/pin';
 import { getUrl, shorten, sleep } from '@/helpers/utils';
 import { generateMerkleTree, getMerkleRoot } from '@/helpers/whitelistServer';
 import { NetworkID, StrategyParsedMetadata, VoteType } from '@/types';
-import { StrategyConfig } from '../types';
+import { EVM_CONNECTORS } from '../common/constants';
+import { AuthenticatorSupportInfo, StrategyConfig } from '../types';
 import IHBeaker from '~icons/heroicons-outline/beaker';
 import IHClock from '~icons/heroicons-outline/clock';
 import IHCode from '~icons/heroicons-outline/code';
@@ -26,16 +27,26 @@ export function createConstants(
   const config = evmNetworks[networkId];
   if (!config) throw new Error(`Unsupported network ${networkId}`);
 
-  const SUPPORTED_AUTHENTICATORS = {
-    [config.Authenticators.EthSigV2]: true,
-    [config.Authenticators.EthSig]: true,
-    [config.Authenticators.EthTx]: true
-  };
-
-  const CONTRACT_SUPPORTED_AUTHENTICATORS = {
-    [config.Authenticators.EthSigV2]: true,
-    [config.Authenticators.EthTx]: true
-  };
+  const AUTHENTICATORS_SUPPORT_INFO: Record<string, AuthenticatorSupportInfo> =
+    {
+      [config.Authenticators.EthSigV2]: {
+        isSupported: true,
+        isContractSupported: true,
+        relayerType: 'evm',
+        connectors: EVM_CONNECTORS
+      },
+      [config.Authenticators.EthSig]: {
+        isSupported: true,
+        isContractSupported: false,
+        relayerType: 'evm',
+        connectors: EVM_CONNECTORS
+      },
+      [config.Authenticators.EthTx]: {
+        isSupported: true,
+        isContractSupported: true,
+        connectors: EVM_CONNECTORS
+      }
+    };
 
   const SUPPORTED_STRATEGIES = {
     [config.Strategies.Vanilla]: true,
@@ -51,11 +62,6 @@ export function createConstants(
     Axiom: true,
     Isokratia: true
   };
-
-  const RELAYER_AUTHENTICATORS = {
-    [config.Authenticators.EthSig]: 'evm',
-    [config.Authenticators.EthSigV2]: 'evm'
-  } as const;
 
   const AUTHS = {
     [config.Authenticators.EthSig]: 'Ethereum signature (deprecated)',
@@ -836,11 +842,9 @@ export function createConstants(
   const EDITOR_VOTING_TYPES: VoteType[] = ['basic'];
 
   return {
-    SUPPORTED_AUTHENTICATORS,
-    CONTRACT_SUPPORTED_AUTHENTICATORS,
+    AUTHENTICATORS_SUPPORT_INFO,
     SUPPORTED_STRATEGIES,
     SUPPORTED_EXECUTORS,
-    RELAYER_AUTHENTICATORS,
     AUTHS,
     PROPOSAL_VALIDATIONS,
     STRATEGIES,

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -118,12 +118,8 @@ export function createEvmNetwork(networkId: NetworkID): Network {
   });
 
   const helpers = {
-    isAuthenticatorSupported: (authenticator: string) =>
-      constants.SUPPORTED_AUTHENTICATORS[authenticator],
-    isAuthenticatorContractSupported: (authenticator: string) =>
-      constants.CONTRACT_SUPPORTED_AUTHENTICATORS[authenticator],
-    getRelayerAuthenticatorType: (authenticator: string) =>
-      constants.RELAYER_AUTHENTICATORS[authenticator],
+    getAuthenticatorSupportInfo: (authenticator: string) =>
+      constants.AUTHENTICATORS_SUPPORT_INFO[authenticator] || null,
     isStrategySupported: (strategy: string) =>
       constants.SUPPORTED_STRATEGIES[strategy],
     isExecutorSupported: (executorType: string) =>
@@ -188,7 +184,6 @@ export function createEvmNetwork(networkId: NetworkID): Network {
       'ape',
       'curtis'
     ].includes(networkId),
-    governanceConnectors: EVM_CONNECTORS,
     managerConnectors: EVM_CONNECTORS,
     actions: createActions(provider, helpers, chainId),
     api,

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -188,6 +188,7 @@ export function createEvmNetwork(networkId: NetworkID): Network {
       'ape',
       'curtis'
     ].includes(networkId),
+    governanceConnectors: EVM_CONNECTORS,
     managerConnectors: EVM_CONNECTORS,
     actions: createActions(provider, helpers, chainId),
     api,

--- a/apps/ui/src/networks/offchain/index.ts
+++ b/apps/ui/src/networks/offchain/index.ts
@@ -93,6 +93,7 @@ export function createOffchainNetwork(networkId: NetworkID): Network {
     baseChainId: l1ChainId,
     currentChainId: l1ChainId,
     supportsSimulation: true,
+    governanceConnectors: constants.CONNECTORS,
     managerConnectors: constants.CONNECTORS,
     api,
     constants,

--- a/apps/ui/src/networks/offchain/index.ts
+++ b/apps/ui/src/networks/offchain/index.ts
@@ -7,6 +7,7 @@ import { NetworkID, Space } from '@/types';
 import { createActions } from './actions';
 import { createApi } from './api';
 import * as constants from './constants';
+import { EVM_CONNECTORS } from '../common/constants';
 
 const HUB_URLS: Partial<Record<NetworkID, string | undefined>> = {
   s: 'https://hub.snapshot.org/graphql',
@@ -40,9 +41,11 @@ export function createOffchainNetwork(networkId: NetworkID): Network {
   };
 
   const helpers = {
-    isAuthenticatorSupported: () => true,
-    isAuthenticatorContractSupported: () => false,
-    getRelayerAuthenticatorType: () => null,
+    getAuthenticatorSupportInfo: () => ({
+      isSupported: true,
+      isContractSupported: false,
+      connectors: EVM_CONNECTORS
+    }),
     isStrategySupported: () => true,
     isExecutorSupported: isExecutorSupported,
     isExecutorActionsSupported: isExecutorActionsSupported,
@@ -93,7 +96,6 @@ export function createOffchainNetwork(networkId: NetworkID): Network {
     baseChainId: l1ChainId,
     currentChainId: l1ChainId,
     supportsSimulation: true,
-    governanceConnectors: constants.CONNECTORS,
     managerConnectors: constants.CONNECTORS,
     api,
     constants,

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -91,9 +91,7 @@ export function createActions(
   };
 
   const pickAuthenticatorAndStrategies = createStrategyPicker({
-    helpers,
-    managerConnectors: STARKNET_CONNECTORS,
-    lowPriorityAuthenticators: ['evm-tx']
+    helpers
   });
 
   const getIsContract = async (

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -6,8 +6,12 @@ import { pinPineapple } from '@/helpers/pin';
 import { _n, getUrl, shorten, sleep, verifyNetwork } from '@/helpers/utils';
 import { generateMerkleTree, getMerkleRoot } from '@/helpers/whitelistServer';
 import { NetworkID, StrategyParsedMetadata, VoteType } from '@/types';
-import { EVM_CONNECTORS } from '../common/constants';
-import { StrategyConfig, StrategyTemplate } from '../types';
+import { EVM_CONNECTORS, STARKNET_CONNECTORS } from '../common/constants';
+import {
+  AuthenticatorSupportInfo,
+  StrategyConfig,
+  StrategyTemplate
+} from '../types';
 import IHCode from '~icons/heroicons-outline/code';
 import IHCube from '~icons/heroicons-outline/cube';
 import IHLightningBolt from '~icons/heroicons-outline/lightning-bolt';
@@ -22,16 +26,32 @@ export function createConstants(
   const config = starknetNetworks[networkId as 'sn' | 'sn-sep'];
   if (!config) throw new Error(`Unsupported network ${networkId}`);
 
-  const SUPPORTED_AUTHENTICATORS = {
-    [config.Authenticators.EthSig]: true,
-    [config.Authenticators.EthTx]: true,
-    [config.Authenticators.StarkSig]: true,
-    [config.Authenticators.StarkTx]: true
-  };
-
-  const CONTRACT_SUPPORTED_AUTHENTICATORS = {
-    [config.Authenticators.EthTx]: true
-  };
+  const AUTHENTICATORS_SUPPORT_INFO: Record<string, AuthenticatorSupportInfo> =
+    {
+      [config.Authenticators.EthSig]: {
+        isSupported: true,
+        isContractSupported: false,
+        relayerType: 'evm',
+        connectors: EVM_CONNECTORS
+      },
+      [config.Authenticators.EthTx]: {
+        isSupported: true,
+        isContractSupported: true,
+        relayerType: 'evm-tx',
+        connectors: EVM_CONNECTORS
+      },
+      [config.Authenticators.StarkSig]: {
+        isSupported: true,
+        isContractSupported: false,
+        relayerType: 'starknet',
+        connectors: STARKNET_CONNECTORS
+      },
+      [config.Authenticators.StarkTx]: {
+        isSupported: true,
+        isContractSupported: false,
+        connectors: STARKNET_CONNECTORS
+      }
+    };
 
   const SUPPORTED_STRATEGIES = {
     [config.Strategies.MerkleWhitelist]: true,
@@ -50,12 +70,6 @@ export function createConstants(
   const SUPPORTED_EXECUTORS = {
     EthRelayer: true
   };
-
-  const RELAYER_AUTHENTICATORS = {
-    [config.Authenticators.StarkSig]: 'starknet',
-    [config.Authenticators.EthSig]: 'evm',
-    [config.Authenticators.EthTx]: 'evm-tx'
-  } as const;
 
   const AUTHS = {
     [config.Authenticators.EthSig]: 'Ethereum signature',
@@ -552,11 +566,9 @@ export function createConstants(
   const EDITOR_VOTING_TYPES: VoteType[] = ['basic'];
 
   return {
-    SUPPORTED_AUTHENTICATORS,
-    CONTRACT_SUPPORTED_AUTHENTICATORS,
+    AUTHENTICATORS_SUPPORT_INFO,
     SUPPORTED_STRATEGIES,
     SUPPORTED_EXECUTORS,
-    RELAYER_AUTHENTICATORS,
     AUTHS,
     PROPOSAL_VALIDATIONS,
     STRATEGIES,

--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -11,7 +11,7 @@ import { NetworkID, Space } from '@/types';
 import { createActions } from './actions';
 import { createConstants } from './constants';
 import { createProvider } from './provider';
-import { STARKNET_CONNECTORS } from '../common/constants';
+import { EVM_CONNECTORS, STARKNET_CONNECTORS } from '../common/constants';
 import { createApi } from '../common/graphqlApi';
 import { awaitIndexedOnApi } from '../common/helpers';
 
@@ -177,6 +177,7 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
     currentChainId: baseChainId,
     baseNetworkId,
     supportsSimulation: true,
+    governanceConnectors: [...STARKNET_CONNECTORS, ...EVM_CONNECTORS],
     managerConnectors: STARKNET_CONNECTORS,
     actions: createActions(networkId, provider, helpers, {
       chainId,

--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -11,7 +11,7 @@ import { NetworkID, Space } from '@/types';
 import { createActions } from './actions';
 import { createConstants } from './constants';
 import { createProvider } from './provider';
-import { EVM_CONNECTORS, STARKNET_CONNECTORS } from '../common/constants';
+import { STARKNET_CONNECTORS } from '../common/constants';
 import { createApi } from '../common/graphqlApi';
 import { awaitIndexedOnApi } from '../common/helpers';
 
@@ -75,12 +75,8 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
   });
 
   const helpers = {
-    isAuthenticatorSupported: (authenticator: string) =>
-      constants.SUPPORTED_AUTHENTICATORS[authenticator],
-    isAuthenticatorContractSupported: (authenticator: string) =>
-      constants.CONTRACT_SUPPORTED_AUTHENTICATORS[authenticator],
-    getRelayerAuthenticatorType: (authenticator: string) =>
-      constants.RELAYER_AUTHENTICATORS[authenticator],
+    getAuthenticatorSupportInfo: (authenticator: string) =>
+      constants.AUTHENTICATORS_SUPPORT_INFO[authenticator] || null,
     isStrategySupported: (strategy: string) =>
       constants.SUPPORTED_STRATEGIES[strategy],
     isExecutorSupported: (executor: string) =>
@@ -177,7 +173,6 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
     currentChainId: baseChainId,
     baseNetworkId,
     supportsSimulation: true,
-    governanceConnectors: [...STARKNET_CONNECTORS, ...EVM_CONNECTORS],
     managerConnectors: STARKNET_CONNECTORS,
     actions: createActions(networkId, provider, helpers, {
       chainId,

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -388,12 +388,36 @@ export type NetworkConstants = {
   STORAGE_PROOF_STRATEGIES_TYPES?: string[];
 };
 
+export type AuthenticatorSupportInfo = {
+  /**
+   * Whether the authenticator is supported by the app.
+   */
+  isSupported: boolean;
+  /**
+   * Whether the authenticator can be used with contract-based accounts.
+   */
+  isContractSupported: boolean;
+  /**
+   * Type of the relayer used by authenticator.
+   * Determines how authenticator is interacted with.
+   */
+  relayerType?: 'starknet' | 'evm' | 'evm-tx';
+  /**
+   * List of connectors that can be used with this authenticator.
+   */
+  connectors: ConnectorType[];
+  /**
+   * Priority of the authenticator.
+   * Lower number means higher priority.
+   * Default is 0.
+   */
+  priority?: number;
+};
+
 export type NetworkHelpers = {
-  isAuthenticatorSupported(authenticator: string): boolean;
-  isAuthenticatorContractSupported(authenticator: string): boolean;
-  getRelayerAuthenticatorType(
+  getAuthenticatorSupportInfo(
     authenticator: string
-  ): 'evm' | 'evm-tx' | 'starknet' | null;
+  ): AuthenticatorSupportInfo | null;
   isStrategySupported(strategy: string): boolean;
   /**
    * Checks if the executor type is supported.
@@ -430,10 +454,6 @@ type BaseNetwork = {
   currentChainId: number;
   baseNetworkId?: NetworkID;
   supportsSimulation: boolean;
-  /**
-   * Connectors that can be used for governance (creating proposals, voting).
-   */
-  governanceConnectors: ConnectorType[];
   managerConnectors: ConnectorType[];
   api: NetworkApi;
   constants: NetworkConstants;

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -430,6 +430,10 @@ type BaseNetwork = {
   currentChainId: number;
   baseNetworkId?: NetworkID;
   supportsSimulation: boolean;
+  /**
+   * Connectors that can be used for governance (creating proposals, voting).
+   */
+  governanceConnectors: ConnectorType[];
   managerConnectors: ConnectorType[];
   api: NetworkApi;
   constants: NetworkConstants;


### PR DESCRIPTION
### Summary

Adding simple condition so Starknet wallet can't be used on EVM spaces.

Closes: https://github.com/snapshot-labs/workflow/issues/578

### How to test

1. Go to http://localhost:8080/#/ape:0xa1282429A4a34F9f91D50ecf3d8217Fc6654eF6e/proposal/1
2. Sign in with Starknet wallet.
3. You see message that this wallet is not supported.

### Screenshots

<img width="587" alt="image" src="https://github.com/user-attachments/assets/c41e43b3-5962-436b-ae85-a20efc08543e" />
