### PR TITLE
fix: allow all routes on dev mode

### DIFF
--- a/apps/ui/src/routes/index.ts
+++ b/apps/ui/src/routes/index.ts
@@ -22,7 +22,11 @@ if (isAuctionApp.value) {
   // At this stage, we're not sure whether the app is a whitelabel
   const baseRoutes = !resolved.value ? [splashRoute] : defaultRoutes;
   // In dev mode, include auction routes
-  routes = import.meta.env.DEV ? [...baseRoutes, ...auctionRoutes] : baseRoutes;
+  routes =
+    import.meta.env.DEV &&
+    import.meta.env.VITE_BROKESTER_URL === 'https://brokester.box'
+      ? [...baseRoutes, ...auctionRoutes]
+      : baseRoutes;
 }
 
 const router = createRouter({


### PR DESCRIPTION
### Summary
**Issue:** Right now it is very hard to switch .env when ever we develop some feature with auction then on normal app
**Fix:** we should allow auction routes dev mode, but still be able to test the separate layout functionality from https://github.com/snapshot-labs/sx-monorepo/pull/1839

### Possibilities:
| VITE_BROKESTER_URL | Access URL | Routes Available |
|-------------------|------------|------------------|
| `http://127.0.0.1:8080` | `http://127.0.0.1:8080` | Auction only |
| `http://127.0.0.1:8080` | `http://localhost:8080` | Default only|
| `http://localhost:8080` | `http://127.0.0.1:8080` | Both (default + auction) |
| `http://localhost:8080` | `http://localhost:8080` | Auction only |
| `https://brokester.box` | `http://127.0.0.1:8080` | Both (default + auction) |
| `https://brokester.box` | `http://localhost:8080` | Both (default + auction) |
| *(not set)* | `http://127.0.0.1:8080` | Both (default + auction) |
| *(not set)* | `http://localhost:8080` | Both (default + auction) |

### How to test

1. Should be able to test everything from https://github.com/snapshot-labs/sx-monorepo/pull/1839
2. But with `VITE_BROKESTER_URL=https://brokester.box` and `yarn dev` we should be able to access all pages 