### PR TITLE
fix: check raw proposition power against proposal threshold

### DIFF
--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -185,9 +185,9 @@ export function createConstants(
         required: ['threshold'],
         properties: {
           threshold: {
-            type: 'integer',
+            type: 'string',
+            format: 'uint256',
             title: 'Proposal threshold',
-            minimum: 1,
             examples: ['1']
           }
         }

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -271,9 +271,9 @@ export function createConstants(
         required: ['threshold'],
         properties: {
           threshold: {
-            type: 'integer',
+            type: 'string',
+            format: 'uint256',
             title: 'Proposal threshold',
-            minimum: 1,
             examples: ['1']
           }
         }

--- a/apps/ui/src/queries/propositionPower.ts
+++ b/apps/ui/src/queries/propositionPower.ts
@@ -73,10 +73,7 @@ async function getPropositionPower(space: Space, block: number | null) {
     opts
   );
 
-  const totalPowers = powers.reduce(
-    (acc, b) => acc + Number(b.value) / 10 ** b.cumulativeDecimals,
-    0
-  );
+  const totalPowers = powers.reduce((acc, b) => acc + Number(b.value), 0);
 
   vpItem.canPropose = totalPowers >= BigInt(space.proposal_threshold);
 


### PR DESCRIPTION
### Summary

This PR fixes issue with checking proposal threshold on the UI. The value users provide in the form is provided in base units. So if you insert `5` and you use ERC-20 votes strategy you don't require 1 TEST, you require 0.000000000000000005 TEST. This was always the case, so nothing changes there. The only issue was that UI actually interpreted that threshold as 5 TEST, so users with 1 TEST were prevented from proposing, but they actually met the requirement on the contract level.

This fix is achieved by:
- Proposal threshold is now inserted as string so it doesn't crash ethers when inserting overflowing Numbers.
- We do not divide proposition power by decimals when comparing them to proposal threshold.

The main issue is that if we have proposition strategy that has 18 decimals (for example UNI token) and we want at least 100 UNI to propose we should set it to `100000000000000000000`.

But with previous logic we would compare raw proposal threshold (`100000000000000000000`) with formatted proposition power (`100`).

This shouldn't affect offchain spaces - offchain proposal validation strategies always use 0 decimals.

### How to test

1. You might need following diff if your EVM space settings are not loading.
2. On Sepolia space add proposal validation using [this token](https://sepolia.etherscan.io/address/0x6Fd821e79cDf212aD8b06C59B28FE8C2185291d4#writeContract). You can for example use `1000000000000000000` threshold. Mint 0.5 TEST (`500000000000000000`) for yourself and delegate to self.
3. You shouldn't be able to propose (proposal validation error).
4. Mint 0.5 TEST again (so you have 1 TEST) and now you can propose.

```diff
diff --git a/apps/ui/.env b/apps/ui/.env
index a9908270a..d3b2b770d 100644
--- a/apps/ui/.env
+++ b/apps/ui/.env
@@ -3,7 +3,7 @@ VITE_METADATA_NETWORK=
 VITE_MANA_URL=https://mana.box
 VITE_WHITELIST_SERVER_URL=https://wls.snapshot.box
 VITE_HIGHLIGHT_URL=https://testnet.highlight.red
-VITE_IPFS_GATEWAY=ipfs.snapshot.box
+VITE_IPFS_GATEWAY=pineapple.fyi
 VITE_ALCHEMY_API_KEY=Dg0ixifhoQIaQrgsbK76LcX13Seu92U2
 VITE_OPENSEA_API_KEY=51754bb53b324552ba4741c5b7298096
 VITE_GA_MEASUREMENT_ID=G-8MQS50MVZX
```