### PR TITLE
refactor: use string proposal_id

### DIFF
--- a/apps/api/src/evm/protocols/governor-bravo/writers.ts
+++ b/apps/api/src/evm/protocols/governor-bravo/writers.ts
@@ -270,7 +270,7 @@ export function createWriters(
       spaceMetadataItem?.executors_strategies?.[0];
     if (!executionStrategyAddress) return;
 
-    const executionStrategy = new ExecutionStrategy(
+    const executionStrategy = await ExecutionStrategy.loadEntity(
       executionStrategyAddress,
       config.indexerName
     );
@@ -282,7 +282,7 @@ export function createWriters(
       spaceId: spaceAddress,
       proposalId: id
     });
-    proposal.proposal_id = id;
+    proposal.proposal_id = id.toString();
     proposal.space = space.id;
     proposal.author = proposerAddress;
     proposal.metadata = proposalMetadataId;
@@ -452,7 +452,7 @@ export function createWriters(
     const vote = new Vote(voteId, config.indexerName);
     vote.voter = voterAddress;
     vote.space = space.id;
-    vote.proposal = id;
+    vote.proposal = id.toString();
     vote.choice = choice;
     vote.vp = event.args.votes.toString();
     vote.vp_parsed = getParsedVP(vote.vp, proposal.vp_decimals);

--- a/apps/api/src/evm/protocols/snapshot-x/writers.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/writers.ts
@@ -627,7 +627,7 @@ export function createWriters(
       spaceId,
       proposalId
     });
-    proposal.proposal_id = proposalId;
+    proposal.proposal_id = proposalId.toString();
     proposal.space = spaceId;
     proposal.author = author;
     proposal.metadata = null;
@@ -989,7 +989,7 @@ export function createWriters(
       config.indexerName
     );
     vote.space = spaceId;
-    vote.proposal = proposalId;
+    vote.proposal = proposalId.toString();
     vote.voter = voter;
     vote.choice = choice;
     vote.vp = vp.toString();

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -215,8 +215,8 @@ type Proposal {
   id: String!
   "UI link to proposal interface"
   link: String!
-  "Numeric ID of the proposal within the space"
-  proposal_id: Int!
+  "ID of the proposal within the space"
+  proposal_id: String!
   "Space this proposal belongs to"
   space: Space!
   "User who created the proposal"
@@ -338,8 +338,8 @@ type Vote {
   voter: User!
   "Space where the vote was cast"
   space: Space!
-  "Numeric ID of the proposal being voted on"
-  proposal: Int!
+  "ID of the proposal being voted on"
+  proposal: String!
   "Voting choice (1, 2, 3, etc.)"
   choice: Int!
   "Voting power used for this vote"

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -460,7 +460,7 @@ export function createWriters(config: FullConfig) {
       spaceId,
       proposalId
     });
-    proposal.proposal_id = proposalId;
+    proposal.proposal_id = proposalId.toString();
     proposal.space = spaceId;
     proposal.author = author.address;
     proposal.metadata = null;
@@ -793,7 +793,7 @@ export function createWriters(config: FullConfig) {
       config.indexerName
     );
     vote.space = spaceId;
-    vote.proposal = proposalId;
+    vote.proposal = proposalId.toString();
     vote.voter = voter.address;
     vote.choice = choice;
     vote.vp = vp.toString();


### PR DESCRIPTION
### Summary

This is to accommodate OpenZeppelin which can use string proposal IDs.

This is incompatible change so it's important we don't promote APIs before UI is updated (we will need to coordinate promote and UI update at the same time).

We will wait for APIs to sync up (making sure they are not missing events) and then promote at the same time as we do UI update.