### PR TITLE
chore: use latest yarn v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "engines": {
     "node": ">=22.6"
   },
-  "packageManager": "yarn@1.22.19",
+  "packageManager": "yarn@1.22.22",
   "workspaces": {
     "packages": [
       "apps/*",


### PR DESCRIPTION
### Summary

This will get rid of punycode warning.
