### PR TITLE
fix: update repository URL handling for commit id in footer 

### DIFF
--- a/apps/ui/src/components/Site/Footer.vue
+++ b/apps/ui/src/components/Site/Footer.vue
@@ -6,7 +6,9 @@ import ICGithub from '~icons/c/github';
 import ICX from '~icons/c/x';
 
 const COMMIT_SHA = import.meta.env.VITE_COMMIT_SHA || '';
-const repositoryUrl = repository.url.replace(/^git\+/, '').replace(/\.git$/, '');
+const repositoryUrl = repository.url
+  .replace(/^git\+/, '')
+  .replace(/\.git$/, '');
 
 const SOCIALS = [
   {


### PR DESCRIPTION
### Summary

-  remove 'git+' and '.git' from repo url

### How to test:

- Go to to https://snapshot.box/#/about
- in footer, where we should commit id the link shows [object Object] in the URL `https://github.com/[object Object]/tree/d1154b89dcb3496513fcaa35ed74211e7cba17d7`
- Clicking the link results in a 404 error
- now it should go to monorepo