### PR TITLE
fix: merge evm writers with configs

### DIFF
--- a/apps/api/src/evm/config.ts
+++ b/apps/api/src/evm/config.ts
@@ -1,7 +1,8 @@
 import { evmNetworks } from '@snapshot-labs/sx';
 import { createConfig as createGovernorBravoConfig } from './protocols/governorBravo/config';
 import { createConfig as createSnapshotXConfig } from './protocols/snapshotX/config';
-import { EVMConfig, NetworkID, Protocols } from './types';
+import { EVMConfig, NetworkID, PartialConfig, Protocols } from './types';
+import { applyConfig } from './utils';
 
 export function createConfig(
   indexerName: NetworkID,
@@ -13,30 +14,33 @@ export function createConfig(
   let governorBravoConfig: ReturnType<typeof createGovernorBravoConfig> | null =
     null;
 
-  let sources: EVMConfig['sources'] = [];
-  let templates: EVMConfig['templates'] = {};
-  let abis: EVMConfig['abis'] = {};
+  let partialConfig: PartialConfig = {
+    sources: [],
+    templates: {},
+    abis: {}
+  };
 
   if (protocols.snapshotX) {
     snapshotXConfig = createSnapshotXConfig(indexerName);
-    sources = [...sources, ...(snapshotXConfig.sources ?? [])];
-    templates = { ...templates, ...snapshotXConfig.templates };
-    abis = { ...abis, ...snapshotXConfig.abis };
+    partialConfig = applyConfig(partialConfig, 'snapshotX', snapshotXConfig);
   }
 
   if (protocols.governorBravo) {
     governorBravoConfig = createGovernorBravoConfig(indexerName);
-    sources = [...sources, ...(governorBravoConfig?.sources ?? [])];
-    templates = { ...templates, ...governorBravoConfig?.templates };
-    abis = { ...abis, ...governorBravoConfig?.abis };
+
+    if (governorBravoConfig) {
+      partialConfig = applyConfig(
+        partialConfig,
+        'governorBravo',
+        governorBravoConfig
+      );
+    }
   }
 
   return {
     indexerName,
     network_node_url: `https://rpc.snapshot.org/${network.Meta.eip712ChainId}`,
-    sources,
-    templates,
-    abis,
+    ...partialConfig,
     snapshotXConfig: snapshotXConfig?.protocolConfig,
     governorBravoConfig: governorBravoConfig?.protocolConfig
   };

--- a/apps/api/src/evm/index.ts
+++ b/apps/api/src/evm/index.ts
@@ -4,6 +4,7 @@ import { registerIndexer } from '../register';
 import { createWriters as createGovernorBravoWriters } from './protocols/governorBravo/writers';
 import { createWriters as createSnapshotXWriters } from './protocols/snapshotX/writers';
 import { EVMConfig, Protocols } from './types';
+import { applyProtocolPrefixToWriters } from './utils';
 
 // SnapshotX runs by default unless explicitly disabled
 const ENABLE_SNAPSHOT_X = process.env.ENABLE_SNAPSHOT_X !== 'false';
@@ -28,13 +29,19 @@ function createWriters(config: EVMConfig) {
   let writers: Record<string, evm.Writer> = {};
 
   if (config.snapshotXConfig) {
-    writers = createSnapshotXWriters(config, config.snapshotXConfig);
+    writers = applyProtocolPrefixToWriters(
+      'snapshotX',
+      createSnapshotXWriters(config, config.snapshotXConfig)
+    );
   }
 
   if (config.governorBravoConfig) {
     writers = {
       ...writers,
-      ...createGovernorBravoWriters(config, config.governorBravoConfig)
+      ...applyProtocolPrefixToWriters(
+        'governorBravo',
+        createGovernorBravoWriters(config, config.governorBravoConfig)
+      )
     };
   }
 

--- a/apps/api/src/evm/types.ts
+++ b/apps/api/src/evm/types.ts
@@ -37,3 +37,9 @@ export type EVMConfig = {
   snapshotXConfig?: SnapshotXConfig;
   governorBravoConfig?: GovernorBravoConfig;
 } & CheckpointConfig;
+
+export type PartialConfig = {
+  sources: NonNullable<EVMConfig['sources']>;
+  templates: EVMConfig['templates'];
+  abis: EVMConfig['abis'];
+};

--- a/apps/api/src/evm/utils.test.ts
+++ b/apps/api/src/evm/utils.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { PartialConfig } from './types';
+import { applyConfig, applyProtocolPrefixToWriters } from './utils';
+
+describe('applyProtocolPrefixToWriters', () => {
+  it('should apply prefix to writer keys', () => {
+    const writers = { createProposal: async () => {}, vote: async () => {} };
+
+    const result = applyProtocolPrefixToWriters('snapshotX', writers);
+
+    expect(Object.keys(result)).toEqual([
+      'snapshotX_createProposal',
+      'snapshotX_vote'
+    ]);
+  });
+});
+
+describe('applyConfig', () => {
+  const mockEvent = { name: 'TestEvent', fn: 'handleTest' };
+
+  it('should merge and prefix sources', () => {
+    const target: PartialConfig = {
+      sources: [
+        {
+          start: 0,
+          contract: '0x0',
+          events: [{ name: 'Existing', fn: 'handleExisting' }]
+        }
+      ],
+      templates: {
+        Existing: { events: [{ name: 'Existing', fn: 'handleExisting' }] }
+      },
+      abis: {}
+    };
+
+    const config = {
+      sources: [{ start: 0, contract: '0x0', events: [mockEvent] }],
+      templates: { NewTemplate: { events: [mockEvent] } },
+      abis: { TestAbi: [] }
+    };
+
+    const result = applyConfig(target, 'snapshotX', config);
+
+    expect(result).toEqual({
+      abis: {
+        TestAbi: []
+      },
+      sources: [
+        {
+          start: 0,
+          contract: '0x0',
+          events: [
+            {
+              fn: 'handleExisting',
+              name: 'Existing'
+            }
+          ]
+        },
+        {
+          start: 0,
+          contract: '0x0',
+          events: [
+            {
+              fn: 'snapshotX_handleTest',
+              name: 'TestEvent'
+            }
+          ]
+        }
+      ],
+      templates: {
+        Existing: {
+          events: [
+            {
+              fn: 'handleExisting',
+              name: 'Existing'
+            }
+          ]
+        },
+        NewTemplate: {
+          events: [
+            {
+              fn: 'snapshotX_handleTest',
+              name: 'TestEvent'
+            }
+          ]
+        }
+      }
+    });
+  });
+});

--- a/apps/api/src/evm/utils.ts
+++ b/apps/api/src/evm/utils.ts
@@ -1,0 +1,69 @@
+import { evm } from '@snapshot-labs/checkpoint';
+import { EVMConfig, PartialConfig } from './types';
+
+type ProtocolConfig = Pick<EVMConfig, 'sources' | 'templates' | 'abis'>;
+
+type SourceOrTemplate = {
+  events: NonNullable<EVMConfig['sources']>[number]['events'];
+};
+
+function applyProtocolPrefixToEvents<T extends SourceOrTemplate>(
+  prefix: string,
+  source: T
+) {
+  return {
+    ...source,
+    events: source.events.map(event => ({
+      ...event,
+      fn: `${prefix}_${event.fn}`
+    }))
+  };
+}
+
+function applyProtocolPrefixToSources(
+  prefix: string,
+  sources: NonNullable<EVMConfig['sources']>
+) {
+  return sources.map(source => applyProtocolPrefixToEvents(prefix, source));
+}
+
+function applyProtocolPrefixToTemplates(
+  prefix: string,
+  templates: EVMConfig['templates']
+) {
+  if (!templates) return {};
+
+  return Object.fromEntries(
+    Object.entries(templates).map(([key, template]) => [
+      key,
+      applyProtocolPrefixToEvents(prefix, template)
+    ])
+  );
+}
+
+export function applyProtocolPrefixToWriters(
+  prefix: string,
+  writers: Record<string, evm.Writer>
+) {
+  return Object.fromEntries(
+    Object.entries(writers).map(([key, writer]) => [`${prefix}_${key}`, writer])
+  );
+}
+
+export function applyConfig(
+  target: PartialConfig,
+  prefix: string,
+  config: ProtocolConfig
+): PartialConfig {
+  return {
+    sources: [
+      ...(target.sources ?? []),
+      ...applyProtocolPrefixToSources(prefix, config.sources ?? [])
+    ],
+    templates: {
+      ...target.templates,
+      ...applyProtocolPrefixToTemplates(prefix, config.templates ?? {})
+    },
+    abis: { ...target.abis, ...config.abis }
+  };
+}


### PR DESCRIPTION
### Summary

This change will add prefix to writers for EVM.
Because we use multiple protocols (snapshotX and compoundGovernor) there is possibility of conflict between writer names (for example handleProposalCreated exists in both).

To avoid this we prefix handlers in sources/templates as well as writers itself.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1559

### How to test

1. Run `IS_INDEXER=true ENABLED_NETWORKS=sep ENABLE_SNAPSHOT_X=true ENABLE_GOVERNOR_BRAVO=true yarn --cwd apps/api dev` for a bit.
2. It works.

