### PR TITLE
chore: remove redundant retry configuration from useVoteValidationPowerQuery

### DIFF
--- a/apps/ui/src/queries/voteValidationPower.ts
+++ b/apps/ui/src/queries/voteValidationPower.ts
@@ -82,9 +82,6 @@ export function useVoteValidationPowerQuery(
     ],
     queryFn: async () =>
       getVoteValidationPower(toValue(account), toValue(proposal)),
-    retry: failureCount => {
-      return failureCount < 3;
-    },
     enabled: () => !!toValue(account) && toValue(active),
     staleTime: 60 * 1000
   });


### PR DESCRIPTION
## Description

This PR addresses the feedback from https://github.com/snapshot-labs/sx-monorepo/pull/1452#discussion_r2207302020

The retry configuration with `failureCount < 3` was redundant because this is the default behavior of `@tanstack/vue-query`. This PR removes the unnecessary retry configuration to clean up the code.

## Changes

- Removed explicit retry configuration from `useVoteValidationPowerQuery` in `apps/ui/src/queries/voteValidationPower.ts`

## Related

- Refs: #1452