### PR TITLE
fix: use correct ratio when showing image with UiStampInput*

### DIFF
--- a/apps/ui/src/components/ProposalExecutionsList.vue
+++ b/apps/ui/src/components/ProposalExecutionsList.vue
@@ -31,6 +31,7 @@ function downloadExecution(execution: ProposalExecution) {
   a.href = url;
   a.download = `execution-${execution.safeAddress}.json`;
   a.click();
+  URL.revokeObjectURL(url);
 }
 </script>
 

--- a/apps/ui/src/components/SpaceCover.vue
+++ b/apps/ui/src/components/SpaceCover.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { SPACE_COVER_DIMENSIONS } from '@/helpers/constants';
 import { getCacheHash, getStampUrl } from '@/helpers/utils';
 import { NetworkID } from '@/types';
 
@@ -10,9 +11,6 @@ const props = withDefaults(
   { size: 'lg' }
 );
 
-const width = props.size === 'sm' ? 450 : 1500;
-const height = props.size === 'sm' ? 120 : 400;
-
 const cb = computed(() => getCacheHash(props.space.cover));
 </script>
 
@@ -20,8 +18,8 @@ const cb = computed(() => getCacheHash(props.space.cover));
   <UiStamp
     v-if="space.cover"
     :id="`${space.network}:${space.id}`"
-    :width="width"
-    :height="height"
+    :width="SPACE_COVER_DIMENSIONS[size].width"
+    :height="SPACE_COVER_DIMENSIONS[size].height"
     :cb="cb"
     type="space-cover"
     class="object-cover !rounded-none size-full"

--- a/apps/ui/src/components/Ui/ImagePreview.vue
+++ b/apps/ui/src/components/Ui/ImagePreview.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { loadImageFromIpfs, resizeImage } from '@/helpers/utils';
+
+const props = defineProps<{
+  src?: string | null;
+  width: number;
+  height: number;
+  alt: string;
+}>();
+
+const previewImageUrl = ref<string | null>(null);
+
+onUnmounted(() => {
+  if (previewImageUrl.value) {
+    URL.revokeObjectURL(previewImageUrl.value);
+  }
+});
+
+watch(
+  () => props.src,
+  async () => {
+    const oldUrl = previewImageUrl.value;
+
+    try {
+      if (!props.src?.startsWith('ipfs://')) {
+        previewImageUrl.value = null;
+        return;
+      }
+
+      const file = await loadImageFromIpfs(props.src);
+      const resizedFile = await resizeImage(file, props.width, props.height);
+      previewImageUrl.value = URL.createObjectURL(resizedFile);
+    } catch (error) {
+      console.error('Failed to load image preview', error);
+      previewImageUrl.value = null;
+    } finally {
+      if (oldUrl) {
+        URL.revokeObjectURL(oldUrl);
+      }
+    }
+  },
+  { immediate: true }
+);
+</script>
+
+<template>
+  <img
+    v-if="previewImageUrl"
+    :src="previewImageUrl"
+    :alt="alt"
+    v-bind="$attrs"
+  />
+</template>

--- a/apps/ui/src/components/Ui/InputStamp.vue
+++ b/apps/ui/src/components/Ui/InputStamp.vue
@@ -91,12 +91,11 @@ watch(
       const file = new File([blob], 'image', { type: blob.type });
 
       const resizedFile = await resizeImage(file, props.width, props.height);
-      const newUrl = URL.createObjectURL(resizedFile);
-
-      resizedImageUrl.value = newUrl;
+      resizedImageUrl.value = URL.createObjectURL(resizedFile);
     } catch (error) {
       uiStore.addNotification('error', getUserFacingErrorMessage(error));
       console.error('Failed to resize image:', error);
+      resizedImageUrl.value = null;
     } finally {
       if (oldUrl) {
         URL.revokeObjectURL(oldUrl);

--- a/apps/ui/src/components/Ui/InputStamp.vue
+++ b/apps/ui/src/components/Ui/InputStamp.vue
@@ -31,11 +31,11 @@ const props = withDefaults(
 const uiStore = useUiStore();
 
 const fileInput = ref<HTMLInputElement | null>(null);
-const isUploadingImage = ref(false);
-const resizedImageUrl = ref<string | null>(null);
+const isPreviewImageWorking = ref(false);
+const previewImageUrl = ref<string | null>(null);
 
 function openFilePicker() {
-  if (isUploadingImage.value) return;
+  if (isPreviewImageWorking.value) return;
   fileInput.value?.click();
 }
 
@@ -43,13 +43,13 @@ async function handleFileChange(e: Event) {
   try {
     const file = (e.target as HTMLInputElement).files?.[0];
 
-    isUploadingImage.value = true;
+    isPreviewImageWorking.value = true;
 
     const image = await imageUpload(file as File);
     if (!image) throw new Error('Failed to upload image.');
 
     model.value = image.url;
-    isUploadingImage.value = false;
+    isPreviewImageWorking.value = false;
   } catch (e) {
     uiStore.addNotification('error', getUserFacingErrorMessage(e));
 
@@ -58,26 +58,32 @@ async function handleFileChange(e: Event) {
     if (fileInput.value) {
       fileInput.value.value = '';
     }
-    isUploadingImage.value = false;
+    isPreviewImageWorking.value = false;
   }
 }
+
+onUnmounted(() => {
+  if (previewImageUrl.value) {
+    URL.revokeObjectURL(previewImageUrl.value);
+  }
+});
 
 watch(
   model,
   async () => {
-    const oldUrl = resizedImageUrl.value;
+    const oldUrl = previewImageUrl.value;
 
     try {
       if (!model.value?.startsWith('ipfs://')) {
-        resizedImageUrl.value = null;
+        previewImageUrl.value = null;
         return;
       }
 
-      isUploadingImage.value = true;
+      isPreviewImageWorking.value = true;
 
       const imageUrl = getUrl(model.value);
       if (!imageUrl) {
-        resizedImageUrl.value = null;
+        previewImageUrl.value = null;
         return uiStore.addNotification(
           'error',
           getUserFacingErrorMessage(new Error('Unable to render image preview'))
@@ -91,26 +97,20 @@ watch(
       const file = new File([blob], 'image', { type: blob.type });
 
       const resizedFile = await resizeImage(file, props.width, props.height);
-      resizedImageUrl.value = URL.createObjectURL(resizedFile);
+      previewImageUrl.value = URL.createObjectURL(resizedFile);
     } catch (error) {
       uiStore.addNotification('error', getUserFacingErrorMessage(error));
       console.error('Failed to resize image:', error);
-      resizedImageUrl.value = null;
+      previewImageUrl.value = null;
     } finally {
       if (oldUrl) {
         URL.revokeObjectURL(oldUrl);
       }
-      isUploadingImage.value = false;
+      isPreviewImageWorking.value = false;
     }
   },
   { immediate: true }
 );
-
-onUnmounted(() => {
-  if (resizedImageUrl.value) {
-    URL.revokeObjectURL(resizedImageUrl.value);
-  }
-});
 </script>
 
 <template>
@@ -118,7 +118,8 @@ onUnmounted(() => {
     type="button"
     v-bind="$attrs"
     class="relative group max-w-max cursor-pointer mb-3 border-4 border-skin-bg rounded-lg overflow-hidden bg-skin-border"
-    :disabled="disabled"
+    :disabled="disabled || isPreviewImageWorking"
+    :class="{ '!cursor-not-allowed': disabled || isPreviewImageWorking }"
     :style="{
       'max-width': `${width}px`,
       height: `${height}px`,
@@ -127,13 +128,13 @@ onUnmounted(() => {
     @click="openFilePicker()"
   >
     <img
-      v-if="resizedImageUrl"
-      :src="resizedImageUrl"
+      v-if="previewImageUrl"
+      :src="previewImageUrl"
       alt="Uploaded avatar"
       :class="[
         `object-cover group-hover:opacity-80`,
         {
-          'opacity-80': isUploadingImage
+          'opacity-80': isPreviewImageWorking
         }
       ]"
     />
@@ -146,14 +147,14 @@ onUnmounted(() => {
       class="pointer-events-none !rounded-none group-hover:opacity-80"
       :type="type"
       :class="{
-        'opacity-80': isUploadingImage
+        'opacity-80': isPreviewImageWorking
       }"
     />
     <div v-else class="block w-full h-full" />
     <div
       class="pointer-events-none absolute group-hover:visible inset-0 z-10 flex flex-row size-full items-center content-center justify-center"
     >
-      <UiLoading v-if="isUploadingImage" class="block z-10" />
+      <UiLoading v-if="isPreviewImageWorking" class="block z-10" />
       <IH-pencil v-else class="invisible text-skin-link group-hover:visible" />
     </div>
   </button>

--- a/apps/ui/src/components/Ui/InputStamp.vue
+++ b/apps/ui/src/components/Ui/InputStamp.vue
@@ -1,14 +1,9 @@
 <script setup lang="ts">
-import {
-  getUrl,
-  getUserFacingErrorMessage,
-  imageUpload,
-  resizeImage
-} from '@/helpers/utils';
+import { getUserFacingErrorMessage, imageUpload } from '@/helpers/utils';
 
 const model = defineModel<string>();
 
-const props = withDefaults(
+withDefaults(
   defineProps<{
     error?: string;
     definition: any;
@@ -31,11 +26,10 @@ const props = withDefaults(
 const uiStore = useUiStore();
 
 const fileInput = ref<HTMLInputElement | null>(null);
-const isPreviewImageWorking = ref(false);
-const previewImageUrl = ref<string | null>(null);
+const isUploading = ref(false);
 
 function openFilePicker() {
-  if (isPreviewImageWorking.value) return;
+  if (isUploading.value) return;
   fileInput.value?.click();
 }
 
@@ -43,13 +37,13 @@ async function handleFileChange(e: Event) {
   try {
     const file = (e.target as HTMLInputElement).files?.[0];
 
-    isPreviewImageWorking.value = true;
+    isUploading.value = true;
 
     const image = await imageUpload(file as File);
     if (!image) throw new Error('Failed to upload image.');
 
     model.value = image.url;
-    isPreviewImageWorking.value = false;
+    isUploading.value = false;
   } catch (e) {
     uiStore.addNotification('error', getUserFacingErrorMessage(e));
 
@@ -58,59 +52,9 @@ async function handleFileChange(e: Event) {
     if (fileInput.value) {
       fileInput.value.value = '';
     }
-    isPreviewImageWorking.value = false;
+    isUploading.value = false;
   }
 }
-
-onUnmounted(() => {
-  if (previewImageUrl.value) {
-    URL.revokeObjectURL(previewImageUrl.value);
-  }
-});
-
-watch(
-  model,
-  async () => {
-    const oldUrl = previewImageUrl.value;
-
-    try {
-      if (!model.value?.startsWith('ipfs://')) {
-        previewImageUrl.value = null;
-        return;
-      }
-
-      isPreviewImageWorking.value = true;
-
-      const imageUrl = getUrl(model.value);
-      if (!imageUrl) {
-        previewImageUrl.value = null;
-        return uiStore.addNotification(
-          'error',
-          getUserFacingErrorMessage(new Error('Unable to render image preview'))
-        );
-      }
-
-      const response = await fetch(imageUrl);
-      if (!response.ok) throw new Error('Failed to fetch image');
-
-      const blob = await response.blob();
-      const file = new File([blob], 'image', { type: blob.type });
-
-      const resizedFile = await resizeImage(file, props.width, props.height);
-      previewImageUrl.value = URL.createObjectURL(resizedFile);
-    } catch (error) {
-      uiStore.addNotification('error', getUserFacingErrorMessage(error));
-      console.error('Failed to resize image:', error);
-      previewImageUrl.value = null;
-    } finally {
-      if (oldUrl) {
-        URL.revokeObjectURL(oldUrl);
-      }
-      isPreviewImageWorking.value = false;
-    }
-  },
-  { immediate: true }
-);
 </script>
 
 <template>
@@ -118,8 +62,8 @@ watch(
     type="button"
     v-bind="$attrs"
     class="relative group max-w-max cursor-pointer mb-3 border-4 border-skin-bg rounded-lg overflow-hidden bg-skin-border"
-    :disabled="disabled || isPreviewImageWorking"
-    :class="{ '!cursor-not-allowed': disabled || isPreviewImageWorking }"
+    :disabled="disabled || isUploading"
+    :class="{ '!cursor-not-allowed': disabled || isUploading }"
     :style="{
       'max-width': `${width}px`,
       height: `${height}px`,
@@ -127,14 +71,16 @@ watch(
     }"
     @click="openFilePicker()"
   >
-    <img
-      v-if="previewImageUrl"
-      :src="previewImageUrl"
+    <UiImagePreview
+      v-if="model"
+      :src="model"
+      :width="width"
+      :height="height"
       alt="Uploaded avatar"
       :class="[
         `object-cover group-hover:opacity-80`,
         {
-          'opacity-80': isPreviewImageWorking
+          'opacity-80': isUploading
         }
       ]"
     />
@@ -147,14 +93,14 @@ watch(
       class="pointer-events-none !rounded-none group-hover:opacity-80"
       :type="type"
       :class="{
-        'opacity-80': isPreviewImageWorking
+        'opacity-80': isUploading
       }"
     />
     <div v-else class="block w-full h-full" />
     <div
       class="pointer-events-none absolute group-hover:visible inset-0 z-10 flex flex-row size-full items-center content-center justify-center"
     >
-      <UiLoading v-if="isPreviewImageWorking" class="block z-10" />
+      <UiLoading v-if="isUploading" class="block z-10" />
       <IH-pencil v-else class="invisible text-skin-link group-hover:visible" />
     </div>
   </button>

--- a/apps/ui/src/components/Ui/InputStampCover.vue
+++ b/apps/ui/src/components/Ui/InputStampCover.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { SPACE_COVER_DIMENSIONS } from '@/helpers/constants';
 import {
   getUrl,
   getUserFacingErrorMessage,
@@ -80,7 +81,11 @@ watch(
       const file = new File([blob], 'image', { type: blob.type });
 
       // Resize the image
-      const resizedFile = await resizeImage(file, 1500, 400);
+      const resizedFile = await resizeImage(
+        file,
+        SPACE_COVER_DIMENSIONS.lg.width,
+        SPACE_COVER_DIMENSIONS.lg.height
+      );
       resizedImageUrl.value = URL.createObjectURL(resizedFile);
     } catch (error) {
       console.error('Failed to resize image:', error);

--- a/apps/ui/src/components/Ui/InputStampCover.vue
+++ b/apps/ui/src/components/Ui/InputStampCover.vue
@@ -82,7 +82,10 @@ watch(
     const imageUrl = getUrl(model.value);
     if (!imageUrl) {
       resizedImageUrl.value = null;
-      return;
+      return uiStore.addNotification(
+        'error',
+        getUserFacingErrorMessage(new Error('Unable to render image preview'))
+      );
     }
 
     try {

--- a/apps/ui/src/components/Ui/InputStampCover.vue
+++ b/apps/ui/src/components/Ui/InputStampCover.vue
@@ -61,9 +61,19 @@ async function handleFileChange(e: Event) {
   }
 }
 
+onUnmounted(() => {
+  if (resizedImageUrl.value) {
+    URL.revokeObjectURL(resizedImageUrl.value);
+  }
+});
+
 watch(
   model,
   async () => {
+    if (resizedImageUrl.value) {
+      URL.revokeObjectURL(resizedImageUrl.value);
+    }
+
     if (!model.value?.startsWith('ipfs://')) {
       resizedImageUrl.value = null;
       return;

--- a/apps/ui/src/components/Ui/InputStampCover.vue
+++ b/apps/ui/src/components/Ui/InputStampCover.vue
@@ -110,7 +110,9 @@ watch(
   <button
     type="button"
     v-bind="$attrs"
+    :disabled="isUploadingImage"
     class="relative block bg-skin-border h-[140px] mb-[-50px] w-full overflow-hidden cursor-pointer group"
+    :class="{ '!cursor-not-allowed': isUploadingImage }"
     @click="openFilePicker()"
   >
     <img

--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -265,3 +265,8 @@ export const DELEGATION_TYPES_NAMES: Record<DelegationType, string> = {
   'split-delegation': 'Split Delegation',
   'governor-subgraph': 'ERC-20 Votes'
 };
+
+export const SPACE_COVER_DIMENSIONS = {
+  sm: { width: 450, height: 120 },
+  lg: { width: 1500, height: 400 }
+};

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -530,6 +530,99 @@ export function getStampUrl(
   return `https://cdn.stamp.fyi/${type}/${formatAddress(id)}${sizeParam}${cacheParam}${cropParam}`;
 }
 
+export function resizeImage(
+  file: File,
+  width: number,
+  height: number
+): Promise<File> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      const ctx = canvas.getContext('2d');
+
+      if (!ctx) {
+        reject(new Error('Failed to get canvas context'));
+        return;
+      }
+
+      // Calculate scale factors for both dimensions
+      const scaleX = width / img.width;
+      const scaleY = height / img.height;
+
+      // Use the larger scale factor to ensure both minimum dimensions are met
+      const scale = Math.max(scaleX, scaleY);
+
+      const scaledWidth = img.width * scale;
+      const scaledHeight = img.height * scale;
+
+      // Calculate source dimensions for cropping
+      let sourceX = 0;
+      let sourceY = 0;
+      let sourceWidth = img.width;
+      let sourceHeight = img.height;
+
+      if (scaledWidth > width) {
+        // Image is too wide after scaling, crop from center
+        const cropWidth = width / scale;
+        sourceX = (img.width - cropWidth) / 2;
+        sourceWidth = cropWidth;
+      }
+
+      if (scaledHeight > height) {
+        // Image is too tall after scaling, crop from center
+        const cropHeight = height / scale;
+        sourceY = (img.height - cropHeight) / 2;
+        sourceHeight = cropHeight;
+      }
+
+      canvas.width = width;
+      canvas.height = height;
+
+      // Fill background with transparent
+      ctx.clearRect(0, 0, width, height);
+
+      // Draw the image, cropping from center if necessary
+      ctx.drawImage(
+        img,
+        sourceX,
+        sourceY,
+        sourceWidth,
+        sourceHeight,
+        0,
+        0,
+        width,
+        height
+      );
+
+      canvas.toBlob(
+        blob => {
+          if (!blob) {
+            reject(new Error('Failed to convert canvas to blob'));
+            return;
+          }
+
+          const resizedFile = new File([blob], file.name, {
+            type: file.type,
+            lastModified: Date.now()
+          });
+
+          resolve(resizedFile);
+        },
+        file.type,
+        0.9 // Quality for JPEG
+      );
+    };
+
+    img.onerror = () => {
+      reject(new Error('Failed to load image'));
+    };
+
+    img.src = URL.createObjectURL(file);
+  });
+}
+
 export async function imageUpload(file: File) {
   if (!file) return;
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/272

This PR will show the InputStamp and InputStampCover image preview with the same ratio as the one shown by the UiStamp and UiStampCover component.

The image in space settings was shown differently, due to it coming from stamp, after being resized, while the one in the space settings is the original one without any processing.

Before the fix, the space cover in these 2 pages are different

- https://snapshot.box/#/s:%E3%81%8A%E3%81%AF%E3%82%88%E3%81%86.wa0x6e.eth
- https://snapshot.box/#/s:%E3%81%8A%E3%81%AF%E3%82%88%E3%81%86.wa0x6e.eth/settings/profile

After the fix, the 2 space covers are identical

- http://localhost:8080/#/s:%E3%81%8A%E3%81%AF%E3%82%88%E3%81%86.wa0x6e.eth
- http://localhost:8080/#/s:%E3%81%8A%E3%81%AF%E3%82%88%E3%81%86.wa0x6e.eth/settings/profile

Before the fix, the space avatar do not have the same ratio:

- https://snapshot.box/#/sn:0x049e89d3c62cc95e49b67e86fcb099e340b98886e84a68990dd304414c4e0806/settings/profile
- https://snapshot.box/#/sn:0x049e89d3c62cc95e49b67e86fcb099e340b98886e84a68990dd304414c4e0806

After the fix, the avatars should have the same ratio

### How to test

1. Go to your space profile
2. Upload a space cover image with height smaller than 400px, and width 1500px
3. The space cover should look like the same before saving, after refreshing the space setting page, and on the space main pages
4. Upload an avatar in landscape or portrait, it should be cropped to a square in the preview, and look identical as the one returned by stamp