### PR TITLE
fix: handle empty strategies in API

### DIFF
--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -164,6 +164,10 @@ function getValidationStrategyStrategiesIndices(
   strategies: string[],
   parsedMetadata: ApiStrategyParsedMetadata[]
 ) {
+  if (strategies.length === 0 || parsedMetadata.length === 0) {
+    return [];
+  }
+
   // Those values are default sorted by block_range so newest entries are at the end
   const maxIndex = Math.max(
     ...parsedMetadata.slice(-strategies.length).map(metadata => metadata.index)


### PR DESCRIPTION
### Summary

Extracted from https://github.com/snapshot-labs/sx-monorepo/pull/1514

When strategies are empty we get `-Infinity` for maxIndex which ten throws when we try to create Array of this size. It doesn't change anything for us (no spaces should have empty strategies I think), but will accommodate Governor spaces.
