### PR TITLE
fix: separate completed and execution_settled

### DIFF
--- a/apps/ui/src/components/ProposalExecutionActions.vue
+++ b/apps/ui/src/components/ProposalExecutionActions.vue
@@ -100,7 +100,7 @@ const network = computed(() => getNetwork(props.proposal.network));
       <UiButton
         v-if="
           proposal.state === 'executed' &&
-          !proposal.completed &&
+          !proposal.execution_settled &&
           !proposal.vetoed &&
           proposal.timelock_veto_guardian &&
           compareAddresses(proposal.timelock_veto_guardian, web3.account)

--- a/apps/ui/src/composables/useExecutionActions.ts
+++ b/apps/ui/src/composables/useExecutionActions.ts
@@ -68,7 +68,7 @@ export function useExecutionActions(
       return proposal.state === 'executed' ? isL1ExecutionReady.value : false;
     }
 
-    return proposal.state === 'executed' && !proposal.completed;
+    return proposal.state === 'executed' && !proposal.execution_settled;
   });
 
   const executionCountdown = computed(() => {

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -367,6 +367,7 @@ function formatProposal(
     )
       ? proposal.max_end <= current
       : proposal.min_end <= current,
+    execution_settled: proposal.completed,
     state,
     network: networkId,
     privacy: 'none',

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -372,6 +372,7 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     state,
     cancelled: false,
     vetoed: false,
+    execution_settled: false,
     completed: proposal.state === 'closed' && proposal.scores_state === 'final',
     space: {
       id: proposal.space.id,

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -315,6 +315,13 @@ export type Proposal = {
   has_execution_window_opened: boolean;
   execution_ready: boolean;
   vetoed: boolean;
+  /**
+   * Determines if proposal execution is settled - all transactions have been executed or vetoed.
+   */
+  execution_settled: boolean;
+  /**
+   * Determines if proposal is completed - all votes have been already counted.
+   */
   completed: boolean;
   cancelled: boolean;
   state: ProposalState;


### PR DESCRIPTION
### Summary

Originally `completed` was used only for onchain spaces and was used for execution, but later on it was reused for pending results (https://github.com/snapshot-labs/sx-monorepo/pull/1055).

This meant that it started carrying two very different meanings and broke things, so later on completed for onchain spaces was updated to match offchain space meaning
(https://github.com/snapshot-labs/sx-monorepo/pull/1075) which broke onchain execution.

Closes: https://github.com/snapshot-labs/workflow/issues/595

### How to test

1. Go to http://localhost:8080/#/ape:0xdA5b1a8B80Cd2710e5b0254EB672915E3a75Bea3/proposal/2
2. You see execute queued transactions button.

