### PR TITLE
feat: add support for discourse URLs with specific post numbers

### DIFF
--- a/apps/ui/src/helpers/discourse.ts
+++ b/apps/ui/src/helpers/discourse.ts
@@ -131,11 +131,16 @@ function formatPosts(posts: any[], baseUrl: string): Reply[] {
 
 export async function loadSingleTopic(url: string): Promise<Topic> {
   const baseUrl = new URL(url).origin;
-  const params = new URL(url).pathname.split('/');
-  const topicId = params[params.length - 1];
+  const params = new URL(url).pathname.split('/').filter(Boolean);
+  const lastParam = params[params.length - 1];
+  const secondLastParam = params[params.length - 2];
+  const hasPostNumber =
+    secondLastParam && /^\d+$/.test(secondLastParam) && /^\d+$/.test(lastParam);
 
   const res = await fetch(
-    `${PROXY_URL}/${encodeURIComponent(`${baseUrl}/t/${topicId}.json`)}`
+    `${PROXY_URL}/${encodeURIComponent(
+      `${baseUrl}/t/${hasPostNumber ? `${secondLastParam}/${lastParam}` : lastParam}.json`
+    )}`
   );
   const topic = await res.json();
 
@@ -145,6 +150,13 @@ export async function loadSingleTopic(url: string): Promise<Topic> {
 
   topic.posts_count--;
   topic.posts = formatPosts(topic.post_stream?.posts, baseUrl);
+
+  if (hasPostNumber) {
+    topic.posts = topic.posts.filter(
+      post => post.post_number >= Number(lastParam)
+    );
+  }
+
   return topic;
 }
 

--- a/apps/ui/src/helpers/discourse.ts
+++ b/apps/ui/src/helpers/discourse.ts
@@ -137,10 +137,12 @@ export async function loadSingleTopic(url: string): Promise<Topic> {
   const hasPostNumber =
     secondLastParam && /^\d+$/.test(secondLastParam) && /^\d+$/.test(lastParam);
 
+  const topicPath = hasPostNumber
+    ? `${secondLastParam}/${lastParam}`
+    : lastParam;
+
   const res = await fetch(
-    `${PROXY_URL}/${encodeURIComponent(
-      `${baseUrl}/t/${hasPostNumber ? `${secondLastParam}/${lastParam}` : lastParam}.json`
-    )}`
+    `${PROXY_URL}/${encodeURIComponent(`${baseUrl}/t/${topicPath}.json`)}`
   );
   const topic = await res.json();
 


### PR DESCRIPTION
## Issue

On [this proposal](https://snapshot.box/#/s:lido-snapshot.eth/proposal/0xc3f92bcdf8926cfa7528ca6a979c0fdce1e4d0cfaaa72dd6410a76a2e1e55766) we are displaying wrong discussion under "Discussion" tab

looks like we support only topic URLs like this
https://research.lido.fi/t/community-staking-module/5917

But the link provided in proposal is for post
https://research.lido.fi/t/community-staking-module/5917/139


## Summary
- Enhanced `loadSingleTopic()` to handle Discourse URLs containing both topic ID and post number
- Added automatic post filtering when a specific post number is provided in the URL

### URL Formats Supported
| URL Format | API Request | Post Filtering |
|------------|-------------|----------------|
| `/t/topic-name/139` | `139.json` | None (all posts) |
| `/t/topic-name/5917/139` | `5917/139.json` | Posts ≥ 139 only |


## How to test

1. Go to http://localhost:8080/#/s:lido-snapshot.eth/proposal/0xc3f92bcdf8926cfa7528ca6a979c0fdce1e4d0cfaaa72dd6410a76a2e1e55766/discussion
2. You should see correct post instead of wrong topic
3. All discorse pages should work like before:
- http://localhost:8080/#/s:ens.eth/discussions
- http://localhost:8080/#/s:ens.eth/discussions/5099
- http://localhost:8080/#/s:ens.eth/proposal/0xa9c47b281667a85f80e0cc9be5904438c9205e123352779cbb69b0ecf583307c/discussion
