### PR TITLE
feat: add API blue-green deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,24 +26,26 @@ jobs:
   #     - name: Deploy if files have changed
   #       run: ./scripts/deploy-api-prod.sh
 
-  # deploy_api_testnet:
-  #   name: Deploy API to testnet
-  #   environment: api_testnet
-  #   concurrency:
-  #     group: api_testnet
-  #     cancel-in-progress: true
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout Repo
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 2
-  #     - name: Install doctl
-  #       uses: digitalocean/action-doctl@v2
-  #       with:
-  #         token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-  #     - name: Deploy if files have changed
-  #       run: ./scripts/deploy-changed.sh apps/api ${{ vars.DIGITALOCEAN_APP_ID }}
+  deploy_api_testnet:
+    name: Deploy API to testnet
+    environment: api_testnet
+    concurrency:
+      group: api_testnet
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      - name: Deploy if files have changed (Indexer)
+        run: ./scripts/deploy-changed.sh apps/api ${{ vars.INDEXER_APP_ID }}
+      - name: Deploy if files have changed (GraphQL API)
+        run: ./scripts/deploy-changed.sh apps/api ${{ vars.API_APP_ID }}
 
   deploy_mana_prod:
     name: Deploy mana to production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,25 +6,24 @@ on:
       - master
 
 jobs:
-  # Those are disabled as part of transition to unified API
-  # deploy_api_mainnet:
-  #   name: Deploy API to mainnet
-  #   environment: api_mainnet
-  #   concurrency:
-  #     group: api_mainnet
-  #     cancel-in-progress: true
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout Repo
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 2
-  #     - name: Install doctl
-  #       uses: digitalocean/action-doctl@v2
-  #       with:
-  #         token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-  #     - name: Deploy if files have changed
-  #       run: ./scripts/deploy-api-prod.sh
+  deploy_api_mainnet:
+    name: Deploy API to mainnet
+    environment: api_mainnet
+    concurrency:
+      group: api_mainnet
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      - name: Deploy if files have changed
+        run: ./scripts/deploy-api-prod.sh
 
   deploy_api_testnet:
     name: Deploy API to testnet

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/scripts/deploy-api-prod.sh
+++ b/scripts/deploy-api-prod.sh
@@ -2,22 +2,18 @@
 
 set -euo pipefail
 
-NAME_SERVER="ns1.3dns.box"
-PRODUCTION_DOMAIN="api.snapshot.box"
-APP_DOMAIN_1="sx-api-starknet-mainnet-dfghg.ondigitalocean.app."
-APP_DOMAIN_2="sx-api-mainnet-2-fmlg8.ondigitalocean.app."
-APP_ID_1="c4eba570-abea-4ab3-8941-d968db6cad36"
+APP_ID_1="a2730f1c-94cc-414f-a68c-179a3adee405"
 APP_ID_2="9282b162-7280-43b9-b429-9f53810003bc"
 
-CURRENT_DOMAIN=$(dig -t CNAME +short "$PRODUCTION_DOMAIN" @"$NAME_SERVER")
+APP_ID=$(curl -s https://api.snapshot.box/deployment | jq '.index|tonumber')
 
 CURRENT_STAGING_APP_ID=""
-if [ "$CURRENT_DOMAIN" = "$APP_DOMAIN_1" ]; then
+if [ "$APP_ID" = "1" ]; then
   CURRENT_STAGING_APP_ID=$APP_ID_2
-elif [ "$CURRENT_DOMAIN" = "$APP_DOMAIN_2" ]; then
+elif [ "$APP_ID" = "2" ]; then
   CURRENT_STAGING_APP_ID=$APP_ID_1
 else
-  echo "Unknown domain: $CURRENT_DOMAIN"
+  echo "Unknown app: $APP_ID"
   exit -1
 fi
 


### PR DESCRIPTION
### Summary

This will reintroduce [blue-green deployments](https://en.wikipedia.org/wiki/Blue%E2%80%93green_deployment). Changes will be automatically deployed to staging app (detected using https://api.snapshot.box/deployment).

We have issue in this workflow currently which is that once we upgrade API-1 to be production app then it's often the case that we forget to trigger redeployment of API-2 so it can pull latest changes - this will need to be automated so it's all handled automatically.

### Test plan

Apply diff below:
```diff
diff --git a/scripts/deploy-api-prod.sh b/scripts/deploy-api-prod.sh
index 11ea41a6..f22e5d96 100755
--- a/scripts/deploy-api-prod.sh
+++ b/scripts/deploy-api-prod.sh
@@ -19,4 +19,4 @@ fi
 
 echo "Starting deployment to staging app: $CURRENT_STAGING_APP_ID"
 
-./scripts/deploy-changed.sh apps/api "$CURRENT_STAGING_APP_ID"
+# ./scripts/deploy-changed.sh apps/api "$CURRENT_STAGING_APP_ID"
```

Run `./scripts/deploy-api-prod.sh`

It should return:

```
Starting deployment to staging app: a2730f1c-94cc-414f-a68c-179a3adee405
```

which is api-1.
