### PR TITLE
ci: increase reference commit count for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          fetch-depth: 100
+          fetch-depth: 1000
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
         with:
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 1000
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
         with:


### PR DESCRIPTION
### Summary

We need to fetch some history to compare current deployed commit and new commit to see if files has changed.

Increased it to 1000 on both API and mana (Mana was broken because it only compared 2 commits because it was not updated when we moved to new change detection).