### PR TITLE
feat: remove OZ/Bravo governor badges

### DIFF
--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -75,12 +75,6 @@ watchEffect(() => setTitle(props.space.name));
             :turbo="space.turbo"
           />
         </div>
-        <div v-if="space.protocol === 'governor-bravo'" class="mb-3">
-          <UiProposalLabel label="Governor Bravo space" color="#272727" />
-        </div>
-        <div v-if="space.protocol === '@openzeppelin/governor'" class="mb-3">
-          <UiProposalLabel label="OpenZeppelin space" color="#272727" />
-        </div>
         <div class="mb-3 flex flex-wrap gap-x-1 items-center">
           <div>
             <b class="text-skin-link">{{ _n(space.proposal_count) }}</b>


### PR DESCRIPTION
### Summary

We will no longer show badges with space type on the Space overview.