### PR TITLE
feat: compute start/min_end/max_end timestamps on API

### DIFF
--- a/apps/api/src/evm/protocols/governor-bravo/writers.ts
+++ b/apps/api/src/evm/protocols/governor-bravo/writers.ts
@@ -29,6 +29,7 @@ import {
   VotingPowerValidationStrategiesParsedMetadataItem
 } from '../../../../.checkpoint/models';
 import { EVMConfig, GovernorBravoConfig } from '../../types';
+import { getTimestampFromBlock as _getTimestampFromBlock } from '../../utils';
 
 type SpaceData = {
   name: string;
@@ -286,14 +287,22 @@ export function createWriters(
     proposal.space = space.id;
     proposal.author = proposerAddress;
     proposal.metadata = proposalMetadataId;
-    proposal.start = event.args.startBlock.toNumber();
-    proposal.start_block_number = proposal.start;
-    proposal.min_end = event.args.endBlock.toNumber();
-    proposal.min_end_block_number = proposal.min_end;
+
+    const getTimestampFromBlock = (value: number) =>
+      _getTimestampFromBlock({
+        networkId: config.indexerName,
+        blockNumber: value,
+        currentBlockNumber: blockNumber,
+        currentTimestamp: block?.timestamp ?? getCurrentTimestamp()
+      });
+
+    proposal.start = getTimestampFromBlock(event.args.startBlock.toNumber());
+    proposal.start_block_number = event.args.startBlock.toNumber();
+    proposal.min_end = getTimestampFromBlock(event.args.endBlock.toNumber());
+    proposal.min_end_block_number = event.args.endBlock.toNumber();
     proposal.max_end = proposal.min_end;
     proposal.max_end_block_number = proposal.max_end;
     proposal.snapshot = proposal.start;
-    proposal.snapshot_block_number = proposal.snapshot;
     proposal.treasuries = spaceMetadataItem?.treasuries || [];
     proposal.quorum = executionStrategy.quorum;
     proposal.strategies = space.strategies;

--- a/apps/api/src/evm/utils.ts
+++ b/apps/api/src/evm/utils.ts
@@ -1,5 +1,6 @@
 import { evm } from '@snapshot-labs/checkpoint';
-import { EVMConfig, PartialConfig } from './types';
+import { evmNetworks } from '@snapshot-labs/sx';
+import { EVMConfig, NetworkID, PartialConfig } from './types';
 
 type ProtocolConfig = Pick<EVMConfig, 'sources' | 'templates' | 'abis'>;
 
@@ -66,4 +67,22 @@ export function applyConfig(
     },
     abis: { ...target.abis, ...config.abis }
   };
+}
+
+export function getTimestampFromBlock({
+  networkId,
+  blockNumber,
+  currentBlockNumber,
+  currentTimestamp
+}: {
+  networkId: NetworkID;
+  blockNumber: number;
+  currentBlockNumber: number;
+  currentTimestamp: number;
+}) {
+  const blockDifference = blockNumber - currentBlockNumber;
+
+  return Math.round(
+    currentTimestamp + blockDifference * evmNetworks[networkId].Meta.blockTime
+  );
 }

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -225,22 +225,20 @@ type Proposal {
   execution_hash: String!
   "Proposal metadata containing title, body, and choices"
   metadata: ProposalMetadataItem
-  "When voting starts (blocks on EVM, seconds on Starknet)"
+  "Timestamp when proposal starts"
   start: Int!
   "When voting starts (only defined on EVM)"
   start_block_number: Int
-  "Minimum timepoint when voting can end (blocks on EVM, seconds on Starknet)"
+  "Minimum timestamp when voting can end"
   min_end: Int!
   "Minimum block number when voting can end (only defined on EVM)"
   min_end_block_number: Int
-  "Maximum timepoint when voting must end (blocks on EVM, seconds on Starknet)"
+  "Maximum timestamp when voting must end"
   max_end: Int!
   "Maximum block number when voting must end (only defined on EVM)"
   max_end_block_number: Int
   "Timepoint used for voting power calculation (blocks on EVM, seconds on Starknet)"
   snapshot: Int!
-  "Block number used for voting power calculation (only defined on EVM)"
-  snapshot_block_number: Int
   "Timestamp when proposal can be executed"
   execution_time: Int!
   "Address of the execution strategy contract"


### PR DESCRIPTION
### Summary

Those values will now be computed on API so `start`/`min_end`/`max_end` are always timestamps.

Towards: https://github.com/snapshot-labs/sx-monorepo/issues/1583
Depends on: https://github.com/snapshot-labs/sx-monorepo/pull/1600

### How to test

1. Apply patch from below.
2. Run query from below.
3. You see both block numbers and timestamps and values are fairly accurate when looking at explorer.

```diff
diff --git a/scripts/dev-interactive.ts b/scripts/dev-interactive.ts
index af201d16b..b9e4d5564 100644
--- a/scripts/dev-interactive.ts
+++ b/scripts/dev-interactive.ts
@@ -14,8 +14,8 @@ const SERVICES: Record<ServiceType, Service> = {
   api: {
     env: {
       UI_URL: 'http://localhost:8080',
-      ENABLED_NETWORKS: 'sep,sn-sep',
-      VITE_ENABLED_NETWORKS: 's-tn,sep,sn-sep',
+      ENABLED_NETWORKS: 'sep',
+      VITE_ENABLED_NETWORKS: 's-tn,sep',
       VITE_METADATA_NETWORK: 's-tn',
       VITE_API_TESTNET_URL: 'http://localhost:3000'
     }

```

```gql
{
  proposals {
    id
    _indexer
    start
    start_block_number
    min_end
    min_end_block_number
    max_end
    max_end_block_number
  }
}
```