### PR TITLE
fix(auction): update referral leaderboard header position

### DIFF
--- a/apps/ui/src/components/FormAuctionReferral.vue
+++ b/apps/ui/src/components/FormAuctionReferral.vue
@@ -262,7 +262,9 @@ async function handleConfirmed() {
   <div class="border-t border-skin-border">
     <h4 class="px-4 py-2">Leaderboard</h4>
 
-    <UiColumnHeader class="overflow-hidden gap-3">
+    <UiColumnHeader
+      class="overflow-hidden gap-3 !top-header-height-with-offset"
+    >
       <div class="flex-1 min-w-0 truncate">Referee</div>
       <div class="w-[80px] text-right truncate">Referrals</div>
     </UiColumnHeader>


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/708

### How to test

1. Go to http://localhost:8080/#/auction/sep:142
2. Select Referral tab.
3. Make your window has less than 400px height.
4. Scroll down.
5. Column header is positioned correctly.

### Screenshots

<img width="369" height="365" alt="image" src="https://github.com/user-attachments/assets/c330c8d0-c3f2-48ea-9f15-fd63b52ac56e" />
