### PR TITLE
feat: add keyboard shortcut to focus search bar

### DIFF
--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -86,6 +86,32 @@ watch(
   { immediate: true }
 );
 
+function handleKeyboardShortcut(event: KeyboardEvent) {
+  if (event.key !== '/') return;
+
+  const activeElement = document.activeElement;
+  const tagName = activeElement?.tagName.toLowerCase() || '';
+
+  if (
+    activeElement === searchInput.value ||
+    ['input', 'textarea'].includes(tagName)
+  ) {
+    return;
+  }
+
+  event.preventDefault();
+  searchInput.value?.focus();
+}
+
+watchEffect(onCleanup => {
+  if (searchConfig.value) {
+    document.addEventListener('keydown', handleKeyboardShortcut);
+    onCleanup(() => {
+      document.removeEventListener('keydown', handleKeyboardShortcut);
+    });
+  }
+});
+
 onUnmounted(() => {
   resetAccountModal();
 });


### PR DESCRIPTION
### Summary
- added a keyboard shortcut to focus the search bar when "/" is pressed
- event listener added to document when search is available and removed while moving to different page
- don't trigger if user is typing in any other input/textarea

### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1616

### How to test

1. Go to pages with search bar (explore page/proposals page etc)
2. Click `/` it should focus on search bar
3. Go to settings page, while typing `/` inside some input field should not focus search bar
4. everything else should work same as before