### PR TITLE
style: fix stepper layout alignment

### DIFF
--- a/apps/ui/src/components/Ui/Stepper.vue
+++ b/apps/ui/src/components/Ui/Stepper.vue
@@ -38,7 +38,7 @@ function goToStep(stepName: string) {
 </script>
 
 <template>
-  <div class="flex">
+  <div class="flex justify-center">
     <div
       class="flex fixed lg:sticky top-header-height inset-x-0 p-3 border-b z-10 bg-skin-bg lg:top-auto lg:inset-x-auto lg:p-0 lg:pr-5 lg:border-0 lg:flex-col gap-1 min-w-[180px] overflow-auto"
     >
@@ -57,7 +57,7 @@ function goToStep(stepName: string) {
         {{ step.title }}
       </button>
     </div>
-    <div class="flex-1 space-y-4">
+    <div class="flex-1 space-y-4 max-w-[592px]">
       <div class="mt-8 lg:mt-0">
         <slot
           name="content"


### PR DESCRIPTION
### Summary
- fix space creation layout on medium screens (ipad)

### How to test
- Go to http://localhost:8080/#/create/snapshot and https://snapshot.org/#/create/snapshot
- Adjust screen size to 1000px
- On snapshot.org: (aligned to left and button is bigger than form
<img width="995" height="852" alt="image" src="https://github.com/user-attachments/assets/7b5fe2e7-8046-457d-b288-8ceb6e13e637" />
- With new changes: (aligns to center and button is same width as form)
<img width="978" height="910" alt="image" src="https://github.com/user-attachments/assets/b210e4aa-b0f8-4311-af34-ab391822625f" />

