### PR TITLE
fix: custom whitelabel should ignore pro spaces filter

### DIFF
--- a/apps/ui/src/composables/useWhiteLabel.ts
+++ b/apps/ui/src/composables/useWhiteLabel.ts
@@ -93,7 +93,7 @@ export function useWhiteLabel() {
 
       if (!space.value) return;
 
-      if (!space.value.turbo) {
+      if (!space.value.turbo && !MAPPING[domain]) {
         const redirectUrl = new URL(
           `${window.location.protocol}//${DEFAULT_DOMAIN}`
         );


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an issue where the hardcoded mapping is being ignored when the space is not turbo.

Whitelabel defined in the custom MAPPING should also have whitelabel enabled, regardless of its pro status