### PR TITLE
fix: fix billing page not using the new dropdownItem signature

### DIFF
--- a/apps/ui/src/components/SpaceBilling.vue
+++ b/apps/ui/src/components/SpaceBilling.vue
@@ -151,19 +151,13 @@ const statusText = computed(() => {
             </div>
           </template>
           <template #items>
-            <UiDropdownItem v-slot="{ active }">
-              <a
-                :href="
-                  getGenericExplorerUrl(chainId, payment.id, 'transaction') ||
-                  ''
-                "
-                target="_blank"
-                class="flex items-center gap-2"
-                :class="{ 'opacity-80': active }"
-              >
-                <IH-arrow-sm-right class="-rotate-45" :width="16" />
-                View transaction
-              </a>
+            <UiDropdownItem
+              :to="
+                getGenericExplorerUrl(chainId, payment.id, 'transaction') || ''
+              "
+            >
+              <IH-arrow-sm-right class="-rotate-45" :width="16" />
+              View transaction
             </UiDropdownItem>
           </template>
         </UiDropdown>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fixes the billing page dropdown menu still using the old UiDropdownItem signature, which is causing typecheck issue

### How to test

1. Go to a space billing page
2. The payment dropdown menu works
3. The typecheck pass
