### PR TITLE
fix: handle null reference for votesHeader

### DIFF
--- a/apps/ui/src/views/Proposal/Votes.vue
+++ b/apps/ui/src/views/Proposal/Votes.vue
@@ -68,7 +68,8 @@ function handleScrollEvent(target: HTMLElement) {
     :ref="
       ref =>
         (votesHeader =
-          (ref as InstanceType<typeof UiColumnHeader>)?.container ?? null)
+          (ref as InstanceType<typeof UiColumnHeader> | null)?.container ??
+          null)
     "
     class="!px-0 z-40 overflow-hidden"
   >


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/sx-monorepo/issues/1677

### Summary

- added nullish coalescing to ensure votesHeader is set to null if undefined

### How to test

- Run `yarn dev`
 - Go to http://localhost:8080/#/s:arbitrumfoundation.eth/proposal/0x44dedacbdae958904427db9ee93065917f57f50b71b4e87a94a318de18df399b
- Cick votes and click overview again
- Should not show error in console anymore
