### PR TITLE
feat: add Icons gallery to Storybook

### DIFF
--- a/apps/ui/src/docs/icons.mdx
+++ b/apps/ui/src/docs/icons.mdx
@@ -1,0 +1,31 @@
+import { Meta, IconGallery, IconItem } from '@storybook/addon-docs/blocks';
+import { icons as outlineIcons } from '@iconify-json/heroicons-outline';
+import { icons as solidIcons } from '@iconify-json/heroicons-solid';
+
+<Meta title="Iconography" />
+
+# Iconography
+
+<h2>Outline icons</h2>
+<IconGallery>
+  {Object.entries(outlineIcons.icons).map(([name, icon]) => (
+    <IconItem
+      key={name}
+      name={name}
+    >
+      <svg dangerouslySetInnerHTML={{ __html: icon.body }} width="20" height="20" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" />
+    </IconItem>
+  ))}
+</IconGallery>
+
+<h2>Solid icons</h2>
+<IconGallery>
+  {Object.entries(solidIcons.icons).map(([name, icon]) => (
+    <IconItem
+      key={name}
+      name={name}
+    >
+      <svg dangerouslySetInnerHTML={{ __html: icon.body }} width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" />
+    </IconItem>
+  ))}
+</IconGallery>


### PR DESCRIPTION
### Summary

This PR adds icons gallery for Heroicons.

Closes: https://github.com/snapshot-labs/workflow/issues/624

### How to test

1. Go to Storybook.
2. Go to iconography.


### Screenshots

<img width="1627" height="935" alt="image" src="https://github.com/user-attachments/assets/eee11782-a737-4064-8f91-40fd9826f782" />
