### PR TITLE
refactor: extract parseUnits helper that returns bigint

### DIFF
--- a/apps/ui/src/components/FormAuctionBid.vue
+++ b/apps/ui/src/components/FormAuctionBid.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Contract } from '@ethersproject/contracts';
-import { formatUnits, parseUnits } from '@ethersproject/units';
+import { formatUnits } from '@ethersproject/units';
 import { useQuery } from '@tanstack/vue-query';
 import { abis } from '@/helpers/abis';
 import {
@@ -13,6 +13,7 @@ import { AuctionDetailFragment } from '@/helpers/auction/gql/graphql';
 import { getOrderBuyAmount } from '@/helpers/auction/orders';
 import { CHAIN_IDS } from '@/helpers/constants';
 import { getProvider } from '@/helpers/provider';
+import { parseUnits } from '@/helpers/token';
 import { _n, _t } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
 
@@ -214,23 +215,15 @@ const hasErrors = computed<boolean>(() => {
   );
 });
 
-// TODO: decide what to do with this function.
-// We could write our own variant and use it throughout the codebase.
-// Or we could just use ethers.js parseUnits directly.
-// Plain parseFloat() * 10 ** decimals could lead to precision issues.
-function toRawUnits(value: string, decimals: number): bigint {
-  return parseUnits(value, decimals).toBigInt();
-}
-
 function handlePlaceOrder() {
   if (hasErrors.value) return;
 
-  const sellAmount = toRawUnits(
+  const sellAmount = parseUnits(
     bidAmount.value,
     Number(props.auction.decimalsBiddingToken)
   );
 
-  const price = toRawUnits(
+  const price = parseUnits(
     bidPrice.value,
     Number(props.auction.decimalsBiddingToken)
   );

--- a/apps/ui/src/helpers/token.ts
+++ b/apps/ui/src/helpers/token.ts
@@ -1,5 +1,6 @@
 import { Contract } from '@ethersproject/contracts';
 import { Web3Provider } from '@ethersproject/providers';
+import { parseUnits as _parseUnits } from '@ethersproject/units';
 import { abis } from '@/helpers/abis';
 
 export async function getTokenAllowance(
@@ -27,4 +28,8 @@ export async function approve(
   const contract = new Contract(tokenAddress, abis.erc20, web3.getSigner());
 
   return contract.approve(spenderAddress, amount);
+}
+
+export function parseUnits(value: string, decimals: number): bigint {
+  return _parseUnits(value, decimals).toBigInt();
 }

--- a/apps/ui/src/helpers/transactions.ts
+++ b/apps/ui/src/helpers/transactions.ts
@@ -1,5 +1,4 @@
 import { Interface } from '@ethersproject/abi';
-import { parseUnits } from '@ethersproject/units';
 import {
   ContractCallTransaction,
   SendNftTransaction,
@@ -12,6 +11,7 @@ import { Nft } from '@/composables/useNfts';
 import { abis } from '@/helpers/abis';
 import { Token } from '@/helpers/alchemy';
 import { resolver } from '@/helpers/resolver';
+import { parseUnits } from '@/helpers/token';
 import { getSalt } from '@/helpers/utils';
 
 export async function createSendTokenTransaction({

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -1,11 +1,11 @@
 import { Interface } from '@ethersproject/abi';
 import { isAddress } from '@ethersproject/address';
-import { parseUnits } from '@ethersproject/units';
 import Ajv, { ErrorObject } from 'ajv';
 import ajvErrors from 'ajv-errors';
 import addFormats from 'ajv-formats';
 import { validateAndParseAddress } from 'starknet';
 import { resolver } from '@/helpers/resolver';
+import { parseUnits } from '@/helpers/token';
 import { _n } from './utils';
 
 type Opts = { skipEmptyOptionalFields: boolean };


### PR DESCRIPTION
### Summary

Wrapper around ethers parseUnits that always returns bigint. This should be preferred over using parseUnits directly, writing our own via value * 10 ** decimals.

Having this wrapper we should be able to make swapping implementation easier.

From discussion there: https://github.com/snapshot-labs/sx-monorepo/pull/1803#discussion_r2599388609

We still can figure out exact approach and naming, but this is a starting point and if agree it's fine like this we can merge this and start using it more.