### PR TITLE
fix: mark cancelled not-settled auctions as finalizing

### DIFF
--- a/apps/ui/src/helpers/auction/index.ts
+++ b/apps/ui/src/helpers/auction/index.ts
@@ -9,6 +9,7 @@ import {
   previousOrderQuery,
   unclaimedOrdersQuery
 } from './queries';
+import { ChartGranularity } from '../charts';
 import { getNames } from '../stamp';
 import {
   AuctionDetailFragment,
@@ -27,7 +28,6 @@ import {
   AuctionState,
   Order
 } from './types';
-import { ChartGranularity } from '../charts';
 
 export * from './types';
 
@@ -71,11 +71,10 @@ export function getAuctionState(
   const currentBiddingAmount = BigInt(auction.currentBiddingAmount);
   const minFundingThreshold = BigInt(auction.minFundingThreshold);
 
+  if (!auction.clearingPriceOrder) return 'finalizing';
   if (currentBiddingAmount < minFundingThreshold) return 'canceled';
 
   if (auction.ordersWithoutClaimed?.length) {
-    if (!auction.clearingPriceOrder) return 'finalizing';
-
     return 'claiming';
   }
 


### PR DESCRIPTION
### Summary

Before it would go straight to cancelled state and it would show claim button, which would not work.

Closes: https://github.com/snapshot-labs/workflow/issues/702

### How to test

1. Go to http://localhost:8080/#/auction/sep:138?as=0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70
2. It's finalizing and there is no claiming button.
3. Go to https://testnet.brokester.box/#/auction/sep:138?as=0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70 and there is claiming button (there shouldn't be).

