### PR TITLE
fix(ui): remove extra space in space overview actions buttons

### DIFF
--- a/apps/ui/src/components/ButtonFollow.vue
+++ b/apps/ui/src/components/ButtonFollow.vue
@@ -60,9 +60,8 @@ async function handleClick() {
 </script>
 
 <template>
-  <UiTooltip :title="tooltipMessage">
+  <UiTooltip v-if="!isWhiteLabel" :title="tooltipMessage">
     <UiButton
-      v-if="!isWhiteLabel"
       :disabled="loading || isSafeWallet || preventFollowingMore"
       class="group"
       :class="{ 'hover:border-skin-danger': spaceFollowed }"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR removes the extra space in the space overview action buttons, appearing only on whitelabel

<img width="1079" height="2134" alt="image" src="https://github.com/user-attachments/assets/7ffc92ab-ccc2-4cd0-b0b2-4b0dd3aade3d" />

### How to test

1. Go to a whitelabel space
2. The buttons are now aligned to right, without extra space
