### PR TITLE
fix: add gap inside buttons

### DIFF
--- a/apps/ui/src/components/Site/Topnav.vue
+++ b/apps/ui/src/components/Site/Topnav.vue
@@ -48,7 +48,7 @@ const { toggleTheme, currentTheme } = useTheme();
         <IH-sun v-if="currentTheme === 'dark'" class="inline-block" />
         <IH-moon v-else class="inline-block" />
       </UiButton>
-      <UiButton :to="{ name: 'my-home' }" primary>
+      <UiButton :to="{ name: 'my-home' }" primary class="!gap-0">
         Launch
         <span class="hidden md:inline-block">&nbsp;app</span>
       </UiButton>

--- a/apps/ui/src/components/Ui/Button.vue
+++ b/apps/ui/src/components/Ui/Button.vue
@@ -65,12 +65,7 @@ const buttonStyles = computed(() => {
 
 <style lang="scss" scoped>
 .button {
-  @apply rounded-full leading-[100%] border text-skin-link bg-skin-bg inline-flex items-center justify-center;
-
-  &:has(svg),
-  &:has(img) {
-    @apply gap-2;
-  }
+  @apply rounded-full leading-[100%] border text-skin-link bg-skin-bg inline-flex items-center justify-center gap-2;
 
   &:disabled:deep() {
     color: rgba(var(--border)) !important;


### PR DESCRIPTION
### Summary
Related to https://github.com/snapshot-labs/sx-monorepo/pull/1763 and https://github.com/snapshot-labs/sx-monorepo/pull/1667

### How to test

1. Go to any page 
2. click on login
3. should see more gap after image
<img width="976" height="926" alt="image" src="https://github.com/user-attachments/assets/41f55130-2cdd-4524-bee3-d49321ad6c6c" />

