### PR TITLE
refactor: properly type config in evm constants

### DIFF
--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -24,8 +24,11 @@ export function createConstants(
   networkId: NetworkID,
   { pin }: { pin: PinFunction }
 ) {
-  const config = evmNetworks[networkId];
-  if (!config) throw new Error(`Unsupported network ${networkId}`);
+  if (!(networkId in evmNetworks)) {
+    throw new Error(`Unsupported network ${networkId}`);
+  }
+
+  const config = evmNetworks[networkId as keyof typeof evmNetworks];
 
   const AUTHENTICATORS_SUPPORT_INFO: Record<string, AuthenticatorSupportInfo> =
     {
@@ -61,7 +64,9 @@ export function createConstants(
     [config.Strategies.Comp]: true,
     [config.Strategies.OZVotes]: true,
     [config.Strategies.Whitelist]: true,
-    [config.Strategies.ApeGas]: true
+    ...(config.Strategies.ApeGas && {
+      [config.Strategies.ApeGas]: true
+    })
   };
 
   const SUPPORTED_EXECUTORS = {
@@ -88,7 +93,9 @@ export function createConstants(
     [config.Strategies.Comp]: 'ERC-20 Votes Comp (EIP-5805)',
     [config.Strategies.OZVotes]: 'ERC-20 Votes (EIP-5805)',
     [config.Strategies.Whitelist]: 'Merkle whitelist',
-    [config.Strategies.ApeGas]: 'ApeChain Delegated Gas'
+    ...(config.Strategies.ApeGas && {
+      [config.Strategies.ApeGas]: 'ApeChain Delegated Gas'
+    })
   };
 
   const EXECUTORS = {

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -23,8 +23,11 @@ export function createConstants(
   baseNetworkId: NetworkID,
   baseChainId: number
 ) {
-  const config = starknetNetworks[networkId as 'sn' | 'sn-sep'];
-  if (!config) throw new Error(`Unsupported network ${networkId}`);
+  if (!(networkId in starknetNetworks)) {
+    throw new Error(`Unsupported network ${networkId}`);
+  }
+
+  const config = starknetNetworks[networkId as keyof typeof starknetNetworks];
 
   const AUTHENTICATORS_SUPPORT_INFO: Record<string, AuthenticatorSupportInfo> =
     {


### PR DESCRIPTION
### Summary

Before it was typed as any so we didn't get any typechecking for values there. Now it gets properly typed.

Now it's typed as expected:
<img width="832" height="761" alt="image" src="https://github.com/user-attachments/assets/5d041832-47df-4de5-83f7-8a5b61acc1c7" />


### How to test

1. Check that `config` is typed (as not `any`).
