### PR TITLE
refactor(auction): store sell orders as sellAmount/buyAmount

### DIFF
--- a/apps/ui/src/components/FormAuctionBid.vue
+++ b/apps/ui/src/components/FormAuctionBid.vue
@@ -213,14 +213,30 @@ const hasErrors = computed<boolean>(() => {
   );
 });
 
+function toRawUnits(value: number, decimals: number): bigint {
+  return BigInt(Math.floor(value * 10 ** decimals));
+}
+
 function handlePlaceOrder() {
   if (hasErrors.value) return;
 
-  const price = isPriceInverted.value
-    ? (1 / parseFloat(bidPrice.value)).toString()
-    : bidPrice.value;
+  const bidPriceValue = parseFloat(bidPrice.value);
 
-  emit('submit', { sellAmount: bidAmount.value, price });
+  const price = isPriceInverted.value ? 1 / bidPriceValue : bidPriceValue;
+
+  const sellAmount = parseFloat(bidAmount.value);
+  const buyAmount = price ? sellAmount / price : 0;
+
+  emit('submit', {
+    sellAmount: toRawUnits(
+      sellAmount,
+      Number(props.auction.decimalsBiddingToken)
+    ),
+    buyAmount: toRawUnits(
+      buyAmount,
+      Number(props.auction.decimalsAuctioningToken)
+    )
+  });
 }
 
 onMounted(() => {

--- a/apps/ui/src/composables/useAuctionOrderFlow.ts
+++ b/apps/ui/src/composables/useAuctionOrderFlow.ts
@@ -28,7 +28,7 @@ export function useAuctionOrderFlow(
   const { getIsTokenApproved, approveToken, placeSellOrder } =
     useAuctionActions(networkId, auction);
 
-  const sellOrder = ref<SellOrder>({ sellAmount: '0', price: '0' });
+  const sellOrder = ref<SellOrder>({ sellAmount: 0n, buyAmount: 0n });
   const currentStepId = ref<StepId>(FIRST_STEP);
   const stepExecuteResults = ref<Map<StepId, boolean>>(new Map());
 

--- a/apps/ui/src/helpers/auction/actions.ts
+++ b/apps/ui/src/helpers/auction/actions.ts
@@ -1,6 +1,5 @@
 import { Contract } from '@ethersproject/contracts';
 import { Web3Provider } from '@ethersproject/providers';
-import { parseUnits } from '@ethersproject/units';
 import {
   AUCTION_CONTRACT_ADDRESSES,
   AuctionNetworkId,
@@ -24,25 +23,14 @@ export async function placeSellOrder(
     web3.getSigner()
   );
   let previousOrderId: string;
-  const rawSellAmount = parseUnits(
-    sellOrder.sellAmount,
-    auction.decimalsBiddingToken
-  );
-  const price = parseFloat(sellOrder.price);
-  const buyAmount = (
-    price
-      ? (parseFloat(sellOrder.sellAmount) / price).toFixed(
-          Number(auction.decimalsAuctioningToken)
-        )
-      : 0
-  ).toString();
-  const rawBuyAmount = parseUnits(buyAmount, auction.decimalsAuctioningToken);
+
+  const price = Number(sellOrder.sellAmount) / Number(sellOrder.buyAmount);
 
   try {
     previousOrderId = await getPreviousOrderId(
       auction.id,
       networkId,
-      sellOrder.price
+      price.toFixed(34)
     );
   } catch (e) {
     console.error(
@@ -55,8 +43,8 @@ export async function placeSellOrder(
 
   return contract.placeSellOrders(
     auction.id,
-    [rawBuyAmount],
-    [rawSellAmount],
+    [sellOrder.buyAmount],
+    [sellOrder.sellAmount],
     [previousOrderId],
     auction.allowListSigner
   );

--- a/apps/ui/src/helpers/auction/types.ts
+++ b/apps/ui/src/helpers/auction/types.ts
@@ -2,4 +2,4 @@ import { OrderFragment } from './gql/graphql';
 
 export type AuctionNetworkId = 'eth' | 'sep';
 export type Order = OrderFragment & { name: string | null };
-export type SellOrder = Pick<Order, 'sellAmount' | 'price'>;
+export type SellOrder = { buyAmount: bigint; sellAmount: bigint };

--- a/apps/ui/src/helpers/token.ts
+++ b/apps/ui/src/helpers/token.ts
@@ -1,7 +1,5 @@
-import { BigNumber } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
 import { Web3Provider } from '@ethersproject/providers';
-import { parseUnits } from '@ethersproject/units';
 import { abis } from '@/helpers/abis';
 
 export type Token = {
@@ -15,7 +13,7 @@ export async function getIsApproved(
   token: Token,
   web3: Web3Provider,
   spenderAddress: string,
-  amount: string
+  amount: bigint
 ): Promise<boolean> {
   const signer = web3.getSigner();
   const contract = new Contract(token.contractAddress, abis.erc20, signer);
@@ -24,19 +22,19 @@ export async function getIsApproved(
     spenderAddress
   );
 
-  return BigNumber.from(allowance).gte(parseUnits(amount, token.decimals));
+  return allowance.toBigInt() >= amount;
 }
 
 export async function approve(
   token: Token,
   web3: Web3Provider,
   spenderAddress: string,
-  amount: string
+  amount: bigint
 ) {
   const contract = new Contract(
     token.contractAddress,
     abis.erc20,
     web3.getSigner()
   );
-  return contract.approve(spenderAddress, parseUnits(amount, token.decimals));
+  return contract.approve(spenderAddress, amount);
 }


### PR DESCRIPTION
### Summary

To reduce dependence on the price (which is not used on the contracts) we store sell orders as { sellAmount, buyAmount } where both of them are bigints representing raw units of applicable tokens.

We convert to this format as soon as possible and use those amounts in entire flow (with exception of fetching previous order from API as there is no other way, however this price is computed based on those values instead of being user input). This will be further improved in https://github.com/snapshot-labs/sx-monorepo/pull/1799

### How to test

1.  Create order here: http://localhost:8080/#/auction/sep:117