### PR TITLE
chore: remove deprecated addTypename property

### DIFF
--- a/apps/ui/src/composables/useDelegates.ts
+++ b/apps/ui/src/composables/useDelegates.ts
@@ -140,9 +140,7 @@ export function useDelegates(
 
   const apollo = new ApolloClient({
     link: httpLink,
-    cache: new InMemoryCache({
-      addTypename: false
-    }),
+    cache: new InMemoryCache(),
     defaultOptions: {
       query: {
         fetchPolicy: 'no-cache'

--- a/apps/ui/src/composables/useExecutionActions.ts
+++ b/apps/ui/src/composables/useExecutionActions.ts
@@ -119,9 +119,7 @@ export function useExecutionActions(
     const httpLink = createHttpLink({ uri: baseNetwork.api.apiUrl });
     const apollo = new ApolloClient({
       link: httpLink,
-      cache: new InMemoryCache({
-        addTypename: false
-      }),
+      cache: new InMemoryCache(),
       defaultOptions: {
         query: {
           fetchPolicy: 'no-cache'

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -405,9 +405,7 @@ export function createApi(
 
   const apollo = new ApolloClient({
     link: httpLink,
-    cache: new InMemoryCache({
-      addTypename: false
-    }),
+    cache: new InMemoryCache(),
     defaultOptions: {
       query: {
         fetchPolicy: 'no-cache'
@@ -418,9 +416,7 @@ export function createApi(
   const highlightApolloClient = opts.highlightApiUrl
     ? new ApolloClient({
         link: createHttpLink({ uri: opts.highlightApiUrl }),
-        cache: new InMemoryCache({
-          addTypename: false
-        }),
+        cache: new InMemoryCache(),
         defaultOptions: {
           query: {
             fetchPolicy: 'no-cache'

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -536,9 +536,7 @@ export function createApi(
 
   const apollo = new ApolloClient({
     link: httpLink,
-    cache: new InMemoryCache({
-      addTypename: false
-    }),
+    cache: new InMemoryCache(),
     defaultOptions: {
       query: {
         fetchPolicy: 'no-cache'

--- a/apps/ui/src/queries/payments.ts
+++ b/apps/ui/src/queries/payments.ts
@@ -48,9 +48,7 @@ async function fetchPayments(
 
   const client = new ApolloClient({
     uri,
-    cache: new InMemoryCache({
-      addTypename: false
-    }),
+    cache: new InMemoryCache(),
     defaultOptions: {
       query: {
         fetchPolicy: 'no-cache'


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix console warning, about deprecated apollo option

<img width="1311" height="300" alt="image" src="https://github.com/user-attachments/assets/8851122f-10ca-4b61-9fc5-9e29792562e8" />

See https://github.com/apollographql/apollo-client/issues/12184, `typename` option has been removed in v4, and is always ON by default.

### How to test

1. Visit http://localhost:8080/#/
2. All pages load as usual
