### PR TITLE
fix(ui): do not bubble the drag event when resizing

### DIFF
--- a/apps/ui/src/components/Ui/ResizableHorizontal.vue
+++ b/apps/ui/src/components/Ui/ResizableHorizontal.vue
@@ -85,6 +85,7 @@ onMounted(() => {
   >
     <div
       ref="sliderEl"
+      data-no-sidebar-swipe
       :class="[
         'slider',
         {


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1555

This PR fixes a drag event bubbling issue during resizing by adding a data attribute to prevent sidebar swipe interactions.

This will prevent the sidebar opening action on some screen resolution, while resizing the proposal sidebar

### How to test

1. Go to a proposal page on a touch screen device
2. Resolution of the device should allow the left sidebar to be hidden by default
3. Click on the left border of the proposal sidebar, and drag to resize
4. You should be able to resize by dragging left and right, without triggering the sidebar opening event
5. When swiping the page from left to right, it should open the sidebar
