### PR TITLE
fix: add missing margin around claim button

### DIFF
--- a/apps/ui/src/views/Auction/Overview.vue
+++ b/apps/ui/src/views/Auction/Overview.vue
@@ -551,14 +551,16 @@ function handleScrollEvent(target: HTMLElement) {
             </div>
           </UiScrollerHorizontal>
         </div>
-        <UiButton
-          v-if="claimText"
-          class="w-full mt-4"
-          primary
-          @click="handleClaimOrders"
-        >
-          {{ claimText }}
-        </UiButton>
+        <div class="px-4">
+          <UiButton
+            v-if="claimText"
+            class="w-full"
+            primary
+            @click="handleClaimOrders"
+          >
+            {{ claimText }}
+          </UiButton>
+        </div>
       </template>
     </div>
     <div v-else-if="bidsType === 'allBids'" class="space-y-4">


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/701

This PR fix the missing margin around the "Claim" button

### How to test

1. Go to an auction where you can claim
2. There is a margin on the left and right of the claim button
