### PR TITLE
feat: add snapshot pro link to settings menu

### DIFF
--- a/apps/ui/src/components/App/Nav.vue
+++ b/apps/ui/src/components/App/Nav.vue
@@ -168,7 +168,11 @@ function getNavigationConfig(
           controller: getSettingsRoute({
             name: 'Controller',
             tab: 'controller'
-          })
+          }),
+          snapshotPro: {
+            name: 'Snapshot Pro',
+            link: { name: 'space-pro' }
+          }
         }
       };
     }


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/sx-monorepo/issues/1619

### Summary
- added a new navigation item for Snapshot Pro
- should redirect to pro page

### How to test
- Go to http://localhost:8080/#/s:arbitrumfoundation.eth/settings
- Click on "Snapshot Pro"
<img width="258" height="200" alt="Untitled 4" src="https://github.com/user-attachments/assets/42259b0e-6a31-43dd-bcc6-8d52d5ddcae8" />

- It should redirect to pro page http://localhost:8080/#/s:arbitrumfoundation.eth/pro