### PR TITLE
chore: add spark delegation strategy to the registry

### DIFF
--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -257,7 +257,8 @@ export const DELEGATE_REGISTRY_STRATEGIES = [
   'delegation-with-cap',
   'delegation-with-overrides',
   'with-delegation',
-  'erc20-balance-of-with-delegation'
+  'erc20-balance-of-with-delegation',
+  'spark-with-delegation'
 ];
 
 export const DELEGATION_TYPES_NAMES: Record<DelegationType, string> = {


### PR DESCRIPTION
### Summary
Missing delegates page on http://localhost:8080/#/s:youcanjustbuildthings.eth

### How to test
You should see delegates tab on http://localhost:8080/#/s:youcanjustbuildthings.eth
