### PR TITLE
fix(ui): rename "ens domain" to a more generic term

### DIFF
--- a/apps/ui/src/components/EnsConfiguratorOffchain.vue
+++ b/apps/ui/src/components/EnsConfiguratorOffchain.vue
@@ -70,8 +70,8 @@ function handleSelect(value: string) {
 <template>
   <div v-if="hasError" class="flex flex-col gap-3 items-start">
     <UiAlert type="error">
-      An error happened while fetching the ENS names associated to your wallet.
-      Please try again
+      An error happened while fetching the domain names associated to your
+      wallet. Please try again
     </UiAlert>
     <UiButton
       class="flex items-center gap-2"
@@ -86,7 +86,10 @@ function handleSelect(value: string) {
     <div class="space-y-2">
       <div>
         To create a space, you need an ENS name on
-        {{ isTestnet ? 'Sepolia testnet' : 'Ethereum mainnet' }}.
+        {{ isTestnet ? 'Sepolia testnet' : 'Ethereum mainnet'
+        }}{{
+          !isTestnet ? ', or a web3 domain name on a mainnet network' : ''
+        }}.
       </div>
       <UiMessage v-if="!isTestnet" type="info">
         Still experimenting?
@@ -142,12 +145,12 @@ function handleSelect(value: string) {
               <div class="flex flex-col">
                 <div class="text-skin-danger" v-text="name.name" />
                 <div v-if="name.status === 'TOO_LONG'">
-                  ENS name is too long. It must be less than
+                  Domain name is too long. It must be less than
                   {{ MAX_ENS_NAME_LENGTH }} characters
                 </div>
                 <div v-else-if="name.status === 'DELETED'">
-                  ENS name was used by a previously deleted space and can not be
-                  reused to create a new space.
+                  Domain name was used by a previously deleted space and can not
+                  be reused to create a new space.
                   <AppLink
                     to="https://docs.snapshot.box/faq/im-a-snapshot-user/space-settings#why-cant-i-create-a-new-space-with-my-previous-deleted-space-ens-name"
                     class="text-skin-link"
@@ -163,11 +166,11 @@ function handleSelect(value: string) {
             v-if="!validNames.length && !invalidNames.length"
             type="danger"
           >
-            No more ENS names available for space creation found.
+            No more domain names available for space creation found.
           </UiMessage>
         </div>
         <UiMessage v-else type="danger">
-          No ENS names found for the current wallet.
+          No domain names found for the current wallet.
         </UiMessage>
         <AppLink :to="ensUrl" class="inline-block">
           Register a new ENS name
@@ -180,9 +183,9 @@ function handleSelect(value: string) {
       <div class="space-y-3">
         <h4 class="eyebrow">Controller</h4>
         <UiMessage type="info">
-          By default, the ENS domain’s controller is its owner. You can change
-          it later in your space setting.</UiMessage
-        >
+          By default, the space's controller is the domain owner. You can change
+          this later in your space setting.
+        </UiMessage>
         <FormSpaceController
           :controller="web3.account"
           :network="getNetwork(networkId)"
@@ -194,7 +197,7 @@ function handleSelect(value: string) {
       <button class="text-skin-link" @click="modalAccountOpen = true">
         Connect your wallet
       </button>
-      in order to see your ENS names
+      in order to see your domain names
     </UiMessage>
   </div>
   <teleport to="#modal">

--- a/apps/ui/src/views/CreateSpaceSnapshot.vue
+++ b/apps/ui/src/views/CreateSpaceSnapshot.vue
@@ -49,10 +49,10 @@ const STEPS: extendedStepRecords = {
     isValid: () => !stepsErrors.value['profile']
   },
   id: {
-    title: 'ENS name',
+    title: 'Domain name',
     isValid: () => !!settingsForm.value.id,
-    contentTitle: 'ENS name',
-    contentDescription: 'Select your space ENS name.'
+    contentTitle: 'Domain name',
+    contentDescription: 'Select your space domain name.'
   },
   network: {
     title: 'Network',

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -191,7 +191,8 @@ const error = computed(() => {
     if (
       !isTicketValid.value ||
       strategies.value.some(s => DISABLED_STRATEGIES.includes(s.address)) ||
-      (!props.space.turbo && strategies.value.some(s => OVERRIDING_STRATEGIES.includes(s.address)))
+      (!props.space.turbo &&
+        strategies.value.some(s => OVERRIDING_STRATEGIES.includes(s.address)))
     ) {
       return 'Strategies are invalid';
     }


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This address a concern from some of our domain name partner, where we refer to the domain name of an offchain space as "ENS Domain" when creating a space, although we support more than ens domain.

Just to name a few, we also support:h

- .bnb name
- .sonic name
- .shib name
- a few other names from offchain resolvers

This PR will fix the wording on our space creation UI, to migrate reference from "ENS domain name" to just "domain name".

### How to test

1. Go to http://localhost:8080/#/create/snapshot
2. The copy should not imply that we support only ens domain as sole domain provider
