### PR TITLE
fix: pro payment expiration date should ignore expired subscription

### DIFF
--- a/apps/ui/src/views/Space/Pro.vue
+++ b/apps/ui/src/views/Space/Pro.vue
@@ -425,7 +425,7 @@ onMounted(() => {
           <div class="text-skin-heading">
             {{
               dayjs(
-                selectedSpace.turbo_expiration
+                (selectedSpace.turbo_expiration || 0) * 1e3 > Date.now()
                   ? selectedSpace.turbo_expiration * 1e3
                   : new Date()
               )


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

#### Issue

<img width="972" height="1088" alt="image" src="https://github.com/user-attachments/assets/7ad131b7-00e3-4b90-9c62-ae90a30e24b2" />

The "end date" is showing as 9 sept 2025, even though the current date is 4 sept 2025, and the plan is for 1 month.

#### Reason

The expiration date is taking into account existing subscription, and is adding +1 month to the existing subscription.

Issue is that if a space has an expired subscription (expired on 9 aug 2025 for the space in the example), the expiration date is not taking that into account.

#### Fix

This PR fix the expiration date, by ignoring expired subscription.

- if a space has an active subscription expiring in the future, it will add +n from that future date
- if a space has an expired subscription, or no previous subscription, it will add +n from current date


### How to test

1. Go to http://localhost:8080/#/s:zyfai.eth/pro
2. Open the payment modal
3. The expiration date should start from the current date + n year|month

### Note

This is for UI only, schnaps contract has its own separate expiration date computation logic