### PR TITLE
fix: show notice for polygon on settings but not editor

### DIFF
--- a/apps/ui/src/composables/useSpaceAlerts.ts
+++ b/apps/ui/src/composables/useSpaceAlerts.ts
@@ -6,7 +6,7 @@ import { offchainNetworks } from '@/networks';
 import { Space } from '@/types';
 
 const UPCOMING_PRO_ONLY_NETWORKS: readonly number[] = [
-  137 // Polygon
+  // 137 // Polygon (disabled as it throws an error in the editor)
 ];
 
 type AlertType =

--- a/apps/ui/src/composables/useSpaceAlerts.ts
+++ b/apps/ui/src/composables/useSpaceAlerts.ts
@@ -69,12 +69,11 @@ export function useSpaceAlerts(
       )
     ]);
 
+    const isNetworkUpcomingPro = (networkId: number) =>
+      UPCOMING_PRO_ONLY_NETWORKS.includes(networkId) && !options.isEditor;
+
     return Array.from(ids)
-      .filter(
-        n =>
-          !premiumChainIds.value.has(n) ||
-          UPCOMING_PRO_ONLY_NETWORKS.includes(n)
-      )
+      .filter(n => !premiumChainIds.value.has(n) || isNetworkUpcomingPro(n))
       .map(chainId => networks.value.find(n => n.chainId === chainId))
       .filter(network => !!network);
   });
@@ -94,7 +93,7 @@ export function useSpaceAlerts(
       });
     }
 
-    if (unsupportedProOnlyNetworks.value.length && !options.isEditor) {
+    if (unsupportedProOnlyNetworks.value.length) {
       alertsMap.set('HAS_PRO_ONLY_NETWORKS', {
         networks: unsupportedProOnlyNetworks.value
       });

--- a/apps/ui/src/composables/useSpaceAlerts.ts
+++ b/apps/ui/src/composables/useSpaceAlerts.ts
@@ -6,7 +6,7 @@ import { offchainNetworks } from '@/networks';
 import { Space } from '@/types';
 
 const UPCOMING_PRO_ONLY_NETWORKS: readonly number[] = [
-  // 137 // Polygon (disabled as it throws an error in the editor)
+  137 // Polygon
 ];
 
 type AlertType =
@@ -15,7 +15,12 @@ type AlertType =
   | 'HAS_PRO_ONLY_NETWORKS'
   | 'HAS_PRO_ONLY_WHITELABEL';
 
-export function useSpaceAlerts(space: Ref<Space>) {
+export function useSpaceAlerts(
+  space: Ref<Space>,
+  options = {
+    isEditor: false
+  }
+) {
   const {
     networks,
     premiumChainIds,
@@ -89,7 +94,7 @@ export function useSpaceAlerts(space: Ref<Space>) {
       });
     }
 
-    if (unsupportedProOnlyNetworks.value.length) {
+    if (unsupportedProOnlyNetworks.value.length && !options.isEditor) {
       alertsMap.set('HAS_PRO_ONLY_NETWORKS', {
         networks: unsupportedProOnlyNetworks.value
       });

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -53,7 +53,9 @@ const termsStore = useTermsStore();
 const timestamp = useTimestamp({ interval: 1000 });
 const { limits, lists } = useSettings();
 const { isWhiteLabel } = useWhiteLabel();
-const { alerts } = useSpaceAlerts(toRef(props, 'space'));
+const { alerts } = useSpaceAlerts(toRef(props, 'space'), {
+  isEditor: true
+});
 
 const modalOpen = ref(false);
 const modalOpenTerms = ref(false);
@@ -188,6 +190,7 @@ const isSubmitButtonLoading = computed(() => {
   );
 });
 const canSubmit = computed(() => {
+  console.log(alerts);
   const hasUnsupportedNetworks =
     alerts.value.has('HAS_PRO_ONLY_NETWORKS') && !proposal.value?.proposalId;
   const hasFormErrors = Object.keys(formErrors.value).length > 0;

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -190,7 +190,6 @@ const isSubmitButtonLoading = computed(() => {
   );
 });
 const canSubmit = computed(() => {
-  console.log(alerts);
   const hasUnsupportedNetworks =
     alerts.value.has('HAS_PRO_ONLY_NETWORKS') && !proposal.value?.proposalId;
   const hasFormErrors = Object.keys(formErrors.value).length > 0;


### PR DESCRIPTION
### How to test:
- Go to http://localhost:8080/#/s:aavegotchi.eth/settings/voting-strategies
- You should see polygon notice like before
- Go to http://localhost:8080/#/s:aavegotchi.eth/create/eq2qk
- You should not see polygon notice like before
