### PR TITLE
fix: fix invalid topic ID when under a category

### DIFF
--- a/apps/highlight/src/api/writers.ts
+++ b/apps/highlight/src/api/writers.ts
@@ -178,7 +178,7 @@ export function createWriters(indexerName: string) {
     const metadata = await getJSON(metadataUri);
 
     const spaceEntityId = spaceId.toString();
-    const categoryEntityId = `${spaceId}/${metadata.category}`;
+    const categoryEntityId = `${spaceId}/${category}`;
     const topic = new Topic(`${spaceId}/${id}`, indexerName);
     topic.category_id = category;
     topic.category = category !== 0 ? categoryEntityId : null;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fix an issue where creating a new topic under a category is failing

### How to test

1. Create a new topic, inside a category
2. It should create the topic
