### PR TITLE
feat: compute parsed VP on API

### DIFF
--- a/apps/api/src/common/ipfs.ts
+++ b/apps/api/src/common/ipfs.ts
@@ -76,7 +76,7 @@ export async function handleStrategiesParsedMetadata(
     dropIpfs(metadataUri),
     config.indexerName
   );
-  if (exists) return;
+  if (exists) return { decimals: exists.decimals };
 
   const strategiesParsedMetadataItem = new StrategiesParsedMetadataDataItem(
     dropIpfs(metadataUri),
@@ -103,6 +103,8 @@ export async function handleStrategiesParsedMetadata(
   }
 
   await strategiesParsedMetadataItem.save();
+
+  return { decimals: strategiesParsedMetadataItem.decimals };
 }
 
 export async function handleVoteMetadata(
@@ -135,6 +137,8 @@ export async function handleStrategiesMetadata(
     | typeof StrategiesParsedMetadataItem
     | typeof VotingPowerValidationStrategiesParsedMetadataItem = StrategiesParsedMetadataItem
 ) {
+  const strategiesDecimals = [];
+
   for (let i = 0; i < metadataUris.length; i++) {
     const metadataUri = metadataUris[i];
     if (!metadataUri) continue;
@@ -149,11 +153,18 @@ export async function handleStrategiesMetadata(
     if (metadataUri.startsWith('ipfs://')) {
       strategiesParsedMetadataItem.data = dropIpfs(metadataUri);
 
-      await handleStrategiesParsedMetadata(metadataUri, config);
+      const { decimals } = await handleStrategiesParsedMetadata(
+        metadataUri,
+        config
+      );
+
+      strategiesDecimals.push(decimals);
     }
 
     await strategiesParsedMetadataItem.save();
   }
+
+  return { strategiesDecimals };
 }
 
 export async function handleVotingPowerValidationMetadata(

--- a/apps/api/src/common/utils.ts
+++ b/apps/api/src/common/utils.ts
@@ -125,3 +125,13 @@ export function getExecutionHash({
 
   return `0x${poseidonHashMany(data.executionParams.map(v => BigInt(v))).toString(16)}`;
 }
+
+export function getParsedVP(value: string, decimals: number) {
+  const parsedValue = parseInt(value, 10);
+
+  const vp = parsedValue / 10 ** decimals;
+
+  return new Intl.NumberFormat('en', {
+    useGrouping: false
+  }).format(vp);
+}

--- a/apps/api/src/common/utils.ts
+++ b/apps/api/src/common/utils.ts
@@ -129,9 +129,5 @@ export function getExecutionHash({
 export function getParsedVP(value: string, decimals: number) {
   const parsedValue = parseInt(value, 10);
 
-  const vp = parsedValue / 10 ** decimals;
-
-  return new Intl.NumberFormat('en', {
-    useGrouping: false
-  }).format(vp);
+  return parsedValue / 10 ** decimals;
 }

--- a/apps/api/src/evm/writers.ts
+++ b/apps/api/src/evm/writers.ts
@@ -508,7 +508,7 @@ export function createWriters(config: FullConfig) {
         ...space.strategies_decimals,
         ...strategiesDecimals
       ];
-      space.vp_decimals = Math.max(...strategiesDecimals);
+      space.vp_decimals = Math.max(...space.strategies_decimals);
     } catch (e) {
       console.log('failed to handle strategies metadata', e);
     }

--- a/apps/api/src/evm/writers.ts
+++ b/apps/api/src/evm/writers.ts
@@ -35,6 +35,7 @@ import {
 import {
   dropIpfs,
   getCurrentTimestamp,
+  getParsedVP,
   getProposalLink,
   getSpaceLink,
   updateCounter
@@ -236,6 +237,8 @@ export function createWriters(config: FullConfig) {
     space.next_strategy_index = votingStrategies.length;
     space.strategies_params = votingStrategies.map(s => s.params);
     space.strategies_metadata = event.args.input.votingStrategyMetadataURIs;
+    space.strategies_decimals = [];
+    space.vp_decimals = 0;
     space.authenticators = event.args.input.authenticators.map(
       (address: string) => getAddress(address)
     );
@@ -284,12 +287,15 @@ export function createWriters(config: FullConfig) {
     }
 
     try {
-      await handleStrategiesMetadata(
+      const { strategiesDecimals } = await handleStrategiesMetadata(
         space.id,
         space.strategies_metadata,
         0,
         config
       );
+
+      space.strategies_decimals = strategiesDecimals;
+      space.vp_decimals = Math.max(...strategiesDecimals);
     } catch (e) {
       console.log('failed to handle strategies metadata', e);
     }
@@ -491,12 +497,18 @@ export function createWriters(config: FullConfig) {
     ];
 
     try {
-      await handleStrategiesMetadata(
+      const { strategiesDecimals } = await handleStrategiesMetadata(
         space.id,
         strategiesMetadataUris,
         initialNextStrategy,
         config
       );
+
+      space.strategies_decimals = [
+        ...space.strategies_decimals,
+        ...strategiesDecimals
+      ];
+      space.vp_decimals = Math.max(...strategiesDecimals);
     } catch (e) {
       console.log('failed to handle strategies metadata', e);
     }
@@ -533,6 +545,10 @@ export function createWriters(config: FullConfig) {
     space.strategies_metadata = space.strategies_metadata.filter(
       (_, i) => !indicesToRemove.includes(i)
     );
+    space.strategies_decimals = space.strategies_decimals.filter(
+      (_, i) => !indicesToRemove.includes(i)
+    );
+    space.vp_decimals = Math.max(...space.strategies_decimals);
 
     await space.save();
   };
@@ -604,13 +620,18 @@ export function createWriters(config: FullConfig) {
     proposal.snapshot = event.args.proposal.startBlockNumber;
     proposal.type = 'basic';
     proposal.scores_1 = '0';
+    proposal.scores_1_parsed = '0';
     proposal.scores_2 = '0';
+    proposal.scores_2_parsed = '0';
     proposal.scores_3 = '0';
+    proposal.scores_3_parsed = '0';
     proposal.scores_total = '0';
+    proposal.scores_total_parsed = '0';
     proposal.quorum = 0n;
     proposal.strategies_indices = space.strategies_indices;
     proposal.strategies = space.strategies;
     proposal.strategies_params = space.strategies_params;
+    proposal.vp_decimals = space.vp_decimals;
     proposal.created = created;
     proposal.tx = tx.hash;
     proposal.execution_tx = null;
@@ -928,6 +949,12 @@ export function createWriters(config: FullConfig) {
       return;
     }
 
+    const proposal = await Proposal.loadEntity(
+      `${spaceId}/${proposalId}`,
+      config.indexerName
+    );
+    if (!proposal) return;
+
     const created = block?.timestamp ?? getCurrentTimestamp();
 
     const voter = getAddress(event.args.voter);
@@ -941,6 +968,7 @@ export function createWriters(config: FullConfig) {
     vote.voter = voter;
     vote.choice = choice;
     vote.vp = vp.toString();
+    vote.vp_parsed = getParsedVP(vp.toString(), proposal.vp_decimals);
     vote.created = created;
     vote.tx = tx.hash;
 
@@ -996,20 +1024,22 @@ export function createWriters(config: FullConfig) {
       await space.save();
     }
 
-    const proposal = await Proposal.loadEntity(
-      `${spaceId}/${proposalId}`,
-      config.indexerName
+    proposal.vote_count += 1;
+    proposal.scores_total = (
+      BigInt(proposal.scores_total) + BigInt(vote.vp)
+    ).toString();
+    proposal.scores_total_parsed = getParsedVP(
+      proposal.scores_total,
+      proposal.vp_decimals
     );
-    if (proposal) {
-      proposal.vote_count += 1;
-      proposal.scores_total = (
-        BigInt(proposal.scores_total) + BigInt(vote.vp)
-      ).toString();
-      proposal[`scores_${choice}`] = (
-        BigInt(proposal[`scores_${choice}`]) + BigInt(vote.vp)
-      ).toString();
-      await proposal.save();
-    }
+    proposal[`scores_${choice}`] = (
+      BigInt(proposal[`scores_${choice}`]) + BigInt(vote.vp)
+    ).toString();
+    proposal[`scores_${choice}_parsed`] = getParsedVP(
+      proposal[`scores_${choice}`],
+      proposal.vp_decimals
+    );
+    await proposal.save();
   };
 
   const handleTimelockProposalExecuted: evm.Writer = async ({

--- a/apps/api/src/evm/writers.ts
+++ b/apps/api/src/evm/writers.ts
@@ -620,13 +620,13 @@ export function createWriters(config: FullConfig) {
     proposal.snapshot = event.args.proposal.startBlockNumber;
     proposal.type = 'basic';
     proposal.scores_1 = '0';
-    proposal.scores_1_parsed = '0';
+    proposal.scores_1_parsed = 0;
     proposal.scores_2 = '0';
-    proposal.scores_2_parsed = '0';
+    proposal.scores_2_parsed = 0;
     proposal.scores_3 = '0';
-    proposal.scores_3_parsed = '0';
+    proposal.scores_3_parsed = 0;
     proposal.scores_total = '0';
-    proposal.scores_total_parsed = '0';
+    proposal.scores_total_parsed = 0;
     proposal.quorum = 0n;
     proposal.strategies_indices = space.strategies_indices;
     proposal.strategies = space.strategies;

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -21,6 +21,8 @@ type Space {
   strategies_metadata: [String!]!
   strategies_parsed_metadata: [StrategiesParsedMetadataItem!]!
     @derivedFrom(field: "space")
+  strategies_decimals: [Int!]!
+  vp_decimals: Int!
   authenticators: [String!]!
   validation_strategy: String!
   validation_strategy_params: Text!
@@ -129,11 +131,16 @@ type Proposal {
   strategies_indices: [Int!]!
   strategies: [String!]!
   strategies_params: [String!]!
+  vp_decimals: Int!
   type: String!
   scores_1: BigDecimalVP!
+  scores_1_parsed: String!
   scores_2: BigDecimalVP!
+  scores_2_parsed: String!
   scores_3: BigDecimalVP!
+  scores_3_parsed: String!
   scores_total: BigDecimalVP!
+  scores_total_parsed: String!
   quorum: BigInt!
   created: Int!
   edited: Int
@@ -165,6 +172,7 @@ type Vote {
   proposal: Int!
   choice: Int!
   vp: BigDecimalVP!
+  vp_parsed: String!
   metadata: VoteMetadataItem
   created: Int!
   tx: String!

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -134,13 +134,13 @@ type Proposal {
   vp_decimals: Int!
   type: String!
   scores_1: BigDecimalVP!
-  scores_1_parsed: String!
+  scores_1_parsed: Float!
   scores_2: BigDecimalVP!
-  scores_2_parsed: String!
+  scores_2_parsed: Float!
   scores_3: BigDecimalVP!
-  scores_3_parsed: String!
+  scores_3_parsed: Float!
   scores_total: BigDecimalVP!
-  scores_total_parsed: String!
+  scores_total_parsed: Float!
   quorum: BigInt!
   created: Int!
   edited: Int
@@ -172,7 +172,7 @@ type Vote {
   proposal: Int!
   choice: Int!
   vp: BigDecimalVP!
-  vp_parsed: String!
+  vp_parsed: Float!
   metadata: VoteMetadataItem
   created: Int!
   tx: String!

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -473,13 +473,13 @@ export function createWriters(config: FullConfig) {
     proposal.execution_strategy_type = 'none';
     proposal.type = 'basic';
     proposal.scores_1 = '0';
-    proposal.scores_1_parsed = '0';
+    proposal.scores_1_parsed = 0;
     proposal.scores_2 = '0';
-    proposal.scores_2_parsed = '0';
+    proposal.scores_2_parsed = 0;
     proposal.scores_3 = '0';
-    proposal.scores_3_parsed = '0';
+    proposal.scores_3_parsed = 0;
     proposal.scores_total = '0';
-    proposal.scores_total_parsed = '0';
+    proposal.scores_total_parsed = 0;
     proposal.quorum = 0n;
     proposal.strategies_indices = space.strategies_indices;
     proposal.strategies = space.strategies;

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -342,7 +342,7 @@ export function createWriters(config: FullConfig) {
         ...space.strategies_decimals,
         ...strategiesDecimals
       ];
-      space.vp_decimals = Math.max(...strategiesDecimals);
+      space.vp_decimals = Math.max(...space.strategies_decimals);
     } catch (e) {
       console.log('failed to handle strategies metadata', e);
     }


### PR DESCRIPTION
### Summary

With this change:
1. API tracks voting strategies decimals. Those can be accessed using vp_decimals on Space or Proposal entities.
2. Vote VP and Proposal scores now have parsed variant (_parsed suffix) that is formatted using decimals value.


Closes: https://github.com/snapshot-labs/workflow/issues/567

### How to test

1. Apply diff from below (Curtis is easier to sync up).
2. Run query below on http://localhost:3000
3. Values are formatted.

```diff
diff --git a/scripts/dev-interactive.ts b/scripts/dev-interactive.ts
index 5a60152e..39560f2c 100644
--- a/scripts/dev-interactive.ts
+++ b/scripts/dev-interactive.ts
@@ -14,8 +14,8 @@ const SERVICES: Record<ServiceType, Service> = {
   api: {
     env: {
       UI_URL: 'http://localhost:8080',
-      ENABLED_NETWORKS: 'sep,sn-sep',
-      VITE_ENABLED_NETWORKS: 's-tn,sep,sn-sep',
+      ENABLED_NETWORKS: 'curtis',
+      VITE_ENABLED_NETWORKS: 's-tn,curtis',
       VITE_METADATA_NETWORK: 's-tn',
       VITE_UNIFIED_API_TESTNET_URL: 'http://localhost:3000'
     }
```

```gql
{
  proposal(id: "0xf6238F73A87D390CB00b2B380D2B777E13Fe2725/12") {
    scores_1
    scores_2
    scores_3
    scores_total
    scores_1_parsed
    scores_2_parsed
    scores_3_parsed
    scores_total_parsed
  }
   votes {
    id
    vp
    vp_parsed
  }
  space(id: "0xf6238F73A87D390CB00b2B380D2B777E13Fe2725") {
    id
    vp_decimals
  }
}
```