### PR TITLE
fix: wrong proposal id is passed

### DIFF
--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -408,7 +408,7 @@ export function createActions(
 
       const data = {
         space: space.id,
-        proposal: Number(proposal.id),
+        proposal: Number(proposal.proposal_id),
         authenticator,
         executionStrategy: selectedExecutionStrategy,
         metadataUri: `ipfs://${pinned.cid}`
@@ -448,7 +448,7 @@ export function createActions(
       return client.cancelProposal({
         signer: web3.provider.account,
         space: proposal.space.id,
-        proposal: Number(proposal.id)
+        proposal: Number(proposal.proposal_id)
       });
     },
     vote: async (
@@ -589,7 +589,7 @@ export function createActions(
       return executionCall('eth', l1ChainId, 'executeStarknetProposal', {
         space: proposal.space.id,
         executor: proposal.execution_destination,
-        proposalId: Number(proposal.id),
+        proposalId: Number(proposal.proposal_id),
         proposal: proposalData,
         votesFor,
         votesAgainst,


### PR DESCRIPTION
Regression from https://github.com/snapshot-labs/sx-monorepo/pull/1595 but need to check why

### Summary
Before we were passing `proposal.id` but need to pass `proposal.proposal_id`

`proposal.id = 0x07bd3419669f9f0cc8f19e9e2457089cdd4804a4c41a5729ee9c7fd02ab8ab62/proposal/76`
`proposal_id = 76`

### How to test

1. Go to http://localhost:8080/#/sn:0x07bd3419669f9f0cc8f19e9e2457089cdd4804a4c41a5729ee9c7fd02ab8ab62
2. Try to vote with sn wallet
