### PR TITLE
chore: disable cache on lint scripts

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -11,8 +11,12 @@
       "dependsOn": ["build"],
       "outputs": ["out/**"]
     },
-    "lint": {},
-    "lint:fix": {},
+    "lint": {
+      "cache": false
+    },
+    "lint:fix": {
+      "cache": false
+    },
     "//#lint:scripts": {},
     "typecheck": {
       "dependsOn": ["^build"]


### PR DESCRIPTION
Sometime the lint scripts are using cache and hiding the errors