### PR TITLE
chore: add viewport-fit=cover

### DIFF
--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title></title>
     <link rel="icon" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.json" />


### PR DESCRIPTION
### Summary

This seems to cause issues on Chrome on iOS.

Closes: https://github.com/snapshot-labs/workflow/issues/622

### How to test

1. Open explore page on Chrome iOS.
2. Scroll down and up to see bottom bar with Login button to be sticky on bottom.

### Screenshots


https://github.com/user-attachments/assets/c3f2c838-0c65-4bde-b3e6-5452dfc8568a

