### PR TITLE
chore: remove deprecated "indicies"

### DIFF
--- a/apps/api/src/evm/writers.ts
+++ b/apps/api/src/evm/writers.ts
@@ -232,8 +232,6 @@ export function createWriters(config: FullConfig) {
     space.max_voting_period = event.args.input.maxVotingDuration;
     space.proposal_threshold = '0';
     space.strategies_indices = votingStrategies.map((_, i) => i);
-    // NOTE: deprecated
-    space.strategies_indicies = space.strategies_indices;
     space.strategies = votingStrategies.map(s => getAddress(s.addr));
     space.next_strategy_index = votingStrategies.length;
     space.strategies_params = votingStrategies.map(s => s.params);
@@ -484,8 +482,6 @@ export function createWriters(config: FullConfig) {
       ...space.strategies_indices,
       ...strategies.map((_, i) => space.next_strategy_index + i)
     ];
-    // NOTE: deprecated
-    space.strategies_indicies = space.strategies_indices;
     space.strategies = [...space.strategies, ...strategies];
     space.next_strategy_index += strategies.length;
     space.strategies_params = [...space.strategies_params, ...strategiesParams];
@@ -528,8 +524,6 @@ export function createWriters(config: FullConfig) {
     space.strategies_indices = space.strategies_indices.filter(
       (_, i) => !indicesToRemove.includes(i)
     );
-    // NOTE: deprecated
-    space.strategies_indicies = space.strategies_indices;
     space.strategies = space.strategies.filter(
       (_, i) => !indicesToRemove.includes(i)
     );
@@ -615,8 +609,6 @@ export function createWriters(config: FullConfig) {
     proposal.scores_total = '0';
     proposal.quorum = 0n;
     proposal.strategies_indices = space.strategies_indices;
-    // NOTE: deprecated
-    proposal.strategies_indicies = proposal.strategies_indices;
     proposal.strategies = space.strategies;
     proposal.strategies_params = space.strategies_params;
     proposal.created = created;

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -16,8 +16,6 @@ type Space {
   proposal_threshold: BigDecimalVP!
   next_strategy_index: Int!
   strategies_indices: [Int!]!
-  # Deprecated
-  strategies_indicies: [Int!]!
   strategies: [String!]!
   strategies_params: [String!]!
   strategies_metadata: [String!]!
@@ -129,8 +127,6 @@ type Proposal {
   axiom_snapshot_slot: BigInt
   treasuries: [String!]!
   strategies_indices: [Int!]!
-  # Deprecated
-  strategies_indicies: [Int!]!
   strategies: [String!]!
   strategies_params: [String!]!
   type: String!

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -95,8 +95,6 @@ export function createWriters(config: FullConfig) {
     );
     space.proposal_threshold = '0';
     space.strategies_indices = strategies.map((_, i) => i);
-    // NOTE: deprecated
-    space.strategies_indicies = space.strategies_indices;
     space.strategies = strategies;
     space.next_strategy_index = strategies.length;
     space.strategies_params = strategiesParams;
@@ -318,8 +316,6 @@ export function createWriters(config: FullConfig) {
       ...space.strategies_indices,
       ...strategies.map((_, i) => space.next_strategy_index + i)
     ];
-    // NOTE: deprecated
-    space.strategies_indicies = space.strategies_indices;
     space.strategies = [...space.strategies, ...strategies];
     space.next_strategy_index += strategies.length;
     space.strategies_params = [...space.strategies_params, ...strategiesParams];
@@ -362,8 +358,6 @@ export function createWriters(config: FullConfig) {
     space.strategies_indices = space.strategies_indices.filter(
       (_, i) => !indicesToRemove.includes(i)
     );
-    // NOTE: deprecated
-    space.strategies_indicies = space.strategies_indices;
     space.strategies = space.strategies.filter(
       (_, i) => !indicesToRemove.includes(i)
     );
@@ -468,8 +462,6 @@ export function createWriters(config: FullConfig) {
     proposal.scores_total = '0';
     proposal.quorum = 0n;
     proposal.strategies_indices = space.strategies_indices;
-    // NOTE: deprecated
-    proposal.strategies_indicies = proposal.strategies_indices;
     proposal.strategies = space.strategies;
     proposal.strategies_params = space.strategies_params;
     proposal.created = parseInt(created.toString());

--- a/apps/ui/src/networks/common/helpers.ts
+++ b/apps/ui/src/networks/common/helpers.ts
@@ -71,14 +71,14 @@ export function createStrategyPicker({ helpers }: { helpers: NetworkHelpers }) {
   return function pick({
     authenticators,
     strategies,
-    strategiesIndicies,
+    strategiesIndices,
     isContract,
     connectorType,
     ignoreRelayer
   }: {
     authenticators: string[];
     strategies: string[];
-    strategiesIndicies: number[];
+    strategiesIndices: number[];
     isContract: boolean;
     connectorType: ConnectorType;
     ignoreRelayer?: boolean;
@@ -128,7 +128,7 @@ export function createStrategyPicker({ helpers }: { helpers: NetworkHelpers }) {
         (strategy, index) =>
           ({
             address: strategy,
-            index: strategiesIndicies[index],
+            index: strategiesIndices[index],
             paramsIndex: index
           }) as const
       )

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -267,7 +267,7 @@ export function createActions(
         pickAuthenticatorAndStrategies({
           authenticators: space.authenticators,
           strategies: space.voting_power_validation_strategy_strategies,
-          strategiesIndicies:
+          strategiesIndices:
             space.voting_power_validation_strategy_strategies.map((_, i) => i),
           connectorType,
           isContract,
@@ -379,7 +379,7 @@ export function createActions(
       const { relayerType, authenticator } = pickAuthenticatorAndStrategies({
         authenticators: space.authenticators,
         strategies: space.voting_power_validation_strategy_strategies,
-        strategiesIndicies:
+        strategiesIndices:
           space.voting_power_validation_strategy_strategies.map((_, i) => i),
         connectorType,
         isContract,
@@ -477,7 +477,7 @@ export function createActions(
         pickAuthenticatorAndStrategies({
           authenticators: proposal.space.authenticators,
           strategies: proposal.strategies,
-          strategiesIndicies: proposal.strategies_indices,
+          strategiesIndices: proposal.strategies_indices,
           connectorType,
           isContract,
           ignoreRelayer: !relayer?.hasMinimumBalance

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -254,7 +254,7 @@ export function createActions(
         pickAuthenticatorAndStrategies({
           authenticators: space.authenticators,
           strategies: space.voting_power_validation_strategy_strategies,
-          strategiesIndicies:
+          strategiesIndices:
             space.voting_power_validation_strategy_strategies.map((_, i) => i),
           connectorType,
           isContract,
@@ -373,7 +373,7 @@ export function createActions(
       const { relayerType, authenticator } = pickAuthenticatorAndStrategies({
         authenticators: space.authenticators,
         strategies: space.voting_power_validation_strategy_strategies,
-        strategiesIndicies:
+        strategiesIndices:
           space.voting_power_validation_strategy_strategies.map((_, i) => i),
         connectorType,
         isContract,
@@ -468,7 +468,7 @@ export function createActions(
         pickAuthenticatorAndStrategies({
           authenticators: proposal.space.authenticators,
           strategies: proposal.strategies,
-          strategiesIndicies: proposal.strategies_indices,
+          strategiesIndices: proposal.strategies_indices,
           connectorType,
           isContract,
           ignoreRelayer: !relayer?.hasMinimumBalance


### PR DESCRIPTION
### Summary

Those were renamed to "indices".
This PR removes deprecated fields using wrong grammar from API as well updates some leftovers in UI code.