### PR TITLE
refactor(ui): use default start/min_end/max_end directly

### DIFF
--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -324,8 +324,6 @@ function formatProposal(
   current: number,
   baseNetworkId?: NetworkID
 ): Proposal {
-  const { getTsFromCurrent } = useMetaStore();
-
   const executionNetworkId =
     proposal.execution_strategy_type === 'EthRelayer' && baseNetworkId
       ? baseNetworkId
@@ -383,17 +381,6 @@ function formatProposal(
       : (proposal.min_end_block_number ?? proposal.min_end) <= current,
     execution_settled: proposal.execution_settled,
     state,
-    start:
-      proposal.start_block_number !== null
-        ? getTsFromCurrent(networkId, proposal.start_block_number)
-        : proposal.start,
-    min_end:
-      proposal.min_end_block_number !== null
-        ? getTsFromCurrent(networkId, proposal.min_end_block_number)
-        : proposal.min_end,
-    max_end: proposal.max_end_block_number
-      ? getTsFromCurrent(networkId, proposal.max_end_block_number)
-      : proposal.max_end,
     network: networkId,
     privacy: 'none',
     quorum: Number(proposal.execution_strategy_details?.quorum || 0),

--- a/apps/ui/src/stores/meta.ts
+++ b/apps/ui/src/stores/meta.ts
@@ -52,23 +52,10 @@ export const useMetaStore = defineStore('meta', () => {
     return Math.round(current * getConfigBlockTime(networkId));
   }
 
-  function getTsFromCurrent(networkId: NetworkID, current: number) {
-    if (!evmNetworks.includes(networkId)) return current;
-
-    const networkBlockNum = currentBlocks.value.get(networkId) || 0;
-    const blockDiff = networkBlockNum - current;
-
-    return (
-      (currentTs.value.get(networkId) || 0) -
-      getConfigBlockTime(networkId) * blockDiff
-    );
-  }
-
   return {
     getCurrent,
     fetchBlock,
     getCurrentFromDuration,
-    getDurationFromCurrent,
-    getTsFromCurrent
+    getDurationFromCurrent
   };
 });


### PR DESCRIPTION
### Summary

Those values are now always timestamps so we don't need conversions.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1583
Depends on: https://github.com/snapshot-labs/sx-monorepo/pull/1601

**Note:** This PR won't work until API is updated.

### How to test

1. Go to EVM space.
2. Check proposal timestamps.
3. It all looks good again.
