### PR TITLE
fix:  open modal only when provider is not set

### DIFF
--- a/apps/ui/src/helpers/connectors/walletconnect.ts
+++ b/apps/ui/src/helpers/connectors/walletconnect.ts
@@ -83,13 +83,8 @@ export default class Walletconnect extends Connector {
         projectId
       });
 
-      // This is needed in case the user changes the theme mode
-      // otherwise modal will be opened with half light and half dark theme
-      await this.modal.setThemeMode(currentTheme.value);
-
-      if (!isAutoConnect) {
+      if (!isAutoConnect && !this.provider) {
         await this.disconnect();
-
         await this.modal.open();
       }
 


### PR DESCRIPTION
### Issue: Unable to connect with Safe Wallet connect

### Summary
- adjusted logic to open modal only when provider is not set


### How to test

1. Try to connect Safe with wallet connect
2. Before it was disconnecting once the Safe wallet is connected
3. Not we should be able to connect and vote 
4. Try refreshing, disconnecting and reconnecting
5. Try with different walletconnect wallet like trust wallet/bitcoin.com wallet
