### PR TITLE
refactor: add missing return types in defineEmits

### DIFF
--- a/apps/ui/src/components/CreateDeploymentProgress.vue
+++ b/apps/ui/src/components/CreateDeploymentProgress.vue
@@ -45,7 +45,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'back');
+  (e: 'back'): void;
 }>();
 
 const { deployDependency, createSpace } = useActions();

--- a/apps/ui/src/components/EditorStatement.vue
+++ b/apps/ui/src/components/EditorStatement.vue
@@ -8,7 +8,7 @@ const model = defineModel<Statement>({
 });
 
 const emit = defineEmits<{
-  (e: 'close');
+  (e: 'close'): void;
 }>();
 
 const actions = useActions();

--- a/apps/ui/src/components/EnsConfiguratorOffchain.vue
+++ b/apps/ui/src/components/EnsConfiguratorOffchain.vue
@@ -5,7 +5,7 @@ import { NetworkID } from '@/types';
 const spaceId = defineModel<string>();
 
 const emit = defineEmits<{
-  (e: 'select');
+  (e: 'select'): void;
 }>();
 
 const props = defineProps<{

--- a/apps/ui/src/components/ExecutionButton.vue
+++ b/apps/ui/src/components/ExecutionButton.vue
@@ -9,7 +9,7 @@ withDefaults(
 );
 
 const emit = defineEmits<{
-  (e: 'click');
+  (e: 'click'): void;
 }>();
 </script>
 

--- a/apps/ui/src/components/FormController.vue
+++ b/apps/ui/src/components/FormController.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'errors', value: any);
+  (e: 'errors', value: any): void;
 }>();
 
 const definition = computed(() => ({

--- a/apps/ui/src/components/FormSpaceAdvanced.vue
+++ b/apps/ui/src/components/FormSpaceAdvanced.vue
@@ -44,7 +44,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'updateValidity', valid: boolean, resolved: boolean): void;
-  (e: 'deleteSpace');
+  (e: 'deleteSpace'): void;
 }>();
 
 const {

--- a/apps/ui/src/components/FormSpaceController.vue
+++ b/apps/ui/src/components/FormSpaceController.vue
@@ -8,7 +8,7 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'save', value: string);
+  (e: 'save', value: string): void;
 }>();
 
 const changeControllerModalOpen = ref(false);

--- a/apps/ui/src/components/FormSpaceProfile.vue
+++ b/apps/ui/src/components/FormSpaceProfile.vue
@@ -16,8 +16,8 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'errors', value: any);
-  (e: 'pick', field: any);
+  (e: 'errors', value: any): void;
+  (e: 'pick', field: any): void;
 }>();
 
 const isOffchainNetwork = computed(

--- a/apps/ui/src/components/FormSpaceWhitelabel.vue
+++ b/apps/ui/src/components/FormSpaceWhitelabel.vue
@@ -71,7 +71,7 @@ const skinSettings = defineModel<SkinSettings>('skinSettings', {
 const props = defineProps<{ space: Space }>();
 
 const emit = defineEmits<{
-  (e: 'errors', value: any);
+  (e: 'errors', value: any): void;
 }>();
 
 const { encodeSkin } = useSkin();

--- a/apps/ui/src/components/FormStrategiesStrategyActive.vue
+++ b/apps/ui/src/components/FormStrategiesStrategyActive.vue
@@ -27,9 +27,9 @@ const props = defineProps<{
 }>();
 
 defineEmits<{
-  (e: 'editStrategy', strategy: Strategy);
-  (e: 'deleteStrategy', strategy: Strategy);
-  (e: 'testStrategies', strategies: StrategyConfig[]);
+  (e: 'editStrategy', strategy: Strategy): void;
+  (e: 'deleteStrategy', strategy: Strategy): void;
+  (e: 'testStrategies', strategies: StrategyConfig[]): void;
 }>();
 
 const network = computed(() => getNetwork(props.networkId));

--- a/apps/ui/src/components/FormVoting.vue
+++ b/apps/ui/src/components/FormVoting.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'errors', value: any);
+  (e: 'errors', value: any): void;
 }>();
 
 const isOffchainNetwork = computed(() =>

--- a/apps/ui/src/components/IndicatorVotingPower.vue
+++ b/apps/ui/src/components/IndicatorVotingPower.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'fetch');
+  (e: 'fetch'): void;
 }>();
 
 const { auth } = useWeb3();

--- a/apps/ui/src/components/MessageErrorFetchPower.vue
+++ b/apps/ui/src/components/MessageErrorFetchPower.vue
@@ -4,7 +4,7 @@ const props = defineProps<{
 }>();
 
 defineEmits<{
-  (e: 'fetch');
+  (e: 'fetch'): void;
 }>();
 
 const typeName = computed(() => {

--- a/apps/ui/src/components/Modal/AddMembers.vue
+++ b/apps/ui/src/components/Modal/AddMembers.vue
@@ -16,7 +16,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'add', value: Member[]): void;
-  (e: 'close');
+  (e: 'close'): void;
 }>();
 
 const form: Ref<{

--- a/apps/ui/src/components/Modal/ChangeController.vue
+++ b/apps/ui/src/components/Modal/ChangeController.vue
@@ -14,8 +14,8 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'save', value: string);
-  (e: 'close');
+  (e: 'save', value: string): void;
+  (e: 'close'): void;
 }>();
 
 const controllerDefinition = computed(() => ({

--- a/apps/ui/src/components/Modal/CustomStrategy.vue
+++ b/apps/ui/src/components/Modal/CustomStrategy.vue
@@ -16,8 +16,8 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (e: 'close');
-  (e: 'save', strategy: { address: string; type: string });
+  (e: 'close'): void;
+  (e: 'save', strategy: { address: string; type: string }): void;
 }>();
 
 const uiStore = useUiStore();

--- a/apps/ui/src/components/Modal/Delegate.vue
+++ b/apps/ui/src/components/Modal/Delegate.vue
@@ -46,7 +46,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'close');
+  (e: 'close'): void;
 }>();
 
 const { delegate } = useActions();

--- a/apps/ui/src/components/Modal/DelegationConfig.vue
+++ b/apps/ui/src/components/Modal/DelegationConfig.vue
@@ -19,7 +19,7 @@ const props = defineProps<{
   initialState?: SpaceMetadataDelegation;
 }>();
 const emit = defineEmits<{
-  (e: 'add', config: SpaceMetadataDelegation);
+  (e: 'add', config: SpaceMetadataDelegation): void;
   (e: 'close'): void;
 }>();
 

--- a/apps/ui/src/components/Modal/DeleteSpace.vue
+++ b/apps/ui/src/components/Modal/DeleteSpace.vue
@@ -13,8 +13,8 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'confirm');
-  (e: 'close');
+  (e: 'confirm'): void;
+  (e: 'close'): void;
 }>();
 
 const form: Ref<{

--- a/apps/ui/src/components/Modal/Drafts.vue
+++ b/apps/ui/src/components/Modal/Drafts.vue
@@ -6,7 +6,7 @@ const props = defineProps<{
 }>();
 
 defineEmits<{
-  (e: 'close');
+  (e: 'close'): void;
 }>();
 
 const route = useRoute();

--- a/apps/ui/src/components/Modal/EditContact.vue
+++ b/apps/ui/src/components/Modal/EditContact.vue
@@ -13,7 +13,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'close');
+  (e: 'close'): void;
 }>();
 
 const contactsStore = useContactsStore();

--- a/apps/ui/src/components/Modal/EditStrategy.vue
+++ b/apps/ui/src/components/Modal/EditStrategy.vue
@@ -27,8 +27,8 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (e: 'close');
-  (e: 'save', value: Record<string, any>, network: ChainId);
+  (e: 'close'): void;
+  (e: 'save', value: Record<string, any>, network: ChainId): void;
 }>();
 
 const network: Ref<ChainId> = ref('');

--- a/apps/ui/src/components/Modal/EditUser.vue
+++ b/apps/ui/src/components/Modal/EditUser.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'close');
+  (e: 'close'): void;
 }>();
 
 const definition = {

--- a/apps/ui/src/components/Modal/EnsName.vue
+++ b/apps/ui/src/components/Modal/EnsName.vue
@@ -27,8 +27,8 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'close');
-  (e: 'attach', name: string);
+  (e: 'close'): void;
+  (e: 'attach', name: string): void;
 }>();
 
 const { attachCustomName } = useWalletEns(props.networkId);

--- a/apps/ui/src/components/Modal/LabelConfig.vue
+++ b/apps/ui/src/components/Modal/LabelConfig.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'add', config: SpaceMetadataLabel);
+  (e: 'add', config: SpaceMetadataLabel): void;
   (e: 'close'): void;
 }>();
 

--- a/apps/ui/src/components/Modal/LinkWalletConnect.vue
+++ b/apps/ui/src/components/Modal/LinkWalletConnect.vue
@@ -34,7 +34,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'close');
+  (e: 'close'): void;
 }>();
 
 const { transaction } = useWalletConnectTransaction();

--- a/apps/ui/src/components/Modal/Payment.vue
+++ b/apps/ui/src/components/Modal/Payment.vue
@@ -28,8 +28,8 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (e: 'close');
-  (e: 'confirmed');
+  (e: 'close'): void;
+  (e: 'confirmed'): void;
 }>();
 
 const { auth } = useWeb3();

--- a/apps/ui/src/components/Modal/PendingTransactions.vue
+++ b/apps/ui/src/components/Modal/PendingTransactions.vue
@@ -6,7 +6,7 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'close');
+  (e: 'close'): void;
 }>();
 
 const uiStore = useUiStore();

--- a/apps/ui/src/components/Modal/SelectPrivacy.vue
+++ b/apps/ui/src/components/Modal/SelectPrivacy.vue
@@ -10,8 +10,8 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'save', type: SpacePrivacy);
-  (e: 'close');
+  (e: 'save', type: SpacePrivacy): void;
+  (e: 'close'): void;
 }>();
 
 function handleSelect(type: SpacePrivacy) {

--- a/apps/ui/src/components/Modal/SelectValidation.vue
+++ b/apps/ui/src/components/Modal/SelectValidation.vue
@@ -41,8 +41,8 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (e: 'save', type: Validation);
-  (e: 'close');
+  (e: 'save', type: Validation): void;
+  (e: 'close'): void;
 }>();
 
 const isLoading = ref(false);

--- a/apps/ui/src/components/Modal/SelectVotingType.vue
+++ b/apps/ui/src/components/Modal/SelectVotingType.vue
@@ -17,8 +17,8 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (e: 'save', type: AvailableVotingTypes);
-  (e: 'close');
+  (e: 'save', type: AvailableVotingTypes): void;
+  (e: 'close'): void;
 }>();
 
 const availableVotingTypes = computed(() =>

--- a/apps/ui/src/components/Modal/SendToken.vue
+++ b/apps/ui/src/components/Modal/SendToken.vue
@@ -24,8 +24,8 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'add', transaction: Transaction);
-  (e: 'close');
+  (e: 'add', transaction: Transaction): void;
+  (e: 'close'): void;
 }>();
 
 const searchInput: Ref<HTMLElement | null> = ref(null);

--- a/apps/ui/src/components/Modal/StakeToken.vue
+++ b/apps/ui/src/components/Modal/StakeToken.vue
@@ -47,8 +47,8 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'add', transaction: Transaction);
-  (e: 'close');
+  (e: 'add', transaction: Transaction): void;
+  (e: 'close'): void;
 }>();
 
 const form: {

--- a/apps/ui/src/components/Modal/Strategies.vue
+++ b/apps/ui/src/components/Modal/Strategies.vue
@@ -15,8 +15,8 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'addStrategy', strategy: StrategyTemplate);
-  (e: 'close');
+  (e: 'addStrategy', strategy: StrategyTemplate): void;
+  (e: 'close'): void;
 }>();
 
 const searchValue = ref('');

--- a/apps/ui/src/components/Modal/TestStrategy.vue
+++ b/apps/ui/src/components/Modal/TestStrategy.vue
@@ -31,7 +31,7 @@ const props = defineProps<{
 }>();
 
 defineEmits<{
-  (e: 'close');
+  (e: 'close'): void;
 }>();
 
 const isPickerShown = ref(false);

--- a/apps/ui/src/components/Modal/TreasuryConfig.vue
+++ b/apps/ui/src/components/Modal/TreasuryConfig.vue
@@ -15,7 +15,7 @@ const props = defineProps<{
   initialState?: SpaceMetadataTreasury;
 }>();
 const emit = defineEmits<{
-  (e: 'add', config: SpaceMetadataTreasury);
+  (e: 'add', config: SpaceMetadataTreasury): void;
   (e: 'close'): void;
 }>();
 

--- a/apps/ui/src/components/Modal/Vote.vue
+++ b/apps/ui/src/components/Modal/Vote.vue
@@ -25,8 +25,8 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'close');
-  (e: 'voted');
+  (e: 'close'): void;
+  (e: 'voted'): void;
 }>();
 
 const queryClient = useQueryClient();

--- a/apps/ui/src/components/Modal/VotingPower.vue
+++ b/apps/ui/src/components/Modal/VotingPower.vue
@@ -11,8 +11,8 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'close');
-  (e: 'fetch');
+  (e: 'close'): void;
+  (e: 'fetch'): void;
 }>();
 </script>
 

--- a/apps/ui/src/components/PickerContact.vue
+++ b/apps/ui/src/components/PickerContact.vue
@@ -14,7 +14,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (e: 'pick', value: string);
+  (e: 'pick', value: string): void;
 }>();
 
 const { account } = useAccount();

--- a/apps/ui/src/components/PickerNft.vue
+++ b/apps/ui/src/components/PickerNft.vue
@@ -8,7 +8,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'pick', value: string);
+  (e: 'pick', value: string): void;
 }>();
 
 const filteredNfts = computed(() =>

--- a/apps/ui/src/components/PickerToken.vue
+++ b/apps/ui/src/components/PickerToken.vue
@@ -18,8 +18,8 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'pick', value: string);
-  (e: 'add', token: Token);
+  (e: 'pick', value: string): void;
+  (e: 'add', token: Token): void;
 }>();
 
 const customTokenLoading = ref(false);

--- a/apps/ui/src/components/ProposalVote.vue
+++ b/apps/ui/src/components/ProposalVote.vue
@@ -12,7 +12,7 @@ const props = withDefaults(
 );
 
 defineEmits<{
-  (e: 'enterEditMode');
+  (e: 'enterEditMode'): void;
 }>();
 
 const { auth } = useWeb3();

--- a/apps/ui/src/components/ProposalVoteApproval.vue
+++ b/apps/ui/src/components/ProposalVoteApproval.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'vote', value: Choice);
+  (e: 'vote', value: Choice): void;
 }>();
 
 const selectedChoices = ref<ApprovalChoice>(

--- a/apps/ui/src/components/ProposalVoteBasic.vue
+++ b/apps/ui/src/components/ProposalVoteBasic.vue
@@ -10,7 +10,7 @@ withDefaults(
 );
 
 const emit = defineEmits<{
-  (e: 'vote', value: Choice);
+  (e: 'vote', value: Choice): void;
 }>();
 </script>
 

--- a/apps/ui/src/components/ProposalVoteRankedChoice.vue
+++ b/apps/ui/src/components/ProposalVoteRankedChoice.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'vote', value: Choice);
+  (e: 'vote', value: Choice): void;
 }>();
 
 const selectedChoices = ref<RankedChoice>(

--- a/apps/ui/src/components/ProposalVoteSingleChoice.vue
+++ b/apps/ui/src/components/ProposalVoteSingleChoice.vue
@@ -7,7 +7,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'vote', value: number);
+  (e: 'vote', value: number): void;
 }>();
 
 const selectedChoice = ref<number | null>(

--- a/apps/ui/src/components/ProposalVoteWeighted.vue
+++ b/apps/ui/src/components/ProposalVoteWeighted.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
 }>();
 
 defineEmits<{
-  (e: 'vote', value: Choice);
+  (e: 'vote', value: Choice): void;
 }>();
 
 const selectedChoices = ref<WeightedChoice>(

--- a/apps/ui/src/components/ProposalsList.vue
+++ b/apps/ui/src/components/ProposalsList.vue
@@ -23,7 +23,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (e: 'endReached');
+  (e: 'endReached'): void;
 }>();
 
 const currentLimit = computed(() => {

--- a/apps/ui/src/components/Ui/Alert.vue
+++ b/apps/ui/src/components/Ui/Alert.vue
@@ -7,7 +7,7 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'close');
+  (e: 'close'): void;
 }>();
 </script>
 

--- a/apps/ui/src/components/Ui/ContainerInfiniteScroll.vue
+++ b/apps/ui/src/components/Ui/ContainerInfiniteScroll.vue
@@ -10,7 +10,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (e: 'endReached');
+  (e: 'endReached'): void;
 }>();
 
 const container: Ref<HTMLElement | null> = ref(null);

--- a/apps/ui/src/components/Ui/Editable.vue
+++ b/apps/ui/src/components/Ui/Editable.vue
@@ -24,7 +24,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (e: 'save', value: string | number);
+  (e: 'save', value: string | number): void;
 }>();
 
 const editing = ref(false);

--- a/apps/ui/src/components/Ui/InputAddress.vue
+++ b/apps/ui/src/components/Ui/InputAddress.vue
@@ -20,7 +20,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'pick', path: string);
+  (e: 'pick', path: string): void;
 }>();
 
 const networkDetails = computed<NetworkDetails | null>(() => {

--- a/apps/ui/src/components/Ui/Modal.vue
+++ b/apps/ui/src/components/Ui/Modal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 const emit = defineEmits<{
-  (e: 'close');
+  (e: 'close'): void;
 }>();
 
 const props = withDefaults(

--- a/apps/ui/src/components/Ui/ScrollerHorizontal.vue
+++ b/apps/ui/src/components/Ui/ScrollerHorizontal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 const emit = defineEmits<{
-  (e: 'scroll', target: HTMLElement);
+  (e: 'scroll', target: HTMLElement): void;
 }>();
 
 withDefaults(

--- a/apps/ui/src/components/Ui/SelectorCard.vue
+++ b/apps/ui/src/components/Ui/SelectorCard.vue
@@ -20,7 +20,7 @@ withDefaults(
 );
 
 const emit = defineEmits<{
-  (e: 'click', key: string);
+  (e: 'click', key: string): void;
 }>();
 </script>
 

--- a/apps/ui/src/components/Ui/Stepper.vue
+++ b/apps/ui/src/components/Ui/Stepper.vue
@@ -16,7 +16,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (e: 'submit');
+  (e: 'submit'): void;
 }>();
 
 const stepper = useStepper(props.steps);


### PR DESCRIPTION
### Summary

If not specified those returns types are any which conflicts with noImplicitAny which we will want to enable in the future.
