### PR TITLE
.feat: disable proposal creation and space edition on disabled strategies

### DIFF
--- a/apps/ui/src/components/FormSpaceStrategies.vue
+++ b/apps/ui/src/components/FormSpaceStrategies.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { DISABLED_STRATEGIES } from '@/helpers/constants';
 import { StrategyConfig } from '@/networks/types';
 import { NetworkID, Space } from '@/types';
 
@@ -85,6 +86,7 @@ function handleTestStrategies(strategies: StrategyConfig[]) {
       :limit="strategiesLimit"
       :space-id="space.id"
       :voting-power-symbol="space.voting_power_symbol"
+      :hidden-strategies="[...DISABLED_STRATEGIES]"
       @test-strategies="handleTestStrategies"
     />
   </UiContainerSettings>

--- a/apps/ui/src/components/Modal/SelectValidation.vue
+++ b/apps/ui/src/components/Modal/SelectValidation.vue
@@ -14,7 +14,10 @@ const validations = ref([] as ValidationDetails[]);
 </script>
 
 <script setup lang="ts">
-import { VALIDATION_TYPES_INFO } from '@/helpers/constants';
+import {
+  DISABLED_STRATEGIES,
+  VALIDATION_TYPES_INFO
+} from '@/helpers/constants';
 import { clone } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
 import { StrategyConfig } from '@/networks/types';
@@ -322,6 +325,7 @@ watch(
             allow-duplicates
             :network-id="networkId"
             :default-chain-id="defaultChainId"
+            :hidden-strategies="[...DISABLED_STRATEGIES]"
             @test-strategies="handleTestStrategies"
           >
             <template #empty>

--- a/apps/ui/src/components/SetupStrategiesConfiguratorOffchain.vue
+++ b/apps/ui/src/components/SetupStrategiesConfiguratorOffchain.vue
@@ -4,6 +4,7 @@ const editStrategyModalStrategyId = ref<StrategyTemplate['address']>();
 </script>
 
 <script setup lang="ts">
+import { DISABLED_STRATEGIES } from '@/helpers/constants';
 import { getNetwork } from '@/networks';
 import { StrategyConfig, StrategyTemplate } from '@/networks/types';
 import { ChainId, NetworkID } from '@/types';
@@ -14,6 +15,11 @@ const POPULAR_STRATEGIES: Record<string, StrategyTemplate['address']> = {
   'ERC-721': 'erc721',
   'ERC-1155': 'erc1155-balance-of'
 } as const;
+
+const HIDDEN_STRATEGIES: StrategyTemplate['address'][] = [
+  ...DISABLED_STRATEGIES,
+  'ticket'
+];
 
 const strategies = defineModel<StrategyConfig[]>({ required: true });
 
@@ -112,7 +118,7 @@ onMounted(() => {
         v-model:model-value="strategies"
         :network-id="networkId"
         :default-chain-id="chainId"
-        :hidden-strategies="['ticket']"
+        :hidden-strategies="HIDDEN_STRATEGIES"
         :limit="limits['space.default.strategies_limit']"
         @test-strategies="handleTestStrategies"
       >

--- a/apps/ui/src/components/SpaceAlerts.vue
+++ b/apps/ui/src/components/SpaceAlerts.vue
@@ -11,6 +11,7 @@ const pendingTasks = computed(() => {
 
   if (
     alerts.value.has('HAS_DEPRECATED_STRATEGIES') ||
+    alerts.value.has('HAS_DISABLED_STRATEGIES') ||
     alerts.value.has('HAS_PRO_ONLY_STRATEGIES') ||
     alerts.value.has('HAS_PRO_ONLY_NETWORKS')
   ) {

--- a/apps/ui/src/components/SpaceSettingsAlerts.vue
+++ b/apps/ui/src/components/SpaceSettingsAlerts.vue
@@ -27,11 +27,19 @@ const deprecatedStrategies = computed(
       ?.strategies.map((s: string) => `"${s}"`) || []
 );
 
+const disabledStrategies = computed(
+  () =>
+    alerts.value
+      .get('HAS_DISABLED_STRATEGIES')
+      ?.strategies.map((s: string) => `"${s}"`) || []
+);
+
 const hasVotingStrategiesAlerts = computed(
   () =>
     props.activeTab === 'voting-strategies' &&
     (unsupportedProOnlyStrategies.value.length > 0 ||
       deprecatedStrategies.value.length > 0 ||
+      disabledStrategies.value.length > 0 ||
       unsupportedProOnlyNetworks.value.length > 0)
 );
 
@@ -61,6 +69,11 @@ const hasAnyAlerts = computed(
           <IH-arrow-sm-right class="-rotate-45" />
         </AppLink>
       </UiAlert>
+      <UiAlert v-if="disabledStrategies.length" type="error">
+        The {{ prettyConcat(disabledStrategies, 'and') }}
+        {{ disabledStrategies.length > 1 ? 'strategies are' : 'strategy is' }}
+        no longer available.
+      </UiAlert>
       <UiAlert v-if="unsupportedProOnlyStrategies.length" type="error">
         The
         {{ prettyConcat(unsupportedProOnlyStrategies, 'and') }}
@@ -79,7 +92,6 @@ const hasAnyAlerts = computed(
           follow migration guide
           <IH-arrow-sm-right class="-rotate-45" />
         </AppLink>
-        before August 15, 2025
       </UiAlert>
       <UiAlert v-if="unsupportedProOnlyNetworks.length" type="error">
         The
@@ -98,7 +110,6 @@ const hasAnyAlerts = computed(
           change to a premium network
           <IH-arrow-sm-right class="-rotate-45" />
         </AppLink>
-        before August 15, 2025
       </UiAlert>
     </template>
     <template v-if="hasWhitelabelAlerts">
@@ -113,7 +124,6 @@ const hasAnyAlerts = computed(
           follow migration guide
           <IH-arrow-sm-right class="-rotate-45" />
         </AppLink>
-        before August 15, 2025
       </UiAlert>
     </template>
   </div>

--- a/apps/ui/src/composables/useSpaceAlerts.ts
+++ b/apps/ui/src/composables/useSpaceAlerts.ts
@@ -1,5 +1,6 @@
 import {
   DEPRECATED_STRATEGIES,
+  DISABLED_STRATEGIES,
   OVERRIDING_STRATEGIES
 } from '@/helpers/constants';
 import { offchainNetworks } from '@/networks';
@@ -11,6 +12,7 @@ const UPCOMING_PRO_ONLY_NETWORKS: readonly string[] = [
 
 type AlertType =
   | 'HAS_DEPRECATED_STRATEGIES'
+  | 'HAS_DISABLED_STRATEGIES'
   | 'HAS_PRO_ONLY_STRATEGIES'
   | 'HAS_PRO_ONLY_NETWORKS'
   | 'HAS_PRO_ONLY_WHITELABEL';
@@ -46,6 +48,14 @@ export function useSpaceAlerts(
 
     return space.value.strategies.filter(strategy =>
       (DEPRECATED_STRATEGIES as readonly string[]).includes(strategy)
+    );
+  });
+
+  const disabledStrategies = computed(() => {
+    if (!isOffchainSpace.value) return [];
+
+    return space.value.strategies.filter(strategy =>
+      (DISABLED_STRATEGIES as readonly string[]).includes(strategy)
     );
   });
 
@@ -85,6 +95,12 @@ export function useSpaceAlerts(
     if (deprecatedStrategies.value.length) {
       alertsMap.set('HAS_DEPRECATED_STRATEGIES', {
         strategies: deprecatedStrategies.value
+      });
+    }
+
+    if (disabledStrategies.value.length) {
+      alertsMap.set('HAS_DISABLED_STRATEGIES', {
+        strategies: disabledStrategies.value
       });
     }
 

--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -250,7 +250,8 @@ export const OVERRIDING_STRATEGIES = [
   'split-delegation',
   'sonic-staked-balance'
 ] as const;
-export const DEPRECATED_STRATEGIES = ['multichain'] as const;
+export const DISABLED_STRATEGIES = ['multichain'] as const;
+export const DEPRECATED_STRATEGIES = [] as const;
 export const DELEGATE_REGISTRY_STRATEGIES = [
   'delegation',
   'erc20-balance-of-delegation',

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -72,6 +72,14 @@ const nonPremiumNetworksList = computed(() => {
   return prettyConcat(boldNames, 'and');
 });
 
+const disabledStrategiesList = computed(() => {
+  return (
+    alerts.value
+      .get('HAS_DISABLED_STRATEGIES')
+      ?.strategies?.map((n: any) => `<b>${n}</b>`) || []
+  );
+});
+
 const privacy = computed({
   get() {
     return proposal.value?.privacy === 'shutter';
@@ -192,7 +200,8 @@ const isSubmitButtonLoading = computed(() => {
 });
 const canSubmit = computed(() => {
   const hasUnsupportedNetworks =
-    alerts.value.has('HAS_PRO_ONLY_NETWORKS') &&
+    (alerts.value.has('HAS_PRO_ONLY_NETWORKS') ||
+      alerts.value.has('HAS_DISABLED_STRATEGIES')) &&
     !proposal.value?.originalProposal;
   const hasFormErrors = Object.keys(formErrors.value).length > 0;
 
@@ -527,6 +536,20 @@ watchEffect(() => {
               upgrade your space
             </AppLink>
             to continue.
+          </UiAlert>
+          <UiAlert
+            v-else-if="disabledStrategiesList.length"
+            type="error"
+            class="mb-4"
+          >
+            You can not create proposals. The
+            <span v-html="prettyConcat(disabledStrategiesList)" />
+            {{
+              disabledStrategiesList.length > 1
+                ? 'strategies are'
+                : 'strategy is'
+            }}
+            no longer available.
           </UiAlert>
           <template v-else>
             <template v-if="proposalLimitReached">

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -55,6 +55,7 @@ const { invalidateController } = useSpaceController(toRef(props, 'space'));
 const uiStore = useUiStore();
 const queryClient = useQueryClient();
 const { setTitle } = useTitle();
+const { alerts } = useSpaceAlerts(toRef(props, 'space'));
 
 const el = ref(null);
 const { height: bottomToolbarHeight } = useElementSize(el);
@@ -184,7 +185,7 @@ const error = computed(() => {
       return 'At least one strategy is required';
     }
 
-    if (!isTicketValid.value) {
+    if (!isTicketValid.value || alerts.value.has('HAS_DISABLED_STRATEGIES')) {
       return 'Strategies are invalid';
     }
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward https://github.com/snapshot-labs/workflow/issues/631

This PR will disable:

- proposal creation
- offchain space edition 

When the space is using some disabled strategies

Before, we were only showing an alert on the UI about deprecated strategies, this PR will "upgrade" the deprecated strategies to the list of disabled strategies, and block the action, in addition of showing the alert.

The disabled strategies will also not appear in the list is strategies anymore.

Currently, only `multichain` strategy is disabled

### How to test

<img width="1778" height="1868" alt="image" src="https://github.com/user-attachments/assets/af8b0663-a9c6-4d95-b9f0-9accc052b496" />


1. Go to a space with multichain strategies: http://localhost:8080/#/s:test.wa0x6e.eth/settings/voting-strategies
2. It should show that the "Strategies are invalid" in the bottom toolbar, and prevent you from saving the space settings.
3. It shows an alert that "The "multichain" strategy is no longer available."
4. When trying to add a strategy, the `multichain` strategy no longer appear in the list

<img width="2254" height="672" alt="image" src="https://github.com/user-attachments/assets/2223a753-d532-4973-b46a-e44a1b94e973" />

1. When trying to create a proposal, it shows an error message about disabled strategies, and PUBLISH button is disabled

<img width="1326" height="1166" alt="image" src="https://github.com/user-attachments/assets/3c48bed5-1915-44ff-a1ab-599dd0b2aaa2" />

1. It shows an alert on the space home page

### To-Do

- [ ] In a later PR, fetch the list of disabled strategies from score-api, to have a single source of truth