### PR TITLE
feat(ui): add proposal executions tab

### DIFF
--- a/apps/ui/src/routes/common.ts
+++ b/apps/ui/src/routes/common.ts
@@ -1,4 +1,5 @@
 import { RouteRecordRaw } from 'vue-router';
+import ProposalExecutions from '@/views/Proposal/Executions.vue';
 import ProposalOverview from '@/views/Proposal/Overview.vue';
 import ProposalVotes from '@/views/Proposal/Votes.vue';
 import Proposal from '@/views/Proposal.vue';
@@ -38,6 +39,11 @@ export const spaceChildrenRoutes: RouteRecordRaw[] = [
         component: ProposalOverview
       },
       { path: 'votes', name: 'space-proposal-votes', component: ProposalVotes },
+      {
+        path: 'executions',
+        name: 'space-proposal-executions',
+        component: ProposalExecutions
+      },
       {
         path: 'discussion',
         name: 'space-proposal-discussion',

--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -161,6 +161,27 @@ watchEffect(() => {
               />
             </AppLink>
             <AppLink
+              v-if="
+                proposal.executions.length ||
+                proposal.execution_strategy_type === 'safeSnap'
+              "
+              :to="{
+                name: 'space-proposal-executions',
+                params: {
+                  proposal: proposal.proposal_id,
+                  space: `${proposal.network}:${proposal.space.id}`
+                }
+              }"
+              class="flex items-center"
+            >
+              <UiLink
+                :is-active="route.name === 'space-proposal-executions'"
+                :count="proposal.executions.length"
+                text="Executions"
+                class="inline-block"
+              />
+            </AppLink>
+            <AppLink
               :to="{
                 name: 'space-proposal-votes',
                 params: {

--- a/apps/ui/src/views/Proposal/Executions.vue
+++ b/apps/ui/src/views/Proposal/Executions.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { SNAPSHOT_URLS } from '@/networks/offchain';
+import { Proposal } from '@/types';
+
+defineProps<{
+  proposal: Proposal;
+}>();
+</script>
+
+<template>
+  <div
+    v-if="
+      (proposal.executions && proposal.executions.length > 0) ||
+      proposal.execution_strategy_type === 'safeSnap'
+    "
+    class="p-4"
+  >
+    <UiAlert
+      v-if="proposal.execution_strategy_type === 'safeSnap'"
+      type="warning"
+    >
+      This proposal uses SafeSnap execution which is currently not supported on
+      the new interface. You can view execution details on the
+      <a
+        :href="`${SNAPSHOT_URLS[proposal.network]}/#/${proposal.space.id}/proposal/${proposal.id}`"
+        target="_blank"
+        class="inline-flex items-center font-bold"
+      >
+        previous interface
+        <IH-arrow-sm-right class="inline-block -rotate-45" />
+      </a>
+      .
+    </UiAlert>
+    <ProposalExecutionsList
+      :network-id="proposal.network"
+      :proposal="proposal"
+      :executions="proposal.executions"
+    />
+  </div>
+  <div v-else class="px-4 py-3 flex items-center gap-2">
+    <IH-exclamation-circle class="shrink-0" />
+    This proposal has no executions.
+  </div>
+</template>

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -10,7 +10,6 @@ import {
   shortenAddress
 } from '@/helpers/utils';
 import { offchainNetworks } from '@/networks';
-import { SNAPSHOT_URLS } from '@/networks/offchain';
 import { PROPOSALS_KEYS } from '@/queries/proposals';
 import { Proposal } from '@/types';
 
@@ -541,41 +540,6 @@ onBeforeUnmount(() => destroyAudio());
         <a :href="discussion" target="_blank" class="block mb-5">
           <UiLinkPreview :url="discussion" :show-default="true" />
         </a>
-      </div>
-      <div
-        v-if="
-          (proposal.executions && proposal.executions.length > 0) ||
-          proposal.execution_strategy_type === 'safeSnap'
-        "
-      >
-        <h4 class="mb-3 eyebrow flex items-center gap-2">
-          <IH-play />
-          <span>Execution</span>
-        </h4>
-        <div class="mb-4">
-          <UiAlert
-            v-if="proposal.execution_strategy_type === 'safeSnap'"
-            type="warning"
-          >
-            This proposal uses SafeSnap execution which is currently not
-            supported on the new interface. You can view execution details on
-            the
-            <a
-              :href="`${SNAPSHOT_URLS[proposal.network]}/#/${proposal.space.id}/proposal/${proposal.id}`"
-              target="_blank"
-              class="inline-flex items-center font-bold"
-            >
-              previous interface
-              <IH-arrow-sm-right class="inline-block -rotate-45" />
-            </a>
-            .
-          </UiAlert>
-          <ProposalExecutionsList
-            :network-id="proposal.network"
-            :proposal="proposal"
-            :executions="proposal.executions"
-          />
-        </div>
       </div>
       <div>
         <router-link


### PR DESCRIPTION

### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1523

This PR will create a new EXECUTIONS tab/page in the proposal, for proposals with executions.

<img width="1274" height="810" alt="image" src="https://github.com/user-attachments/assets/c1ca4f5c-bbe9-4bf3-8a49-495ec7cffe43" />

This is just a simple UI update, moving the executions list from the overview tab to a new "executions" tab.

### How to test

- onchain proposal: http://localhost:8080/#/base:0x282d013BF31374D0046F04D6a7644d97751ed339/proposal/6/executions
- offchain proposal: http://localhost:8080/#/s:%E3%81%8A%E3%81%AF%E3%82%88%E3%81%86.wa0x6e.eth/proposal/0x42b8e4c663318fbda0fc04c089fac6fdda96abdcb25d9549a5bcf15e293aae73/executions

1. Go to the urls mentioned above
2. You should see an executions tab, with the list of executions
3. The tab title should show the executions count
4. In the main tab (overview), there is no more executions sections
5. Go to a proposal without executions: http://localhost:8080/#/s:aavedao.eth/proposal/0x1c12498028d114d73fd1614a7f5c8ba7e922ff129b5807d35d83f436bf8b4bcd
6. There is no "executions" tab
7. If you go to the executions tab manually (http://localhost:8080/#/s:aavedao.eth/proposal/0x1c12498028d114d73fd1614a7f5c8ba7e922ff129b5807d35d83f436bf8b4bcd/executions), it should show a message.

### Note

We're showing an alert on overview page for some shady proposals, about executions:

<img width="1314" height="494" alt="image" src="https://github.com/user-attachments/assets/3a43a102-fdb5-410d-adbe-42982488b26d" />

Should we also show it on the executions page ?