### PR TITLE
fix: remove bravo from my spaces view

### DIFF
--- a/apps/ui/src/views/Settings/Spaces.vue
+++ b/apps/ui/src/views/Settings/Spaces.vue
@@ -5,12 +5,13 @@ import { useExploreSpacesQuery } from '@/queries/spaces';
 
 useTitle('My spaces');
 
-const protocols = Object.values(explorePageProtocols).map(
-  ({ key, label }: ProtocolConfig) => ({
+const protocols = Object.values(explorePageProtocols)
+  .filter(protocol => !protocol.disabled)
+  .map(({ key, label }: ProtocolConfig) => ({
     key,
     label
-  })
-);
+  }));
+
 const DEFAULT_PROTOCOL = 'snapshot';
 
 const route = useRoute();


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/658

### How to test

1. Go to http://localhost:8080/#/settings
2. Should not see bravo in protocol filter anymore 
