### PR TITLE
fix: remove unused props

### DIFF
--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -41,7 +41,6 @@ const {
   votingType,
   privacy,
   voteValidation,
-  ignoreAbstainVotes,
   snapshotChainId,
   strategies,
   members,
@@ -437,7 +436,6 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
           v-model:voting-type="votingType"
           v-model:privacy="privacy"
           v-model:vote-validation="voteValidation"
-          v-model:ignore-abstain-votes="ignoreAbstainVotes"
           :snapshot-chain-id="snapshotChainId"
           :space="space"
           @update-validity="v => (hasVotingErrors = !v)"


### PR DESCRIPTION
### Summary

Left over from https://github.com/snapshot-labs/sx-monorepo/pull/1382

This PR fixes a warning, about unused props in the space settings voting page:

```
Settings.vue:331 [Vue warn]: Extraneous non-props attributes (ignore-abstain-votes) were passed to component but could not be automatically inherited because component renders fragment or text root nodes. 
  at <FormSpaceVoting voting-delay=null onUpdate:votingDelay=fn min-voting-period=null  ... > 
  at <ContainerSettings key=2 title="Voting" description="Set the proposal delay, minimum duration, which is the shortest time needed to execute a proposal if quorum passes, and maximum duration for voting." > 
  at <Settings space= {id: 'test.wa0x6e.eth', protocol: 'snapshot', network: 's', verified: false, turbo: false, …} class="h-full pb-10" onVnodeUnmounted=fn<onVnodeUnmounted>  ... > 
  at <RouterView key=1 space= {id: 'test.wa0x6e.eth', protocol: 'snapshot', network: 's', verified: false, turbo: false, …} class="h-full pb-10" > 
  at <Space class="h-full pb-10" onVnodeUnmounted=fn<onVnodeUnmounted> ref=Ref< Proxy(Object) {__v_skip: true} > > 
  at <RouterView class="h-full pb-10" > 
  at <App key=2 > 
  at <App> 
  at <App>
```

<!-- Related issues, a description or list of the changes and the motivation behind them -->

### How to test

1. Go to a space settings > voting
2. No more warning about unused props in the console
