### PR TITLE
fix(auction): account for decimals in price computation

### DIFF
--- a/apps/ui/src/helpers/auction/actions.ts
+++ b/apps/ui/src/helpers/auction/actions.ts
@@ -29,9 +29,14 @@ export async function placeSellOrder(
   );
   let previousOrderId: string;
 
-  const price = new Decimal(sellOrder.sellAmount).div(
-    new Decimal(sellOrder.buyAmount)
+  const sellAmount = new Decimal(sellOrder.sellAmount).div(
+    10n ** BigInt(auction.decimalsBiddingToken)
   );
+  const buyAmount = new Decimal(sellOrder.buyAmount).div(
+    10n ** BigInt(auction.decimalsAuctioningToken)
+  );
+
+  const price = sellAmount.div(buyAmount);
 
   try {
     previousOrderId = await getPreviousOrderId(


### PR DESCRIPTION
### Summary

This price is needed to query previous order ID.

After https://github.com/snapshot-labs/sx-monorepo/pull/1799 we compute price from sell and buy amounts, but it didn't account for decimals.

This PR fixes that.

### How to test

1. Go to http://localhost:8080/#/auction/sep:120
2. Try creating an order.
3. It works.

