### PR TITLE
fix: TS type after filtering nulls

### DIFF
--- a/packages/sx.js/src/utils/strategies.ts
+++ b/packages/sx.js/src/utils/strategies.ts
@@ -67,5 +67,5 @@ export async function getStrategiesWithParams(
     })
   );
 
-  return results.filter(result => result !== null);
+  return results.filter((result): result is IndexedConfig => result !== null);
 }


### PR DESCRIPTION
### Summary

TS was still seeing `null` in the array after a regular filter.
switched to a type predicate:

```ts
return results.filter((r): r is IndexedConfig => r !== null);
```

now TS knows all nulls are gone and the type checks out.

