### PR TITLE
 fix: fix empty strategy modal state on first open

### DIFF
--- a/apps/ui/src/components/Modal/EditStrategy.vue
+++ b/apps/ui/src/components/Modal/EditStrategy.vue
@@ -147,16 +147,14 @@ function cloneInitialState(state: any) {
   return clone(state);
 }
 
-watchEffect(() => {
-  if (props.open && props.initialNetwork) {
-    network.value = props.initialNetwork;
-  }
-});
-
 watch(
   () => props.open,
   () => {
     showPicker.value = false;
+
+    if (props.initialNetwork) {
+      network.value = props.initialNetwork;
+    }
 
     if (props.initialState) {
       form.value = cloneInitialState(props.initialState);
@@ -165,7 +163,8 @@ watch(
       form.value = {};
       rawParams.value = '';
     }
-  }
+  },
+  { immediate: true }
 );
 </script>
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1757

### How to test

1. Go to a space settings > voting strategies
2. Edit an existing strategy
3. The modal should open, prefilled with the existing info
