### PR TITLE
fix: filter follows by enabled network

### DIFF
--- a/apps/ui/src/stores/followedSpaces.ts
+++ b/apps/ui/src/stores/followedSpaces.ts
@@ -1,6 +1,11 @@
 import { useQuery, useQueryClient } from '@tanstack/vue-query';
 import { defineStore } from 'pinia';
-import { getNetwork, metadataNetwork, offchainNetworks } from '@/networks';
+import {
+  enabledNetworks,
+  getNetwork,
+  metadataNetwork,
+  offchainNetworks
+} from '@/networks';
 import { useFollowedSpacesQuery } from '@/queries/spaces';
 import { NetworkID, Space } from '@/types';
 import pkg from '../../package.json';
@@ -35,7 +40,9 @@ export const useFollowedSpacesStore = defineStore('followedSpaces', () => {
     queryFn: async () => {
       const follows = await network.api.loadFollows(web3.value.account);
 
-      return follows.map(follow => getCompositeSpaceId(follow.space));
+      return follows
+        .filter(follow => enabledNetworks.includes(follow.space.network))
+        .map(follow => getCompositeSpaceId(follow.space));
     },
     enabled: () =>
       authInitiated.value && !isWhiteLabel.value && !!web3.value.account


### PR DESCRIPTION
### Summary

Sometimes we run UI without all networks enabled. In that case follows for spaces on unsupported network will be attempted to be loaded which might fail for some actions.

This commit will only load spaces on networks that are supported.

### How to test

1. Go to https://snapshot.box/#/notifications?as=fabien.eth
2. It should load.