### PR TITLE
Fix avatar endpoint in edit profile modal

### DIFF
--- a/apps/ui/src/components/Ui/InputStamp.vue
+++ b/apps/ui/src/components/Ui/InputStamp.vue
@@ -16,12 +16,14 @@ withDefaults(
     disabled?: boolean;
     fallback?: boolean;
     cropped?: boolean;
+    type?: 'avatar' | 'space';
   }>(),
   {
     width: 80,
     height: 80,
     fallback: true,
-    cropped: true
+    cropped: true,
+    type: 'avatar'
   }
 );
 
@@ -96,7 +98,7 @@ async function handleFileChange(e: Event) {
       :height="height"
       :cropped="cropped"
       class="pointer-events-none !rounded-none group-hover:opacity-80"
-      type="space"
+      :type="type"
       :class="{
         'opacity-80': isUploadingImage
       }"


### PR DESCRIPTION
Fixes #609

Edit profile modal was using space endpoint instead of avatar endpoint.

## Test Steps
1. Go to: http://localhost:8080/#/profile/0x1F3D3A7A9c548bE39539b39D7400302753E20591?as=0x1F3D3A7A9c548bE39539b39D7400302753E20591
2. Click settings icon to open edit profile modal
3. Check network tab - should see `cdn.stamp.fyi/avatar/...` instead of `cdn.stamp.fyi/space/...`