### PR TITLE
feat: add Governor spaces metadata

### DIFF
--- a/apps/api/src/evm/protocols/governor-bravo/writers.ts
+++ b/apps/api/src/evm/protocols/governor-bravo/writers.ts
@@ -30,6 +30,12 @@ import { convertChoice, getProposalTitle } from '../openzeppelin/utils';
 
 type SpaceData = {
   name: string;
+  about?: string;
+  avatar?: string;
+  externalUrl?: string;
+  github?: string;
+  twitter?: string;
+  farcaster?: string;
   symbol: string;
   decimals: number;
   governanceToken: string;
@@ -43,6 +49,14 @@ type SpaceData = {
 const spaceData: Record<string, SpaceData | undefined> = {
   '0x408ED6354d4973f66138C91495F2f2FCbd8724C3': {
     name: 'Uniswap',
+    about:
+      'The largest onchain marketplace. Buy and sell crypto on Ethereum and 14+ other chains.',
+    avatar:
+      'ipfs://bafkreigzzj4yc3khx4mn2zmdrdgtvae3s36e5ae2sgry2azuqvxfakjuoa',
+    externalUrl: 'https://app.uniswap.org',
+    github: 'uniswap',
+    twitter: 'Uniswap',
+    farcaster: 'uniswap',
     symbol: 'UNI',
     decimals: 18,
     governanceToken: '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
@@ -54,6 +68,12 @@ const spaceData: Record<string, SpaceData | undefined> = {
   },
   '0xc0Da02939E1441F497fd74F78cE7Decb17B66529': {
     name: 'Compound',
+    about: 'Building infrastructure for the future of finance.',
+    avatar:
+      'ipfs://bafkreia4lin2o6uux2375uhekvgqlr466tes7gsdzg6aldakw5jicylcd4',
+    externalUrl: 'https://compound.finance',
+    github: 'compound-finance',
+    twitter: 'compoundfinance',
     symbol: 'COMP',
     decimals: 18,
     governanceToken: '0xc00e94Cb662C3520282E6f5717214004A7f26888',
@@ -224,6 +244,12 @@ export function createWriters(
 
     const spaceMetadata = new SpaceMetadataItem(metadataId, config.indexerName);
     spaceMetadata.name = name;
+    spaceMetadata.about = spaceDataEntry.about || '';
+    spaceMetadata.avatar = spaceDataEntry.avatar || '';
+    spaceMetadata.external_url = spaceDataEntry.externalUrl || '';
+    spaceMetadata.twitter = spaceDataEntry.twitter || '';
+    spaceMetadata.github = spaceDataEntry.github || '';
+    spaceMetadata.farcaster = spaceDataEntry.farcaster || '';
     spaceMetadata.voting_power_symbol = symbol;
     spaceMetadata.treasuries = [JSON.stringify(treasury)];
     spaceMetadata.executors_strategies = [executionStrategy.id];

--- a/apps/api/src/evm/protocols/openzeppelin/governances.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/governances.ts
@@ -2,6 +2,12 @@ import { NetworkID } from '../../types';
 
 type Governance = {
   name: string;
+  about?: string;
+  avatar?: string;
+  externalUrl?: string;
+  github?: string;
+  twitter?: string;
+  farcaster?: string;
   address: `0x${string}`;
   startBlock: number;
 };
@@ -12,6 +18,13 @@ export const GOVERNANCES: Partial<
   eth: {
     ENS: {
       name: 'ENS',
+      about: 'Your web3 username.',
+      avatar:
+        'ipfs://bafkreiftpnmdytmh3ccqsujvehipn5nklcsooy4janusmwt4oujrwisubm',
+      externalUrl: 'https://ens.domains',
+      github: 'ensdomains',
+      twitter: 'ensdomains',
+      farcaster: 'ensdomains',
       address: '0x323A76393544d5ecca80cd6ef2A560C6a395b7E3',
       startBlock: 13533772
     }

--- a/apps/api/src/evm/protocols/openzeppelin/writers.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/writers.ts
@@ -237,6 +237,12 @@ export function createWriters(
 
     const spaceMetadata = new SpaceMetadataItem(metadataId, config.indexerName);
     spaceMetadata.name = governanceInfo.name;
+    spaceMetadata.about = governanceInfo.about || '';
+    spaceMetadata.avatar = governanceInfo.avatar || '';
+    spaceMetadata.external_url = governanceInfo.externalUrl || '';
+    spaceMetadata.github = governanceInfo.github || '';
+    spaceMetadata.twitter = governanceInfo.twitter || '';
+    spaceMetadata.farcaster = governanceInfo.farcaster || '';
     spaceMetadata.voting_power_symbol = symbol;
     spaceMetadata.treasuries = createTreasuries(timelock);
     spaceMetadata.executors_strategies = [executionStrategy.id];


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1669

### How to test

1. Apply diff from below.
2. Run `yarn dev:interactive` with UI and API for a minute.
3. Go to http://localhost:8080/#/eth:0xc0Da02939E1441F497fd74F78cE7Decb17B66529
4. You see metadata (avatar is missing because it goes through stamp and it uses prod API).

```diff
diff --git a/scripts/dev-interactive.ts b/scripts/dev-interactive.ts
index af201d16b..ebe607a6a 100644
--- a/scripts/dev-interactive.ts
+++ b/scripts/dev-interactive.ts
@@ -14,10 +14,12 @@ const SERVICES: Record<ServiceType, Service> = {
   api: {
     env: {
       UI_URL: 'http://localhost:8080',
-      ENABLED_NETWORKS: 'sep,sn-sep',
-      VITE_ENABLED_NETWORKS: 's-tn,sep,sn-sep',
-      VITE_METADATA_NETWORK: 's-tn',
-      VITE_API_TESTNET_URL: 'http://localhost:3000'
+      ENABLED_NETWORKS: 'eth',
+      ENABLE_SNAPSHOT_X: 'false',
+      ENABLE_GOVERNOR_BRAVO: 'true',
+      VITE_ENABLED_NETWORKS: 's,eth',
+      VITE_METADATA_NETWORK: 's',
+      VITE_API_URL: 'http://localhost:3000'
     }
   },
   mana: {
```

### Screenshots

<img width="1424" height="680" alt="image" src="https://github.com/user-attachments/assets/71864681-1a24-48e2-a872-578433d29721" />
