### PR TITLE
fix(ui): fix transaction form error when updating from valid to invalid address

### DIFF
--- a/apps/ui/src/components/Modal/Transaction.vue
+++ b/apps/ui/src/components/Modal/Transaction.vue
@@ -147,7 +147,10 @@ function handleMethodChange() {
 }
 
 async function handleToChange(to: string) {
-  form.abi = [];
+  form.abi = DEFAULT_FORM_STATE.abi;
+  form.method = DEFAULT_FORM_STATE.method;
+  form.args = DEFAULT_FORM_STATE.args;
+  form.amount = DEFAULT_FORM_STATE.amount;
   abiStr.value = '';
   addressInvalid.value = false;
   showAbiInput.value = false;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1549

When inputing an invalid address after a valid contract address in the transaction form, the form crash.

See [issue](https://github.com/snapshot-labs/sx-monorepo/issues/1549) for more details

### How to test

1. Go 
2. Input `0x000000000000cd1734581aa8147b8D3950260FF` in the address
3. It refresh the form with the contract fields
4. Input a non-contract address in the contract input e.g. `0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3`
5. It should clear the form, and show an error message on the address field
6. Put a valid contract address again: `0x000000000000cd1734581aa8147b8D3950260FF`
7. It should refresh the form, and show the contract fields again