### PR TITLE
fix(ui): add missing + icon in add button

### DIFF
--- a/apps/ui/src/components/FormSpaceDelegations.vue
+++ b/apps/ui/src/components/FormSpaceDelegations.vue
@@ -85,6 +85,7 @@ function deleteDelegation(index: number) {
     class="w-full"
     @click="addDelegation"
   >
+    <IH-plus class="shrink-0 size-[16px]" />
     Add delegation
   </UiButton>
   <teleport to="#modal">

--- a/apps/ui/src/components/FormSpaceMembers.vue
+++ b/apps/ui/src/components/FormSpaceMembers.vue
@@ -142,7 +142,10 @@ function deleteMember(index: number) {
         </button>
       </div>
     </div>
-    <UiButton class="w-full" @click="modalOpen = true">Add members</UiButton>
+    <UiButton class="w-full" @click="modalOpen = true">
+      <IH-plus class="shrink-0 size-[16px]" />
+      Add members
+    </UiButton>
   </div>
   <teleport to="#modal">
     <ModalAddMembers

--- a/apps/ui/src/components/FormSpaceTreasuries.vue
+++ b/apps/ui/src/components/FormSpaceTreasuries.vue
@@ -134,8 +134,10 @@ function deleteTreasury(index: number) {
     v-if="limit ? model.length < limit : true"
     class="w-full"
     @click="addTreasury"
-    >Add treasury</UiButton
   >
+    <IH-plus class="shrink-0 size-[16px]" />
+    Add treasury
+  </UiButton>
   <teleport to="#modal">
     <ModalTreasuryConfig
       :open="modalOpen"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an inconsistency in the space settings forms, where some of the ADD buttons have a + icon, while some other don't.

This PR will add the icon on all remaining buttons

<img width="1224" height="142" alt="image" src="https://github.com/user-attachments/assets/f74b3fd0-3aa1-47d0-b863-3cd01cc502a2" />

### How to test

1. Go to a space settings
2. All the "ADD xxx" buttons should have a + icon
