### PR TITLE
fix: add migration ensuring unique apegas_proposals

### DIFF
--- a/apps/mana/migrations/20251010124617_add_apegas_proposals_index.ts
+++ b/apps/mana/migrations/20251010124617_add_apegas_proposals_index.ts
@@ -1,0 +1,15 @@
+// This is a workaround for Node v23.
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import { type Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('apegas_proposals', t => {
+    t.unique(['chainId', 'viewId', 'snapshot']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('apegas_proposals', t => {
+    t.dropUnique(['chainId', 'viewId', 'snapshot']);
+  });
+}


### PR DESCRIPTION
### Summary

(chainId, viewId, snapshot) define unique proposal. Before we would keep adding new entries in database on each resync.

It doesn't cover removing old data - it needs to be done manually:
```sql
DELETE FROM apegas_proposals a USING apegas_proposals b WHERE a.created_at > b.created_at AND a."chainId" = b."chainId" AND a."viewId" = b."viewId" AND a."snapshot" = b."snapshot";
```

### How to test

1. Run query above in your mana database.
2. Start mana.
3. It should work.
