### PR TITLE
refactor: use API vp_decimals

### DIFF
--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -117,6 +117,7 @@ gql(`
     min_end
     max_end
     snapshot
+    vp_decimals
     scores_1
     scores_2
     scores_3

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -376,6 +376,7 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     labels: proposal.labels,
     scores: proposal.scores,
     scores_total: proposal.scores_total,
+    vp_decimals: 0,
     vote_count: proposal.votes,
     state,
     cancelled: false,

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -259,6 +259,7 @@ export type Proposal = {
    * If proposal is invalid it means that it was not created correctly.
    */
   isInvalid: boolean;
+  vp_decimals: number;
   type: VoteType;
   quorum: number;
   quorum_type?: 'default' | 'rejection';

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -53,15 +53,7 @@ const discussion = computed(() => {
   return sanitizeUrl(proposal.value.discussion);
 });
 
-const votingPowerDecimals = computed(() => {
-  if (!proposal.value) return 0;
-  return Math.max(
-    ...proposal.value.space.strategies_parsed_metadata.map(
-      metadata => metadata.decimals
-    ),
-    0
-  );
-});
+const votingPowerDecimals = computed(() => proposal.value?.vp_decimals ?? 0);
 
 const currentVote = computed(
   () =>

--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -21,14 +21,7 @@ const votesHeader = ref<HTMLElement | null>(null);
 const { x: votesHeaderX } = useScroll(votesHeader);
 
 const network = computed(() => getNetwork(props.proposal.network));
-const votingPowerDecimals = computed(() => {
-  return Math.max(
-    ...props.proposal.space.strategies_parsed_metadata.map(
-      metadata => metadata.decimals
-    ),
-    0
-  );
-});
+const votingPowerDecimals = computed(() => props.proposal.vp_decimals);
 
 const {
   data,


### PR DESCRIPTION
### Summary

This PR uses `vp_decimals` from API instead of recomputing it on UI. This will be also helpful for Governor integration.

Extracted from: https://github.com/snapshot-labs/sx-monorepo/pull/1514

### How to test

1. Go to http://localhost:8080/#/sn:0x009fedaf0d7a480d21a27683b0965c0f8ded35b3f1cac39827a25a06a8a682a4/proposal/10/votes
2. VP values are formatted as expected.
3. Go to http://localhost:8080/#/s:stgdao.eth/proposal/0xfe2a457fd2cbb45ff1afaf6e3681489f4ab96be6c28becd1adaf758621e4ff98/votes
4. VP values are formatted as expected.

