### PR TITLE
refactor: use string chainId in getProvider/getABI/walletconnect

### DIFF
--- a/apps/ui/src/components/Modal/CustomStrategy.vue
+++ b/apps/ui/src/components/Modal/CustomStrategy.vue
@@ -54,7 +54,7 @@ async function handleSubmit() {
     const contract = new Contract(
       contractAddress.value,
       ABI,
-      getProvider(props.chainId as number)
+      getProvider(props.chainId.toString())
     );
 
     const type = await contract.getStrategyType();

--- a/apps/ui/src/components/Modal/LinkWalletConnect.vue
+++ b/apps/ui/src/components/Modal/LinkWalletConnect.vue
@@ -40,7 +40,7 @@ const emit = defineEmits<{
 const { transaction } = useWalletConnectTransaction();
 const { loading, logged, proposal, connect, logout } = useWalletConnect(
   props.networkId,
-  Number(props.network),
+  props.network.toString(),
   props.address,
   props.spaceKey,
   props.executionStrategy

--- a/apps/ui/src/components/Modal/Transaction.vue
+++ b/apps/ui/src/components/Modal/Transaction.vue
@@ -178,7 +178,7 @@ async function handleToChange(to: string) {
       return;
     }
 
-    form.abi = await getABI(Number(props.network), contractAddress);
+    form.abi = await getABI(network, contractAddress);
   } catch (e) {
     console.log(e);
     showAbiInput.value = true;

--- a/apps/ui/src/components/Modal/Transaction.vue
+++ b/apps/ui/src/components/Modal/Transaction.vue
@@ -161,13 +161,15 @@ async function handleToChange(to: string) {
     return;
   }
 
-  if (typeof props.network === 'string') {
+  const network = props.network.toString();
+
+  if (!/^[0-9]+$/.test(network)) {
     console.log('network is not a number (starknet is not supported)');
     return;
   }
 
   loading.value = true;
-  const provider = getProvider(props.network);
+  const provider = getProvider(network);
 
   try {
     const isContract = await getIsContract(provider, contractAddress);
@@ -176,7 +178,7 @@ async function handleToChange(to: string) {
       return;
     }
 
-    form.abi = await getABI(props.network, contractAddress);
+    form.abi = await getABI(Number(props.network), contractAddress);
   } catch (e) {
     console.log(e);
     showAbiInput.value = true;

--- a/apps/ui/src/components/PickerToken.vue
+++ b/apps/ui/src/components/PickerToken.vue
@@ -59,22 +59,23 @@ function handlePick(token: Token) {
   emit('pick', token.contractAddress);
 }
 
-async function fetchCustomToken(address) {
+async function fetchCustomToken(address: string) {
   if (props.assets.find(asset => asset.contractAddress === address)) return;
 
-  if (typeof props.network === 'string') {
+  const network = props.network.toString();
+
+  if (!/^[0-9]+$/.test(network)) {
     console.log('network is not a number (starknet is not supported)');
     return;
   }
 
   customTokenLoading.value = true;
 
-  const network = props.network;
   const provider = getProvider(network);
   const tokens = [address];
 
   try {
-    const multi = new Multicaller(network.toString(), provider, abis.erc20);
+    const multi = new Multicaller(network, provider, abis.erc20);
     tokens.forEach(token => {
       multi.call(`${token}.name`, token, 'name');
       multi.call(`${token}.symbol`, token, 'symbol');

--- a/apps/ui/src/composables/useSafeWallet.ts
+++ b/apps/ui/src/composables/useSafeWallet.ts
@@ -7,7 +7,7 @@ import { NetworkID } from '@/types';
 
 const getSafeVersion = useMemoize(
   async (networkKey: string, account: string) => {
-    const provider = getProvider(Number(networkKey));
+    const provider = getProvider(networkKey);
 
     const isContract = await getIsContract(provider, account);
     if (!isContract) return undefined;

--- a/apps/ui/src/composables/useWalletConnect.ts
+++ b/apps/ui/src/composables/useWalletConnect.ts
@@ -39,7 +39,7 @@ async function getConnector() {
 
 const connections: Ref<Record<string, ConnectionData | undefined>> = ref({});
 
-async function parseCall(chainId: number, call) {
+async function parseCall(chainId: string, call) {
   const params = call.params[0];
 
   const abi = await getABI(chainId, params.to);
@@ -75,7 +75,7 @@ async function parseCall(chainId: number, call) {
 
 export function useWalletConnect(
   networkId: NetworkID,
-  chainId: number,
+  chainId: string,
   account: string,
   spaceKey: string,
   executionStrategy: SelectedStrategy | null
@@ -149,7 +149,7 @@ export function useWalletConnect(
 
   function getApprovedNamespaces(
     proposal: ProposalTypes.Struct,
-    chainId: number,
+    chainId: string,
     account: string
   ) {
     const requiredChains = proposal.requiredNamespaces.eip155?.chains || [];

--- a/apps/ui/src/composables/useWalletConnectTransaction.ts
+++ b/apps/ui/src/composables/useWalletConnectTransaction.ts
@@ -2,7 +2,7 @@ import { NetworkID, SelectedStrategy, Transaction } from '@/types';
 
 const spaceKey = ref<string | null>(null);
 const spaceNetwork = ref<NetworkID | null>(null);
-const network = ref<number | null>(null);
+const network = ref<string | null>(null);
 const executionStrategy = ref<SelectedStrategy | null>(null);
 const transaction = ref<Transaction | null>(null);
 
@@ -10,7 +10,7 @@ export function useWalletConnectTransaction() {
   function setTransaction(
     _spaceKey: string,
     _spaceNetwork: NetworkID,
-    _network: number,
+    _network: string,
     _executionStrategy: SelectedStrategy | null,
     _tx: Transaction | null
   ) {

--- a/apps/ui/src/helpers/alchemy/index.ts
+++ b/apps/ui/src/helpers/alchemy/index.ts
@@ -101,7 +101,7 @@ export async function getBalance(
   address: string,
   chainId: ChainId
 ): Promise<string> {
-  const provider = getProvider(Number(chainId));
+  const provider = getProvider(chainId.toString());
   const balance = await provider.getBalance(address, 'latest');
 
   return balance.toHexString();

--- a/apps/ui/src/helpers/contracts.ts
+++ b/apps/ui/src/helpers/contracts.ts
@@ -14,7 +14,7 @@ export async function getIsContract(provider: Provider, address: string) {
 }
 
 export async function getTokensMetadata(chainId: number, tokens: string[]) {
-  const provider = getProvider(chainId);
+  const provider = getProvider(chainId.toString());
 
   const multi = new Multicaller(chainId.toString(), provider, abis.erc20);
   tokens.forEach(token => {

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -81,7 +81,7 @@ async function deepResolve(
   property: string,
   params: any[]
 ) {
-  const provider = getProvider(chainId);
+  const provider = getProvider(chainId.toString());
   const resolvers = ENS_CONTRACTS.resolvers[chainId];
   if (!resolvers) throw new Error('Unsupported chainId');
 
@@ -146,7 +146,7 @@ export async function setEnsTextRecord(
   const ensHash = namehash(ensNormalize(ens));
 
   const resolverAddress = await call(
-    getProvider(chainId),
+    getProvider(chainId.toString()),
     ENS_CONTRACTS.registryAbi,
     [ENS_CONTRACTS.registry, 'resolver', [ensHash]]
   );
@@ -164,7 +164,7 @@ export async function setEnsTextRecord(
 }
 
 export async function getNameOwner(name: string, chainId: ENSChainId) {
-  const provider = getProvider(chainId);
+  const provider = getProvider(chainId.toString());
   const ensHash = namehash(name);
 
   let owner = await call(

--- a/apps/ui/src/helpers/etherscan.ts
+++ b/apps/ui/src/helpers/etherscan.ts
@@ -1,11 +1,11 @@
 import { call } from './call';
 import { getProvider } from './provider';
 
-export async function getABI(chainId: number, address: string) {
+export async function getABI(chainId: string, address: string) {
   const apiHost = `https://api.etherscan.io/v2/api`;
 
   const params = new URLSearchParams({
-    chainid: chainId.toString(),
+    chainid: chainId,
     module: 'contract',
     action: 'getAbi',
     address,
@@ -18,11 +18,10 @@ export async function getABI(chainId: number, address: string) {
 
   // if there is a `implementation` method, get the ABI for that instead
   if (abi.find(({ name }) => name === 'implementation')) {
-    const implementationAddress = await call(
-      getProvider(chainId.toString()),
-      abi,
-      [address, 'implementation']
-    );
+    const implementationAddress = await call(getProvider(chainId), abi, [
+      address,
+      'implementation'
+    ]);
 
     if (implementationAddress) {
       return await getABI(chainId, implementationAddress);

--- a/apps/ui/src/helpers/etherscan.ts
+++ b/apps/ui/src/helpers/etherscan.ts
@@ -18,10 +18,11 @@ export async function getABI(chainId: number, address: string) {
 
   // if there is a `implementation` method, get the ABI for that instead
   if (abi.find(({ name }) => name === 'implementation')) {
-    const implementationAddress = await call(getProvider(chainId), abi, [
-      address,
-      'implementation'
-    ]);
+    const implementationAddress = await call(
+      getProvider(chainId.toString()),
+      abi,
+      [address, 'implementation']
+    );
 
     if (implementationAddress) {
       return await getABI(chainId, implementationAddress);

--- a/apps/ui/src/helpers/generic.ts
+++ b/apps/ui/src/helpers/generic.ts
@@ -67,7 +67,7 @@ export async function waitForTransaction(
     try {
       networkId = getEvmNetworkId(chainId);
     } catch {
-      const provider = getProvider(chainId);
+      const provider = getProvider(chainId.toString());
       return provider.waitForTransaction(txId);
     }
   } else {

--- a/apps/ui/src/helpers/provider.ts
+++ b/apps/ui/src/helpers/provider.ts
@@ -1,14 +1,17 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 
-const providers: Record<number, StaticJsonRpcProvider | undefined> = {};
+const providers: Record<string, StaticJsonRpcProvider | undefined> = {};
 
-export function getProvider(networkId: number): StaticJsonRpcProvider {
+export function getProvider(networkId: string): StaticJsonRpcProvider {
   const url = `https://rpc.snapshot.org/${networkId}`;
 
   let provider = providers[networkId];
 
   if (!provider) {
-    provider = new StaticJsonRpcProvider({ url, timeout: 25000 }, networkId);
+    provider = new StaticJsonRpcProvider(
+      { url, timeout: 25000 },
+      parseInt(networkId)
+    );
     providers[networkId] = provider;
   }
 

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -835,7 +835,7 @@ async function getUnstoppableDomainsNameOwner(name: string, chainId: number) {
     throw new Error('Unsupported network');
   }
 
-  const provider = getProvider(chainId);
+  const provider = getProvider(chainId.toString());
   const tokenId = namehash(name);
 
   return call(

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -114,7 +114,7 @@ export function createActions(
   const getSigner = (web3: Web3Provider) => {
     const signer = web3.getSigner();
     signer.provider.getResolver = (value: string) => {
-      return getProvider(1).getResolver(value);
+      return getProvider('1').getResolver(value);
     };
 
     return signer;
@@ -737,7 +737,7 @@ export function createActions(
 
       const multi = new Multicaller(
         delegation.chainId.toString(),
-        getProvider(delegation.chainId as number),
+        getProvider(delegation.chainId.toString()),
         [
           'function decimals() view returns (uint8)',
           'function balanceOf(address account) view returns (uint256)',

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -111,7 +111,7 @@ export function createEvmNetwork(networkId: NetworkID): Network {
 
   const pin = networkId === 'mnt' ? pinPineapple : pinGraph;
 
-  const provider = getProvider(chainId);
+  const provider = getProvider(chainId.toString());
   const constants = createConstants(networkId, { pin });
   const api = createApi(apiUrl, networkId, constants, {
     // NOTE: Highlight is currently disabled

--- a/apps/ui/src/networks/offchain/helpers.ts
+++ b/apps/ui/src/networks/offchain/helpers.ts
@@ -36,7 +36,7 @@ export async function getLatestBlockNumber(chainId: string): Promise<number> {
       }
       provider = createProvider(starknetMetadata.rpcUrl);
     } else {
-      provider = getProvider(Number(chainId));
+      provider = getProvider(chainId);
       blockOffset = EDITOR_SNAPSHOT_OFFSET;
     }
 

--- a/apps/ui/src/networks/offchain/index.ts
+++ b/apps/ui/src/networks/offchain/index.ts
@@ -27,7 +27,7 @@ export function createOffchainNetwork(networkId: NetworkID): Network {
   const hubUrl = HUB_URLS[networkId];
   if (!hubUrl || !l1ChainId) throw new Error(`Unknown network ${networkId}`);
 
-  const provider = getProvider(l1ChainId);
+  const provider = getProvider(l1ChainId.toString());
   const api = createApi(hubUrl, networkId, constants);
 
   const isExecutorSupported = (executorType: string) => {

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -80,7 +80,7 @@ export function createActions(
   const networkConfig = CONFIGS[networkId];
   if (!networkConfig) throw new Error(`Unsupported network ${networkId}`);
 
-  const l1Provider = getProvider(l1ChainId);
+  const l1Provider = getProvider(l1ChainId.toString());
 
   const clientConfig = {
     starkProvider,

--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -80,7 +80,7 @@ async function fetchApeChainDelegatees(
   const accountDelegation = await getDelegation(account.toLowerCase());
   if (!accountDelegation) return [];
 
-  const provider = getProvider(Number(delegation.chainId));
+  const provider = getProvider((delegation.chainId || '').toString());
   const balance = await provider.getBalance(account);
 
   const [names, [apiDelegate]] = await Promise.all([

--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -80,7 +80,7 @@ async function fetchApeChainDelegatees(
   const accountDelegation = await getDelegation(account.toLowerCase());
   if (!accountDelegation) return [];
 
-  const provider = getProvider((delegation.chainId || '').toString());
+  const provider = getProvider((delegation.chainId || '33139').toString());
   const balance = await provider.getBalance(account);
 
   const [names, [apiDelegate]] = await Promise.all([

--- a/apps/ui/src/stores/meta.ts
+++ b/apps/ui/src/stores/meta.ts
@@ -17,7 +17,9 @@ export const useMetaStore = defineStore('meta', () => {
   async function fetchBlock(networkId: NetworkID) {
     if (currentBlocks.value.get(networkId)) return;
 
-    const provider = getProvider(getNetwork(networkId).currentChainId);
+    const provider = getProvider(
+      getNetwork(networkId).currentChainId.toString()
+    );
 
     try {
       const blockNumber = await provider.getBlockNumber();


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward https://github.com/snapshot-labs/workflow/issues/644

This PR is a part of the refactoring task, moving the chainId type from `number` to `string`.

This PR will only refactor the following functions to use `string` instead of `number` for the chain id:

- getProvider
- getABI
- useWalletConnect and useWalletConnectTransaction composables

Those 3 modules have been chosen to be refactored together because they're the most interlinked, and to avoid too much PR (one per function)

We end up with a few `.toString()` casting, which will be removed in a later PR, once the chainId will be refactored to be only a `string`.
