### PR TITLE
fix(ui): remove extra spacing in space setting bottom toolbar

### DIFF
--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -315,7 +315,7 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
   <div
     v-bind="$attrs"
     class="!h-auto"
-    :style="`min-height: calc(100vh - ${bottomToolbarHeight + 114}px)`"
+    :style="`min-height: calc(100vh - ${bottomToolbarHeight + 73}px)`"
   >
     <div v-if="loading" class="p-4">
       <UiLoading />


### PR DESCRIPTION
Settings has not been updated to take into account the removed horizontal scroller menu

### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1449

Remove extra spacing in space settings toolbar

### How to test

1. Go to your space settings
2. Dirty the settings to make the bottom toolbar appears
3. When the page content shorter than the browser height, the bottom toobar should stick to the bottom of the page, without extra gap