### PR TITLE
fix: fix missing error message when the delegate address input is invalid

### DIFF
--- a/apps/ui/src/components/FormBasicDelegation.vue
+++ b/apps/ui/src/components/FormBasicDelegation.vue
@@ -86,7 +86,7 @@ watchEffect(async () => {
   <UiInputAddress
     v-model="form.delegatees[0].id"
     :definition="delegateDefinition"
-    :error="formErrors.delegatees?.[0]?.id"
+    :error="formErrors.delegatee"
     :required="true"
     @pick="emit('pick')"
   />


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/442

This PR fix the missing error message on the address input, in the basic delegation form

### How to test

1. Go to http://localhost:8080/#/s:cow.eth/delegates
2. Open the delegation modal
3. Fill something invalid in the address field
4. It should show the error message