### PR TITLE
fix: increase bottom margin for proposal body

### DIFF
--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -555,7 +555,7 @@ onBeforeUnmount(() => destroyAudio());
           AI can be inaccurate or misleading.
         </div>
       </div>
-      <UiMarkdown v-if="proposal.body" class="mb-4" :body="proposal.body" />
+      <UiMarkdown v-if="proposal.body" class="mb-12" :body="proposal.body" />
       <div v-if="discussion">
         <h4 class="mb-3 eyebrow flex items-center gap-2">
           <IH-chat-alt />

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -555,7 +555,7 @@ onBeforeUnmount(() => destroyAudio());
           AI can be inaccurate or misleading.
         </div>
       </div>
-      <UiMarkdown v-if="proposal.body" class="mb-12" :body="proposal.body" />
+      <UiMarkdown v-if="proposal.body" class="mb-8" :body="proposal.body" />
       <div v-if="discussion">
         <h4 class="mb-3 eyebrow flex items-center gap-2">
           <IH-chat-alt />


### PR DESCRIPTION
Fixes #1614

### Summary
- changed bottom margin of proposal body from mb-4 to mb-12

### How to test
- Go to any proposal
- Should see extra space after proposal body

[With discussion ](http://localhost:8080/#/sn:0x05ea5ef0c54c84dc7382629684c6e536c0b06246b3b0981c426b42372e3ef263/proposal/2)
<img width="903" height="535" alt="Untitled 8" src="https://github.com/user-attachments/assets/681834b3-4091-4bca-94c7-bd3da407b7b8" />

[With Execution](http://localhost:8080/#/s:shutterdao0x36.eth/proposal/0x6f543fc4ba0e4d98bc4403fafb3bdb9b77838dea797af9a24f3a919b434621f7)
<img width="762" height="519" alt="Untitled 9" src="https://github.com/user-attachments/assets/5f3be3ef-3525-45c0-967a-74f025134213" />

[Without discussion or execution](http://localhost:8080/#/s:ipistr.eth/proposal/0xc5ed0ff5a7bbb19a20bd4647b37c517a790da41de9dab8318b67238f3559559c)
<img width="782" height="279" alt="Untitled 10" src="https://github.com/user-attachments/assets/a47c0f46-5bd7-4956-8799-51d5bdd00fab" />

