### PR TITLE
feat: show snapshot block with VP

### DIFF
--- a/apps/ui/src/components/Modal/Vote.vue
+++ b/apps/ui/src/components/Modal/Vote.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { useQueryClient } from '@tanstack/vue-query';
 import { LocationQueryValue } from 'vue-router';
-import { getChoiceText, getFormattedVotingPower } from '@/helpers/utils';
+import { _n, getChoiceText, getFormattedVotingPower } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
 import { getNetwork, offchainNetworks } from '@/networks';
 import { PROPOSALS_KEYS } from '@/queries/proposals';
@@ -78,6 +79,19 @@ const formValidator = getValidator({
 const formattedVotingPower = computed(() =>
   getFormattedVotingPower(votingPower.value)
 );
+
+const blockExplorerUrl = computed(() => {
+  const chainId = props.proposal.space.snapshot_chain_id;
+  const snapshot = props.proposal.snapshot;
+
+  if (!chainId || !snapshot) return null;
+
+  const network = networks[chainId];
+
+  return network?.explorer?.url
+    ? `${network.explorer.url}/block/${snapshot}`
+    : null;
+});
 
 const offchainProposal = computed<boolean>(() =>
   offchainNetworks.includes(props.proposal.network)
@@ -229,9 +243,23 @@ watchEffect(async () => {
         </dd>
         <dd
           v-else-if="votingPower"
-          class="font-semibold text-skin-heading text-[20px] leading-6"
-          v-text="formattedVotingPower"
-        />
+          class="font-semibold text-skin-heading text-[20px] leading-6 flex gap-1.5"
+        >
+          <span>{{ formattedVotingPower }}</span>
+          <span
+            v-if="proposal.snapshot && blockExplorerUrl"
+            class="text-skin-text font-normal flex gap-0.5"
+          >
+            (
+            <a :href="blockExplorerUrl" target="_blank">{{
+              _n(proposal.snapshot)
+            }}</a>
+            <UiTooltip title="Snapshot block number">
+              <IH-information-circle class="mt-0.5" />
+            </UiTooltip>
+            )
+          </span>
+        </dd>
       </dl>
       <div v-if="proposal.privacy === 'none'" class="s-box">
         <UiForm


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1607

### How to test

1. Go to any active proposal 
2. Try to vote
3. Inside vote modal, you should see Snapshot block is added beside VP
4. <img width="436" height="285" alt="image" src="https://github.com/user-attachments/assets/d928ad51-eb3e-418b-a92f-50da14c9595c" />
5. Tooltip should show "Snapshot block number"
6. clicking snapshot block should redirect to explorer block of space network
7. Should not show snapshot on [non-offchain spaces](http://localhost:8080/#/ape:0xE0CfEeF9d0E38561bA286bF1B2289BaBd5365d47/proposal/4)