### PR TITLE
fix: fix terms of services url not available on whitelabel

### DIFF
--- a/apps/ui/src/components/Modal/Payment.vue
+++ b/apps/ui/src/components/Modal/Payment.vue
@@ -248,8 +248,8 @@ watch(
                     : { name: 'site-terms' }
                 "
                 @click.stop
-                >Terms of service
-              </AppLink></span
+                >Terms of service</AppLink
+              ></span
             >.
           </div>
         </UiCheckbox>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Depends on https://github.com/snapshot-labs/sx-monorepo/pull/1705

This PR fix the Terms of Service link in the payment modal, which is not available on whitelabel sites.

The fix is to use a hardcoded url to the main site when on whitelabel

### How to test

1. Start server with `VITE_WHITELABEL_MAPPING='localhost;s:aavedao.eth' yarn dev`
2. Go to http://localhost:8080/#/pro
3. Open the payment modal
4. Clicking on the ToS link in the bottom should open the page on snapshot.box website
5. Start server with `yarn dev`
6. With the same steps above, the ToS link should open with localhost
