### PR TITLE
fix: add ENABLE_OPENZEPPELIN to versionTag

### DIFF
--- a/apps/api/src/evm/index.ts
+++ b/apps/api/src/evm/index.ts
@@ -11,12 +11,12 @@ import { applyProtocolPrefixToWriters } from './utils';
 export const ENABLE_SNAPSHOT_X = process.env.ENABLE_SNAPSHOT_X !== 'false';
 export const ENABLE_GOVERNOR_BRAVO =
   process.env.ENABLE_GOVERNOR_BRAVO === 'true';
-export const ENABLE_OPEN_ZEPPELIN = process.env.ENABLE_OPEN_ZEPPELIN === 'true';
+export const ENABLE_OPENZEPPELIN = process.env.ENABLE_OPENZEPPELIN === 'true';
 
 const protocols: Protocols = {
   snapshotX: ENABLE_SNAPSHOT_X,
   governorBravo: ENABLE_GOVERNOR_BRAVO,
-  openZeppelin: ENABLE_OPEN_ZEPPELIN
+  openZeppelin: ENABLE_OPENZEPPELIN
 };
 
 const ethConfig = createConfig('eth', protocols);

--- a/apps/api/src/indexer.ts
+++ b/apps/api/src/indexer.ts
@@ -3,6 +3,7 @@ import Checkpoint from '@snapshot-labs/checkpoint';
 import {
   addEvmIndexers,
   ENABLE_GOVERNOR_BRAVO,
+  ENABLE_OPENZEPPELIN,
   ENABLE_SNAPSHOT_X
 } from './evm';
 import logger from './logger';
@@ -25,7 +26,7 @@ async function initializeCheckpoint(checkpoint: Checkpoint) {
     return;
   }
 
-  const currentVersionTag = `commit:${GIT_COMMIT}|snapshotX:${ENABLE_SNAPSHOT_X}|governorBravo:${ENABLE_GOVERNOR_BRAVO}`;
+  const currentVersionTag = `commit:${GIT_COMMIT}|snapshotX:${ENABLE_SNAPSHOT_X}|governorBravo:${ENABLE_GOVERNOR_BRAVO}|openZeppelin:${ENABLE_OPENZEPPELIN}`;
   const { knex } = checkpoint.getBaseContext();
 
   const isInitialized = await knex.schema.hasTable('_metadatas');

--- a/turbo.json
+++ b/turbo.json
@@ -26,7 +26,7 @@
         "ENABLED_NETWORKS",
         "ENABLE_SNAPSHOT_X",
         "ENABLE_GOVERNOR_BRAVO",
-        "ENABLE_OPEN_ZEPPELIN",
+        "ENABLE_OPENZEPPELIN",
         "VITE_MANA_URL"
       ]
     },


### PR DESCRIPTION
### Summary

This way changes of this flag will trigger resync.

Also renaming OPEN_ZEPPELIN TO OPENZEPPELIN to match naming convention.
