### PR TITLE
fix: keep original type for chainId on onchain treasuries

### DIFF
--- a/apps/ui/src/components/Ui/SelectorNetwork.vue
+++ b/apps/ui/src/components/Ui/SelectorNetwork.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { getUrl } from '@/helpers/utils';
-import { enabledNetworks, getNetwork } from '@/networks';
+import { enabledNetworks, getNetwork, offchainNetworks } from '@/networks';
 import { BaseDefinition, NetworkID } from '@/types';
 
 const network = defineModel<string | number | null>({
@@ -33,7 +33,10 @@ const allOptions = computed(() => {
         return true;
       })
       .map(network => ({
-        id: String(network.chainId),
+        // NOTE: onchain networks should keep default chainId type
+        id: offchainNetworks.includes(props.definition.networkId)
+          ? String(network.chainId)
+          : network.chainId,
         name: network.name,
         icon: h('img', {
           src: getUrl(network.logo),


### PR DESCRIPTION
### Summary

Regression from https://github.com/snapshot-labs/sx-monorepo/pull/1447

Refactoring it elsewhere is quite difficult, so to keep it simple for now we just revert part of original PR to only affect offchain spaces.

### How to test

1. Go to your space and modify your treasury (if you have old format it will be empty network).
2. After that you can create execution on proposal page (if your treasury links to execution).
