### PR TITLE
fix: do not use locale capitalization for non-localized text

### DIFF
--- a/.changeset/slow-breads-sniff.md
+++ b/.changeset/slow-breads-sniff.md
@@ -1,0 +1,5 @@
+---
+'@snapshot-labs/sx': patch
+---
+
+do not use toLocaleLowerCase for addresses

--- a/apps/ui/src/components/Modal/AddMembers.vue
+++ b/apps/ui/src/components/Modal/AddMembers.vue
@@ -82,15 +82,12 @@ const formErrors = computed(() => {
   const errors = validateForm(definition.value, form.value);
 
   const existingAddresses = new Map(
-    props.currentMembers.map(member => [
-      member.address.toLocaleLowerCase(),
-      true
-    ])
+    props.currentMembers.map(member => [member.address.toLowerCase(), true])
   );
 
   if (
     uniqueAddresses.value.some(address =>
-      existingAddresses.has(address.toLocaleLowerCase())
+      existingAddresses.has(address.toLowerCase())
     )
   ) {
     errors.addresses = 'Member already exists';

--- a/apps/ui/src/components/PickerContact.vue
+++ b/apps/ui/src/components/PickerContact.vue
@@ -40,11 +40,8 @@ const allContacts = computed(() => {
 const filteredContacts = computed(() =>
   allContacts.value.filter(contact => {
     return (
-      contact.name
-        .toLocaleLowerCase()
-        .includes(props.searchValue.toLocaleLowerCase()) ||
-      contact.address.toLocaleLowerCase() ===
-        props.searchValue.toLocaleLowerCase()
+      contact.name.toLowerCase().includes(props.searchValue.toLowerCase()) ||
+      contact.address.toLowerCase() === props.searchValue.toLowerCase()
     );
   })
 );

--- a/apps/ui/src/components/PickerNft.vue
+++ b/apps/ui/src/components/PickerNft.vue
@@ -14,8 +14,8 @@ const emit = defineEmits<{
 const filteredNfts = computed(() =>
   props.nfts.filter(nft => {
     return nft.displayTitle
-      .toLocaleLowerCase()
-      .includes(props.searchValue.toLocaleLowerCase());
+      .toLowerCase()
+      .includes(props.searchValue.toLowerCase());
   })
 );
 </script>

--- a/apps/ui/src/components/PickerToken.vue
+++ b/apps/ui/src/components/PickerToken.vue
@@ -33,14 +33,9 @@ const filteredAssets = computed(() => {
   return props.assets
     .filter(asset => {
       return (
-        asset.symbol
-          .toLocaleLowerCase()
-          .includes(props.searchValue.toLocaleLowerCase()) ||
-        asset.name
-          .toLocaleLowerCase()
-          .includes(props.searchValue.toLocaleLowerCase()) ||
-        asset.contractAddress.toLocaleLowerCase() ===
-          props.searchValue.toLocaleLowerCase()
+        asset.symbol.toLowerCase().includes(props.searchValue.toLowerCase()) ||
+        asset.name.toLowerCase().includes(props.searchValue.toLowerCase()) ||
+        asset.contractAddress.toLowerCase() === props.searchValue.toLowerCase()
       );
     })
     .sort((a, b) => {

--- a/apps/ui/src/helpers/auction/index.ts
+++ b/apps/ui/src/helpers/auction/index.ts
@@ -77,6 +77,6 @@ export async function getOrders(
 
   return orders.map(order => ({
     ...order,
-    name: names[order.userAddress.toLocaleLowerCase()] || null
+    name: names[order.userAddress.toLowerCase()] || null
   }));
 }

--- a/apps/ui/src/helpers/resolver.ts
+++ b/apps/ui/src/helpers/resolver.ts
@@ -32,7 +32,7 @@ function createResolver() {
 
     return {
       networkId: ENS_NETWORK_ID,
-      address: resolvedAddress.toLocaleLowerCase()
+      address: resolvedAddress.toLowerCase()
     };
   }
 

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -330,9 +330,9 @@ function getErrorMessage(errorObject: Partial<ErrorObject>): string {
     return `Must be at most ${_n(errorObject.params.limit)}.`;
   }
 
-  return `${errorObject.message.charAt(0).toLocaleUpperCase()}${errorObject.message
+  return `${errorObject.message.charAt(0).toUpperCase()}${errorObject.message
     .slice(1)
-    .toLocaleLowerCase()}.`;
+    .toLowerCase()}.`;
 }
 
 const getFormValues = (schema: any, form: any, opts: Opts) => {

--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -47,7 +47,7 @@ async function fetchGovernorSubgraphDelegatees(
       orderDirection: 'desc',
       where: {
         // NOTE: This is subgraph, needs to be lowercase
-        user: delegateeData.address.toLocaleLowerCase()
+        user: delegateeData.address.toLowerCase()
       }
     })
   ]);
@@ -92,7 +92,7 @@ async function fetchApeChainDelegatees(
       orderDirection: 'desc',
       where: {
         // NOTE: This is subgraph, needs to be lowercase
-        user: accountDelegation.delegate.toLocaleLowerCase()
+        user: accountDelegation.delegate.toLowerCase()
       }
     })
   ]);

--- a/packages/sx.js/src/clients/starknet/ethereum-tx/index.ts
+++ b/packages/sx.js/src/clients/starknet/ethereum-tx/index.ts
@@ -225,7 +225,7 @@ export class EthereumTx {
     const hash = await this.getProposeHash(address, data);
 
     return this.getMessageFee(data.authenticator, [
-      address.toLocaleLowerCase(),
+      address.toLowerCase(),
       hash
     ]);
   }
@@ -234,7 +234,7 @@ export class EthereumTx {
     const hash = await this.getVoteHash(address, data);
 
     return this.getMessageFee(data.authenticator, [
-      address.toLocaleLowerCase(),
+      address.toLowerCase(),
       hash
     ]);
   }
@@ -243,7 +243,7 @@ export class EthereumTx {
     const hash = await this.getUpdateProposalHash(address, data);
 
     return this.getMessageFee(data.authenticator, [
-      address.toLocaleLowerCase(),
+      address.toLowerCase(),
       hash
     ]);
   }


### PR DESCRIPTION
### Summary

toLocaleUpperCase and toLocaleLowerCase have benefits of handling localized casing rules, but it's only of benefit when processing localized text.

In other cases it might actually cause issues (I think the only difference is around I character and tr-tr locale).

For example if we are comparing addresses and our address includes capital I (not possible with EVM, Bitcoin and Starknet addresses) converting '0xASDFI' would return '0xasdfı' (note last character) with locale set to tr-tr.

We might want to avoid this potential issue if we expand types of addresses supported (although I is avoided in address formats due to similarity to lower-case L).

This change also applies to other values (like searching for token name, symbol) - in this case we can assume those values are not localized in tr-tr, so we don't want to hit this edge case where token name gets converted from 'Interesting token' to 'ıntresting token'.

Pretty much all of those usages come from me (sorry). I only gave it second thought after it was mentioned here:
https://github.com/snapshot-labs/sx-monorepo/pull/1773#discussion_r2561719822