### PR TITLE
fix: fix truncated network badge

### DIFF
--- a/apps/ui/src/components/SpacesListItem.vue
+++ b/apps/ui/src/components/SpacesListItem.vue
@@ -12,10 +12,10 @@ const compositeSpaceId = `${props.space.network}:${props.space.id}`;
     :to="{ name: 'space-overview', params: { space: compositeSpaceId } }"
     class="text-skin-text mx-4 group overflow-hidden flex border-b items-center py-[18px] space-x-3"
   >
-    <div class="grow flex items-center truncate">
+    <div class="grow flex items-center">
       <UiBadgeNetwork
         :id="space.network"
-        class="mr-2.5"
+        class="mr-2.5 shrink-0"
         :size="!offchainNetworks.includes(space.network) ? 16 : 0"
       >
         <SpaceAvatar :space="space" :size="32" class="rounded-md" />


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fix truncated network badge

<img width="1142" height="812" alt="image" src="https://github.com/user-attachments/assets/775ae565-4f64-4445-9a03-ea30e9d91f90" />

Also prevent the space avatar from shrinking on narrow screen