### PR TITLE
fix(ui): fix w-full button not shrinking when in loading state

### DIFF
--- a/apps/ui/src/components/Ui/Button.vue
+++ b/apps/ui/src/components/Ui/Button.vue
@@ -23,12 +23,18 @@ const props = withDefaults(
 
 const attrs = useAttrs();
 
+const isCompact = computed(() => {
+  const isFullWidth = (attrs.class as 'string')?.includes('w-full');
+
+  return (props.loading || props.uniform) && !isFullWidth;
+});
+
 const classNames = computed(() => {
   return {
     button: true,
     primary: props.primary,
-    'px-0 shrink-0': props.loading || props.uniform,
-    'px-3.5': !props.loading && !props.uniform
+    'px-0 shrink-0': isCompact.value,
+    'px-3.5': !isCompact.value
   };
 });
 
@@ -36,11 +42,7 @@ const buttonStyles = computed(() => {
   return {
     height: `${props.size}px`,
     minWidth: `${props.size}px`,
-    width:
-      (props.loading || props.uniform) &&
-      !(attrs.class as 'string')?.includes('w-full')
-        ? `${props.size}px`
-        : undefined
+    width: isCompact.value ? `${props.size}px` : undefined
   };
 });
 </script>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fix 

https://github-production-user-asset-6210df.s3.amazonaws.com/16245250/505406923-89ae54f6-aad6-4c60-a7ae-d48a29e118ac.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20251024%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20251024T171759Z&X-Amz-Expires=300&X-Amz-Signature=b18ccd70d81d61f0b8a504c46f3dd4ecefb8ae6f94d5f4e85cf4f4981ea44d31&X-Amz-SignedHeaders=host

### How to test

1. Vote
2. The Vote button should stay the same size when in loading state
