### PR TITLE
fix: stringify treasury_chain

### DIFF
--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -228,7 +228,7 @@ function processExecutions(
     return (
       match.treasury &&
       compareAddresses(treasury.address, match.treasury) &&
-      match.treasury_chain === treasury.chainId
+      String(match.treasury_chain) === treasury.chainId
     );
   });
 


### PR DESCRIPTION
### Summary

Regression from: https://github.com/snapshot-labs/sx-monorepo/pull/1464

### How to test

1. Go to http://localhost:8080/#/eth:0x323A76393544d5ecca80cd6ef2A560C6a395b7E3/proposal/12950686153984121876325788121804936905339482144562527684056466889156345680789/execution
2. You see "Timelock" as execution name instead of "Unnamed treasury"
