### PR TITLE
fix: open account modal when follow button clicked without login

### DIFF
--- a/apps/ui/src/components/ButtonFollow.vue
+++ b/apps/ui/src/components/ButtonFollow.vue
@@ -13,8 +13,6 @@ const { isSafeWallet } = useSafeWallet(
 const followedSpacesStore = useFollowedSpacesStore();
 const { isWhiteLabel } = useWhiteLabel();
 const uiStore = useUiStore();
-const { web3 } = useWeb3();
-const { modalAccountOpen } = useModal();
 
 const spaceIdComposite = computed(
   () => `${props.space.network}:${props.space.id}`
@@ -53,11 +51,6 @@ const tooltipMessage = computed(() => {
 });
 
 async function handleClick() {
-  if (!web3.value.account) {
-    modalAccountOpen.value = true;
-    return;
-  }
-
   try {
     await followedSpacesStore.toggleSpaceFollow(spaceIdComposite.value);
   } catch (error) {

--- a/apps/ui/src/components/ButtonFollow.vue
+++ b/apps/ui/src/components/ButtonFollow.vue
@@ -13,6 +13,8 @@ const { isSafeWallet } = useSafeWallet(
 const followedSpacesStore = useFollowedSpacesStore();
 const { isWhiteLabel } = useWhiteLabel();
 const uiStore = useUiStore();
+const { web3 } = useWeb3();
+const { modalAccountOpen } = useModal();
 
 const spaceIdComposite = computed(
   () => `${props.space.network}:${props.space.id}`
@@ -51,6 +53,11 @@ const tooltipMessage = computed(() => {
 });
 
 async function handleClick() {
+  if (!web3.value.account) {
+    modalAccountOpen.value = true;
+    return;
+  }
+
   try {
     await followedSpacesStore.toggleSpaceFollow(spaceIdComposite.value);
   } catch (error) {

--- a/apps/ui/src/stores/followedSpaces.ts
+++ b/apps/ui/src/stores/followedSpaces.ts
@@ -96,9 +96,7 @@ export const useFollowedSpacesStore = defineStore('followedSpaces', () => {
   );
 
   async function toggleSpaceFollow(id: string) {
-    if (!followedSpacesIds.value) return;
-
-    const alreadyFollowed = followedSpacesIds.value.includes(id);
+    const alreadyFollowed = followedSpacesIds.value?.includes(id) ?? false;
     const [spaceNetwork, spaceId] = id.split(':') as [NetworkID, string];
     followedSpaceLoading.add(id);
 


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/workflow/issues/656

### Summary
- Open account modal if user is not logged in before attempting to follow


### How to test

1. Disconnect the wallet
2. Click on follow button on explore page and space page
3. It should open account modal
