### PR TITLE
feat: add Queued & Vetoed proposal status

### DIFF
--- a/apps/ui/src/components/ProposalExecutionActions.vue
+++ b/apps/ui/src/components/ProposalExecutionActions.vue
@@ -26,7 +26,10 @@ const {
   executeProposal,
   executeQueuedProposal,
   vetoProposal
-} = useExecutionActions(props.proposal, props.execution);
+} = useExecutionActions(
+  () => props.proposal,
+  () => props.execution
+);
 
 const network = computed(() => getNetwork(props.proposal.network));
 </script>

--- a/apps/ui/src/components/ProposalExecutionActions.vue
+++ b/apps/ui/src/components/ProposalExecutionActions.vue
@@ -72,7 +72,7 @@ const network = computed(() => getNetwork(props.proposal.network));
         Finalize proposal
       </UiButton>
       <UiButton
-        v-else-if="proposal.state !== 'executed'"
+        v-else-if="!['queued', 'vetoed', 'executed'].includes(proposal.state)"
         class="w-full flex justify-center items-center gap-2"
         :loading="executeProposalSending"
         @click="executeProposal"
@@ -99,8 +99,7 @@ const network = computed(() => getNetwork(props.proposal.network));
       </UiButton>
       <UiButton
         v-if="
-          proposal.state === 'executed' &&
-          !proposal.execution_settled &&
+          proposal.state === 'queued' &&
           !proposal.vetoed &&
           proposal.timelock_veto_guardian &&
           compareAddresses(proposal.timelock_veto_guardian, web3.account)

--- a/apps/ui/src/components/ProposalIconStatus.vue
+++ b/apps/ui/src/components/ProposalIconStatus.vue
@@ -7,6 +7,8 @@ const titles: Record<ProposalState, string> = {
   passed: 'Passed',
   closed: 'Closed',
   rejected: 'Rejected',
+  queued: 'Queued',
+  vetoed: 'Vetoed',
   executed: 'Executed'
 };
 
@@ -45,12 +47,17 @@ const style = computed(() => ({
       :style="style"
     />
     <IS-play
+      v-else-if="state === 'queued'"
+      class="text-gray-400"
+      :style="style"
+    />
+    <IS-play
       v-else-if="state === 'executed'"
       class="text-purple-500"
       :style="style"
     />
     <IS-x-circle
-      v-else-if="state === 'rejected'"
+      v-else-if="['rejecteed', 'vetoed'].includes(state)"
       class="text-skin-danger"
       :style="style"
     />

--- a/apps/ui/src/components/ProposalIconStatus.vue
+++ b/apps/ui/src/components/ProposalIconStatus.vue
@@ -57,7 +57,7 @@ const style = computed(() => ({
       :style="style"
     />
     <IS-x-circle
-      v-else-if="['rejecteed', 'vetoed'].includes(state)"
+      v-else-if="['rejected', 'vetoed'].includes(state)"
       class="text-skin-danger"
       :style="style"
     />

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -95,6 +95,7 @@ const otherResultsSummary = computed(() => {
 
 const isFinalizing = computed(() => {
   return (
+    offchainNetworks.includes(props.proposal.network) &&
     !props.proposal.completed &&
     ['passed', 'executed', 'rejected', 'closed'].includes(props.proposal.state)
   );
@@ -121,9 +122,7 @@ async function refreshScores() {
 }
 
 onMounted(() => {
-  if (offchainNetworks.includes(props.proposal.network) && isFinalizing.value) {
-    refreshScores();
-  }
+  if (isFinalizing.value) refreshScores();
 });
 </script>
 

--- a/apps/ui/src/components/ProposalStatus.vue
+++ b/apps/ui/src/components/ProposalStatus.vue
@@ -7,6 +7,8 @@ const titles: Record<ProposalState, string> = {
   passed: 'Passed',
   closed: 'Closed',
   rejected: 'Rejected',
+  queued: 'Queued',
+  vetoed: 'Vetoed',
   executed: 'Executed'
 };
 
@@ -16,11 +18,11 @@ defineProps<{ state: ProposalState }>();
 <template>
   <div
     :class="{
-      'bg-gray-400': state === 'pending',
+      'bg-gray-400': state === 'pending' || state === 'queued',
       'bg-skin-success': state === 'active',
       'bg-skin-link': ['passed', 'closed'].includes(state),
       'bg-purple-500': state === 'executed',
-      'bg-skin-danger': state === 'rejected',
+      'bg-skin-danger': ['rejected', 'vetoed'].includes(state),
       '!text-skin-bg': ['passed', 'closed'].includes(state)
     }"
     class="inline-block rounded-full pl-2 pr-[10px] pb-0.5 text-white mb-2"
@@ -42,11 +44,15 @@ defineProps<{ state: ProposalState }>();
       class="text-skin-bg inline-block size-[17px] mb-[1px]"
     />
     <IS-play
+      v-else-if="state === 'queued'"
+      class="text-white inline-block size-[17px]"
+    />
+    <IS-play
       v-else-if="state === 'executed'"
       class="text-white inline-block size-[17px]"
     />
     <IS-x-circle
-      v-else-if="state === 'rejected'"
+      v-else-if="['rejected', 'vetoed'].includes(state)"
       class="text-white inline-block size-[17px] mb-[1px]"
     />
     {{ titles[state] }}

--- a/apps/ui/src/components/ProposalVote.vue
+++ b/apps/ui/src/components/ProposalVote.vue
@@ -144,7 +144,11 @@ const isEditable = computed(() => {
   </slot>
 
   <slot
-    v-else-if="['passed', 'rejected', 'executed'].includes(proposal.state)"
+    v-else-if="
+      ['passed', 'rejected', 'queued', 'vetoed', 'executed'].includes(
+        proposal.state
+      )
+    "
     name="ended"
   >
     Proposal voting window has ended

--- a/apps/ui/src/composables/useExecutionActions.ts
+++ b/apps/ui/src/composables/useExecutionActions.ts
@@ -68,7 +68,7 @@ export function useExecutionActions(
       return proposal.state === 'executed' ? isL1ExecutionReady.value : false;
     }
 
-    return proposal.state === 'executed' && !proposal.execution_settled;
+    return proposal.state === 'queued';
   });
 
   const executionCountdown = computed(() => {

--- a/apps/ui/src/composables/useExecutionActions.ts
+++ b/apps/ui/src/composables/useExecutionActions.ts
@@ -4,6 +4,7 @@ import {
   InMemoryCache
 } from '@apollo/client/core';
 import gql from 'graphql-tag';
+import { MaybeRefOrGetter } from 'vue';
 import { getGenericExplorerUrl } from '@/helpers/generic';
 import {
   getModuleAddressForTreasury,
@@ -27,74 +28,84 @@ const STRATEGIES_WITH_FINALIZE = ['Axiom'];
 const STRATEGIES_WITH_EXTERNAL_DETAILS = ['EthRelayer', 'oSnap'];
 
 export function useExecutionActions(
-  proposal: Proposal,
-  execution: ProposalExecution
+  proposal: MaybeRefOrGetter<Proposal>,
+  execution: MaybeRefOrGetter<ProposalExecution>
 ) {
   const actions = useActions();
 
   const currentTimestamp = ref(Date.now());
   const isL1ExecutionReady = ref(false);
 
-  const fetchingDetails = ref(
-    STRATEGIES_WITH_EXTERNAL_DETAILS.includes(execution.strategyType) &&
-      (execution.strategyType === 'EthRelayer' ? proposal.execution_tx : true)
-  );
+  const fetchingDetails = ref(false);
+  const executionTx = ref<string | null>(null);
   const message: Ref<string | null> = ref(null);
-  const executionTx = ref<string | null>(
-    execution.strategyType !== 'EthRelayer' ? proposal.execution_tx : null
-  );
-  const executionNetwork = ref<Network>(getNetwork(proposal.network));
+  const executionNetwork = ref<Network>(getNetwork(toValue(proposal).network));
   const finalizeProposalSending = ref(false);
   const executeProposalSending = ref(false);
   const executeQueuedProposalSending = ref(false);
   const vetoProposalSending = ref(false);
 
   const { pause } = useIntervalFn(() => {
-    if (currentTimestamp.value > proposal.execution_time * 1000) {
+    const proposalValue = toValue(proposal);
+
+    if (
+      proposalValue.state === 'queued' &&
+      currentTimestamp.value > proposalValue.execution_time * 1000
+    ) {
       pause();
     }
 
     currentTimestamp.value = Date.now();
   }, 1000);
 
-  const network = computed(() => getNetwork(proposal.network));
+  const network = computed(() => getNetwork(toValue(proposal).network));
   const hasFinalize = computed(
     () =>
-      STRATEGIES_WITH_FINALIZE.includes(execution.strategyType) &&
-      !proposal.execution_ready
+      STRATEGIES_WITH_FINALIZE.includes(toValue(execution).strategyType) &&
+      !toValue(proposal).execution_ready
   );
   const hasExecuteQueued = computed(() => {
-    if (execution.strategyType === 'EthRelayer') {
-      return proposal.state === 'executed' ? isL1ExecutionReady.value : false;
+    const executionValue = toValue(execution);
+    const proposalValue = toValue(proposal);
+
+    if (executionValue.strategyType === 'EthRelayer') {
+      return proposalValue.state === 'executed'
+        ? isL1ExecutionReady.value
+        : false;
     }
 
-    return proposal.state === 'queued';
+    return proposalValue.state === 'queued';
   });
 
   const executionCountdown = computed(() => {
-    return Math.max(proposal.execution_time * 1000 - currentTimestamp.value, 0);
+    return Math.max(
+      toValue(proposal).execution_time * 1000 - currentTimestamp.value,
+      0
+    );
   });
 
   const executionTxUrl = computed(() => {
     if (!executionTx.value) return null;
 
     return getGenericExplorerUrl(
-      execution.chainId,
+      toValue(execution).chainId,
       executionTx.value,
       'transaction'
     );
   });
 
   async function fetchEthRelayerExecutionDetails() {
-    if (currentTimestamp.value < proposal.max_end * 1000) {
+    const proposalValue = toValue(proposal);
+
+    if (currentTimestamp.value < proposalValue.max_end * 1000) {
       message.value =
         'This execution strategy requires max end time to be reached.';
     }
 
-    if (!proposal.execution_tx) return;
+    if (!proposalValue.execution_tx) return;
 
     const tx = await network.value.helpers.getTransaction(
-      proposal.execution_tx
+      proposalValue.execution_tx
     );
     if (tx.finality_status !== 'ACCEPTED_ON_L1') {
       message.value = 'Waiting for execution to be received on L1.';
@@ -119,7 +130,9 @@ export function useExecutionActions(
 
     const { data } = await apollo.query({
       query: STARKNET_L1_EXECUTION_QUERY,
-      variables: { id: `${proposal.space.id}/${proposal.proposal_id}` }
+      variables: {
+        id: `${proposalValue.space.id}/${proposalValue.proposal_id}`
+      }
     });
 
     if (!data.starknetL1Execution) {
@@ -131,30 +144,35 @@ export function useExecutionActions(
   }
 
   async function fetchOSnapExecutionDetails() {
+    const executionValue = toValue(execution);
+
     try {
-      if (!execution.chainId || typeof execution.chainId !== 'number') {
+      if (
+        !executionValue.chainId ||
+        typeof executionValue.chainId !== 'number'
+      ) {
         throw new Error('Chain ID is required for oSnap execution');
       }
 
       const proposalHash = getProposalHashFromTransactions(
-        execution.transactions
+        executionValue.transactions
       );
       const moduleAddress = await getModuleAddressForTreasury(
-        execution.chainId,
-        execution.safeAddress
+        executionValue.chainId,
+        executionValue.safeAddress
       );
 
       const data = await getOgProposalGql({
-        chainId: execution.chainId,
-        explanation: proposal.metadata_uri,
+        chainId: executionValue.chainId,
+        explanation: toValue(proposal).metadata_uri,
         moduleAddress,
         proposalHash
       });
 
       if (!data) {
         const configCompliant = await isConfigCompliant(
-          execution.safeAddress,
-          execution.chainId
+          executionValue.safeAddress,
+          executionValue.chainId
         );
 
         message.value = configCompliant.automaticExecution
@@ -180,7 +198,7 @@ export function useExecutionActions(
     finalizeProposalSending.value = true;
 
     try {
-      await actions.finalizeProposal(proposal);
+      await actions.finalizeProposal(toValue(proposal));
     } finally {
       finalizeProposalSending.value = false;
     }
@@ -190,7 +208,7 @@ export function useExecutionActions(
     executeProposalSending.value = true;
 
     try {
-      await actions.executeTransactions(proposal);
+      await actions.executeTransactions(toValue(proposal));
     } finally {
       executeProposalSending.value = false;
     }
@@ -200,7 +218,7 @@ export function useExecutionActions(
     executeQueuedProposalSending.value = true;
 
     try {
-      await actions.executeQueuedProposal(proposal);
+      await actions.executeQueuedProposal(toValue(proposal));
     } finally {
       executeQueuedProposalSending.value = false;
     }
@@ -210,29 +228,42 @@ export function useExecutionActions(
     vetoProposalSending.value = true;
 
     try {
-      await actions.vetoProposal(proposal);
+      await actions.vetoProposal(toValue(proposal));
     } finally {
       vetoProposalSending.value = false;
     }
   }
 
-  onMounted(async () => {
-    if (!STRATEGIES_WITH_EXTERNAL_DETAILS.includes(execution.strategyType)) {
-      return;
-    }
+  watch(
+    () => toValue(proposal),
+    async proposal => {
+      const executionValue = toValue(execution);
 
-    try {
-      if (execution.strategyType === 'EthRelayer') {
-        await fetchEthRelayerExecutionDetails();
-      } else if (execution.strategyType === 'oSnap') {
-        await fetchOSnapExecutionDetails();
-      } else {
-        throw new Error('Unsupported strategy');
+      const isEthRelayer = executionValue.strategyType === 'EthRelayer';
+      const hasExternalDetails = STRATEGIES_WITH_EXTERNAL_DETAILS.includes(
+        executionValue.strategyType
+      );
+
+      executionTx.value = !isEthRelayer ? proposal.execution_tx : null;
+
+      if (!hasExternalDetails) return;
+
+      fetchingDetails.value = isEthRelayer ? !!proposal.execution_tx : true;
+
+      try {
+        if (isEthRelayer) {
+          await fetchEthRelayerExecutionDetails();
+        } else if (executionValue.strategyType === 'oSnap') {
+          await fetchOSnapExecutionDetails();
+        } else {
+          throw new Error('Unsupported strategy');
+        }
+      } finally {
+        fetchingDetails.value = false;
       }
-    } finally {
-      fetchingDetails.value = false;
-    }
-  });
+    },
+    { immediate: true }
+  );
 
   return {
     hasFinalize,

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -111,7 +111,10 @@ function getProposalState(
   const scoresFor = BigInt(proposal.scores_1);
   const scoresAgainst = BigInt(proposal.scores_2);
 
-  if (proposal.executed) return 'executed';
+  if (proposal.executed) {
+    if (proposal.vetoed) return 'vetoed';
+    return proposal.execution_settled ? 'executed' : 'queued';
+  }
   if (proposal.max_end <= current) {
     if (currentQuorum < quorum) return 'rejected';
     return scoresFor > scoresAgainst ? 'passed' : 'rejected';
@@ -371,14 +374,16 @@ function formatProposal(
     )
       ? proposal.max_end <= current
       : proposal.min_end <= current,
-    execution_settled: proposal.completed,
+    execution_settled: proposal.execution_settled,
     state,
     network: networkId,
     privacy: 'none',
     quorum: Number(proposal.execution_strategy_details?.quorum || 0),
     flagged: false,
     flag_code: 0,
-    completed: ['passed', 'executed', 'rejected'].includes(state),
+    completed: ['passed', 'rejected', 'queued', 'vetoed', 'executed'].includes(
+      state
+    ),
     plugins: {},
     voting_power_validation_strategy_strategies: [],
     voting_power_validation_strategy_strategies_params: []

--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -149,7 +149,7 @@ gql(`
     execution_ready
     executed
     vetoed
-    completed
+    execution_settled
     cancelled
   }
 `);

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -21,6 +21,8 @@ export type ProposalState =
   | 'passed'
   | 'rejected'
   | 'closed'
+  | 'queued'
+  | 'vetoed'
   | 'executed';
 
 export type NetworkID =

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -91,7 +91,7 @@ const cancellable = computed(() => {
   } else {
     return (
       compareAddresses(props.proposal.space.controller, web3.value.account) &&
-      props.proposal.state !== 'executed' &&
+      !['queued', 'vetoed', 'executed'].includes(props.proposal.state) &&
       props.proposal.cancelled === false
     );
   }


### PR DESCRIPTION
### Summary

This PR adds support for timelock Queued and Vetoed proposal statuses. Before Governor support is merged this will affect only SnapshotX proposals with Timelock.

This was extracted from https://github.com/snapshot-labs/sx-monorepo/pull/1514.

There are two commits there: one that adds queued/vetoed statuses and second one that refactors `useExecutionAction` composables to fix reactivity. It's recommended to review this PR per-commit to avoid mixing kind of different concerns.

### How to test

1. Create SnapshotX space with timelock (or use existing one), make sure you have treasury created for your timelock so it can be used in the UI.
2. Create proposal with execution.
3. Vote, you can Execute transactions.
4. Proposal will now become Queued (you need to F5 or go away from the page and come back to refresh those statuses).
5. You will see `Execution available in ...` counter and Veto transaction buttons.
6. Veto this proposal, proposal will become Vetoed (again refresh or navigate away).
7. Create other proposal as above but this time try waiting and executing it.
8. It should become executed.

### Screenshots

<img width="500" height="916" alt="image" src="https://github.com/user-attachments/assets/c2aafce3-9297-4d52-bab8-f97c5647d6ec" />
<img width="500" height="1072" alt="image" src="https://github.com/user-attachments/assets/51e81cd4-6b04-4123-9d78-e4594d90ceb0" />
<img width="500" height="1006" alt="image" src="https://github.com/user-attachments/assets/625f309e-9c14-45cb-bde5-1be729426f7e" />


Executed:
<img width="500" height="986" alt="image" src="https://github.com/user-attachments/assets/7db875a3-d6f9-4bbc-8586-adcd3963269f" />

