### PR TITLE
fix: redirect to space if proposal is deleted

### DIFF
--- a/apps/ui/src/views/Proposal.vue
+++ b/apps/ui/src/views/Proposal.vue
@@ -35,6 +35,8 @@ const { data: proposal, isPending } = useProposalQuery(
   id
 );
 
+const router = useRouter();
+
 const {
   data: votingPower,
   error: votingPowerError,
@@ -92,12 +94,20 @@ async function handleVoteSubmitted() {
 }
 
 watch(
-  [id, proposal],
-  async ([id, proposal]) => {
+  [id, proposal, isPending],
+  async ([id, proposal, isPending]) => {
     modalOpenVote.value = false;
     editMode.value = false;
     discourseTopic.value = null;
     boostCount.value = 0;
+
+    if (!isPending && !proposal) {
+      router.push({
+        name: 'space-overview',
+        params: { space: `${props.space.network}:${props.space.id}` }
+      });
+      return;
+    }
 
     if (!proposal) return;
 


### PR DESCRIPTION
### Summary

redirect to space overview if proposal is deleted

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1638

### How to test

1. Go to http://localhost:8080/#/s:arbitrumfoundation.eth/proposal/0x2cffe228c7c8f1b57fb3140ed4d2a8f194f655e551c54177091bdcec43357fe3
2. It should redirect to the space page instead of blank page