### PR TITLE
chore(auction): disable autocomplete on UiRawInputAmount

### DIFF
--- a/apps/ui/src/components/Ui/RawInputAmount.vue
+++ b/apps/ui/src/components/Ui/RawInputAmount.vue
@@ -38,5 +38,11 @@ function handleInput(event: Event) {
 </script>
 
 <template>
-  <input :value="model" type="text" inputmode="decimal" @input="handleInput" />
+  <input
+    :value="model"
+    type="text"
+    inputmode="decimal"
+    autocomplete="off"
+    @input="handleInput"
+  />
 </template>


### PR DESCRIPTION
### Summary

For some reason it was sometimes being saved in autocomplete history.