### PR TITLE
feat: add Compound governance module on API

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,4 +1,4 @@
 DATABASE_URL=postgres://postgres:password@localhost:5432/api
 IS_INDEXER=true
 ENABLE_SNAPSHOT_X=true
-ENABLE_GOVERNOR_BRAVO=false
+ENABLE_GOVERNOR_BRAVO=true

--- a/apps/api/src/evm/protocols/governorBravo/config.ts
+++ b/apps/api/src/evm/protocols/governorBravo/config.ts
@@ -5,13 +5,18 @@ import Timelock from './abis/Timelock.json';
 import { GovernorBravoConfig, NetworkID } from '../../types';
 
 const START_BLOCKS: Partial<Record<NetworkID, number>> = {
-  eth: 22590664,
+  eth: 12006099,
   sep: 9025765
 };
 
-const MODULE_ADDRESSES: Partial<Record<NetworkID, string>> = {
-  eth: '0x408ed6354d4973f66138c91495f2f2fcbd8724c3',
-  sep: '0x69112d158a607dd388034c0c09242ff966985258'
+const MODULE_ADDRESSES: Partial<Record<NetworkID, string[]>> = {
+  eth: [
+    // Compound Governor
+    '0xc0Da02939E1441F497fd74F78cE7Decb17B66529',
+    // Uniswap Governor
+    '0x408ED6354d4973f66138C91495F2f2FCbd8724C3'
+  ],
+  sep: ['0x69112D158A607DD388034c0C09242FF966985258']
 };
 
 type Config = Pick<CheckpointConfig, 'sources' | 'templates' | 'abis'> & {
@@ -22,46 +27,44 @@ export function createConfig(indexerName: NetworkID): Config | null {
   const network = evmNetworks[indexerName];
 
   const start = START_BLOCKS[indexerName];
-  const contract = MODULE_ADDRESSES[indexerName];
-  if (!start || !contract) return null;
+  const contracts = MODULE_ADDRESSES[indexerName];
+  if (!start || !contracts) return null;
 
-  const sources = [
-    {
-      contract,
-      start,
-      abi: 'GovernorModule',
-      events: [
-        {
-          name: 'ProposalCreated(uint256,address,address[],uint256[],string[],bytes[],uint256,uint256,string)',
-          fn: 'handleProposalCreated'
-        },
-        {
-          name: 'VoteCast(address,uint256,uint8,uint256,string)',
-          fn: 'handleVoteCast'
-        },
-        {
-          name: 'ProposalCanceled(uint256)',
-          fn: 'handleProposalCanceled'
-        },
-        {
-          name: 'ProposalQueued(uint256,uint256)',
-          fn: 'handleProposalQueued'
-        },
-        {
-          name: 'ProposalExecuted(uint256)',
-          fn: 'handleProposalExecuted'
-        },
-        {
-          name: 'ProposalThresholdSet(uint256, uint256)',
-          fn: 'handleProposalThresholdSet'
-        },
-        {
-          name: 'NewAdmin(address,address)',
-          fn: 'handleNewAdmin'
-        }
-      ]
-    }
-  ];
+  const sources = contracts.map(contract => ({
+    contract,
+    start,
+    abi: 'GovernorModule',
+    events: [
+      {
+        name: 'ProposalCreated(uint256,address,address[],uint256[],string[],bytes[],uint256,uint256,string)',
+        fn: 'handleProposalCreated'
+      },
+      {
+        name: 'VoteCast(address,uint256,uint8,uint256,string)',
+        fn: 'handleVoteCast'
+      },
+      {
+        name: 'ProposalCanceled(uint256)',
+        fn: 'handleProposalCanceled'
+      },
+      {
+        name: 'ProposalQueued(uint256,uint256)',
+        fn: 'handleProposalQueued'
+      },
+      {
+        name: 'ProposalExecuted(uint256)',
+        fn: 'handleProposalExecuted'
+      },
+      {
+        name: 'ProposalThresholdSet(uint256, uint256)',
+        fn: 'handleProposalThresholdSet'
+      },
+      {
+        name: 'NewAdmin(address,address)',
+        fn: 'handleNewAdmin'
+      }
+    ]
+  }));
 
   return {
     sources,

--- a/apps/api/src/evm/protocols/governorBravo/writers.ts
+++ b/apps/api/src/evm/protocols/governorBravo/writers.ts
@@ -54,6 +54,17 @@ const spaceData: Record<string, SpaceData | undefined> = {
       chain_id: 1
     }
   },
+  '0xc0Da02939E1441F497fd74F78cE7Decb17B66529': {
+    name: 'Compound',
+    symbol: 'COMP',
+    decimals: 18,
+    governanceToken: '0xc00e94Cb662C3520282E6f5717214004A7f26888',
+    treasury: {
+      name: 'Compound Treasury',
+      address: '0x6d903f6003cca6255D85CcA4D3B5E5146dC33925',
+      chain_id: 1
+    }
+  },
   '0x69112D158A607DD388034c0C09242FF966985258': {
     name: 'Sepolia Governor Bravo',
     symbol: 'MOCK',


### PR DESCRIPTION
### Summary

After this is merged we will start syncing GovernorBravo on APIs.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1558

### How to test

1. Apply patch below
2. Run `yarn dev:interactive` with both UI and API.
3. Wait til it reaches block `13 000 000+`
4. You should see both Compound and Uniswap spaces [there](http://localhost:8080/#/explore?p=governor-bravo&n=all).

```diff
diff --git a/scripts/dev-interactive.ts b/scripts/dev-interactive.ts
index 5a60152e3..3cf1293f0 100644
--- a/scripts/dev-interactive.ts
+++ b/scripts/dev-interactive.ts
@@ -14,9 +14,13 @@ const SERVICES: Record<ServiceType, Service> = {
   api: {
     env: {
       UI_URL: 'http://localhost:8080',
-      ENABLED_NETWORKS: 'sep,sn-sep',
-      VITE_ENABLED_NETWORKS: 's-tn,sep,sn-sep',
+      ENABLED_NETWORKS: 'eth',
+      ENABLE_SNAPSHOT_X: 'false',
+      ENABLE_GOVERNOR_BRAVO: 'true',
+      VITE_ENABLED_NETWORKS: 's-tn,eth',
       VITE_METADATA_NETWORK: 's-tn',
+      VITE_ENABLE_GOVERNOR_BRAVO: 'true',
+      VITE_UNIFIED_API_URL: 'http://localhost:3000',
       VITE_UNIFIED_API_TESTNET_URL: 'http://localhost:3000'
     }
   },
```

### Screenshots

<img width="802" height="605" alt="image" src="https://github.com/user-attachments/assets/ea36a624-dfda-410e-acbd-f0c5ca1b6666" />
<img width="1651" height="937" alt="image" src="https://github.com/user-attachments/assets/59248101-47b1-4db7-b047-997b3e7cc695" />
