### PR TITLE
refactor: remove retry from usePaymentQuery

### DIFF
--- a/apps/ui/src/queries/payments.ts
+++ b/apps/ui/src/queries/payments.ts
@@ -9,7 +9,6 @@ const SCHNAPS_URLS: Record<string, string> = {
 };
 
 const PAYMENTS_LIMIT = 20;
-const RETRY_COUNT = 3;
 
 export type Payment = {
   id: string;
@@ -87,11 +86,6 @@ export function usePaymentsQuery(
       if (lastPage.length < PAYMENTS_LIMIT) return null;
 
       return pages.length * PAYMENTS_LIMIT;
-    },
-    retry: (failureCount, error) => {
-      if (error?.message.includes('Row not found')) return false;
-
-      return failureCount < RETRY_COUNT;
     }
   });
 }


### PR DESCRIPTION
### Summary

This error can't be thrown in this query as it uses multi-entity query.

If this error could be thrown it should also be handled differently, in `queryFn` directly otherwise this would be stuck in error state (but just returning empty array makes more sense).