### PR TITLE
fix: check loading state for userRefereesOrders

### DIFF
--- a/apps/ui/src/components/FormAuctionReferral.vue
+++ b/apps/ui/src/components/FormAuctionReferral.vue
@@ -63,7 +63,7 @@ const {
 const {
   data: userRefereesOrders,
   isError: isUserRefereesOrdersError,
-  isPending: isUserRefereesOrdersPending
+  isLoading: isUserRefereesOrdersLoading
 } = useBidsSummaryQuery({
   network: () => props.network,
   auction: () => props.auction,
@@ -223,7 +223,7 @@ async function handleConfirmed() {
       <div v-if="web3Account && userReferees">
         <h4 class="py-2">Your rewards</h4>
         <UiLoading
-          v-if="isUserRefereesPending || isUserRefereesOrdersPending"
+          v-if="isUserRefereesPending || isUserRefereesOrdersLoading"
           class="py-3 block"
         />
         <UiStateWarning


### PR DESCRIPTION
### Summary

This query is not always enabled so we want to only show loading when it's loading, not where it's pending.

### How to test

1. Go to http://localhost:8080/#/auction/sep:125?as=less.eth
2. Go to Referral tab
3. You see rewards (0).
