### PR TITLE
fix(ui): use consistent actions buttons style on spaces settings treasuries

### DIFF
--- a/apps/ui/src/components/FormSpaceTreasuries.vue
+++ b/apps/ui/src/components/FormSpaceTreasuries.vue
@@ -115,17 +115,13 @@ function deleteTreasury(index: number) {
             </div>
           </div>
         </div>
-        <div class="flex gap-2">
-          <UiTooltip title="Edit treasury">
-            <UiButton uniform @click="editTreasury(i)">
-              <IH-pencil />
-            </UiButton>
-          </UiTooltip>
-          <UiTooltip title="Delete treasury">
-            <UiButton uniform @click="deleteTreasury(i)">
-              <IH-trash />
-            </UiButton>
-          </UiTooltip>
+        <div class="flex gap-3 self-start items-center h-[24px]">
+          <button type="button" @click="() => editTreasury(i)">
+            <IH-pencil />
+          </button>
+          <button type="button" @click="() => deleteTreasury(i)">
+            <IH-trash />
+          </button>
         </div>
       </div>
     </template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an inconsistency with the space setting treasuries list actions buttons, using a regular UiButton with border and tooltip. This PR will convert those to match the style used in all other pages

OLD

<img width="1256" height="740" alt="image" src="https://github.com/user-attachments/assets/ef48cb08-da74-4dac-9562-217f841ca99f" />

NEW

<img width="1246" height="716" alt="image" src="https://github.com/user-attachments/assets/8b52c057-2375-4e50-8ec5-87e54e9bd7d5" />


### How to test

1. Go to a spaces settings > treasury
2. The buttons style should match the screenshot above
