### PR TITLE
fix: disable unsupportedProOnlyNetworks for onchain spaces

### DIFF
--- a/apps/ui/src/composables/useSpaceAlerts.ts
+++ b/apps/ui/src/composables/useSpaceAlerts.ts
@@ -46,6 +46,7 @@ export function useSpaceAlerts(space: Ref<Space>) {
 
   const unsupportedProOnlyNetworks = computed(() => {
     if (
+      !isOffchainSpace.value ||
       !space.value.snapshot_chain_id ||
       !networksLoaded.value ||
       space.value.turbo


### PR DESCRIPTION
### Summary

This PR disabled `unsupportedProOnlyNetworks` on onchain spaces (other alerts had this check already).

Closes: https://github.com/snapshot-labs/workflow/issues/597

### How to test

1. Go to http://localhost:8080/#/base:0x282d013BF31374D0046F04D6a7644d97751ed339/settings/voting-strategies
2. You don't see an alert.
