### PR TITLE
ci: add Promote API workflow

### DIFF
--- a/.github/actions/get-deployments/action.yml
+++ b/.github/actions/get-deployments/action.yml
@@ -17,6 +17,12 @@ outputs:
   staging-app-id:
     description: "DigitalOcean App ID for staging app"
     value: ${{ steps.set-app-ids.outputs.staging-app-id }}
+  production-index:
+    description: "Index of the production app"
+    value: ${{ steps.set-app-ids.outputs.production-index }}
+  staging-index:
+    description: "Index of the staging app"
+    value: ${{ steps.set-app-ids.outputs.staging-index }}
 runs:
   using: "composite"
   steps:
@@ -34,9 +40,13 @@ runs:
         if [ "$DEPLOYMENT_ID" = "1" ]; then
           echo "production-app-id=$INPUT_APP_1_ID" >> $GITHUB_OUTPUT
           echo "staging-app-id=$INPUT_APP_2_ID" >> $GITHUB_OUTPUT
+          echo "production-index=1" >> $GITHUB_OUTPUT
+          echo "staging-index=2" >> $GITHUB_OUTPUT
         elif [ "$DEPLOYMENT_ID" = "2" ]; then
           echo "production-app-id=$INPUT_APP_2_ID" >> $GITHUB_OUTPUT
           echo "staging-app-id=$INPUT_APP_1_ID" >> $GITHUB_OUTPUT
+          echo "production-index=2" >> $GITHUB_OUTPUT
+          echo "staging-index=1" >> $GITHUB_OUTPUT
         else
           echo "Error: Unexpected deployment-id value: $DEPLOYMENT_ID"
           exit 1

--- a/.github/workflows/promote-api.yml
+++ b/.github/workflows/promote-api.yml
@@ -1,0 +1,48 @@
+name: Promote API
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to promote'
+        required: true
+        type: choice
+        options:
+        - api_mainnet
+        - api_testnet
+
+jobs:
+  promote-api:
+    environment: ${{ inputs.environment }}_promote
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Install doctl
+      uses: digitalocean/action-doctl@v2
+      with:
+        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+    - name: Get deployments
+      id: get-deployments
+      uses: ./.github/actions/get-deployments
+      with:
+        public-api-url: ${{ vars.PUBLIC_API_URL }}
+        app-1-id: ${{ vars.APP_1_ID }}
+        app-2-id: ${{ vars.APP_2_ID }}
+    - name: Promoting staging to production
+      run: |
+        doctl apps spec get "$APP_ID" --format "json" | \
+        jq '.services[0].envs |= map(if .key == "DATABASE_URL_INDEX" then .value = "'$NEW_INDEX'" else . end)' | \
+        doctl apps update "$APP_ID" --wait --spec -
+      env:
+        APP_ID: ${{ vars.PUBLIC_API_APP_ID }}
+        NEW_INDEX: ${{ steps.get-deployments.outputs.staging-index }}
+    - name: Get new deployments
+      id: get-new-deployments
+      uses: ./.github/actions/get-deployments
+      with:
+        public-api-url: ${{ vars.PUBLIC_API_URL }}
+        app-1-id: ${{ vars.APP_1_ID }}
+        app-2-id: ${{ vars.APP_2_ID }}
+    - name: Deploying new changes to new staging
+      run: ./scripts/deploy-changed.sh apps/api ${{ steps.get-new-deployments.outputs.staging-app-id }}

--- a/.github/workflows/promote-api.yml
+++ b/.github/workflows/promote-api.yml
@@ -45,4 +45,4 @@ jobs:
         app-1-id: ${{ vars.APP_1_ID }}
         app-2-id: ${{ vars.APP_2_ID }}
     - name: Deploying new changes to new staging
-      run: ./scripts/deploy-changed.sh apps/api ${{ steps.get-new-deployments.outputs.staging-app-id }}
+      run: doctl apps create-deployment ${{ steps.get-new-deployments.outputs.staging-app-id }}


### PR DESCRIPTION
### Summary

This workflow will be used to promote staging API to production (it will be possible to trigger this workflow using Github UI). This workflow does following:
1. Checks current production/staging apps.
2. Updates public app to use staging app (so it becomes production app).
3. Deploys new changes to (new) staging app.

Used environment should require confirmation from authorized users before it can run.

### Test plan

Tested using `act` promoting testnet-api-1 to production.

TODO:
- [x] Create environments `api_mainnet_promote` and `api_testnet_promote`.