### PR TITLE
fix: call deployAccount in herodotus/execute calls

### DIFF
--- a/apps/mana/src/stark/herodotus.ts
+++ b/apps/mana/src/stark/herodotus.ts
@@ -167,7 +167,7 @@ export async function processProposal(proposal: DbProposal) {
   }
 
   const { getAccount, herodotusController } = getClient(proposal.chainId);
-  const { account, nonceManager } = getAccount('0x0');
+  const { account, nonceManager, deployAccount } = getAccount('0x0');
   const mapping = HERODOTUS_MAPPING.get(proposal.chainId);
   if (!mapping) throw new Error('Invalid chainId');
   const { DESTINATION_CHAIN_ID, ACCUMULATES_CHAIN_ID } = mapping;
@@ -199,6 +199,8 @@ export async function processProposal(proposal: DbProposal) {
   );
 
   const tree = await res.json();
+
+  await deployAccount();
 
   try {
     await nonceManager.acquire();

--- a/apps/mana/src/stark/rpc.ts
+++ b/apps/mana/src/stark/rpc.ts
@@ -61,7 +61,9 @@ export const createNetworkHandler = (chainId: string) => {
   async function execute(id: number, params: any, res: Response) {
     try {
       const { space, proposalId, executionParams } = params;
-      const { account, nonceManager } = getAccount(space);
+      const { account, nonceManager, deployAccount } = getAccount(space);
+
+      await deployAccount();
 
       let receipt;
       try {


### PR DESCRIPTION
### Summary

`deployAccount` needs to be called so address is deployed before usage.