### PR TITLE
feat: normalize starknet proposal timestamps

### DIFF
--- a/apps/api/test/unit/starknet/normalizeProposalTimestamps.test.ts
+++ b/apps/api/test/unit/starknet/normalizeProposalTimestamps.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeProposalTimestamps } from '../../../src/starknet/writers';
+
+describe('normalizeProposalTimestamps', () => {
+  it('should return created timestamp without adjustment', () => {
+    const res = normalizeProposalTimestamps(1000n, 1200n, 100n, false);
+    expect(res).toEqual({ created: 900n, start: 1000n, minEnd: 1200n });
+  });
+
+  it('should apply minimum delay for erc20votes', () => {
+    const res = normalizeProposalTimestamps(1000n, 1020n, 100n, true);
+    expect(res).toEqual({ created: 900n, start: 1500n, minEnd: 1500n });
+  });
+
+  it('should keep start if already greater than minimum delay', () => {
+    const res = normalizeProposalTimestamps(2000n, 2020n, 1000n, true);
+    expect(res).toEqual({ created: 1000n, start: 2000n, minEnd: 2020n });
+  });
+});


### PR DESCRIPTION
### Summary

- Added a new helper `normalizeProposalTimestamps` to centralize Starknet proposal timestamp logic, ensuring `ERC20Votes` delays are handled consistently

- Created unit tests covering various timestamp scenarios to validate the new normalization logic