### PR TITLE
fix: show notice if oSnap service is unavailable

### DIFF
--- a/apps/ui/src/components/ProposalExecutionActions.vue
+++ b/apps/ui/src/components/ProposalExecutionActions.vue
@@ -15,6 +15,7 @@ const {
   hasExecuteQueued,
   fetchingDetails,
   message,
+  warningMessage,
   executionTx,
   executionTxUrl,
   finalizeProposalSending,
@@ -39,8 +40,11 @@ const network = computed(() => getNetwork(props.proposal.network));
     <div v-if="fetchingDetails" class="flex justify-center">
       <UiLoading class="text-center" />
     </div>
-    <div v-else-if="message">
-      {{ message }}
+    <div v-else-if="message" class="space-y-2">
+      <div>{{ message }}</div>
+      <UiAlert v-if="warningMessage" type="warning">
+        {{ warningMessage }}
+      </UiAlert>
     </div>
     <div v-else-if="executionTx">
       Proposal has been already executed at

--- a/apps/ui/src/composables/useExecutionActions.ts
+++ b/apps/ui/src/composables/useExecutionActions.ts
@@ -40,6 +40,7 @@ export function useExecutionActions(
   const fetchingDetails = ref(false);
   const executionTx = ref<string | null>(null);
   const message: Ref<string | null> = ref(null);
+  const warningMessage: Ref<string | null> = ref(null);
   const executionNetwork = ref<Network>(getNetwork(toValue(proposal).network));
   const finalizeProposalSending = ref(false);
   const executeProposalSending = ref(false);
@@ -176,14 +177,19 @@ export function useExecutionActions(
       });
 
       if (!data) {
-        const configCompliant = await isConfigCompliant(
-          executionValue.safeAddress,
-          chainId
-        );
-
-        message.value = configCompliant.automaticExecution
-          ? 'Waiting for execution to be initiated.'
-          : 'Space is not configured for automatic execution.';
+        try {
+          const configCompliant = await isConfigCompliant(
+            executionValue.safeAddress,
+            chainId
+          );
+          message.value = configCompliant.automaticExecution
+            ? 'Waiting for execution to be initiated.'
+            : 'Space is not configured for automatic execution.';
+        } catch {
+          message.value = 'Waiting for execution to be initiated.';
+          warningMessage.value =
+            'oSnap service may be temporarily unavailable to check automatic execution status.';
+        }
       } else if (data.executionTransactionHash) {
         try {
           executionTx.value = data.executionTransactionHash;
@@ -276,6 +282,7 @@ export function useExecutionActions(
     hasExecuteQueued,
     fetchingDetails,
     message,
+    warningMessage,
     executionTx,
     executionTxUrl,
     finalizeProposalSending,


### PR DESCRIPTION
### Summary
- Right now we display "Execution details failed to load." 
- With this change, we still display: "Waiting for execution to be initiated." with a notice
- <img width="757" height="261" alt="image" src="https://github.com/user-attachments/assets/d7c83900-70f1-4f96-99c4-c752805fd6b9" />


### How to test

1. Go to http://localhost:8080/#/s:acrossprotocol.eth/proposal/0x97839ddf3cfe90d2a352339d5a6513e66ba074929db992fbf7c05e14c60087e1
2. should see a notice
