### PR TITLE
fix: remove gap from buttons without icons

### DIFF
--- a/apps/ui/src/components/EnsConfiguratorOffchain.vue
+++ b/apps/ui/src/components/EnsConfiguratorOffchain.vue
@@ -104,7 +104,7 @@ function handleSelect(value: string) {
           <UiEyebrow>Domain names</UiEyebrow>
           <UiButton
             v-if="names"
-            class="gap-1 !text-skin-text !p-0 !border-0 !h-auto"
+            class="!gap-1 !text-skin-text !p-0 !border-0 !h-auto"
             :disabled="isLoading"
             :loading="isRefreshing"
             @click="refresh"

--- a/apps/ui/src/components/Ui/Button.vue
+++ b/apps/ui/src/components/Ui/Button.vue
@@ -65,7 +65,11 @@ const buttonStyles = computed(() => {
 
 <style lang="scss" scoped>
 .button {
-  @apply rounded-full leading-[100%] border text-skin-link bg-skin-bg inline-flex items-center justify-center gap-2;
+  @apply rounded-full leading-[100%] border text-skin-link bg-skin-bg inline-flex items-center justify-center;
+
+  &:has(svg) {
+    @apply gap-2;
+  }
 
   &:disabled:deep() {
     color: rgba(var(--border)) !important;


### PR DESCRIPTION
### Summary
Looks like we are adding gap-2 by default from here https://github.com/snapshot-labs/sx-monorepo/pull/1667/files
we just need it when there is a icon inside button

### How to test

1. <img width="580" height="460" alt="image" src="https://github.com/user-attachments/assets/07ea7dbf-c544-4ecd-8343-6c1c1c9fe4c0" />
2. This should not be the case anymore
3. All other buttons should be same as before
