### PR TITLE
chore: add friendly names for Governor executors

### DIFF
--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -110,7 +110,9 @@ export function createConstants(
     SimpleQuorumAvatar: 'Safe module (Zodiac)',
     SimpleQuorumTimelock: 'Timelock',
     Axiom: 'Axiom',
-    Isokratia: 'Isokratia'
+    Isokratia: 'Isokratia',
+    GovernorBravoTimelock: 'Timelock',
+    OpenZeppelinTimelockController: 'Timelock'
   };
 
   const EDITOR_AUTHENTICATORS = [


### PR DESCRIPTION
### Summary

It used to show as "Custom execution", not will show it as "Timelock execution" same as SnapshotX.

### How to test

1. Go there http://localhost:8080/#/eth:0x323A76393544d5ecca80cd6ef2A560C6a395b7E3/proposal/12950686153984121876325788121804936905339482144562527684056466889156345680789/execution
2. It shows as as "Timelock execution" (name is missing, but it's unrelated here).
