### PR TITLE
fix: use 0 decimals if strategies are empty

### DIFF
--- a/apps/api/src/common/utils.ts
+++ b/apps/api/src/common/utils.ts
@@ -126,6 +126,12 @@ export function getExecutionHash({
   return `0x${poseidonHashMany(data.executionParams.map(v => BigInt(v))).toString(16)}`;
 }
 
+export function getSpaceDecimals(decimals: number[]) {
+  if (decimals.length === 0) return 0;
+
+  return Math.max(...decimals);
+}
+
 export function getParsedVP(value: string, decimals: number) {
   const parsedValue = parseInt(value, 10);
 

--- a/apps/api/src/evm/writers.ts
+++ b/apps/api/src/evm/writers.ts
@@ -37,6 +37,7 @@ import {
   getCurrentTimestamp,
   getParsedVP,
   getProposalLink,
+  getSpaceDecimals,
   getSpaceLink,
   updateCounter
 } from '../common/utils';
@@ -295,7 +296,7 @@ export function createWriters(config: FullConfig) {
       );
 
       space.strategies_decimals = strategiesDecimals;
-      space.vp_decimals = Math.max(...strategiesDecimals);
+      space.vp_decimals = getSpaceDecimals(space.strategies_decimals);
     } catch (e) {
       console.log('failed to handle strategies metadata', e);
     }
@@ -508,7 +509,7 @@ export function createWriters(config: FullConfig) {
         ...space.strategies_decimals,
         ...strategiesDecimals
       ];
-      space.vp_decimals = Math.max(...space.strategies_decimals);
+      space.vp_decimals = getSpaceDecimals(space.strategies_decimals);
     } catch (e) {
       console.log('failed to handle strategies metadata', e);
     }
@@ -548,7 +549,7 @@ export function createWriters(config: FullConfig) {
     space.strategies_decimals = space.strategies_decimals.filter(
       (_, i) => !indicesToRemove.includes(i)
     );
-    space.vp_decimals = Math.max(...space.strategies_decimals);
+    space.vp_decimals = getSpaceDecimals(space.strategies_decimals);
 
     await space.save();
   };

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -30,6 +30,7 @@ import {
   getCurrentTimestamp,
   getParsedVP,
   getProposalLink,
+  getSpaceDecimals,
   getSpaceLink,
   updateCounter
 } from '../common/utils';
@@ -139,7 +140,7 @@ export function createWriters(config: FullConfig) {
       );
 
       space.strategies_decimals = strategiesDecimals;
-      space.vp_decimals = Math.max(...strategiesDecimals);
+      space.vp_decimals = getSpaceDecimals(space.strategies_decimals);
     } catch (e) {
       console.log('failed to handle strategies metadata', e);
     }
@@ -342,7 +343,7 @@ export function createWriters(config: FullConfig) {
         ...space.strategies_decimals,
         ...strategiesDecimals
       ];
-      space.vp_decimals = Math.max(...space.strategies_decimals);
+      space.vp_decimals = getSpaceDecimals(space.strategies_decimals);
     } catch (e) {
       console.log('failed to handle strategies metadata', e);
     }
@@ -382,7 +383,7 @@ export function createWriters(config: FullConfig) {
     space.strategies_decimals = space.strategies_decimals.filter(
       (_, i) => !indicesToRemove.includes(i)
     );
-    space.vp_decimals = Math.max(...space.strategies_decimals);
+    space.vp_decimals = getSpaceDecimals(space.strategies_decimals);
 
     await space.save();
   };


### PR DESCRIPTION
### Summary

Before it would return -Infinity which can't be written to DB.

Fixes issue in https://github.com/snapshot-labs/sx-monorepo/pull/1435
