### PR TITLE
fix: filter out broken ERC20 tokens

### DIFF
--- a/apps/ui/src/helpers/alchemy/index.ts
+++ b/apps/ui/src/helpers/alchemy/index.ts
@@ -189,6 +189,12 @@ export async function getBalances(
         value: 0,
         change: 0
       }))
-      .filter(token => !token?.symbol?.includes('.'))
+      .filter(token => {
+        if (!token.name) return false;
+        if (!token.symbol) return false;
+        if (token.symbol.includes('.')) return false;
+
+        return true;
+      })
   ];
 }


### PR DESCRIPTION
### Summary

Some tokens fail to resolve name or symbol. We should remove it from the list otherwise they might break some components.

### How to test

1. Go to http://localhost:8080/#/eth:0x408ED6354d4973f66138C91495F2f2FCbd8724C3/create/1r8so
2. Click on Send token.
3. Open token picker.
4. It works.

