### PR TITLE
feat(auction): display volume

### DIFF
--- a/apps/ui/src/views/Auction/Overview.vue
+++ b/apps/ui/src/views/Auction/Overview.vue
@@ -151,6 +151,12 @@ const fdv = computed(
     )
 );
 
+const volume = computed(
+  () =>
+    Number(props.auction.currentBiddingAmount) /
+    10 ** Number(props.auction.decimalsBiddingToken)
+);
+
 const userOrdersSummary = computed(() => {
   let auctioningTokenToClaim = 0n;
   let biddingTokenToClaim = 0n;
@@ -399,9 +405,15 @@ function handleScrollEvent(target: HTMLElement) {
           />
           <AuctionCounter
             :title="isAuctionOpen ? 'Current volume' : 'Total volume'"
-            amount="N/A"
+            :amount="_n(volume, 'compact')"
             :symbol="auction.symbolBiddingToken"
-            subamount="N/A"
+            :subamount="`$${_n(
+              biddingTokenPrice ? volume * biddingTokenPrice : 0,
+              'standard',
+              {
+                maximumFractionDigits: 0
+              }
+            )}`"
           />
         </div>
         <div v-if="countdown" class="flex gap-3.5">


### PR DESCRIPTION
### Summary

Looks like volume was already available (as `currentBiddingAmount`).

Also updated counter titles as mentioned [here](https://github.com/snapshot-labs/sx-monorepo/pull/1817#issuecomment-3665291911), because I missed it before.

### How to test

1. Go to http://localhost:8080/#/auction/eth:98/
2. You see volume.

### Screenshots

<img width="864" height="741" alt="image" src="https://github.com/user-attachments/assets/55c13208-a84e-4f4e-9767-5d51c3f5a1c3" />
