### PR TITLE
fix: address formatting in explorer URL

### DIFF
--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -3,6 +3,7 @@ import { UNIFIED_API_TESTNET_URL, UNIFIED_API_URL } from '@/helpers/constants';
 import { getRelayerInfo } from '@/helpers/mana';
 import { pinGraph, pinPineapple } from '@/helpers/pin';
 import { getProvider } from '@/helpers/provider';
+import { formatAddress } from '@/helpers/utils';
 import { Network } from '@/networks/types';
 import { NetworkID, Space } from '@/types';
 import { createActions } from './actions';
@@ -161,6 +162,8 @@ export function createEvmNetwork(networkId: NetworkID): Network {
       if (type === 'token') dataType = 'token';
       else if (['address', 'contract', 'strategy'].includes(type))
         dataType = 'address';
+
+      if (dataType === 'address') id = formatAddress(id);
 
       return `${networks[chainId].explorer.url}/${dataType}/${id}`;
     }

--- a/apps/ui/src/networks/offchain/index.ts
+++ b/apps/ui/src/networks/offchain/index.ts
@@ -1,7 +1,7 @@
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { pinPineapple } from '@/helpers/pin';
 import { getProvider } from '@/helpers/provider';
-import { getSpaceController } from '@/helpers/utils';
+import { formatAddress, getSpaceController } from '@/helpers/utils';
 import { Network } from '@/networks/types';
 import { ChainId, NetworkID, Space } from '@/types';
 import { createActions } from './actions';
@@ -85,7 +85,7 @@ export function createOffchainNetwork(networkId: NetworkID): Network {
         case 'contract':
         case 'address':
           return network
-            ? `${network.explorer.url}/${network.starknet ? 'contract' : 'address'}/${id}`
+            ? `${network.explorer.url}/${network.starknet ? 'contract' : 'address'}/${formatAddress(id)}`
             : '';
         default:
           throw new Error('Not implemented');

--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -6,6 +6,7 @@ import {
 import { UNIFIED_API_TESTNET_URL, UNIFIED_API_URL } from '@/helpers/constants';
 import { getRelayerInfo } from '@/helpers/mana';
 import { pinPineapple } from '@/helpers/pin';
+import { formatAddress } from '@/helpers/utils';
 import { Network } from '@/networks/types';
 import { NetworkID, Space } from '@/types';
 import { createActions } from './actions';
@@ -159,6 +160,8 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
       if (type === 'token') dataType = 'token';
       else if (['address', 'contract', 'strategy'].includes(type))
         dataType = 'contract';
+
+      if (dataType === 'contract') id = formatAddress(id);
 
       return `${explorerUrl}/${dataType}/${id}`;
     }


### PR DESCRIPTION
### Problem
For relayer addresses, we display address with padding `0` but the link redirect without `0`
<img width="1280" height="307" alt="image" src="https://github.com/user-attachments/assets/ec776a65-77ed-40b3-be58-0a8cbda5c242" />
This address without `0` is not accepted inside argent wallet

### Summary
This will add address formatting in all explorer URLs for addresses (EVM, starknet, offchain)

### How to test
- Go to http://localhost:8080/#/sn:0x07c251045154318a2376a3bb65be47d3c90df1740d8e35c9b9d943aa3f240e50/settings/authenticators
- Click on relayer address
- It should redirect to address with `0` padding 
