### PR TITLE
fix: allow starknet network on offchain spaces

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -56,7 +56,7 @@
     "@snapshot-labs/highlight": "^0.1.0-beta.2",
     "@snapshot-labs/pineapple": "^1.1.0",
     "@snapshot-labs/prettier-config": "^0.1.0-beta.19",
-    "@snapshot-labs/snapshot.js": "^0.12.60",
+    "@snapshot-labs/snapshot.js": "^0.14.2",
     "@snapshot-labs/sx": "^0.1.0",
     "@tanstack/vue-query": "^5.64.2",
     "@vueuse/core": "^10.4.1",

--- a/apps/ui/src/components/ButtonFollow.vue
+++ b/apps/ui/src/components/ButtonFollow.vue
@@ -3,7 +3,7 @@ import { getUserFacingErrorMessage } from '@/helpers/utils';
 import { NetworkID } from '@/types';
 
 const props = defineProps<{
-  space: { id: string; network: NetworkID; snapshot_chain_id?: number };
+  space: { id: string; network: NetworkID; snapshot_chain_id?: string };
 }>();
 
 const { isSafeWallet } = useSafeWallet(

--- a/apps/ui/src/components/FormSpaceStrategies.vue
+++ b/apps/ui/src/components/FormSpaceStrategies.vue
@@ -48,7 +48,7 @@ function handleTestStrategies(strategies: StrategyConfig[]) {
           'The default network used for this space. Networks can also be specified in individual strategies',
         examples: ['Select network'],
         networkId,
-        networksListKind: 'offchain'
+        networksListKind: 'full'
       }"
     />
   </div>

--- a/apps/ui/src/components/FormSpaceStrategies.vue
+++ b/apps/ui/src/components/FormSpaceStrategies.vue
@@ -2,7 +2,7 @@
 import { StrategyConfig } from '@/networks/types';
 import { NetworkID, Space } from '@/types';
 
-const snapshotChainId = defineModel<number>('snapshotChainId', {
+const snapshotChainId = defineModel<string>('snapshotChainId', {
   required: true
 });
 const strategies = defineModel<StrategyConfig[]>('strategies', {

--- a/apps/ui/src/components/Modal/Delegate.vue
+++ b/apps/ui/src/components/Modal/Delegate.vue
@@ -177,22 +177,7 @@ function isValidDelegation(delegation?: SpaceMetadataDelegation): boolean {
 }
 
 function getNetworkDetails(chainId: number | string) {
-  if (typeof chainId === 'number') {
-    return networks[chainId];
-  }
-
-  const starknetNetwork = Object.entries(STARKNET_NETWORK_METADATA).find(
-    ([, { chainId: starknetChainId }]) => starknetChainId === chainId
-  )?.[0];
-
-  if (!starknetNetwork) {
-    return { name: 'Unknown network', logo: '' };
-  }
-
-  return {
-    name: STARKNET_NETWORK_METADATA[starknetNetwork].name,
-    logo: STARKNET_NETWORK_METADATA[starknetNetwork].avatar
-  };
+  return networks[chainId] || { name: 'Unknown network', logo: '' };
 }
 
 async function handleSubmit() {

--- a/apps/ui/src/components/Modal/EditStrategy.vue
+++ b/apps/ui/src/components/Modal/EditStrategy.vue
@@ -167,7 +167,7 @@ watchEffect(() => {
           title: 'Network',
           examples: ['Select network'],
           networkId,
-          networksListKind: 'offchain'
+          networksListKind: 'full'
         }"
       />
       <UiForm

--- a/apps/ui/src/components/Modal/TestStrategy.vue
+++ b/apps/ui/src/components/Modal/TestStrategy.vue
@@ -106,7 +106,7 @@ async function handleSubmit() {
       null,
       {
         id: props.spaceId,
-        snapshot_chain_id: props.chainId as number | undefined,
+        snapshot_chain_id: props.chainId as string | undefined,
         network: props.networkId,
         voting_power_symbol: props.votingPowerSymbol
       },

--- a/apps/ui/src/components/Ui/BadgeNetwork.vue
+++ b/apps/ui/src/components/Ui/BadgeNetwork.vue
@@ -34,7 +34,7 @@ const networkData = computed<NetworkData | null>(() => {
     } catch {}
   }
 
-  if (props.chainId && typeof props.chainId === 'number') {
+  if (props.chainId) {
     try {
       const network: SnapshotJSNetwork | undefined =
         networks[String(props.chainId)];

--- a/apps/ui/src/components/Ui/InputAddress.vue
+++ b/apps/ui/src/components/Ui/InputAddress.vue
@@ -1,18 +1,7 @@
 <script setup lang="ts">
 import snapshotJsNetworks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { getUrl } from '@/helpers/utils';
-import { METADATA as STARKNET_NETWORK_METADATA } from '@/networks/starknet';
 import { BaseDefinition } from '@/types';
-
-const STARKNET_NETWORKS = Object.fromEntries(
-  Object.values(STARKNET_NETWORK_METADATA).map(metadata => [
-    metadata.chainId,
-    {
-      name: metadata.name,
-      logoUrl: getUrl(metadata.avatar)
-    }
-  ])
-);
 
 type NetworkDetails = {
   name: string;
@@ -44,9 +33,7 @@ const networkDetails = computed<NetworkDetails | null>(() => {
 
   if (!chainId) return null;
 
-  if (typeof chainId === 'string' && chainId in STARKNET_NETWORKS) {
-    return STARKNET_NETWORKS[chainId];
-  } else if (chainId in snapshotJsNetworks) {
+  if (chainId in snapshotJsNetworks) {
     const network = snapshotJsNetworks[chainId];
     return {
       name: network.name,

--- a/apps/ui/src/components/Ui/SelectorNetwork.vue
+++ b/apps/ui/src/components/Ui/SelectorNetwork.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { getUrl } from '@/helpers/utils';
 import { enabledNetworks, getNetwork } from '@/networks';
-import { METADATA as STARKNET_NETWORK_METADATA } from '@/networks/starknet';
 import { BaseDefinition, NetworkID } from '@/types';
 
 const network = defineModel<string | number | null>({
@@ -11,7 +10,7 @@ const network = defineModel<string | number | null>({
 const props = defineProps<{
   definition: BaseDefinition<string | number | null> & {
     networkId: NetworkID;
-    networksListKind?: 'full' | 'builtin' | 'offchain';
+    networksListKind?: 'full' | 'builtin';
     networksFilter?: unknown[];
   };
 }>();
@@ -20,8 +19,8 @@ const { networks } = useOffchainNetworksList(props.definition.networkId);
 
 const allOptions = computed(() => {
   const networksListKind = props.definition.networksListKind;
-  if (networksListKind === 'full' || networksListKind === 'offchain') {
-    const baseNetworks = networks.value
+  if (networksListKind === 'full') {
+    return networks.value
       .filter(network => {
         if (
           props.definition.networkId === 's' &&
@@ -34,7 +33,7 @@ const allOptions = computed(() => {
         return true;
       })
       .map(network => ({
-        id: network.chainId,
+        id: String(network.chainId),
         name: network.name,
         icon: h('img', {
           src: getUrl(network.logo),
@@ -42,31 +41,6 @@ const allOptions = computed(() => {
           class: 'rounded-full'
         })
       }));
-    if (networksListKind === 'offchain') return baseNetworks;
-
-    return [
-      ...baseNetworks,
-      ...Object.values(STARKNET_NETWORK_METADATA)
-        .filter(metadata => {
-          if (
-            props.definition.networkId === 's' &&
-            metadata.name.includes('Sepolia')
-          ) {
-            return false;
-          }
-
-          return true;
-        })
-        .map(metadata => ({
-          id: metadata.chainId,
-          name: metadata.name,
-          icon: h('img', {
-            src: getUrl(metadata.avatar),
-            alt: metadata.name,
-            class: 'rounded-full'
-          })
-        }))
-    ];
   }
 
   return enabledNetworks

--- a/apps/ui/src/composables/useOffchainNetworksList.ts
+++ b/apps/ui/src/composables/useOffchainNetworksList.ts
@@ -1,9 +1,9 @@
 import snapshotJsNetworks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { getNetwork } from '@/networks';
-import { ChainId, NetworkID } from '@/types';
+import { NetworkID } from '@/types';
 
-const usage = ref<Record<ChainId, number | undefined> | null>(null);
-const premiumChainIds = ref<Set<ChainId>>(new Set());
+const usage = ref<Record<string, number | undefined> | null>(null);
+const premiumChainIds = ref<Set<string>>(new Set());
 const loaded = ref(false);
 
 export function useOffchainNetworksList(
@@ -11,9 +11,7 @@ export function useOffchainNetworksList(
   hideUnused = false
 ) {
   const networks = computed(() => {
-    const rawNetworks = Object.values(snapshotJsNetworks).filter(
-      ({ chainId }) => typeof chainId === 'number'
-    );
+    const rawNetworks = Object.values(snapshotJsNetworks);
 
     const usageValue = usage.value;
     if (!usageValue) return rawNetworks;
@@ -36,17 +34,14 @@ export function useOffchainNetworksList(
     const network = getNetwork(networkId);
     const networks = await network.api.getNetworks();
 
-    usage.value = Object.keys(networks).reduce(
-      (acc, chainId) => {
-        acc[chainId] = networks[chainId].spaces_count;
-        return acc;
-      },
-      {} as Record<ChainId, number>
-    );
+    usage.value = Object.keys(networks).reduce((acc, chainId) => {
+      acc[chainId] = networks[chainId].spaces_count;
+      return acc;
+    }, {});
 
     Object.keys(networks).forEach(chainId => {
       if (networks[chainId].premium) {
-        premiumChainIds.value.add(Number(chainId));
+        premiumChainIds.value.add(chainId);
       }
     });
 

--- a/apps/ui/src/composables/useSafeWallet.ts
+++ b/apps/ui/src/composables/useSafeWallet.ts
@@ -18,10 +18,12 @@ const getSafeVersion = useMemoize(
   }
 );
 
-export function useSafeWallet(network: NetworkID, chainId = 1) {
+export function useSafeWallet(network: NetworkID, chainId = '1') {
   const { web3, auth } = useWeb3();
 
-  const signedChainId = computed(() => web3.value.network.key);
+  const signedChainId = computed<string>(() =>
+    String(web3.value.network.chainId)
+  );
 
   const isSafeContract = computedAsync(async () => {
     if (!web3.value.account) return false;
@@ -42,7 +44,7 @@ export function useSafeWallet(network: NetworkID, chainId = 1) {
     return (
       isSafeWallet.value &&
       offchainNetworks.includes(network) &&
-      Number(signedChainId.value) !== chainId
+      signedChainId.value !== chainId
     );
   });
 

--- a/apps/ui/src/composables/useSpaceAlerts.ts
+++ b/apps/ui/src/composables/useSpaceAlerts.ts
@@ -61,11 +61,11 @@ export function useSpaceAlerts(
     const ids = new Set<string>([
       space.value.snapshot_chain_id,
       ...space.value.strategies_params.map(strategy =>
-        strategy.network.toString()
+        String(strategy.network)
       ),
       ...space.value.strategies_params.flatMap(strategy =>
         Array.isArray(strategy.params?.strategies)
-          ? strategy.params.strategies.map(param => param.network.toString())
+          ? strategy.params.strategies.map(param => String(param.network))
           : []
       )
     ]);
@@ -75,9 +75,7 @@ export function useSpaceAlerts(
 
     return Array.from(ids)
       .filter(n => !premiumChainIds.value.has(n) || isNetworkUpcomingPro(n))
-      .map(chainId =>
-        networks.value.find(n => n.chainId.toString() === chainId)
-      )
+      .map(chainId => networks.value.find(n => String(n.chainId) === chainId))
       .filter(network => !!network);
   });
 

--- a/apps/ui/src/composables/useSpaceAlerts.ts
+++ b/apps/ui/src/composables/useSpaceAlerts.ts
@@ -5,8 +5,8 @@ import {
 import { offchainNetworks } from '@/networks';
 import { Space } from '@/types';
 
-const UPCOMING_PRO_ONLY_NETWORKS: readonly number[] = [
-  137 // Polygon
+const UPCOMING_PRO_ONLY_NETWORKS: readonly string[] = [
+  '137' // Polygon
 ];
 
 type AlertType =
@@ -58,24 +58,26 @@ export function useSpaceAlerts(
     )
       return [];
 
-    const ids = new Set<number>([
+    const ids = new Set<string>([
       space.value.snapshot_chain_id,
       ...space.value.strategies_params.map(strategy =>
-        Number(strategy.network)
+        strategy.network.toString()
       ),
       ...space.value.strategies_params.flatMap(strategy =>
         Array.isArray(strategy.params?.strategies)
-          ? strategy.params.strategies.map(param => Number(param.network))
+          ? strategy.params.strategies.map(param => param.network.toString())
           : []
       )
     ]);
 
-    const isNetworkUpcomingPro = (networkId: number) =>
+    const isNetworkUpcomingPro = (networkId: string) =>
       UPCOMING_PRO_ONLY_NETWORKS.includes(networkId) && !options.isEditor;
 
     return Array.from(ids)
       .filter(n => !premiumChainIds.value.has(n) || isNetworkUpcomingPro(n))
-      .map(chainId => networks.value.find(n => n.chainId === chainId))
+      .map(chainId =>
+        networks.value.find(n => n.chainId.toString() === chainId)
+      )
       .filter(network => !!network);
   });
 

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -184,7 +184,7 @@ export function useSpaceSettings(space: Ref<Space>) {
   const privacy = ref('none' as SpacePrivacy);
   const voteValidation = ref({ name: 'any', params: {} } as Validation);
   const ignoreAbstainVotes = ref(false);
-  const snapshotChainId: Ref<number> = ref(1);
+  const snapshotChainId: Ref<string> = ref('1');
   const strategies = ref([] as StrategyConfig[]);
   const members = ref([] as Member[]);
   const parent = ref('');
@@ -517,7 +517,7 @@ export function useSpaceSettings(space: Ref<Space>) {
 
     return space.additionalRawData.strategies.map(strategy => ({
       id: crypto.randomUUID(),
-      chainId: Number(strategy.network),
+      chainId: strategy.network,
       address: strategy.name,
       name: strategy.name,
       paramsDefinition: null,
@@ -580,7 +580,7 @@ export function useSpaceSettings(space: Ref<Space>) {
         form.value.categories ?? space.value.additionalRawData.categories,
       avatar: form.value.avatar ?? space.value.avatar,
       cover: form.value.cover ?? space.value.cover,
-      network: String(snapshotChainId.value),
+      network: snapshotChainId.value,
       symbol: form.value.votingPowerSymbol ?? space.value.voting_power_symbol,
       terms: termsOfServices.value,
       website: form.value.externalUrl ?? space.value.external_url,
@@ -795,7 +795,7 @@ export function useSpaceSettings(space: Ref<Space>) {
         }
       );
 
-      snapshotChainId.value = space.value.snapshot_chain_id ?? 1;
+      snapshotChainId.value = space.value.snapshot_chain_id ?? '1';
 
       if (space.value.additionalRawData?.type === 'offchain') {
         strategies.value = getInitialStrategies(space.value);
@@ -939,7 +939,7 @@ export function useSpaceSettings(space: Ref<Space>) {
           return true;
         }
 
-        if (snapshotChainIdValue !== (space.value.snapshot_chain_id ?? 1)) {
+        if (snapshotChainIdValue !== (space.value.snapshot_chain_id ?? '1')) {
           return true;
         }
 

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -597,7 +597,9 @@ export function useSpaceSettings(space: Ref<Space>) {
       template: template.value,
       strategies: strategies.value.map(strategy => ({
         name: strategy.name,
-        network: strategy.chainId?.toString() ?? snapshotChainId.value,
+        network: strategy.chainId
+          ? String(strategy.chainId)
+          : snapshotChainId.value,
         params: strategy.params
       })),
       treasuries: form.value.treasuries.map(treasury => ({

--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -1,7 +1,6 @@
 import { Web3Provider } from '@ethersproject/providers';
 import { formatUnits } from '@ethersproject/units';
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
-import { constants } from 'starknet';
 import {
   LAST_USED_CONNECTOR_CACHE_KEY,
   RECENT_CONNECTOR
@@ -19,21 +18,6 @@ type Web3providerWithSafe = Web3Provider & {
     };
   };
 };
-
-const STARKNET_NETWORKS = {
-  [constants.StarknetChainId.SN_MAIN]: {
-    key: constants.StarknetChainId.SN_MAIN,
-    chainId: constants.StarknetChainId.SN_MAIN,
-    explorer: { url: 'https://starkscan.co' }
-  },
-  [constants.StarknetChainId.SN_SEPOLIA]: {
-    key: constants.StarknetChainId.SN_SEPOLIA,
-    chainId: constants.StarknetChainId.SN_SEPOLIA,
-    explorer: { url: 'https://sepolia.starkscan.co' }
-  }
-};
-
-Object.assign(networks, STARKNET_NETWORKS);
 
 const defaultNetwork: any =
   import.meta.env.VITE_DEFAULT_NETWORK || Object.keys(networks)[0];

--- a/apps/ui/src/networks/offchain/actions.ts
+++ b/apps/ui/src/networks/offchain/actions.ts
@@ -60,7 +60,7 @@ const CONFIGS: Record<number, OffchainNetworkConfig> = {
   5: offchainGoerli
 };
 
-const STARKNET_CHAIN_IDS = Object.values(STARKNET_METADATA).map(
+const STARKNET_CHAIN_IDS: string[] = Object.values(STARKNET_METADATA).map(
   metadata => metadata.chainId
 );
 
@@ -79,11 +79,9 @@ export function createActions(
     web3: Web3Provider,
     snapshotChainId: string | undefined
   ) {
-    // TODO: Add check when space is using starknet
-    // or when signer chain id is different from snapshot chain id
     if (
       snapshotChainId &&
-      !STARKNET_CHAIN_IDS.includes(snapshotChainId as any) &&
+      !STARKNET_CHAIN_IDS.includes(snapshotChainId) &&
       (web3.provider as any)._isSequenceProvider
     ) {
       await verifyNetwork(web3, Number(snapshotChainId));
@@ -160,9 +158,18 @@ export function createActions(
       max_end: number,
       executions: ExecutionInfo[]
     ) {
+      // TODO: remove this check after implementing starknet support on getProvider
+      if (
+        space.snapshot_chain_id &&
+        STARKNET_CHAIN_IDS.includes(space.snapshot_chain_id)
+      ) {
+        throw new Error(
+          'Proposal creation not supported for spaces on Starknet network'
+        );
+      }
+
       await verifyOffchainNetwork(web3, space.snapshot_chain_id);
 
-      // TODO: Missing support for starknet, will fail for spaces using starknet
       const provider = getProvider(Number(space.snapshot_chain_id));
       const plugins = await getPlugins(executions);
       const data = {

--- a/apps/ui/src/networks/offchain/actions.ts
+++ b/apps/ui/src/networks/offchain/actions.ts
@@ -75,15 +75,15 @@ export function createActions(
     networkConfig
   });
 
-  async function verifyOffchainNetwork(
+  async function verifyChainNetwork(
     web3: Web3Provider,
     snapshotChainId: string | undefined
   ) {
-    if (
-      snapshotChainId &&
-      !STARKNET_CHAIN_IDS.includes(snapshotChainId) &&
-      (web3.provider as any)._isSequenceProvider
-    ) {
+    if (!snapshotChainId || STARKNET_CHAIN_IDS.includes(snapshotChainId)) {
+      return;
+    }
+
+    if ((web3.provider as any)._isSequenceProvider) {
       await verifyNetwork(web3, Number(snapshotChainId));
     }
   }
@@ -168,7 +168,7 @@ export function createActions(
         );
       }
 
-      await verifyOffchainNetwork(web3, space.snapshot_chain_id);
+      await verifyChainNetwork(web3, space.snapshot_chain_id);
 
       const provider = getProvider(Number(space.snapshot_chain_id));
       const plugins = await getPlugins(executions);
@@ -206,7 +206,7 @@ export function createActions(
       labels: string[],
       executions: ExecutionInfo[]
     ) {
-      await verifyOffchainNetwork(web3, space.snapshot_chain_id);
+      await verifyChainNetwork(web3, space.snapshot_chain_id);
 
       const plugins = await getPlugins(executions);
 
@@ -226,7 +226,7 @@ export function createActions(
       return client.updateProposal({ signer: web3.getSigner(), data });
     },
     async flagProposal(web3: Web3Provider, proposal: Proposal) {
-      await verifyOffchainNetwork(web3, proposal.space.snapshot_chain_id);
+      await verifyChainNetwork(web3, proposal.space.snapshot_chain_id);
 
       return client.flagProposal({
         signer: web3.getSigner(),
@@ -241,7 +241,7 @@ export function createActions(
       connectorType: ConnectorType,
       proposal: Proposal
     ) {
-      await verifyOffchainNetwork(web3, proposal.space.snapshot_chain_id);
+      await verifyChainNetwork(web3, proposal.space.snapshot_chain_id);
 
       return client.cancel({
         signer: web3.getSigner(),
@@ -260,7 +260,7 @@ export function createActions(
       reason: string,
       app: string
     ): Promise<any> {
-      await verifyOffchainNetwork(web3, proposal.space.snapshot_chain_id);
+      await verifyChainNetwork(web3, proposal.space.snapshot_chain_id);
 
       const data = {
         space: proposal.space.id,

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -911,7 +911,7 @@ export function createApi(
 
       return Object.fromEntries(
         data.networks.map((network: any) => [
-          Number(network.id),
+          network.id,
           {
             spaces_count: network.spacesCount,
             premium: network.premium

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -177,7 +177,7 @@ function formatSpace(
       active_proposals: space.activeProposals,
       turbo: space.turbo,
       verified: space.verified,
-      snapshot_chain_id: parseInt(space.network)
+      snapshot_chain_id: space.network
     };
   }
 
@@ -224,7 +224,7 @@ function formatSpace(
     turbo: space.turbo,
     turbo_expiration: space.turboExpiration,
     controller: '',
-    snapshot_chain_id: parseInt(space.network),
+    snapshot_chain_id: space.network,
     name: space.name || '',
     avatar: space.avatar || '',
     cover: space.cover || '',
@@ -377,7 +377,7 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     space: {
       id: proposal.space.id,
       name: proposal.space.name,
-      snapshot_chain_id: parseInt(proposal.space.network),
+      snapshot_chain_id: proposal.space.network,
       avatar: proposal.space.avatar,
       controller: '',
       admins,

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -1,6 +1,5 @@
 import {
   DelegationType,
-  NetworkID,
   SkinSettings,
   SpaceMetadataLabel,
   VoteType
@@ -9,7 +8,7 @@ import {
 export type ApiRelatedSpace = {
   id: string;
   name: string;
-  network: NetworkID;
+  network: string;
   avatar: string;
   cover: string | null;
   proposalsCount: number;

--- a/apps/ui/src/networks/offchain/index.ts
+++ b/apps/ui/src/networks/offchain/index.ts
@@ -3,7 +3,7 @@ import { pinPineapple } from '@/helpers/pin';
 import { getProvider } from '@/helpers/provider';
 import { getSpaceController } from '@/helpers/utils';
 import { Network } from '@/networks/types';
-import { NetworkID, Space } from '@/types';
+import { ChainId, NetworkID, Space } from '@/types';
 import { createActions } from './actions';
 import { createApi } from './api';
 import * as constants from './constants';
@@ -64,7 +64,7 @@ export function createOffchainNetwork(networkId: NetworkID): Network {
     getExplorerUrl: (
       id: string,
       type: 'transaction' | 'address' | 'contract' | 'strategy' | 'token',
-      chainId?: number
+      chainId?: ChainId
     ) => {
       chainId = chainId || l1ChainId;
       const network = networks[chainId.toString()];
@@ -75,12 +75,16 @@ export function createOffchainNetwork(networkId: NetworkID): Network {
             return network ? `${network.explorer.url}/tx/${id}` : '';
           }
 
+          if (network.starknet) return '';
+
           return `https://signator.io/ipfs/${id}`;
         case 'strategy':
           return `${SNAPSHOT_URLS[networkId]}/#/strategy/${id}`;
         case 'contract':
         case 'address':
-          return network ? `${network.explorer.url}/address/${id}` : '';
+          return network
+            ? `${network.explorer.url}/${network.starknet ? 'contract' : 'address'}/${id}`
+            : '';
         default:
           throw new Error('Not implemented');
       }

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -129,7 +129,7 @@ export type ExecutionInfo = {
 
 export type SnapshotInfo = {
   at: number | null;
-  chainId?: number;
+  chainId?: ChainId;
 };
 
 export type VotingPower = {
@@ -145,7 +145,7 @@ export type VotingPower = {
   displayDecimals: number;
   token: string | null;
   symbol: string;
-  chainId?: number;
+  chainId?: ChainId;
   swapLink?: string;
 };
 
@@ -441,7 +441,7 @@ export type NetworkHelpers = {
   getExplorerUrl(
     id: string,
     type: 'transaction' | 'address' | 'contract' | 'strategy' | 'token',
-    chainId?: number
+    chainId?: ChainId
   ): string;
 };
 

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -145,7 +145,7 @@ export type RelatedSpace = {
   active_proposals: number | null;
   turbo: boolean;
   verified: boolean;
-  snapshot_chain_id: number;
+  snapshot_chain_id: string;
 };
 
 export type Validation = {
@@ -183,7 +183,7 @@ export type Space = {
   verified: boolean;
   turbo: boolean;
   turbo_expiration: number;
-  snapshot_chain_id?: number;
+  snapshot_chain_id?: string;
   name: string;
   avatar: string;
   cover: string;
@@ -265,7 +265,7 @@ export type Proposal = {
   space: {
     id: string;
     name: string;
-    snapshot_chain_id?: number;
+    snapshot_chain_id?: string;
     avatar: string;
     terms: string;
     controller: string;

--- a/apps/ui/src/views/CreateSpaceSnapshot.vue
+++ b/apps/ui/src/views/CreateSpaceSnapshot.vue
@@ -237,7 +237,7 @@ watch(
                   'Networks can also be specified in individual strategies, delegations, treasuries, etc...',
                 examples: ['Select network'],
                 networkId: networkId,
-                networksListKind: 'offchain'
+                networksListKind: 'full'
               }"
             />
           </div>

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -220,7 +220,9 @@ const pendingSpace = computed(() => {
     strategies_params: strategies.value.map(strategy => ({
       name: strategy.name,
       params: strategy.params,
-      network: strategy.chainId?.toString() ?? snapshotChainId.value
+      network: strategy.chainId
+        ? String(strategy.chainId)
+        : snapshotChainId.value
     })),
     snapshot_chain_id: snapshotChainId.value
   };

--- a/packages/sx.js/src/clients/offchain/types.ts
+++ b/packages/sx.js/src/clients/offchain/types.ts
@@ -24,7 +24,7 @@ export type StrategyConfig = {
 
 export type SnapshotInfo = {
   at: number | null;
-  chainId?: number;
+  chainId?: string;
 };
 
 export type Strategy = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3082,6 +3082,13 @@
   dependencies:
     "@noble/hashes" "1.3.2"
 
+"@noble/curves@1.7.0", "@noble/curves@~1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.7.0.tgz#0512360622439256df892f21d25b388f52505e45"
+  integrity sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==
+  dependencies:
+    "@noble/hashes" "1.6.0"
+
 "@noble/curves@1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.8.0.tgz#fe035a23959e6aeadf695851b51a87465b5ba8f7"
@@ -3142,6 +3149,11 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
   integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
 
+"@noble/hashes@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.6.0.tgz#d4bfb516ad6e7b5111c216a5cc7075f4cf19e6c5"
+  integrity sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==
+
 "@noble/hashes@1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.0.tgz#5d9e33af2c7d04fee35de1519b80c958b2e35e39"
@@ -3151,6 +3163,11 @@
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.1.tgz#5738f6d765710921e7a751e00c20ae091ed8db0f"
   integrity sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==
+
+"@noble/hashes@~1.6.0":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.6.1.tgz#df6e5943edcea504bac61395926d6fd67869a0d5"
+  integrity sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==
 
 "@noble/secp256k1@1.7.1", "@noble/secp256k1@~1.7.0":
   version "1.7.1"
@@ -3796,6 +3813,11 @@
   resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.22.8.tgz#9e0c8f195b90f2d5afb839c491960e7c310de8be"
   integrity sha512-4J98MEar6qahXQ0aHD+zc3u4ZBnPdble7wIo7aaqxk9U8n96NvMiiDccPr68GwqFqZHkMP9FVrhIiJ5mN+UgoQ==
 
+"@scure/base@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.1.tgz#dd0b2a533063ca612c17aa9ad26424a2ff5aa865"
+  integrity sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==
+
 "@scure/base@~1.1.0", "@scure/base@~1.1.3", "@scure/base@~1.1.4":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.5.tgz#1d85d17269fe97694b9c592552dd9e5e33552157"
@@ -3878,6 +3900,14 @@
   dependencies:
     "@noble/hashes" "~1.3.2"
     "@scure/base" "~1.1.4"
+
+"@scure/starknet@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@scure/starknet/-/starknet-1.1.0.tgz#d1902e053d98196e161b9b2c3996b20999094e7a"
+  integrity sha512-83g3M6Ix2qRsPN4wqLDqiRZ2GBNbjVWfboJE/9UjfG+MHr6oDSu/CWgy8hsBSJejr09DkkL+l0Ze4KVrlCIdtQ==
+  dependencies:
+    "@noble/curves" "~1.7.0"
+    "@noble/hashes" "~1.6.0"
 
 "@scure/starknet@~0.3.0":
   version "0.3.0"
@@ -3997,10 +4027,10 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.19.tgz#0c463b172ed22668fc9cd69ac8b433110f7e3dee"
   integrity sha512-vpfk3WU4idf7o0go4J+JnzZTRXB+KJEw39yElZhXxq4rzBQBzeZm/9xvlew4ZdN2A2bAHY4Ov6NL0/C8I+R1TA==
 
-"@snapshot-labs/snapshot.js@^0.12.60":
-  version "0.12.60"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.12.60.tgz#a95df10d16ccb6dd3aba666863cca797f2393216"
-  integrity sha512-RdaOeuof/xJGL2qqMmbC44BEJgKnGUZoAKF3mzfde4ec3uYbVAloNv3kuV3Ev4jZPpCqL8+h3HMDN+XZTIy04g==
+"@snapshot-labs/snapshot.js@^0.14.2":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.14.2.tgz#fc5053a2c82cd048459ab3129e09cd68e098a679"
+  integrity sha512-4RDvqluOti++GAacR5C2ExZOgaAWVIgolJmbGLcDzo7Bsx8EYTi1PE/au7pQYbknxVcbNfbLPoPs114JkFuoRg==
   dependencies:
     "@ensdomains/eth-ens-namehash" "^2.0.15"
     "@ethersproject/abi" "^5.6.4"
@@ -4018,7 +4048,7 @@
     cross-fetch "^3.1.6"
     json-to-graphql-query "^2.2.4"
     lodash.set "^4.3.2"
-    starknet "^5.19.3"
+    starknet "^6.11.0"
 
 "@stablelib/aead@^1.0.1":
   version "1.0.1"
@@ -4154,7 +4184,7 @@
     "@stablelib/random" "^1.0.2"
     "@stablelib/wipe" "^1.0.1"
 
-"@starknet-io/types-js@^0.7.7":
+"@starknet-io/types-js@^0.7.7", "starknet-types-07@npm:@starknet-io/types-js@^0.7.7":
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/@starknet-io/types-js/-/types-js-0.7.7.tgz#444be5e4e585ec6f599d42d3407280d98b2dfdf8"
   integrity sha512-WLrpK7LIaIb8Ymxu6KF/6JkGW1sso988DweWu7p5QY/3y7waBIiPvzh27D9bX5KIJNRDyOoOVoHVEKYUYWZ/RQ==
@@ -5599,6 +5629,16 @@ abi-wan-kanabi@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-2.2.2.tgz#82c48e8fa08d9016cf92d3d81d494cc60e934693"
   integrity sha512-sTCv2HyNIj1x2WFUoc9oL8ZT9liosrL+GoqEGZJK1kDND096CfA7lwx06vLxLWMocQ41FQXO3oliwoh/UZHYdQ==
+  dependencies:
+    ansicolors "^0.3.2"
+    cardinal "^2.1.1"
+    fs-extra "^10.0.0"
+    yargs "^17.7.2"
+
+abi-wan-kanabi@^2.2.3:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-2.2.4.tgz#47ebbafbb7f8df81773efbdcca60cdda8008c821"
+  integrity sha512-0aA81FScmJCPX+8UvkXLki3X1+yPQuWxEkqXBVKltgPAK79J+NB+Lp5DouMXa7L6f+zcRlIA/6XO7BN/q9fnvg==
   dependencies:
     ansicolors "^0.3.2"
     cardinal "^2.1.1"
@@ -8400,7 +8440,7 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
     node-domexception "^1.0.0"
     web-streams-polyfill "^3.0.3"
 
-fetch-cookie@^3.0.0:
+fetch-cookie@^3.0.0, fetch-cookie@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/fetch-cookie/-/fetch-cookie-3.0.1.tgz#6a77f7495e1a639ae019db916a234db8c85d5963"
   integrity sha512-ZGXe8Y5Z/1FWqQ9q/CrJhkUD73DyBU9VF0hBQmEO/wPHe4A9PKTjplFDLeFX8aOsYypZUcX5Ji/eByn3VCVO3Q==
@@ -10098,7 +10138,7 @@ iso-url@^1.1.5:
   resolved "https://registry.yarnpkg.com/iso-url/-/iso-url-1.2.1.tgz#db96a49d8d9a64a1c889fc07cc525d093afb1811"
   integrity sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==
 
-isomorphic-fetch@^3.0.0:
+isomorphic-fetch@^3.0.0, isomorphic-fetch@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
   integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
@@ -13526,10 +13566,10 @@ standard-as-callback@^2.1.0:
   resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
   integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
-"starknet-types-07@npm:@starknet-io/types-js@^0.7.7":
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/@starknet-io/types-js/-/types-js-0.7.7.tgz#444be5e4e585ec6f599d42d3407280d98b2dfdf8"
-  integrity sha512-WLrpK7LIaIb8Ymxu6KF/6JkGW1sso988DweWu7p5QY/3y7waBIiPvzh27D9bX5KIJNRDyOoOVoHVEKYUYWZ/RQ==
+"starknet-types-07@npm:@starknet-io/types-js@^0.7.10":
+  version "0.7.10"
+  resolved "https://registry.yarnpkg.com/@starknet-io/types-js/-/types-js-0.7.10.tgz#d21dc973d0cd04d7b6293ce461f2f06a5873c760"
+  integrity sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==
 
 starknet@6.11.0:
   version "6.11.0"
@@ -13550,7 +13590,24 @@ starknet@6.11.0:
     ts-mixer "^6.0.3"
     url-join "^4.0.1"
 
-starknet@^5.19.3, starknet@~5.19.3:
+starknet@^6.11.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/starknet/-/starknet-6.24.1.tgz#87333339795038e93ef32a20726b5272ddb78fe1"
+  integrity sha512-g7tiCt73berhcNi41otlN3T3kxZnIvZhMi8WdC21Y6GC6zoQgbI2z1t7JAZF9c4xZiomlanwVnurcpyfEdyMpg==
+  dependencies:
+    "@noble/curves" "1.7.0"
+    "@noble/hashes" "1.6.0"
+    "@scure/base" "1.2.1"
+    "@scure/starknet" "1.1.0"
+    abi-wan-kanabi "^2.2.3"
+    fetch-cookie "~3.0.0"
+    isomorphic-fetch "~3.0.0"
+    lossless-json "^4.0.1"
+    pako "^2.0.4"
+    starknet-types-07 "npm:@starknet-io/types-js@^0.7.10"
+    ts-mixer "^6.0.3"
+
+starknet@~5.19.3:
   version "5.19.6"
   resolved "https://registry.yarnpkg.com/starknet/-/starknet-5.19.6.tgz#61e43e083888ef64598473bc2e4bd3e1e07fe9d4"
   integrity sha512-MyO48QKu+d8CBH/7ruI/RPrDwoFRNV/uxql2nBeA4ccqBXs698FkeGkMhZv++VIwf1MRajHcTM91KuyZQMyMLw==
@@ -13637,16 +13694,7 @@ string-env-interpolation@^1.0.1:
   resolved "https://registry.yarnpkg.com/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz#ad4397ae4ac53fe6c91d1402ad6f6a52862c7152"
   integrity sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13730,14 +13778,7 @@ string_decoder@^1.1.1, string_decoder@^1.3.0:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15201,7 +15242,7 @@ why-is-node-running@^2.2.2:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15214,15 +15255,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### Summary

Toward https://github.com/snapshot-labs/workflow/issues/562

This PR enables offchain spaces to select Starknet networks in the UI while maintaining backward compatibility with existing EVM-based spaces. This is a foundational change that prepares the system for Starknet integration on offchain spaces.

### 🎯 What This PR Does

- **Enables Starknet Network Selection**: Users can now select Starknet networks (mainnet/testnet) when configuring offchain spaces and strategies
- **Type System Migration**: Updates `snapshot_chain_id` from `number` to `string` to support Starknet's string-based chain IDs
- **Unified Network Lists**: Consolidates network selection to use `networks.json` as the single source of truth
- **Safe Operation Blocking**: Prevents unsupported operations (like proposal creation) on Starknet networks with clear error messages

### 🚧 Limitations (By Design)

This PR focuses **only** on enabling network selection. Actual Starknet functionality (voting, proposals, etc.) will be implemented in https://github.com/snapshot-labs/sx-monorepo/pull/1395.

**Current behavior for Starknet networks:**
- ✅ Can be selected in space/strategy configuration  
- ✅ Space settings can be saved
- ❌ Proposal creation throws clear error message

### 📋 Key Changes

#### Type System Updates
- `snapshot_chain_id: number` → `snapshot_chain_id: string` across all interfaces
- Updated `SnapshotInfo.chainId` to support string values
- Improved string casting patterns for type safety

#### Network Configuration  
- Removed `'offchain'` networks list kind from `SelectorNetwork`
- All network selectors now use `'full'` list (includes Starknet)
- Consolidated to `networks.json` as single source of truth

#### Error Handling & Safety
- Added explicit error messages for unsupported Starknet operations
- Protected `getProvider()` calls with validation
- Consistent string/number conversion with proper type guards

#### UI/UX Improvements
- Starknet networks appear in all relevant dropdowns
- Consistent network display across components
- Better error messaging for unsupported operations

### 🧪 Testing Instructions

#### Basic Functionality Test
1. Navigate to any offchain space settings
2. In space network or strategy network selectors, verify Starknet options are available:
   - "Starknet" (mainnet)
   - "Starknet Sepolia" (testnet) 
3. Select a Starknet network and save - should succeed
4. Try to create a proposal - should show clear error message

### 🔄 Migration & Compatibility  

- **Backward Compatible**: Existing EVM spaces continue working unchanged
- **Type Migration**: Numeric chain IDs automatically converted to strings  
- **No Data Migration**: Existing space configurations remain valid
- **API Compatible**: All external APIs maintain the same interface

### 🔗 Related

- **Follows up**: This PR will be followed by #1395 for full Starknet functionality
- **Depends on**: Updated `@snapshot-labs/snapshot.js` v0.14.2 with Starknet support
- **Toward**: https://github.com/snapshot-labs/workflow/issues/562

### 📝 Breaking Changes

**None for end users**, but developers should note:
- `snapshot_chain_id` type changed from `number` to `string`
- Network selector `'offchain'` kind removed (use `'full'` instead)
- Some internal type assertions may need updates