### PR TITLE
fix: format minimum price with decimals

### DIFF
--- a/apps/ui/src/components/FormAuctionBid.vue
+++ b/apps/ui/src/components/FormAuctionBid.vue
@@ -64,11 +64,6 @@ const formatErrors = computed(() =>
   })
 );
 
-const priceUnit = computed(
-  () =>
-    `${props.auction.symbolBiddingToken} per ${props.auction.symbolAuctioningToken}`
-);
-
 const canCancelOrder = computed(
   () => parseInt(props.auction.orderCancellationEndDate) > Date.now() / 1000
 );
@@ -132,7 +127,7 @@ const priceError = computed(() => {
 
   const minimumSellPrice = parseFloat(props.auction.exactOrder?.price || '0');
   if (minimumSellPrice && price <= minimumSellPrice) {
-    return `Minimum ${_n(minimumSellPrice, 'standard', { maximumFractionDigits: Number(props.auction.decimalsBiddingToken) })} ${priceUnit.value}`;
+    return `Must be higher than ${_n(minimumSellPrice, 'standard', { maximumFractionDigits: Number(props.auction.decimalsBiddingToken) })} ${props.auction.symbolBiddingToken}`;
   }
 
   const maxBiddingPrice = price.toFixed(


### PR DESCRIPTION
### Summary

This PR addresses issue where small min amounts would be formatted as 0.

### How to test

1. Go to http://localhost:8080/#/auction/sep:123
2. You see real minimum instead of 0.
