### PR TITLE
feat(auction): improve price conversions with small values

### DIFF
--- a/apps/ui/src/components/FormAuctionBid.vue
+++ b/apps/ui/src/components/FormAuctionBid.vue
@@ -7,13 +7,15 @@ import { AuctionNetworkId, Order, SellOrder } from '@/helpers/auction';
 import { AuctionDetailFragment } from '@/helpers/auction/gql/graphql';
 import { getOrderBuyAmount } from '@/helpers/auction/orders';
 import { CHAIN_IDS } from '@/helpers/constants';
+import { removeTrailingZeroes } from '@/helpers/format';
 import { getProvider } from '@/helpers/provider';
 import { parseUnits } from '@/helpers/token';
 import { _n, _p, _t } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
 
+const MIN_PRICE_PREMIUM = 0.01; // 1% above minimum price
 const PRICE_PREMIUM = 0.25; // 25% above clearing price will show as 100% chance to pass
-const AMOUNT_DECIMALS = 4;
+const AMOUNT_DECIMALS = 6;
 
 const AMOUNT_DEFINITION = {
   type: 'string',
@@ -160,18 +162,24 @@ const hasErrors = computed<boolean>(() => {
 // and use it across the entire app.
 function convertPercentageToPrice(percentage: number) {
   const clearingPrice = parseFloat(props.auction.currentClearingPrice);
+  const minPrice = parseFloat(props.auction.exactOrder?.price || '0');
+
+  const basePrice = Math.max(clearingPrice, minPrice * (1 + MIN_PRICE_PREMIUM));
 
   const premium = clearingPrice * PRICE_PREMIUM;
-  const premiumPrice = clearingPrice + (percentage / 100) * premium;
+  const premiumPrice = basePrice + (percentage / 100) * premium;
 
   return premiumPrice;
 }
 
 function convertPriceToPercentage(price: number) {
   const clearingPrice = parseFloat(props.auction.currentClearingPrice);
+  const minPrice = parseFloat(props.auction.exactOrder?.price || '0');
+
+  const basePrice = Math.max(clearingPrice, minPrice * (1 + MIN_PRICE_PREMIUM));
 
   const premium = clearingPrice * PRICE_PREMIUM;
-  const difference = price - clearingPrice;
+  const difference = price - basePrice;
   const percentage = (difference / premium) * 100;
 
   return Math.min(Math.max(percentage, 0), 100);
@@ -206,28 +214,6 @@ function handlePlaceOrder() {
   });
 }
 
-function handlePriceUpdate(value: string, fromSlider = false) {
-  bidPrice.value = value;
-
-  const price = parseFloat(value);
-  if (!price || !props.totalSupply) {
-    bidFdv.value = '';
-    return;
-  }
-
-  const totalSupplyFormatted = parseFloat(
-    formatUnits(props.totalSupply, props.auction.decimalsAuctioningToken)
-  );
-
-  const fdv = price * totalSupplyFormatted;
-
-  bidFdv.value = fdv.toFixed(AMOUNT_DECIMALS);
-
-  if (!fromSlider) {
-    sliderValue.value = convertPriceToPercentage(price);
-  }
-}
-
 function getColor(progress: number) {
   // Hardcoded colors for the gradient.
   // Could be computed from the config, but we define those in RGBA so we would need to add code to convert them to HSL.
@@ -256,6 +242,28 @@ function getColor(progress: number) {
   return `hsl(${hue}deg ${saturation}% ${lightness}%)`;
 }
 
+function handlePriceUpdate(value: string, fromSlider = false) {
+  bidPrice.value = value;
+
+  const price = parseFloat(value);
+  if (!price || !props.totalSupply) {
+    bidFdv.value = '';
+    return;
+  }
+
+  const totalSupplyFormatted = parseFloat(
+    formatUnits(props.totalSupply, props.auction.decimalsAuctioningToken)
+  );
+
+  const fdv = price * totalSupplyFormatted;
+
+  bidFdv.value = removeTrailingZeroes(fdv, AMOUNT_DECIMALS);
+
+  if (!fromSlider) {
+    sliderValue.value = convertPriceToPercentage(price);
+  }
+}
+
 function handleFdvUpdate(value: string) {
   bidFdv.value = value;
 
@@ -272,14 +280,14 @@ function handleFdvUpdate(value: string) {
   const price = fdv / totalSupplyFormatted;
   sliderValue.value = convertPriceToPercentage(price);
 
-  bidPrice.value = price.toFixed(AMOUNT_DECIMALS);
+  bidPrice.value = removeTrailingZeroes(price, AMOUNT_DECIMALS);
 }
 
 function handleSliderChange(value: number) {
   sliderValue.value = value;
 
   const price = convertPercentageToPrice(sliderValue.value);
-  handlePriceUpdate(price.toFixed(AMOUNT_DECIMALS), true);
+  handlePriceUpdate(removeTrailingZeroes(price, AMOUNT_DECIMALS), true);
 }
 
 onMounted(() => {

--- a/apps/ui/src/helpers/format.test.ts
+++ b/apps/ui/src/helpers/format.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { removeTrailingZeroes } from './format';
+
+describe('removeTrailingZeroes', () => {
+  it.for([
+    { value: 123.45, maxDecimals: 6, expected: '123.45' },
+    { value: 123.0, maxDecimals: 6, expected: '123' },
+    { value: 123.456789, maxDecimals: 4, expected: '123.4568' },
+    { value: 123.4, maxDecimals: 2, expected: '123.4' },
+    { value: 123.0001, maxDecimals: 6, expected: '123.0001' },
+    { value: 123.9999999, maxDecimals: 6, expected: '124' },
+    { value: 0.0000001, maxDecimals: 6, expected: '0' },
+    { value: 0.1234567, maxDecimals: 6, expected: '0.123457' }
+  ])(
+    'removes trailing zeroes from $value with maxDecimals $maxDecimals',
+    ({ value, maxDecimals, expected }) => {
+      const result = removeTrailingZeroes(value, maxDecimals);
+      expect(result).toBe(expected);
+    }
+  );
+});

--- a/apps/ui/src/helpers/format.ts
+++ b/apps/ui/src/helpers/format.ts
@@ -1,0 +1,3 @@
+export function removeTrailingZeroes(value: number, maxDecimals: number) {
+  return parseFloat(value.toFixed(maxDecimals)).toString();
+}


### PR DESCRIPTION
### Summary

This PR improves two things around price conversions with small values:
1. We increase number of decimals supported with removal of trailing zeroes to address issue of slider not affecting price if small reference price is used.
2. We compute new reference price as higher of currentPrice or minimumPrice * 1.01 to avoid 0% slider landing on minimumPrice which is invalid.

### How to test

1. Go to http://localhost:8080/#/auction/sep:123
2. Play with slider and inptus.
3. You see prices changing as slider is used.
4. You don't see error when slider is at 0%.
