### PR TITLE
fix: verify that bid amount is higher than minimum

### DIFF
--- a/apps/ui/src/components/FormAuctionBid.vue
+++ b/apps/ui/src/components/FormAuctionBid.vue
@@ -145,8 +145,8 @@ const amountError = computed(() => {
     )
   );
 
-  if (amount < minBiddingAmount) {
-    return `Minimum ${_n(minBiddingAmount)} ${props.auction.symbolBiddingToken}`;
+  if (amount <= minBiddingAmount) {
+    return `Amount must be bigger than ${_n(minBiddingAmount)} ${props.auction.symbolBiddingToken}`;
   }
 
   if (hasBalance.value && amount > formattedBalance.value) {


### PR DESCRIPTION
### Summary

If it's exactly the same as minimum it's invalid.

It needs to be higher than minimum:
https://github.com/Gnosis-Auction/auction-contracts/blob/4b4f8bd79487e2ac40d7c3f33caeb9a10272a867/contracts/EasyAuction.sol#L312-L315

### How to test

1. Go there http://localhost:8080/#/auction/sep:105
2. Use 0.1 as amount to bid.
3. You see an error.
