### PR TITLE
fix: allow smaller sidebar width

### DIFF
--- a/apps/ui/src/views/Auction/Overview.vue
+++ b/apps/ui/src/views/Auction/Overview.vue
@@ -547,7 +547,9 @@ function handleScrollEvent(target: HTMLElement) {
     />
   </teleport>
 
-  <div class="w-[400px] md:h-full z-40 border-l-0 md:border-l bg-skin-bg">
+  <div
+    class="w-full max-w-[400px] md:h-full z-40 border-l-0 md:border-l bg-skin-bg"
+  >
     <Affix data-testid="proposal-sidebar" :top="TOTAL_NAV_HEIGHT" :bottom="64">
       <div>
         <UiScrollerHorizontal with-buttons gradient="xxl">


### PR DESCRIPTION
### Summary

400px was overflowing on small screens. It should be at most 400px, not always 400px.
