### PR TITLE
test: do not depend on ranking order in tests

### DIFF
--- a/tests/explore.spec.ts
+++ b/tests/explore.spec.ts
@@ -2,13 +2,9 @@ import { expect, test } from './fixtures/base';
 
 test('should have functional search page', async ({ explorePage }) => {
   await explorePage.goto();
-  await explorePage.isSpaceVisible('Arbitrum DAO');
 
   await explorePage.search('nosuchspacenosuchspacenosuchspacedummy');
   await explorePage.isNoResultsVisible();
-
-  await explorePage.clearSearch();
-  await explorePage.isSpaceVisible('Arbitrum DAO');
 
   await explorePage.search('Fabien');
   await explorePage.isSpaceVisible('Fabien');
@@ -48,10 +44,13 @@ test('should fetch more spaces on scroll', async ({ page, explorePage }) => {
 test('should load space overview page', async ({ explorePage, spacePage }) => {
   await explorePage.goto();
 
+  await explorePage.search('Arbitrum DAO');
+
   // Using dispatchEvent('click') instead of .click() to force click on the space link
   // instead of Follow button that we show on hover
   await explorePage.exploreSpacesList
     .getByRole('link', { name: /Arbitrum DAO/ })
+    .first()
     .dispatchEvent('click');
 
   await spacePage.isReady();


### PR DESCRIPTION
### Summary

Before we assumed that Aribtrum DAO will be visible at the top but due to change in the ranking where spaces with open proposals are ranked higher it's no longer the case.

### How to test

1. Tests should pass.