### PR TITLE
fix: show LinkPreview image

### DIFF
--- a/apps/ui/src/components/Ui/LinkPreview.stories.ts
+++ b/apps/ui/src/components/Ui/LinkPreview.stories.ts
@@ -1,0 +1,29 @@
+import { Meta, StoryObj } from '@storybook/vue3-vite';
+import LinkPreview from './LinkPreview.vue';
+
+const meta = {
+  title: 'Ui/LinkPreview',
+  component: LinkPreview,
+  tags: ['autodocs'],
+  argTypes: {
+    url: { control: 'text' },
+    showDefault: { control: 'boolean' }
+  }
+} satisfies Meta<typeof LinkPreview>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    url: 'https://github.com/snapshot-labs/sx-monorepo',
+    showDefault: false
+  }
+};
+
+export const WithDefault: Story = {
+  args: {
+    url: 'not-a-valid-url',
+    showDefault: true
+  }
+};

--- a/apps/ui/src/components/Ui/LinkPreview.vue
+++ b/apps/ui/src/components/Ui/LinkPreview.vue
@@ -1,6 +1,15 @@
 <script setup lang="ts">
 const props = withDefaults(
-  defineProps<{ url: string; showDefault?: boolean }>(),
+  defineProps<{
+    /**
+     * The URL to preview.
+     */
+    url: string;
+    /**
+     * Whether to show a default link preview when actual preview is not available.
+     */
+    showDefault?: boolean;
+  }>(),
   {
     showDefault: false
   }
@@ -35,11 +44,12 @@ async function update(val: string) {
     preview.value = await result.json();
 
     if (preview.value?.links?.icon[0]?.href) {
-      const image = await fetch(preview.value.links.icon[0].href, {
-        method: 'HEAD'
+      await fetch(preview.value.links.icon[0].href, {
+        method: 'HEAD',
+        mode: 'no-cors'
       });
 
-      previewIconResolved.value = image.ok;
+      previewIconResolved.value = true;
     }
   } catch {
   } finally {


### PR DESCRIPTION
### Summary

Because we try to resolve image using fetch it will almost always fail because of CORS. We need to make this ping request using no-cors mode.

Regression from: https://github.com/snapshot-labs/sx-monorepo/pull/863

### How to test

1. Try discussion URL in proposal editor.

### Screenshots

Before:
<img width="642" height="262" alt="image" src="https://github.com/user-attachments/assets/069be29c-8185-4d81-8caa-69ace97f024d" />

After:
<img width="827" height="305" alt="image" src="https://github.com/user-attachments/assets/8119139e-e9bc-4455-894d-65438c2a5468" />
