### PR TITLE
fix: properly sort authenticators

### DIFF
--- a/apps/ui/src/networks/common/helpers.ts
+++ b/apps/ui/src/networks/common/helpers.ts
@@ -111,7 +111,7 @@ export function createStrategyPicker({ helpers }: { helpers: NetworkHelpers }) {
         const aRelayerPriority = a.supportInfo.priority ?? 0;
         const bRelayerPriority = b.supportInfo.priority ?? 0;
 
-        return bRelayerPriority - aRelayerPriority;
+        return aRelayerPriority - bRelayerPriority;
       })
       .map(({ authenticator, supportInfo }) => ({
         authenticator,

--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -36,12 +36,14 @@ export function createConstants(
         connectors: EVM_CONNECTORS
       },
       [config.Authenticators.EthSig]: {
+        priority: 1,
         isSupported: true,
         isContractSupported: false,
         relayerType: 'evm',
         connectors: EVM_CONNECTORS
       },
       [config.Authenticators.EthTx]: {
+        priority: 2,
         isSupported: true,
         isContractSupported: true,
         connectors: EVM_CONNECTORS

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -35,6 +35,7 @@ export function createConstants(
         connectors: EVM_CONNECTORS
       },
       [config.Authenticators.EthTx]: {
+        priority: 2,
         isSupported: true,
         isContractSupported: true,
         relayerType: 'evm-tx',
@@ -47,6 +48,7 @@ export function createConstants(
         connectors: STARKNET_CONNECTORS
       },
       [config.Authenticators.StarkTx]: {
+        priority: 1,
         isSupported: true,
         isContractSupported: false,
         connectors: STARKNET_CONNECTORS


### PR DESCRIPTION
### Summary

Now authenticators will be sorted by priority (those were not set plus order was messed up in .sort)

Signature relayers (EthSig, StarkSig) get default priority 0. Deprecated EthSig on EVM gets lower priority than new one.

EthTx on EVM and StarkTx on Starknet get lower priority (2 or 1).

EthTx on Starknet gets lowest priority because UX is bad.

### How to test

1. Vote there: http://localhost:8080/#/sn:0x07c251045154318a2376a3bb65be47d3c90df1740d8e35c9b9d943aa3f240e50
2. You get signature prompt, not transaction prompt.