### PR TITLE
fix: fix missing network params when testing offchain strategies

### DIFF
--- a/apps/ui/src/components/Modal/TestStrategy.vue
+++ b/apps/ui/src/components/Modal/TestStrategy.vue
@@ -76,7 +76,7 @@ async function handleSubmit() {
       strategiesParams = props.strategies.map(strategy => {
         return {
           name: strategy.name,
-          network: strategy.chainId ?? props.chainId,
+          network: String(strategy.chainId ?? props.chainId),
           params: strategy.params
         };
       });

--- a/apps/ui/src/components/Modal/TestStrategy.vue
+++ b/apps/ui/src/components/Modal/TestStrategy.vue
@@ -69,10 +69,18 @@ async function handleSubmit() {
   votingPower.value = null;
 
   try {
-    let strategiesParams: any[] = props.strategies;
+    let strategiesParams: any[] = [];
     let strategiesMetadata: any[] = [];
 
-    if (!offchainNetworks.includes(props.networkId)) {
+    if (offchainNetworks.includes(props.networkId)) {
+      strategiesParams = props.strategies.map(strategy => {
+        return {
+          name: strategy.name,
+          network: strategy.chainId ?? props.chainId,
+          params: strategy.params
+        };
+      });
+    } else {
       strategiesParams = await Promise.all(
         props.strategies.map(async strategy => {
           if (evmNetworks.includes(props.networkId)) {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an issue where testing strategies from offchain spaces was ignoring the strategy network.

Also cleanup the payload to send only relevant data to score-api

### How to test

1. Go to an offchain space, using multiple strategy on different network (e.g. http://localhost:8080/#/s:cow.eth/settings/voting-strategies)
2. When testing a strategy on custon network, it should send the request to score-api with the correct network

Before

```json
{
  "jsonrpc": "2.0",
  "method": "get_vp",
  "params": {
    "address": "0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3",
    "space": "cow.eth",
    "strategies": [
      {
        "id": "ecc42e06-5067-446f-8509-9ce8f0127105",
        "chainId": 100,
        "address": "erc20-balance-of",
        "name": "erc20-balance-of",
        "paramsDefinition": null,
        "params": {
          "symbol": "vCOW (GC)",
          "address": "0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB",
          "decimals": 18
        }
      }
    ],
    "network": "1",
    "snapshot": "latest",
    "delegation": false
  }
}
```

After

```json
{
  "jsonrpc": "2.0",
  "method": "get_vp",
  "params": {
    "address": "0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3",
    "space": "cow.eth",
    "strategies": [
      {
        "name": "erc20-balance-of",
        "network": 100,
        "params": {
          "symbol": "vCOW (GC)",
          "address": "0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB",
          "decimals": 18
        }
      }
    ],
    "network": "1",
    "snapshot": "latest",
    "delegation": false
  }
}
```