### PR TITLE
refactor: convert proposalId to string on UI

### DIFF
--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -463,7 +463,7 @@ export function createApi(
           orderDirection,
           where: {
             space: proposal.space.id,
-            proposal: Number(proposal.proposal_id),
+            proposal: proposal.proposal_id,
             ...filters
           }
         }

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -421,7 +421,7 @@ export function createActions(
 
       const data = {
         space: space.id,
-        proposal: proposalId.proposal_id as number,
+        proposal: Number(proposalId.proposal_id),
         authenticator,
         executionStrategy: selectedExecutionStrategy,
         metadataUri: `ipfs://${pinned.cid}`
@@ -466,7 +466,7 @@ export function createActions(
         {
           signer,
           space: proposal.space.id,
-          proposal: proposal.proposal_id as number
+          proposal: Number(proposal.proposal_id)
         },
         { noWait: isContract && connectorType !== 'sequence' }
       );
@@ -488,7 +488,7 @@ export function createActions(
           envelope: {
             data: {
               spaceId: proposal.space.id,
-              proposalId: proposal.proposal_id as number,
+              proposalId: Number(proposal.proposal_id),
               choice: getSdkChoice(choice),
               reason
             }
@@ -540,7 +540,7 @@ export function createActions(
         space: proposal.space.id,
         authenticator,
         strategies: strategiesWithMetadata,
-        proposal: proposal.proposal_id as number,
+        proposal: Number(proposal.proposal_id),
         choice: getSdkChoice(choice),
         metadataUri: pinned ? `ipfs://${pinned.cid}` : '',
         chainId
@@ -582,7 +582,7 @@ export function createActions(
         return governorBravoClient.queue({
           signer: getSigner(web3),
           spaceId: proposal.space.id,
-          proposalId: proposal.proposal_id as number
+          proposalId: Number(proposal.proposal_id)
         });
       }
 
@@ -606,7 +606,7 @@ export function createActions(
         return governorBravoClient.execute({
           signer: getSigner(web3),
           spaceId: proposal.space.id,
-          proposalId: proposal.proposal_id as number
+          proposalId: Number(proposal.proposal_id)
         });
       }
 

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -406,7 +406,7 @@ export function createActions(
 
       const data = {
         space: space.id,
-        proposal: proposal.proposal_id as number,
+        proposal: Number(proposal.id),
         authenticator,
         executionStrategy: selectedExecutionStrategy,
         metadataUri: `ipfs://${pinned.cid}`
@@ -446,7 +446,7 @@ export function createActions(
       return client.cancelProposal({
         signer: web3.provider.account,
         space: proposal.space.id,
-        proposal: proposal.proposal_id as number
+        proposal: Number(proposal.id)
       });
     },
     vote: async (
@@ -507,7 +507,7 @@ export function createActions(
         space: proposal.space.id,
         authenticator,
         strategies: strategiesWithMetadata,
-        proposal: proposal.proposal_id as number,
+        proposal: Number(proposal.id),
         choice: getSdkChoice(choice),
         metadataUri: pinned ? `ipfs://${pinned.cid}` : ''
       };
@@ -586,7 +586,7 @@ export function createActions(
       return executionCall('eth', l1ChainId, 'executeStarknetProposal', {
         space: proposal.space.id,
         executor: proposal.execution_destination,
-        proposalId: proposal.proposal_id as number,
+        proposalId: Number(proposal.id),
         proposal: proposalData,
         votesFor,
         votesAgainst,

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -255,7 +255,7 @@ export type ProposalExecution = {
 
 export type Proposal = {
   id: string;
-  proposal_id: number | string;
+  proposal_id: string;
   network: NetworkID;
   execution_network: NetworkID;
   /**
@@ -402,7 +402,7 @@ export type Vote = {
   space: {
     id: string;
   };
-  proposal: number | string;
+  proposal: string;
   choice: number | number[] | Record<string, number>;
   vp: number;
   reason?: string;


### PR DESCRIPTION
### Summary

Depends on https://github.com/snapshot-labs/sx-monorepo/pull/1594

This PR should be compatible with both API versions (both string and number proposal ID) so it can be merged independently, but ideally we should promote it soon so types actually match what API returns.