### PR TITLE
refactor(sx.js): move Starknet types to starknet clients

### DIFF
--- a/packages/sx.js/src/authenticators/starknet/ethSig.ts
+++ b/packages/sx.js/src/authenticators/starknet/ethSig.ts
@@ -9,7 +9,7 @@ import {
   UpdateProposalCallArgs,
   Vote,
   VoteCallArgs
-} from '../../types';
+} from '../../clients/starknet/types';
 import { getChoiceEnum } from '../../utils/starknet-enums';
 
 const callData = new CallData(EthSigAuthenticatorAbi);

--- a/packages/sx.js/src/authenticators/starknet/ethTx.ts
+++ b/packages/sx.js/src/authenticators/starknet/ethTx.ts
@@ -9,7 +9,7 @@ import {
   UpdateProposalCallArgs,
   Vote,
   VoteCallArgs
-} from '../../types';
+} from '../../clients/starknet/types';
 import { getChoiceEnum } from '../../utils/starknet-enums';
 
 const callData = new CallData(EthTxAuthenticatorAbi);

--- a/packages/sx.js/src/authenticators/starknet/index.ts
+++ b/packages/sx.js/src/authenticators/starknet/index.ts
@@ -3,7 +3,8 @@ import createEthTxAuthenticator from './ethTx';
 import createStarkSigAuthenticator from './starkSig';
 import createStarkTxAuthenticator from './starkTx';
 import createVanillaAuthenticator from './vanilla';
-import { Authenticator, NetworkConfig } from '../../types';
+import { Authenticator } from '../../clients/starknet/types';
+import { NetworkConfig } from '../../types';
 import { hexPadLeft } from '../../utils/encoding';
 
 export function getAuthenticator(

--- a/packages/sx.js/src/authenticators/starknet/starkSig.ts
+++ b/packages/sx.js/src/authenticators/starknet/starkSig.ts
@@ -9,7 +9,7 @@ import {
   UpdateProposalCallArgs,
   Vote,
   VoteCallArgs
-} from '../../types';
+} from '../../clients/starknet/types';
 import { getChoiceEnum } from '../../utils/starknet-enums';
 
 const callData = new CallData(StarkSigAuthenticatorAbi);

--- a/packages/sx.js/src/authenticators/starknet/starkTx.ts
+++ b/packages/sx.js/src/authenticators/starknet/starkTx.ts
@@ -9,7 +9,7 @@ import {
   UpdateProposalCallArgs,
   Vote,
   VoteCallArgs
-} from '../../types';
+} from '../../clients/starknet/types';
 import { getChoiceEnum } from '../../utils/starknet-enums';
 
 const callData = new CallData(StarkTxAuthenticatorAbi);

--- a/packages/sx.js/src/authenticators/starknet/vanilla.ts
+++ b/packages/sx.js/src/authenticators/starknet/vanilla.ts
@@ -9,7 +9,7 @@ import {
   UpdateProposalCallArgs,
   Vote,
   VoteCallArgs
-} from '../../types';
+} from '../../clients/starknet/types';
 import { getChoiceEnum, getUserAddressEnum } from '../../utils/starknet-enums';
 
 const callData = new CallData(SpaceAbi);

--- a/packages/sx.js/src/clients/evm/types.ts
+++ b/packages/sx.js/src/clients/evm/types.ts
@@ -4,13 +4,7 @@ import {
 } from '@ethersproject/abstract-signer';
 import { ContractInterface } from '@ethersproject/contracts';
 import { Provider } from '@ethersproject/providers';
-import { EvmNetworkConfig } from '../../types';
-
-enum Choice {
-  Against = 0,
-  For = 1,
-  Abstain = 2
-}
+import { Choice, EvmNetworkConfig } from '../../types';
 
 export type AddressConfig = {
   addr: string;

--- a/packages/sx.js/src/clients/starknet/ethereum-sig/index.ts
+++ b/packages/sx.js/src/clients/starknet/ethereum-sig/index.ts
@@ -6,6 +6,8 @@ import {
 import randomBytes from 'randombytes';
 import { CallData, shortString } from 'starknet';
 import { proposeTypes, updateProposalTypes, voteTypes } from './types';
+import { getRSVFromSig } from '../../../utils/encoding';
+import { getStrategiesWithParams } from '../../../utils/strategies';
 import {
   ClientConfig,
   ClientOpts,
@@ -17,9 +19,7 @@ import {
   SignatureData,
   UpdateProposal,
   Vote
-} from '../../../types';
-import { getRSVFromSig } from '../../../utils/encoding';
-import { getStrategiesWithParams } from '../../../utils/strategies';
+} from '../types';
 
 export class EthereumSig {
   config: ClientConfig;

--- a/packages/sx.js/src/clients/starknet/ethereum-tx/index.ts
+++ b/packages/sx.js/src/clients/starknet/ethereum-tx/index.ts
@@ -3,6 +3,8 @@ import { Contract } from '@ethersproject/contracts';
 import { poseidonHashMany } from 'micro-starknet';
 import { CallData, shortString } from 'starknet';
 import StarknetCommitAbi from './abis/StarknetCommit.json';
+import { getChoiceEnum } from '../../../utils/starknet-enums';
+import { getStrategiesWithParams } from '../../../utils/strategies';
 import {
   ClientConfig,
   ClientOpts,
@@ -10,9 +12,7 @@ import {
   Propose,
   UpdateProposal,
   Vote
-} from '../../../types';
-import { getChoiceEnum } from '../../../utils/starknet-enums';
-import { getStrategiesWithParams } from '../../../utils/strategies';
+} from '../types';
 
 type CallOptions = {
   noWait?: boolean;

--- a/packages/sx.js/src/clients/starknet/starknet-sig/index.ts
+++ b/packages/sx.js/src/clients/starknet/starknet-sig/index.ts
@@ -14,6 +14,7 @@ import {
   updateProposalTypes,
   voteTypes
 } from './types';
+import { getStrategiesWithParams } from '../../../utils/strategies';
 import {
   Alias,
   ClientConfig,
@@ -27,8 +28,7 @@ import {
   StarknetEIP712VoteMessage,
   UpdateProposal,
   Vote
-} from '../../../types';
-import { getStrategiesWithParams } from '../../../utils/strategies';
+} from '../types';
 
 export class StarknetSig {
   config: ClientConfig & { manaUrl: string };

--- a/packages/sx.js/src/clients/starknet/starknet-tx/index.ts
+++ b/packages/sx.js/src/clients/starknet/starknet-tx/index.ts
@@ -6,6 +6,11 @@ import randomBytes from 'randombytes';
 import { Account, CallData, hash, shortString, uint256 } from 'starknet';
 import SpaceAbi from './abis/Space.json';
 import { getAuthenticator } from '../../../authenticators/starknet';
+import { predictCloneAddress } from '../../../utils/address';
+import { hexPadLeft } from '../../../utils/encoding';
+import { estimateStarknetFee } from '../../../utils/fees';
+import { getStrategiesWithParams } from '../../../utils/strategies';
+import L1AvatarExecutionStrategyFactoryAbi from '../l1-executor/abis/L1AvatarExecutionStrategyFactory.json';
 import {
   AddressConfig,
   ClientConfig,
@@ -14,12 +19,7 @@ import {
   Propose,
   UpdateProposal,
   Vote
-} from '../../../types';
-import { predictCloneAddress } from '../../../utils/address';
-import { hexPadLeft } from '../../../utils/encoding';
-import { estimateStarknetFee } from '../../../utils/fees';
-import { getStrategiesWithParams } from '../../../utils/strategies';
-import L1AvatarExecutionStrategyFactoryAbi from '../l1-executor/abis/L1AvatarExecutionStrategyFactory.json';
+} from '../types';
 
 type SpaceParams = {
   controller: string;

--- a/packages/sx.js/src/clients/starknet/types.ts
+++ b/packages/sx.js/src/clients/starknet/types.ts
@@ -1,0 +1,195 @@
+import { BigNumberish, Call, RpcProvider } from 'starknet';
+import { SignatureData as BaseSignatureData, Choice } from '../../types';
+import { NetworkConfig } from '../../types/networkConfig';
+
+export type SignatureData = BaseSignatureData;
+
+export type ProposeCallArgs = {
+  author: string;
+  executionStrategy: {
+    address: string;
+    params: string[];
+  };
+  // rename to user_proposal_validation_params
+  strategiesParams: string[];
+  metadataUri: string;
+};
+
+export type VoteCallArgs = {
+  voter: string;
+  proposalId: number;
+  choice: Choice;
+  votingStrategies: IndexedConfig[];
+  metadataUri: string;
+};
+
+export type UpdateProposalCallArgs = {
+  author: string;
+  proposalId: number;
+  executionStrategy: {
+    address: string;
+    params: string[];
+  };
+  metadataUri: string;
+};
+
+export type Authenticator = {
+  type: string;
+  createProposeCall(envelope: Envelope<Propose>, args: ProposeCallArgs): Call;
+  createVoteCall(envelope: Envelope<Vote>, args: VoteCallArgs): Call;
+  createUpdateProposalCall(
+    envelope: Envelope<UpdateProposal>,
+    args: UpdateProposalCallArgs
+  ): Call;
+};
+
+export interface Strategy {
+  type: string;
+  getParams(
+    call: 'propose' | 'vote',
+    signerAddress: string,
+    address: string,
+    index: number,
+    params: string,
+    metadata: Record<string, any> | null,
+    envelope: Envelope<Message>,
+    clientConfig: ClientConfig
+  ): Promise<string[]>;
+  getVotingPower: (
+    strategyAddress: string,
+    voterAddress: string,
+    metadata: Record<string, any> | null,
+    timestamp: number | null,
+    params: string[],
+    clientConfig: ClientConfig
+  ) => Promise<bigint>;
+}
+
+export type ClientOpts = {
+  ethUrl: string;
+  starkProvider: RpcProvider;
+  networkConfig: NetworkConfig;
+  whitelistServerUrl: string;
+};
+
+export type ClientConfig = {
+  ethUrl: string;
+  starkProvider: RpcProvider;
+  networkConfig: NetworkConfig;
+  whitelistServerUrl: string;
+};
+
+// TODO: normalize with EVM
+export type AddressConfig = {
+  addr: string;
+  params: string[];
+};
+
+export type IndexedConfig = {
+  index: number;
+  params: string[];
+};
+
+export type StrategyConfig = {
+  index: number;
+  address: string;
+  params: string;
+  metadata?: Record<string, any>;
+};
+
+export type StrategiesAddresses = { index: number; address: string }[];
+
+export type Propose = {
+  space: string;
+  authenticator: string;
+  strategies: StrategyConfig[];
+  executionStrategy: AddressConfig;
+  metadataUri: string;
+};
+
+export type UpdateProposal = {
+  space: string;
+  proposal: number;
+  authenticator: string;
+  executionStrategy: AddressConfig;
+  metadataUri: string;
+};
+
+export type Vote = {
+  space: string;
+  authenticator: string;
+  strategies: StrategyConfig[];
+  proposal: number;
+  choice: Choice;
+  metadataUri: string;
+};
+
+export type Alias = {
+  alias: string;
+};
+
+export type Message = Propose | Vote | UpdateProposal | Alias;
+
+export type Envelope<T extends Message> = {
+  signatureData?: SignatureData;
+  data: T;
+};
+
+export type StarknetEIP712ProposeMessage = {
+  space: string;
+  author: string;
+  executionStrategy: {
+    address: string;
+    params: string[];
+  };
+  userProposalValidationParams: string[];
+  metadataUri: string[];
+  salt: string;
+};
+
+export type StarknetEIP712UpdateProposalMessage = {
+  space: string;
+  author: string;
+  proposalId: { low: BigNumberish; high: BigNumberish };
+  executionStrategy: {
+    address: string;
+    params: string[];
+  };
+  metadataUri: string[];
+  salt: string;
+};
+
+export type StarknetEIP712VoteMessage = {
+  space: string;
+  voter: string;
+  proposalId: { low: BigNumberish; high: BigNumberish };
+  choice: string;
+  userVotingStrategies: { index: number; params: string[] }[];
+  metadataUri: string[];
+};
+
+export type StarknetEIP712AliasMessage = {
+  alias: string;
+  from?: string;
+  timestamp?: number;
+};
+
+export type EIP712ProposeMessage = StarknetEIP712ProposeMessage & {
+  authenticator: string;
+};
+
+export type EIP712UpdateProposalMessage = Omit<
+  StarknetEIP712UpdateProposalMessage,
+  'proposalId'
+> & {
+  authenticator: string;
+  proposalId: string;
+};
+
+export type EIP712VoteMessage = Omit<
+  StarknetEIP712VoteMessage,
+  'proposalId'
+> & {
+  authenticator: string;
+  proposalId: string;
+};

--- a/packages/sx.js/src/strategies/starknet/erc20Votes.ts
+++ b/packages/sx.js/src/strategies/starknet/erc20Votes.ts
@@ -2,7 +2,13 @@
 
 import { Contract } from 'starknet';
 import ERC20VotesTokenAbi from './abis/ERC20VotesToken.json';
-import { ClientConfig, Envelope, Propose, Strategy, Vote } from '../../types';
+import {
+  ClientConfig,
+  Envelope,
+  Propose,
+  Strategy,
+  Vote
+} from '../../clients/starknet/types';
 
 export default function createErc20VotesStrategy(): Strategy {
   return {

--- a/packages/sx.js/src/strategies/starknet/evmSlotValue.ts
+++ b/packages/sx.js/src/strategies/starknet/evmSlotValue.ts
@@ -5,7 +5,13 @@ import { CallData, Contract, LibraryError } from 'starknet';
 import EVMSlotValue from './abis/EVMSlotValue.json';
 import { getSlotKey } from './utils';
 import SpaceAbi from '../../clients/starknet/starknet-tx/abis/Space.json';
-import { ClientConfig, Envelope, Propose, Strategy, Vote } from '../../types';
+import {
+  ClientConfig,
+  Envelope,
+  Propose,
+  Strategy,
+  Vote
+} from '../../clients/starknet/types';
 import { VotingPowerDetailsError } from '../../utils/errors';
 import { getUserAddressEnum } from '../../utils/starknet-enums';
 

--- a/packages/sx.js/src/strategies/starknet/index.ts
+++ b/packages/sx.js/src/strategies/starknet/index.ts
@@ -3,7 +3,8 @@ import createEvmSlotValueStrategy from './evmSlotValue';
 import createMerkleWhitelistStrategy from './merkleWhitelist';
 import createOzVotesStorageProofStrategy from './ozVotesStorageProof';
 import createVanillaStrategy from './vanilla';
-import { NetworkConfig, Strategy } from '../../types';
+import { Strategy } from '../../clients/starknet/types';
+import { NetworkConfig } from '../../types';
 import { hexPadLeft } from '../../utils/encoding';
 
 export function getStrategy(

--- a/packages/sx.js/src/strategies/starknet/merkleWhitelist.ts
+++ b/packages/sx.js/src/strategies/starknet/merkleWhitelist.ts
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { uint256, validateAndParseAddress } from 'starknet';
-import { ClientConfig, Envelope, Propose, Strategy, Vote } from '../../types';
+import {
+  ClientConfig,
+  Envelope,
+  Propose,
+  Strategy,
+  Vote
+} from '../../clients/starknet/types';
 import {
   AddressType,
   generateMerkleProof,

--- a/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
+++ b/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
@@ -8,7 +8,13 @@ import OZVotesStorageProof from './abis/OZVotesStorageProof.json';
 import OzVotesToken from './abis/OzVotesToken.json';
 import { getNestedSlotKey, getSlotKey } from './utils';
 import SpaceAbi from '../../clients/starknet/starknet-tx/abis/Space.json';
-import { ClientConfig, Envelope, Propose, Strategy, Vote } from '../../types';
+import {
+  ClientConfig,
+  Envelope,
+  Propose,
+  Strategy,
+  Vote
+} from '../../clients/starknet/types';
 import { VotingPowerDetailsError } from '../../utils/errors';
 import { getUserAddressEnum } from '../../utils/starknet-enums';
 

--- a/packages/sx.js/src/strategies/starknet/vanilla.ts
+++ b/packages/sx.js/src/strategies/starknet/vanilla.ts
@@ -1,6 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { ClientConfig, Envelope, Propose, Strategy, Vote } from '../../types';
+import {
+  ClientConfig,
+  Envelope,
+  Propose,
+  Strategy,
+  Vote
+} from '../../clients/starknet/types';
 
 export default function createVanillaStrategy(): Strategy {
   return {

--- a/packages/sx.js/src/types/index.ts
+++ b/packages/sx.js/src/types/index.ts
@@ -2,8 +2,7 @@ import {
   TypedDataDomain,
   TypedDataField
 } from '@ethersproject/abstract-signer';
-import { BigNumberish, Call, RpcProvider, StarknetType } from 'starknet';
-import { NetworkConfig } from './networkConfig';
+import { Call, StarknetType } from 'starknet';
 import { MetaTransaction } from '../utils/encoding';
 
 export * from './networkConfig';
@@ -16,206 +15,18 @@ export enum Choice {
 
 export type Privacy = 'shutter' | 'none';
 
-export type ProposeCallArgs = {
-  author: string;
-  executionStrategy: {
-    address: string;
-    params: string[];
-  };
-  // rename to user_proposal_validation_params
-  strategiesParams: string[];
-  metadataUri: string;
-};
-
-export type VoteCallArgs = {
-  voter: string;
-  proposalId: number;
-  choice: Choice;
-  votingStrategies: IndexedConfig[];
-  metadataUri: string;
-};
-
-export type UpdateProposalCallArgs = {
-  author: string;
-  proposalId: number;
-  executionStrategy: {
-    address: string;
-    params: string[];
-  };
-  metadataUri: string;
-};
-
-export type Authenticator = {
-  type: string;
-  createProposeCall(envelope: Envelope<Propose>, args: ProposeCallArgs): Call;
-  createVoteCall(envelope: Envelope<Vote>, args: VoteCallArgs): Call;
-  createUpdateProposalCall(
-    envelope: Envelope<UpdateProposal>,
-    args: UpdateProposalCallArgs
-  ): Call;
-};
-
-export interface Strategy {
-  type: string;
-  getParams(
-    call: 'propose' | 'vote',
-    signerAddress: string,
-    address: string,
-    index: number,
-    params: string,
-    metadata: Record<string, any> | null,
-    envelope: Envelope<Message>,
-    clientConfig: ClientConfig
-  ): Promise<string[]>;
-  getVotingPower: (
-    strategyAddress: string,
-    voterAddress: string,
-    metadata: Record<string, any> | null,
-    timestamp: number | null,
-    params: string[],
-    clientConfig: ClientConfig
-  ) => Promise<bigint>;
-}
-
-export type ClientOpts = {
-  ethUrl: string;
-  starkProvider: RpcProvider;
-  networkConfig: NetworkConfig;
-  whitelistServerUrl: string;
-};
-
-export type ClientConfig = {
-  ethUrl: string;
-  starkProvider: RpcProvider;
-  networkConfig: NetworkConfig;
-  whitelistServerUrl: string;
-};
-
-// TODO: normalize with EVM
-export type AddressConfig = {
-  addr: string;
-  params: string[];
-};
-
-export type IndexedConfig = {
-  index: number;
-  params: string[];
-};
-
-export type StrategyConfig = {
-  index: number;
-  address: string;
-  params: string;
-  metadata?: Record<string, any>;
-};
-
-export type Propose = {
-  space: string;
-  authenticator: string;
-  strategies: StrategyConfig[];
-  executionStrategy: AddressConfig;
-  metadataUri: string;
-};
-
-export type UpdateProposal = {
-  space: string;
-  proposal: number;
-  authenticator: string;
-  executionStrategy: AddressConfig;
-  metadataUri: string;
-};
-
-export type Vote = {
-  space: string;
-  authenticator: string;
-  strategies: StrategyConfig[];
-  proposal: number;
-  choice: Choice;
-  metadataUri: string;
-};
-
-export type Alias = {
-  alias: string;
-};
-
-export type Message = Propose | Vote | UpdateProposal | Alias;
-
+// NOTE: This is shared between starknet and offchain clients.
+// Maybe we should find a way to unify it more or split it.
 export type SignatureData = {
   address: string;
   commitTxId?: string;
   commitHash?: string;
-  signature?: string | string[] | null;
+  signature?: string | string[];
   message?: Record<string, any>;
   domain?: TypedDataDomain;
   types?: Record<string, TypedDataField[] | StarknetType[]>;
   primaryType?: any;
 };
-
-export type Envelope<T extends Message> = {
-  signatureData?: SignatureData;
-  data: T;
-};
-
-export type StarknetEIP712ProposeMessage = {
-  space: string;
-  author: string;
-  executionStrategy: {
-    address: string;
-    params: string[];
-  };
-  userProposalValidationParams: string[];
-  metadataUri: string[];
-  salt: string;
-};
-
-export type StarknetEIP712UpdateProposalMessage = {
-  space: string;
-  author: string;
-  proposalId: { low: BigNumberish; high: BigNumberish };
-  executionStrategy: {
-    address: string;
-    params: string[];
-  };
-  metadataUri: string[];
-  salt: string;
-};
-
-export type StarknetEIP712VoteMessage = {
-  space: string;
-  voter: string;
-  proposalId: { low: BigNumberish; high: BigNumberish };
-  choice: string;
-  userVotingStrategies: { index: number; params: string[] }[];
-  metadataUri: string[];
-};
-
-export type StarknetEIP712AliasMessage = {
-  alias: string;
-  from?: string;
-  timestamp?: number;
-};
-
-export type EIP712ProposeMessage = StarknetEIP712ProposeMessage & {
-  authenticator: string;
-};
-
-export type EIP712UpdateProposalMessage = Omit<
-  StarknetEIP712UpdateProposalMessage,
-  'proposalId'
-> & {
-  authenticator: string;
-  proposalId: string;
-};
-
-export type EIP712VoteMessage = Omit<
-  StarknetEIP712VoteMessage,
-  'proposalId'
-> & {
-  authenticator: string;
-  proposalId: string;
-};
-
-export type StrategiesAddresses = { index: number; address: string }[];
 
 export type ExecutionInput = {
   calls?: Call[];

--- a/packages/sx.js/src/utils/strategies.ts
+++ b/packages/sx.js/src/utils/strategies.ts
@@ -1,4 +1,3 @@
-import { getStrategy } from '../strategies/starknet';
 import {
   ClientConfig,
   IndexedConfig,
@@ -6,7 +5,8 @@ import {
   StrategiesAddresses,
   StrategyConfig,
   Vote
-} from '../types';
+} from '../clients/starknet/types';
+import { getStrategy } from '../strategies/starknet';
 import { getStorageVarAddress } from '../utils/encoding';
 
 export async function getStrategies(

--- a/packages/sx.js/test/unit/fixtures.ts
+++ b/packages/sx.js/test/unit/fixtures.ts
@@ -1,4 +1,4 @@
-import { Envelope, Propose, Vote } from '../../src/types';
+import { Envelope, Propose, Vote } from '../../src/clients/starknet/types';
 
 const proposeData = {
   space: '0x07e6e9047eb910f84f7e3b86cea7b1d7779c109c970a39b54379c1f4fa395b28',


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/56

We used to store EVM related types in clients/evm/types, but Starknet related types were stuck in global types.

To unify it we now moved those Starknet specific types to clients/starknet/types.

This is type only change and shouldn't affect any logic.

In the future we should consider organizing the code by protocol, for example
```
- evm/
  - authenticators/
  - strategies/
  - clients/
  - types.ts
- starknet
  - authenticators/
  - strategies/
  - clients/
  - types.ts
- governorBravo/
  - authenticators/
  - clients/
  - types.ts
```

### How to test

1. CI passes.
