### PR TITLE
test: await rejects assertions

### DIFF
--- a/packages/sx.js/test/unit/strategies/starknet/erc20Votes.test.ts
+++ b/packages/sx.js/test/unit/strategies/starknet/erc20Votes.test.ts
@@ -61,7 +61,7 @@ describe('erc20VotesStrategy', () => {
   });
 
   it('should throw for ethereum address', async () => {
-    expect(
+    await expect(
       erc20VotesStrategy.getParams(
         'vote',
         '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70',

--- a/packages/sx.js/test/unit/strategies/starknet/ozVotesStorageProof.test.ts
+++ b/packages/sx.js/test/unit/strategies/starknet/ozVotesStorageProof.test.ts
@@ -23,7 +23,7 @@ describe('ozVotesStorageProof', () => {
   });
 
   it('should throw for non-ethereum address', async () => {
-    expect(
+    await expect(
       ozVotesStorageProofStrategy.getParams(
         'vote',
         '0x06AbD599AB530c5b3bc603111Bdd20d77890Db330402dC870Fc9866f50eD6d2A',


### PR DESCRIPTION
### Summary

Unawaited reject assertions throw a warning and can break in the future.
