### PR TITLE
chore: extract network send helper

### DIFF
--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -57,6 +57,7 @@ import {
   VoteType
 } from '@/types';
 import { EDITOR_APP_NAME } from '../common/constants';
+import { send } from '../helpers';
 
 const CONFIGS: Record<number, EvmNetworkConfig> = {
   10: evmOptimism,
@@ -850,7 +851,7 @@ export function createActions(
     deleteSpace: () => {
       throw new Error('Not implemented');
     },
-    send: (envelope: any) => ethSigClient.send(envelope),
+    send: (envelope: any) => send(ethSigClient, envelope),
     getVotingPower: async (
       spaceId: string,
       strategiesAddresses: string[],

--- a/apps/ui/src/networks/helpers/index.ts
+++ b/apps/ui/src/networks/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './send';

--- a/apps/ui/src/networks/helpers/send.test.ts
+++ b/apps/ui/src/networks/helpers/send.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it, vi } from 'vitest';
+import { send } from './send';
+
+describe('send helper', () => {
+  it('delegates to client.send', async () => {
+    const expected = { hash: '0x123' };
+    const client = { send: vi.fn(async () => expected) };
+
+    await expect(send(client, {})).resolves.toBe(expected);
+    expect(client.send).toHaveBeenCalledWith({});
+  });
+});

--- a/apps/ui/src/networks/helpers/send.ts
+++ b/apps/ui/src/networks/helpers/send.ts
@@ -1,0 +1,6 @@
+export async function send(
+  client: { send: (envelope: any) => Promise<any> },
+  envelope: any
+) {
+  return client.send(envelope);
+}

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -57,6 +57,7 @@ import {
   VoteType
 } from '@/types';
 import { EDITOR_APP_NAME } from '../common/constants';
+import { send } from '../helpers';
 
 const CONFIGS: Partial<Record<NetworkID, NetworkConfig>> = {
   sn: starknetMainnet,
@@ -843,6 +844,6 @@ export function createActions(
     deleteSpace: () => {
       throw new Error('Not implemented');
     },
-    send: (envelope: any) => starkSigClient.send(envelope) // TODO: extract it out of client to common helper
+    send: (envelope: any) => send(starkSigClient, envelope)
   };
 }


### PR DESCRIPTION
### Summary

Introduced a shared helper to dispatch envelopes through a client, consolidating send logic across networks