### PR TITLE
hotfix: fix missing executions and treasuries from mismatched chain id type

### DIFF
--- a/apps/ui/src/composables/useBalances.ts
+++ b/apps/ui/src/composables/useBalances.ts
@@ -74,7 +74,7 @@ export function useBalances({
       ? { name: metadata.name, symbol: metadata.ticker }
       : { name: 'Ether', symbol: 'ETH' };
 
-    const data = await getBalances(address, chainId, baseToken);
+    const data = await getBalances(address, chainId.toString(), baseToken);
     const tokensWithBalance = data.filter(
       asset =>
         formatUnits(asset.tokenBalance, asset.decimals) !== '0.0' ||

--- a/apps/ui/src/composables/useTreasuries.ts
+++ b/apps/ui/src/composables/useTreasuries.ts
@@ -55,7 +55,7 @@ export function useTreasuries(spaceRef: ComputedRef<InputType> | InputType) {
             strategy.treasury_chain &&
             treasury.address &&
             compareAddresses(strategy.treasury, treasury.address) &&
-            treasury.chainId === strategy.treasury_chain
+            treasury.chainId?.toString() === strategy.treasury_chain.toString()
           );
         });
 

--- a/apps/ui/src/composables/useTreasury.ts
+++ b/apps/ui/src/composables/useTreasury.ts
@@ -15,8 +15,10 @@ export function useTreasury(treasuryData: SpaceMetadataTreasury) {
       network: chainId,
       wallet: address,
       name,
-      supportsTokens: TOKENS_SUPPORTED_CHAIN_IDS.includes(chainId as any),
-      supportsNfts: NFTS_SUPPORTED_CHAIN_IDS.includes(chainId as any)
+      supportsTokens: TOKENS_SUPPORTED_CHAIN_IDS.includes(
+        chainId.toString() as any
+      ),
+      supportsNfts: NFTS_SUPPORTED_CHAIN_IDS.includes(chainId.toString() as any)
     };
   });
 

--- a/apps/ui/src/helpers/alchemy/index.ts
+++ b/apps/ui/src/helpers/alchemy/index.ts
@@ -1,5 +1,4 @@
 import { ETH_CONTRACT } from '@/helpers/constants';
-import { ChainId } from '@/types';
 import { GetBalancesResponse, GetTokenBalancesResponse } from './types';
 import { getTokensMetadata } from '../contracts';
 import { getProvider } from '../provider';
@@ -8,24 +7,24 @@ export * from './types';
 const apiKey = import.meta.env.VITE_ALCHEMY_API_KEY;
 
 export const ALCHEMY_SUPPORTED_CHAIN_IDS = [
-  1, // Ethereum,
-  10, // Optimism,
-  100, // Gnosis Safe
-  137, // Polygon,
-  324, // ZkSync Era
-  8453, // Base
-  33111, // Curtis
-  33139, // Apechain
-  42161, // Arbitrum
-  42170, // Arbitrum Nova
-  11155111 // Sepolia
+  '1', // Ethereum,
+  '10', // Optimism,
+  '100', // Gnosis Safe
+  '137', // Polygon,
+  '324', // ZkSync Era
+  '8453', // Base
+  '33111', // Curtis
+  '33139', // Apechain
+  '42161', // Arbitrum
+  '42170', // Arbitrum Nova
+  '11155111' // Sepolia
 ] as const;
 
 /**
  * Those ChainIds will only show native token balance.
  */
 export const MINIMAL_SUPPORTED_CHAIN_IDS = [
-  5000 // Mantle
+  '5000' // Mantle
 ] as const;
 
 export const SUPPORTED_CHAIN_IDS = [
@@ -34,27 +33,27 @@ export const SUPPORTED_CHAIN_IDS = [
 ] as const;
 
 const NETWORKS: Record<(typeof ALCHEMY_SUPPORTED_CHAIN_IDS)[number], string> = {
-  1: 'eth-mainnet',
-  10: 'opt-mainnet',
-  100: 'gnosis-mainnet',
-  137: 'polygon-mainnet',
-  324: 'zksync-mainnet',
-  8453: 'base-mainnet',
-  33111: 'apechain-curtis',
-  33139: 'apechain-mainnet',
-  42161: 'arb-mainnet',
-  42170: 'arbnova-mainnet',
-  11155111: 'eth-sepolia'
+  '1': 'eth-mainnet',
+  '10': 'opt-mainnet',
+  '100': 'gnosis-mainnet',
+  '137': 'polygon-mainnet',
+  '324': 'zksync-mainnet',
+  '8453': 'base-mainnet',
+  '33111': 'apechain-curtis',
+  '33139': 'apechain-mainnet',
+  '42161': 'arb-mainnet',
+  '42170': 'arbnova-mainnet',
+  '11155111': 'eth-sepolia'
 };
 
-function getApiUrl(chainId: ChainId) {
+function getApiUrl(chainId: string) {
   const network = NETWORKS[chainId];
   if (!network) throw new Error('Unsupported chain for Alchemy API');
 
   return `https://${network}.g.alchemy.com/v2/${apiKey}`;
 }
 
-export async function request(method: string, params: any[], chainId: ChainId) {
+export async function request(method: string, params: any[], chainId: string) {
   const res = await fetch(getApiUrl(chainId), {
     method: 'POST',
     body: JSON.stringify({
@@ -72,7 +71,7 @@ export async function request(method: string, params: any[], chainId: ChainId) {
 
 export async function batchRequest(
   requests: { method: string; params: any[] }[],
-  chainId: ChainId
+  chainId: string
 ) {
   const res = await fetch(getApiUrl(chainId), {
     method: 'POST',
@@ -99,7 +98,7 @@ export async function batchRequest(
  */
 export async function getBalance(
   address: string,
-  chainId: ChainId
+  chainId: string
 ): Promise<string> {
   const provider = getProvider(Number(chainId));
   const balance = await provider.getBalance(address, 'latest');
@@ -116,7 +115,7 @@ export async function getBalance(
  */
 export async function getTokenBalances(
   address: string,
-  chainId: ChainId
+  chainId: string
 ): Promise<GetTokenBalancesResponse> {
   const results = { address, tokenBalances: [], pageKey: null };
 
@@ -153,7 +152,7 @@ export async function getTokenBalances(
  */
 export async function getBalances(
   address: string,
-  chainId: ChainId,
+  chainId: string,
   baseToken: { name: string; symbol: string; logo?: string }
 ): Promise<GetBalancesResponse> {
   const [ethBalance, { tokenBalances }] = await Promise.all([

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -221,7 +221,7 @@ function processExecutions(
     return (
       match.treasury &&
       compareAddresses(treasury.address, match.treasury) &&
-      match.treasury_chain === treasury.chainId
+      match.treasury_chain?.toString() === treasury.chainId?.toString()
     );
   });
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fixing https://discord.com/channels/955773041898573854/1031838169282392144/1408128883647316109

This PR is a hotfix, fixing an issue where the executions where missing from the Editor on onchain spaces, which have been saved with string treasuries chain id.

It's adding a string casting on the chain id comparison, a more clean approach will come later with https://github.com/snapshot-labs/workflow/issues/644.

The hotfix will allow us to move on and review https://github.com/snapshot-labs/sx-monorepo/pull/1515

### How to test

1. Go to http://localhost:8080/#/sep:0x27f8afC9Cd899793D00b7385066C95211BD29779/create/fl2b7
2. You should see the execution section (missing on https://testnet.snapshot.box/#/sep:0x27f8afC9Cd899793D00b7385066C95211BD29779/create/3kwts)
3. Go to http://localhost:8080/#/sep:0x27f8afC9Cd899793D00b7385066C95211BD29779/treasury/1/tokens
4. You should see the treasuries token (empty on https://testnet.snapshot.box/#/sep:0x27f8afC9Cd899793D00b7385066C95211BD29779/treasury/1/tokens)

### Note

- We need https://github.com/snapshot-labs/sx-monorepo/pull/1531 to fix the contract call in executions (currently rejecting all string chain id, since considered as starknet)
- The link to etherscan in the treasurie page still not working
