### PR TITLE
fix: fix missing offchain strategy form validation on edit

### DIFF
--- a/apps/ui/src/components/Modal/EditStrategy.vue
+++ b/apps/ui/src/components/Modal/EditStrategy.vue
@@ -61,7 +61,7 @@ const formErrors = computed(() => {
     errors.network = 'Network is required';
   }
 
-  if (!props.definition) {
+  if (!definition.value) {
     try {
       JSON.parse(rawParams.value);
     } catch {
@@ -73,10 +73,10 @@ const formErrors = computed(() => {
   const customError = props.customErrorValidation?.(value, network.value);
   if (customError) errors[CUSTOM_ERROR_SYMBOL] = customError;
 
-  if (props.definition) {
+  if (definition.value) {
     return {
       ...errors,
-      ...validateForm(props.definition, form.value, {
+      ...validateForm(definition.value, form.value, {
         skipEmptyOptionalFields: true
       })
     };


### PR DESCRIPTION
### Summary

Toward https://github.com/snapshot-labs/sx-monorepo/issues/1712

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fixes an issue where the strategy definition was missing when editing an offchain space strategy, resulting in missing form validation.

### How to test

1. Go to an offchain space settings, with strategies with valid schema (erc20-balance-of)
2. Edit the strategy
3. Input some invalid value in the "contract address" field
4. before: no validation occurred, you can save with invalid address
5. after: validation triggered
 