### PR TITLE
feat: format proposal threshold with max decimals

### DIFF
--- a/apps/ui/src/components/MessagePropositionPower.vue
+++ b/apps/ui/src/components/MessagePropositionPower.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { _n, prettyConcat } from '@/helpers/utils';
+import { _n, _vp, prettyConcat } from '@/helpers/utils';
 import { PropositionPowerItem } from '@/queries/propositionPower';
 import { VoteValidationPowerItem } from '@/queries/voteValidationPower';
 
@@ -12,6 +12,12 @@ const props = defineProps<{
 const actionName = computed(() => {
   return 'canPropose' in props.propositionPower ? 'create a proposal' : 'vote';
 });
+
+const thresholdDecimals = computed(() =>
+  Math.max(
+    ...props.propositionPower.strategies.map(s => s.params.decimals ?? 0)
+  )
+);
 
 const offchainErrors = computed(() => ({
   'only-members': () =>
@@ -63,7 +69,8 @@ function prettySymbolsList(symbols: string[]): string {
       </AppLink>
     </template>
     <template v-else>
-      You need at least {{ _n(propositionPower.threshold) }}
+      You need at least
+      {{ _vp(Number(propositionPower.threshold) / 10 ** thresholdDecimals) }}
       {{
         prettySymbolsList(
           propositionPower.strategies.map(


### PR DESCRIPTION
### Summary

This is not ideal, because summation of VP is funky (decimals are display only), but it should work if all strategies have the same decimals.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1640

### How to test

1. Go to http://localhost:8080/#/eth:0x408ED6354d4973f66138C91495F2f2FCbd8724C3/create/m7hly
2. VP is formatted.

### Screenshots

<img width="1025" height="767" alt="image" src="https://github.com/user-attachments/assets/462f6c6b-39cd-4101-9590-9132c1c83526" />
