### PR TITLE
fix(ui): fix wrong text color

### DIFF
--- a/apps/ui/src/views/Space/Pro.vue
+++ b/apps/ui/src/views/Space/Pro.vue
@@ -230,8 +230,8 @@ onMounted(() => {
   <div class="space-y-8">
     <div class="shapes px-4 py-8 bg-skin-border/20 flex items-center">
       <div class="text-center w-full space-y-4">
-        <div class="inline-block text-skin-bg bg-skin-link rounded-full px-2">
-          <UiEyebrow>Snapshot Pro</UiEyebrow>
+        <div class="inline-block bg-skin-link rounded-full px-2">
+          <UiEyebrow class="text-skin-bg">Snapshot Pro</UiEyebrow>
         </div>
         <h1 class="pb-4">
           Level up your governance<br />


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

<img width="1842" height="610" alt="image" src="https://github.com/user-attachments/assets/77474f3c-7bfb-470c-bbda-d631ba65dcbb" />

This PR fix a small UI issue, where the "snapshot pro" text is using the same color as the background

### How to test

1. Go to to any space /pro page
2. The "Snapshot Pro" label should be visible
