### PR TITLE
fix: debounce search in ModalSpace

### DIFF
--- a/apps/ui/src/components/Modal/Space.vue
+++ b/apps/ui/src/components/Modal/Space.vue
@@ -12,7 +12,7 @@ defineEmits<{
 }>();
 
 const searchQuery = ref<string>('');
-const throttledSearchQuery = refThrottled(searchQuery, 500);
+const throttledSearchQuery = refDebounced(searchQuery, 500);
 
 const { data, isPending, isFetchingNextPage, hasNextPage, fetchNextPage } =
   useExploreSpacesQuery({


### PR DESCRIPTION
### Summary

Before we used throttle which would trigger searches as you type. With debounce it will not trigger unless you stop for 500ms.

### How to test

1. Go to http://localhost:8080/#/pro
2. Click Upgrade space.
3. Search for some space.
4. It works as expected.
5. Compare it to https://snapshot.box/#/pro