### PR TITLE
fix: show error if space is using overriding strategies

### DIFF
--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -228,7 +228,7 @@ export const FLAGS = {
   DMCA: 2
 };
 
-export const OVERRIDING_STRATEGIES = [
+export const OVERRIDING_STRATEGIES: readonly string[] = [
   'aura-vlaura-vebal-with-overrides',
   'balance-of-with-linear-vesting-power',
   'balancer-delegation',

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { useQueryClient } from '@tanstack/vue-query';
 import RelayerBalance from '@/components/RelayerBalance.vue';
-import { DISABLED_STRATEGIES } from '@/helpers/constants';
+import {
+  DISABLED_STRATEGIES,
+  OVERRIDING_STRATEGIES
+} from '@/helpers/constants';
 import { evmNetworks, getNetwork, offchainNetworks } from '@/networks';
 import { Space } from '@/types';
 
@@ -187,7 +190,8 @@ const error = computed(() => {
 
     if (
       !isTicketValid.value ||
-      strategies.value.some(s => DISABLED_STRATEGIES.includes(s.address))
+      strategies.value.some(s => DISABLED_STRATEGIES.includes(s.address)) ||
+      strategies.value.some(s => OVERRIDING_STRATEGIES.includes(s.address))
     ) {
       return 'Strategies are invalid';
     }


### PR DESCRIPTION
### Summary
Show "Strategies are invalid" error when space is using overriding strategies similar to when space is using multichain strategy
<img width="216" height="77" alt="Untitled 9" src="https://github.com/user-attachments/assets/67b08805-c229-4236-9552-0d3cdd5a346f" />


Closes: https://github.com/snapshot-labs/workflow/issues/645

### How to test

1. Go to https://snapshot.box/#/s:odos.eth/settings/voting-strategies?as=0x7AEBD46FDbE4f12E9E46988D4Bf0673563005A5e
2. You will not see any error
3. Go to `http://localhost:8080/#/s:odos.eth/settings/voting-strategies?as=0x7AEBD46FDbE4f12E9E46988D4Bf0673563005A5e` 
4. You should not be able to save settings without removing the delegation strategy
