### PR TITLE
fix(ux): avoid content flashing while redirecting non-pro whitelabel to main domain

### DIFF
--- a/apps/ui/src/composables/useWhiteLabel.ts
+++ b/apps/ui/src/composables/useWhiteLabel.ts
@@ -74,43 +74,45 @@ export function useWhiteLabel() {
   async function init() {
     if (resolved.value) return;
 
+    let shouldResolve = true;
+
     try {
       space.value = await getSpace(domain);
 
-      if (space.value) {
-        if (!space.value.turbo) {
-          const redirectUrl = new URL(
-            `${window.location.protocol}//${DEFAULT_DOMAIN}`
-          );
+      if (!space.value) return true;
 
-          const originalHash = window.location.hash.replace(/^#\//, '');
-          const globalPathKey = Object.keys(GLOBAL_PATHS).find(path =>
-            originalHash.startsWith(path)
-          );
+      if (!space.value.turbo) {
+        const redirectUrl = new URL(
+          `${window.location.protocol}//${DEFAULT_DOMAIN}`
+        );
 
-          if (globalPathKey) {
-            redirectUrl.hash = `#/${GLOBAL_PATHS[globalPathKey]}`;
-          } else {
-            const newHash = `#/${encodeURIComponent(space.value.network)}:${encodeURIComponent(space.value.id)}`;
-            redirectUrl.hash = [newHash, originalHash]
-              .filter(Boolean)
-              .join('/');
-          }
+        const originalHash = window.location.hash.replace(/^#\//, '');
+        const globalPathKey = Object.keys(GLOBAL_PATHS).find(path =>
+          originalHash.startsWith(path)
+        );
 
-          window.location.href = redirectUrl.href;
-          return;
+        if (globalPathKey) {
+          redirectUrl.hash = `#/${GLOBAL_PATHS[globalPathKey]}`;
+        } else {
+          const newHash = `#/${encodeURIComponent(space.value.network)}:${encodeURIComponent(space.value.id)}`;
+          redirectUrl.hash = [newHash, originalHash].filter(Boolean).join('/');
         }
 
-        isWhiteLabel.value = true;
-        skinSettings.value =
-          MAPPING[domain]?.skinSettings ||
-          space.value.additionalRawData?.skinSettings;
+        window.location.href = redirectUrl.href;
+        // Don't mark as resolved, to keep the UI splash screen while redirecting
+        shouldResolve = false;
+        return;
       }
+
+      isWhiteLabel.value = true;
+      skinSettings.value =
+        MAPPING[domain]?.skinSettings ||
+        space.value.additionalRawData?.skinSettings;
     } catch (e) {
       console.log(e);
       failed.value = true;
     } finally {
-      resolved.value = true;
+      resolved.value = shouldResolve;
     }
   }
 

--- a/apps/ui/src/composables/useWhiteLabel.ts
+++ b/apps/ui/src/composables/useWhiteLabel.ts
@@ -79,7 +79,7 @@ export function useWhiteLabel() {
     try {
       space.value = await getSpace(domain);
 
-      if (!space.value) return true;
+      if (!space.value) return;
 
       if (!space.value.turbo) {
         const redirectUrl = new URL(


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

#### Issue

We redirect a whitelabel to main site (snapshot.box), when the space is not pro.
But while the redirection is happening, the whitelabel site is showing briefly.

This PR will avoid flashing the whitelabel site while redirecting, and keep the loading spinner  instead.

### How to test

1. Edit your .env file, and set `VITE_HOST=snapshot.box`
2. In the dev console, network, set throttling to something slower
3. Start the server with `VITE_WHITE_LABEL_MAPPING='127.0.0.1;s:aavegotchi.eth' yarn dev`
4. Go to http://127.0.0.1:8080/
5. It should show the loading icon, until the redirection to snapshot.box (before, it will show the resolved whitelabel site, until snapshot.box is loaded)