### PR TITLE
fix: only handle vote metadata if it's defined

### DIFF
--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -803,9 +803,10 @@ export function createWriters(config: FullConfig) {
 
     try {
       const metadataUri = longStringToText(event.metadata_uri);
-      await handleVoteMetadata(metadataUri, config);
-
-      vote.metadata = dropIpfs(metadataUri);
+      if (metadataUri) {
+        await handleVoteMetadata(metadataUri, config);
+        vote.metadata = dropIpfs(metadataUri);
+      }
     } catch (err) {
       logger.warn({ err }, 'Failed to handle vote metadata');
     }


### PR DESCRIPTION
### Summary

Otherwise it will try to load it from database and attempt to make request (and cause warnings).
