### PR TITLE
fix: hide address picker in contact edit form

### DIFF
--- a/apps/ui/src/components/FormController.vue
+++ b/apps/ui/src/components/FormController.vue
@@ -20,7 +20,7 @@ const definition = computed(() => ({
   chainId: props.chainId,
   title: 'Space controller',
   examples: ['0x0000…'],
-  showPicker: false
+  showControls: false
 }));
 
 const formErrors = computed(() =>

--- a/apps/ui/src/components/FormController.vue
+++ b/apps/ui/src/components/FormController.vue
@@ -19,7 +19,8 @@ const definition = computed(() => ({
   format: 'address',
   chainId: props.chainId,
   title: 'Space controller',
-  examples: ['0x0000…']
+  examples: ['0x0000…'],
+  showPicker: false
 }));
 
 const formErrors = computed(() =>
@@ -46,7 +47,6 @@ watch(formErrors, value => emit('errors', value));
   <UiContainerSettings :title="title" :description="description">
     <div class="s-box">
       <UiInputAddress
-        :show-picker="false"
         :model-value="model"
         :error="formErrors.controller"
         :definition="definition"

--- a/apps/ui/src/components/Modal/EditContact.vue
+++ b/apps/ui/src/components/Modal/EditContact.vue
@@ -33,7 +33,8 @@ const definition = {
       type: 'string',
       format: 'address',
       title: 'Address',
-      examples: ['Address']
+      examples: ['Address'],
+      showPicker: false
     }
   }
 };

--- a/apps/ui/src/components/Modal/EditContact.vue
+++ b/apps/ui/src/components/Modal/EditContact.vue
@@ -34,7 +34,7 @@ const definition = {
       format: 'address',
       title: 'Address',
       examples: ['Address'],
-      showPicker: false
+      showControls: false
     }
   }
 };

--- a/apps/ui/src/components/Modal/Transaction.vue
+++ b/apps/ui/src/components/Modal/Transaction.vue
@@ -313,7 +313,7 @@ watchEffect(async () => {
             title: 'Contract address',
             examples: ['Address or ENS'],
             chainId: props.network,
-            showPicker: !loading
+            showControls: !loading
           }"
           @pick="handlePickerClick('to')"
         />

--- a/apps/ui/src/components/Modal/Transaction.vue
+++ b/apps/ui/src/components/Modal/Transaction.vue
@@ -307,13 +307,13 @@ watchEffect(async () => {
         <UiInputAddress
           v-model="form.to"
           :error="errors.to"
-          :show-picker="!loading"
           :required="true"
           :definition="{
             type: 'string',
             title: 'Contract address',
             examples: ['Address or ENS'],
-            chainId: props.network
+            chainId: props.network,
+            showPicker: !loading
           }"
           @pick="handlePickerClick('to')"
         />

--- a/apps/ui/src/components/Ui/InputAddress.vue
+++ b/apps/ui/src/components/Ui/InputAddress.vue
@@ -10,19 +10,14 @@ type NetworkDetails = {
 
 defineOptions({ inheritAttrs: false });
 
-const props = withDefaults(
-  defineProps<{
+const props = defineProps<{
+  path?: string;
+  definition?: BaseDefinition<string> & {
+    chainId?: number | string;
     showPicker?: boolean;
-    path?: string;
-    definition?: BaseDefinition<string> & {
-      chainId?: number | string;
-    };
-    required?: boolean;
-  }>(),
-  {
-    showPicker: true
-  }
-);
+  };
+  required?: boolean;
+}>();
 
 const emit = defineEmits<{
   (e: 'pick', path: string);
@@ -47,7 +42,10 @@ const networkDetails = computed<NetworkDetails | null>(() => {
 
 <template>
   <div class="relative">
-    <div v-if="showPicker" class="absolute top-3.5 right-3 z-10">
+    <div
+      v-if="definition?.showPicker ?? true"
+      class="absolute top-3.5 right-3 z-10"
+    >
       <button type="button" @click="emit('pick', path || '')">
         <IH-identification />
       </button>
@@ -63,7 +61,7 @@ const networkDetails = computed<NetworkDetails | null>(() => {
       />
     </UiTooltip>
     <UiInputString
-      :definition="props.definition"
+      :definition="definition"
       :required="required"
       v-bind="$attrs as any"
       class="!pr-7"

--- a/apps/ui/src/components/Ui/InputAddress.vue
+++ b/apps/ui/src/components/Ui/InputAddress.vue
@@ -14,7 +14,7 @@ const props = defineProps<{
   path?: string;
   definition?: BaseDefinition<string> & {
     chainId?: number | string;
-    showPicker?: boolean;
+    showControls?: boolean;
   };
   required?: boolean;
 }>();
@@ -40,7 +40,7 @@ const networkDetails = computed<NetworkDetails | null>(() => {
 });
 
 const shouldShowPicker = computed(() => {
-  return props.definition?.showPicker ?? true;
+  return props.definition?.showControls ?? true;
 });
 </script>
 

--- a/apps/ui/src/components/Ui/InputAddress.vue
+++ b/apps/ui/src/components/Ui/InputAddress.vue
@@ -38,6 +38,10 @@ const networkDetails = computed<NetworkDetails | null>(() => {
 
   return null;
 });
+
+const shouldShowPicker = computed(() => {
+  return props.definition?.showPicker ?? true;
+});
 </script>
 
 <template>
@@ -56,9 +60,9 @@ const networkDetails = computed<NetworkDetails | null>(() => {
       :definition="definition"
       :required="required"
       v-bind="$attrs as any"
-      class="!pr-7"
       :class="{
-        '!pl-[42px]': !!networkDetails
+        '!pl-[42px]': !!networkDetails,
+        '!pr-7': shouldShowPicker
       }"
     />
     <button

--- a/apps/ui/src/components/Ui/InputAddress.vue
+++ b/apps/ui/src/components/Ui/InputAddress.vue
@@ -42,14 +42,6 @@ const networkDetails = computed<NetworkDetails | null>(() => {
 
 <template>
   <div class="relative">
-    <div
-      v-if="definition?.showPicker ?? true"
-      class="absolute top-3.5 right-3 z-10"
-    >
-      <button type="button" @click="emit('pick', path || '')">
-        <IH-identification />
-      </button>
-    </div>
     <UiTooltip
       v-if="networkDetails"
       :title="networkDetails.name"
@@ -69,5 +61,13 @@ const networkDetails = computed<NetworkDetails | null>(() => {
         '!pl-[42px]': !!networkDetails
       }"
     />
+    <div
+      v-if="definition?.showPicker ?? true"
+      class="absolute top-3.5 right-3 z-10"
+    >
+      <button type="button" @click="emit('pick', path || '')">
+        <IH-identification />
+      </button>
+    </div>
   </div>
 </template>

--- a/apps/ui/src/components/Ui/InputAddress.vue
+++ b/apps/ui/src/components/Ui/InputAddress.vue
@@ -61,13 +61,14 @@ const networkDetails = computed<NetworkDetails | null>(() => {
         '!pl-[42px]': !!networkDetails
       }"
     />
-    <div
-      v-if="definition?.showPicker ?? true"
+    <button
+      v-if="shouldShowPicker"
       class="absolute top-3.5 right-3 z-10"
+      type="button"
+      aria-label="Pick address from contacts"
+      @click="emit('pick', path || '')"
     >
-      <button type="button" @click="emit('pick', path || '')">
-        <IH-identification />
-      </button>
-    </div>
+      <IH-identification />
+    </button>
   </div>
 </template>

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -258,7 +258,6 @@ ajv.addKeyword({
 ajv.addKeyword('options');
 ajv.addKeyword('tooltip');
 ajv.addKeyword('showControls');
-ajv.addKeyword('showPicker');
 
 // UiSelectorNetwork
 ajv.addFormat('network', {

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -258,6 +258,7 @@ ajv.addKeyword({
 ajv.addKeyword('options');
 ajv.addKeyword('tooltip');
 ajv.addKeyword('showControls');
+ajv.addKeyword('showPicker');
 
 // UiSelectorNetwork
 ajv.addFormat('network', {


### PR DESCRIPTION
### Summary

Closes https://github.com/snapshot-labs/sx-monorepo/issues/1477

In the contact create/edit form, we show a picker icon in the address input, but it is currently not doing anything on click.

It also should not be present logically, as we can not pick a contact when editing/creating a contact (contacts are unique)

This PR will hide the picker icon in create/edit contact form

Also moved the picker button to be after the input in keyboard navigation.

### How to test

1. Go to http://localhost:8080/#/settings/contacts
2. Create/Edit a contact
3. In the form, there is no picker in the address input
4. Go go http://localhost:8080/#/s:test.wa0x6e.eth/create/ygqbl
5. Create a contract call execution
6. Paste `0x000000000000cd17345801aa8147b8D3950260FF` in the address field
7. The picker icon should be replaced by the loading icon while it is loading
8. Go to http://localhost:8080/#/create/snapshot-x then "Controller" section
9. There is no picker icon in the controller input
10. All other existing address input should have a picker
11. When using keyboard to navigate (using TAB), the picker button should be focused after the input