### PR TITLE
test: add E2E tests verifying that WalletConnect loads

### DIFF
--- a/tests/fixtures/poms.ts
+++ b/tests/fixtures/poms.ts
@@ -13,14 +13,14 @@ export class AuthPage {
     this.profileButton = page.getByTestId('profile-button');
   }
 
-  async login() {
+  async login(connector: string = 'MetaMask') {
     await this.loginButton.click();
 
     await expect(
       this.page.getByRole('heading', { name: 'Log in', exact: true })
     ).toBeVisible();
 
-    await this.page.getByRole('button', { name: 'MetaMask' }).click();
+    await this.page.getByRole('button', { name: connector }).click();
   }
 
   async logout() {

--- a/tests/walletconnect.spec.ts
+++ b/tests/walletconnect.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from './fixtures/base';
+
+test.setTimeout(60 * 1000);
+
+test('should load WalletConnect', async ({ page, authPage }) => {
+  await page.goto('/');
+
+  await authPage.login('WalletConnect');
+
+  await expect(
+    page.getByText('Scan this QR Code with your phone')
+  ).toBeVisible();
+});


### PR DESCRIPTION
### Summary

We had WalletConnect breaking due to some dependency conflicts (probably as a sideeffect of running yarn v1). To be able to catch it in the future if it happens I'm adding this test that verifies that WalletConnect properly loads.
