### PR TITLE
fix: check for "Slot is zero" error in storage proof strategies

### DIFF
--- a/.changeset/six-chicken-tickle.md
+++ b/.changeset/six-chicken-tickle.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+Call get_voting_power in storage proof strategies to verify Slot is zero is not thrown

--- a/packages/sx.js/src/strategies/starknet/evmSlotValue.ts
+++ b/packages/sx.js/src/strategies/starknet/evmSlotValue.ts
@@ -89,6 +89,20 @@ export default function createEvmSlotValueStrategy(): Strategy {
         chainId
       );
 
+      // This check is only needed to look for "Slot is zero" error
+      // Current storage proof contracts will revert if we try to use them
+      // and user has no slot value.
+      // This can be removed after contracts include this
+      // https://github.com/snapshot-labs/sx-starknet/pull/624
+      await contract.get_voting_power(
+        startTimestamp,
+        getUserAddressEnum('ETHEREUM', signerAddress),
+        params,
+        CallData.compile({
+          storageProof
+        })
+      );
+
       return CallData.compile({
         storageProof
       });
@@ -152,10 +166,7 @@ export default function createEvmSlotValueStrategy(): Strategy {
       try {
         return await contract.get_voting_power(
           timestamp,
-          getUserAddressEnum(
-            voterAddress.length === 42 ? 'ETHEREUM' : 'STARKNET',
-            voterAddress
-          ),
+          getUserAddressEnum('ETHEREUM', voterAddress),
           params,
           CallData.compile({
             storageProof

--- a/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
+++ b/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
@@ -131,6 +131,22 @@ export default function createOzVotesStorageProofStrategy({
       if (!checkpointMptProof || !exclusionMptProof)
         throw new Error('Invalid proofs');
 
+      // This check is only needed to look for "Slot is zero" error
+      // Current storage proof contracts will revert if we try to use them
+      // and user has no slot value.
+      // This can be removed after contracts include this
+      // https://github.com/snapshot-labs/sx-starknet/pull/624
+      await contract.get_voting_power(
+        startTimestamp,
+        getUserAddressEnum('ETHEREUM', signerAddress),
+        params,
+        CallData.compile({
+          checkpointIndex,
+          checkpointMptProof,
+          exclusionMptProof
+        })
+      );
+
       return CallData.compile({
         checkpointIndex,
         checkpointMptProof,


### PR DESCRIPTION
### Summary

Current contracts (evmSlotValue and ozVotesStorageProofTrace224) will revert with 'Slot is zero' if we try to vote with them and user has no slot.

This was changed in the contracts
(https://github.com/snapshot-labs/sx-starknet/pull/624/files) but we still use old versions.

To prevent UI from trying to use those strategies when Slot is zero is being thrown we simulate get_voting_power call to detect it.

