### PR TITLE
feat: index timeline events with block_number

### DIFF
--- a/apps/api/src/evm/protocols/governor-bravo/writers.ts
+++ b/apps/api/src/evm/protocols/governor-bravo/writers.ts
@@ -287,9 +287,13 @@ export function createWriters(
     proposal.author = proposerAddress;
     proposal.metadata = proposalMetadataId;
     proposal.start = event.args.startBlock.toNumber();
+    proposal.start_block_number = proposal.start;
     proposal.min_end = event.args.endBlock.toNumber();
+    proposal.min_end_block_number = proposal.min_end;
     proposal.max_end = proposal.min_end;
+    proposal.max_end_block_number = proposal.max_end;
     proposal.snapshot = proposal.start;
+    proposal.snapshot_block_number = proposal.snapshot;
     proposal.treasuries = spaceMetadataItem?.treasuries || [];
     proposal.quorum = executionStrategy.quorum;
     proposal.strategies = space.strategies;

--- a/apps/api/src/evm/protocols/snapshot-x/writers.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/writers.ts
@@ -633,9 +633,13 @@ export function createWriters(
     proposal.metadata = null;
     proposal.execution_hash = event.args.proposal.executionPayloadHash;
     proposal.start = event.args.proposal.startBlockNumber;
+    proposal.start_block_number = proposal.start;
     proposal.min_end = event.args.proposal.minEndBlockNumber;
+    proposal.min_end_block_number = proposal.min_end;
     proposal.max_end = event.args.proposal.maxEndBlockNumber;
+    proposal.max_end_block_number = proposal.max_end;
     proposal.snapshot = event.args.proposal.startBlockNumber;
+    proposal.snapshot_block_number = proposal.snapshot;
     proposal.type = 'basic';
     proposal.scores_1 = '0';
     proposal.scores_1_parsed = 0;

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -236,7 +236,7 @@ type Proposal {
   "Maximum timepoint when voting must end (blocks on EVM, seconds on Starknet)"
   max_end: Int!
   "Maximum block number when voting must end (only defined on EVM)"
-  max_end_block_number: Int!
+  max_end_block_number: Int
   "Timepoint used for voting power calculation (blocks on EVM, seconds on Starknet)"
   snapshot: Int!
   "Block number used for voting power calculation (only defined on EVM)"

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -227,12 +227,20 @@ type Proposal {
   metadata: ProposalMetadataItem
   "When voting starts (blocks on EVM, seconds on Starknet)"
   start: Int!
-  "Minimum block number when voting can end"
+  "When voting starts (only defined on EVM)"
+  start_block_number: Int
+  "Minimum timepoint when voting can end (blocks on EVM, seconds on Starknet)"
   min_end: Int!
-  "Maximum block number when voting must end"
+  "Minimum block number when voting can end (only defined on EVM)"
+  min_end_block_number: Int
+  "Maximum timepoint when voting must end (blocks on EVM, seconds on Starknet)"
   max_end: Int!
-  "Block number used for voting power calculation"
+  "Maximum block number when voting must end (only defined on EVM)"
+  max_end_block_number: Int!
+  "Timepoint used for voting power calculation (blocks on EVM, seconds on Starknet)"
   snapshot: Int!
+  "Block number used for voting power calculation (only defined on EVM)"
+  snapshot_block_number: Int
   "Timestamp when proposal can be executed"
   execution_time: Int!
   "Address of the execution strategy contract"


### PR DESCRIPTION
### Summary

On EVM block numbers are native timepoints. We want to migrate API to return timestamps on default start/min_end/max_end/snapshot so we need intermediate update to API where we just duplicate those.

After this PR is merged we will migrate UI to use those `_block_number` variants and we will be free to change how default start/min_end/max_end/snapshot works.

Towards: https://github.com/snapshot-labs/sx-monorepo/issues/1583