### PR TITLE
fix: fix invalid Affix position due to position rounding issue

### DIFF
--- a/apps/ui/src/components/Affix.vue
+++ b/apps/ui/src/components/Affix.vue
@@ -31,9 +31,10 @@ function updatePosition(scrollY: number) {
   if (!el.value) return;
 
   const isBottomReached =
-    el.value.getBoundingClientRect().bottom + props.bottom <=
+    Math.round(el.value.getBoundingClientRect().bottom) + props.bottom <=
     window.innerHeight;
-  const isTopReached = el.value.getBoundingClientRect().top >= props.top;
+  const isTopReached =
+    Math.round(el.value.getBoundingClientRect().top) >= props.top;
   const scrollingDown = lastScrollY.value < scrollY;
   const scrollingUp = lastScrollY.value > scrollY;
   const stickedToBottom = stickStatus.value === StickStatus.BOTTOM;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1639

This PR fix an issue where the affix component will stick to the bottom incorrectly, when the browser page is zoomed at certain level (90 and 80%).

### How to test

1. Go to http://localhost:8080/#/s:arbitrumfoundation.eth/proposal/0xc5f06144fa92aaff99e0e44482ab6f7a3f6486dfb6c854d16271399ffcf895e6/votes
2. Scroll down and up 
3. The right sidebar should scroll properly
4. Zoom out to each level and test the scroll
5. The sidebar should scroll properly, and should not jump to stick to the bottom immediately anymore
