### PR TITLE
fix(api): handle non-native block.number in time estimation

### DIFF
--- a/.changeset/cyan-lemons-sit.md
+++ b/.changeset/cyan-lemons-sit.md
@@ -1,0 +1,5 @@
+---
+"@snapshot-labs/sx": patch
+---
+
+Add hasNonNativeBlockNumbers to EvmNetworkConfig

--- a/apps/api/src/evm/protocols/governor-bravo/writers.ts
+++ b/apps/api/src/evm/protocols/governor-bravo/writers.ts
@@ -293,12 +293,17 @@ export function createWriters(
         networkId: config.indexerName,
         blockNumber: value,
         currentBlockNumber: blockNumber,
-        currentTimestamp: block?.timestamp ?? getCurrentTimestamp()
+        currentTimestamp: block?.timestamp ?? getCurrentTimestamp(),
+        provider
       });
 
-    proposal.start = getTimestampFromBlock(event.args.startBlock.toNumber());
+    proposal.start = await getTimestampFromBlock(
+      event.args.startBlock.toNumber()
+    );
     proposal.start_block_number = event.args.startBlock.toNumber();
-    proposal.min_end = getTimestampFromBlock(event.args.endBlock.toNumber());
+    proposal.min_end = await getTimestampFromBlock(
+      event.args.endBlock.toNumber()
+    );
     proposal.min_end_block_number = event.args.endBlock.toNumber();
     proposal.max_end = proposal.min_end;
     proposal.max_end_block_number = proposal.max_end;

--- a/apps/api/src/evm/protocols/snapshot-x/writers.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/writers.ts
@@ -640,18 +640,19 @@ export function createWriters(
         networkId: config.indexerName,
         blockNumber: value,
         currentBlockNumber: blockNumber,
-        currentTimestamp: block?.timestamp ?? getCurrentTimestamp()
+        currentTimestamp: block?.timestamp ?? getCurrentTimestamp(),
+        provider
       });
 
-    proposal.start = getTimestampFromBlock(
+    proposal.start = await getTimestampFromBlock(
       event.args.proposal.startBlockNumber
     );
     proposal.start_block_number = event.args.proposal.startBlockNumber;
-    proposal.min_end = getTimestampFromBlock(
+    proposal.min_end = await getTimestampFromBlock(
       event.args.proposal.minEndBlockNumber
     );
     proposal.min_end_block_number = event.args.proposal.minEndBlockNumber;
-    proposal.max_end = getTimestampFromBlock(
+    proposal.max_end = await getTimestampFromBlock(
       event.args.proposal.maxEndBlockNumber
     );
     proposal.max_end_block_number = event.args.proposal.maxEndBlockNumber;

--- a/apps/api/src/evm/utils.test.ts
+++ b/apps/api/src/evm/utils.test.ts
@@ -1,6 +1,11 @@
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { describe, expect, it } from 'vitest';
 import { PartialConfig } from './types';
-import { applyConfig, applyProtocolPrefixToWriters } from './utils';
+import {
+  applyConfig,
+  applyProtocolPrefixToWriters,
+  getTimestampFromBlock
+} from './utils';
 
 describe('applyProtocolPrefixToWriters', () => {
   it('should apply prefix to writer keys', () => {
@@ -86,5 +91,37 @@ describe('applyConfig', () => {
         }
       }
     });
+  });
+});
+
+describe('getTimestampFromBlock', () => {
+  it('should return timestamp for networks with own block.number', async () => {
+    const provider = new StaticJsonRpcProvider('https://rpc.snapshot.org/1');
+
+    const actual = await getTimestampFromBlock({
+      networkId: 'eth',
+      blockNumber: 22294892,
+      currentBlockNumber: 22287746,
+      currentTimestamp: 1744881215,
+      provider
+    });
+
+    expect(actual).toBe(1744967610);
+  });
+
+  it('should return timestamp for networks with foreign block.number', async () => {
+    const provider = new StaticJsonRpcProvider(
+      'https://rpc.snapshot.org/42161'
+    );
+
+    const actual = await getTimestampFromBlock({
+      networkId: 'arb1',
+      blockNumber: 22997779,
+      currentBlockNumber: 361494473,
+      currentTimestamp: 1753466114,
+      provider
+    });
+
+    expect(actual).toBe(1753466114);
   });
 });

--- a/packages/sx.js/src/evmNetworks.ts
+++ b/packages/sx.js/src/evmNetworks.ts
@@ -3,6 +3,7 @@ import { EvmNetworkConfig } from './types';
 
 type AdditionalProperties = {
   blockTime: number;
+  hasNonNativeBlockNumbers?: boolean;
   maxPriorityFeePerGas?: BigNumberish;
   authenticators?: Record<string, string>;
   strategies?: {
@@ -28,6 +29,7 @@ function createStandardConfig(
       eip712ChainId,
       maxPriorityFeePerGas: additionalProperties.maxPriorityFeePerGas,
       blockTime: additionalProperties.blockTime,
+      hasNonNativeBlockNumbers: additionalProperties.hasNonNativeBlockNumbers,
       proxyFactory: '0x4B4F7f64Be813Ccc66AEFC3bFCe2baA01188631c',
       masterSpace: '0xC3031A7d3326E47D49BfF9D374d74f364B29CE4D'
     },
@@ -111,6 +113,7 @@ function createEvmConfig(
     eip712ChainId: network.Meta.eip712ChainId,
     maxPriorityFeePerGas: network.Meta.maxPriorityFeePerGas,
     blockTime: network.Meta.blockTime,
+    hasNonNativeBlockNumbers: network.Meta.hasNonNativeBlockNumbers,
     proxyFactory: network.Meta.proxyFactory,
     masterSpace: network.Meta.masterSpace,
     authenticators,
@@ -133,7 +136,10 @@ export const evmNetworks = {
     // }
   }),
   matic: createStandardConfig(137, { blockTime: 2.15812 }),
-  arb1: createStandardConfig(42161, { blockTime: ethMainnetBlockTime }),
+  arb1: createStandardConfig(42161, {
+    blockTime: ethMainnetBlockTime,
+    hasNonNativeBlockNumbers: true
+  }),
   base: createStandardConfig(8453, { blockTime: 2 }),
   mnt: createStandardConfig(5000, {
     blockTime: 2,
@@ -142,12 +148,14 @@ export const evmNetworks = {
   }),
   ape: createStandardConfig(33139, {
     blockTime: ethMainnetBlockTime,
+    hasNonNativeBlockNumbers: true,
     strategies: {
       ApeGas: '0xDd6B74123b2aB93aD701320D3F8D1b92B4fA5202'
     }
   }),
   curtis: createStandardConfig(33111, {
     blockTime: ethSepoliaBlockTime,
+    hasNonNativeBlockNumbers: true,
     strategies: {
       ApeGas: '0x8E7083D3D0174Fe7f33821b2b4bDFE0fEE9C8e87'
     }

--- a/packages/sx.js/src/types/networkConfig.ts
+++ b/packages/sx.js/src/types/networkConfig.ts
@@ -115,6 +115,12 @@ export type EvmNetworkConfig = Omit<
   eip712ChainId: number;
   maxPriorityFeePerGas?: BigNumberish;
   blockTime: number;
+  /**
+   * Indicates that the network block.number returns block
+   *  that is different than the native block number.
+   *  For example on Arbitrum block.number returns L1 block number.
+   * */
+  hasNonNativeBlockNumbers?: boolean;
   proxyFactory: string;
   executionStrategiesImplementations: {
     [key in ExecutorType]?: string;


### PR DESCRIPTION
### Summary

Some networks (like Arbitrum One and Apechain) use different networks blocks in block.number so start/min_end/max_end are actually in different unit than blockNumber we are syncing. We need to fetch L1 block number from Multicall3 in that case to correctly compute timestamps.

### How to test

1. Tests should pass
