### PR TITLE
chore: disable polygon network in api

### DIFF
--- a/apps/api/src/evm/config.ts
+++ b/apps/api/src/evm/config.ts
@@ -13,7 +13,7 @@ export type NetworkID =
   | 'eth'
   | 'sep'
   | 'oeth'
-  | 'matic'
+  // | 'matic'
   | 'arb1'
   | 'base'
   | 'mnt'
@@ -24,7 +24,7 @@ const START_BLOCKS: Record<NetworkID, number> = {
   eth: 18962278,
   sep: 4519171,
   oeth: 118359200,
-  matic: 50858232,
+  // matic: 50858232,
   arb1: 157825417,
   base: 23524251,
   mnt: 75662182,

--- a/apps/api/src/evm/index.ts
+++ b/apps/api/src/evm/index.ts
@@ -6,7 +6,7 @@ import { registerIndexer } from '../register';
 const ethConfig = createConfig('eth');
 const sepConfig = createConfig('sep');
 const oethConfig = createConfig('oeth');
-const maticConfig = createConfig('matic');
+// const maticConfig = createConfig('matic');
 const arb1Config = createConfig('arb1');
 const baseConfig = createConfig('base');
 const mntConfig = createConfig('mnt');
@@ -16,7 +16,7 @@ const curtisConfig = createConfig('curtis');
 const ethIndexer = new evm.EvmIndexer(createWriters(ethConfig));
 const sepIndexer = new evm.EvmIndexer(createWriters(sepConfig));
 const oethIndexer = new evm.EvmIndexer(createWriters(oethConfig));
-const maticIndexer = new evm.EvmIndexer(createWriters(maticConfig));
+// const maticIndexer = new evm.EvmIndexer(createWriters(maticConfig));
 const arb1Indexer = new evm.EvmIndexer(createWriters(arb1Config));
 const baseIndexer = new evm.EvmIndexer(createWriters(baseConfig));
 const mntIndexer = new evm.EvmIndexer(createWriters(mntConfig));
@@ -27,12 +27,12 @@ export function addEvmIndexers(checkpoint: Checkpoint) {
   registerIndexer(checkpoint, ethConfig.indexerName, ethConfig, ethIndexer);
   registerIndexer(checkpoint, sepConfig.indexerName, sepConfig, sepIndexer);
   registerIndexer(checkpoint, oethConfig.indexerName, oethConfig, oethIndexer);
-  registerIndexer(
-    checkpoint,
-    maticConfig.indexerName,
-    maticConfig,
-    maticIndexer
-  );
+  // registerIndexer(
+  //   checkpoint,
+  //   maticConfig.indexerName,
+  //   maticConfig,
+  //   maticIndexer
+  // );
   registerIndexer(checkpoint, arb1Config.indexerName, arb1Config, arb1Indexer);
   registerIndexer(checkpoint, baseConfig.indexerName, baseConfig, baseIndexer);
   registerIndexer(checkpoint, mntConfig.indexerName, mntConfig, mntIndexer);


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/615

This PR disables Polygon network in the API

### How to test

1. `yarn dev:interactive` with api
2. It should stop indexing matic
