### PR TITLE
fix: allow overriding strategies validation for non-turbo spaces

### DIFF
--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -191,7 +191,7 @@ const error = computed(() => {
     if (
       !isTicketValid.value ||
       strategies.value.some(s => DISABLED_STRATEGIES.includes(s.address)) ||
-      strategies.value.some(s => OVERRIDING_STRATEGIES.includes(s.address))
+      (!props.space.turbo && strategies.value.some(s => OVERRIDING_STRATEGIES.includes(s.address)))
     ) {
       return 'Strategies are invalid';
     }


### PR DESCRIPTION
### Summary
- updated strategy check for turbo spaces

### How to test
- turbo space http://localhost:8080/#/s:superfluid.eth/settings/voting-strategies should not show any error
- non turbo space http://localhost:8080/#/s:odos.eth/settings/voting-strategies should still show error