### PR TITLE
feat: add colors to storybook

### DIFF
--- a/apps/ui/src/docs/colors.mdx
+++ b/apps/ui/src/docs/colors.mdx
@@ -1,0 +1,77 @@
+import { Meta, ColorPalette, ColorItem } from '@storybook/addon-docs/blocks';
+
+<Meta title="Colors" />
+
+<ColorPalette>
+  <ColorItem
+    title="Background"
+    colors={{
+      'light': '#ffffff',
+      'dark': '#18171c',
+    }}
+  />
+  <ColorItem
+    title="Border"
+    colors={{
+      'light': '#e5e5e6',
+      'dark': '#2f2e33',
+    }}
+  />
+  <ColorItem
+    title="Input background"
+    colors={{
+      'light': '#fbfbfb',
+      'dark': '#232227',
+    }}
+  />
+  <ColorItem
+    title="Active background"
+    colors={{
+      'light': '#ededed',
+      'dark': '#29282e',
+    }}
+  />
+  <ColorItem
+    title="Headings and links"
+    colors={{
+      'light': '#111111',
+      'dark': '#fbfbfb',
+    }}
+  />
+  <ColorItem
+    title="Text"
+    colors={{
+      'light': '#57606a',
+      'dark': '#a09fa4',
+    }}
+  />
+  <ColorItem
+    title="Content"
+    colors={{
+      'light': '#111111cc',
+      'dark': '#faf9fccc',
+    }}
+  />
+  <ColorItem
+    title="Primary"
+    colors={{
+      'light': '#111111',
+      'dark': '#fbfbfb',
+    }}
+  />
+  <ColorItem
+    title="Accent foreground"
+    colors={{
+      'light': '#fbfbfb',
+      'dark': '#111111',
+    }}
+  />
+  <ColorItem
+    title="Danger"
+    colors={['#eb4c5b']}
+  />
+  <ColorItem
+    title="Success"
+    colors={['#57b375']}
+  />
+</ColorPalette>


### PR DESCRIPTION
### Summary

This PR adds basic colors we **use** in the app to Storybook.

Those colors are duplicated between style.scss and this file as there is no clean way to get those extracted (we could get those from Tailwind config but our colors are parametrized by CSS variables so we don't get anything usable).

Closes: https://github.com/snapshot-labs/workflow/issues/623

### How to test

1. Open storybook.
2. You see colors.

