### PR TITLE
fix: require at least one digit before dot

### DIFF
--- a/apps/ui/src/components/Ui/RawInputAmount.vue
+++ b/apps/ui/src/components/Ui/RawInputAmount.vue
@@ -9,10 +9,10 @@ const props = defineProps<{
 
 const pattern = computed(() => {
   if (!props.decimals) {
-    return /^[0-9]*[.]?[0-9]*$/;
+    return /^[0-9]+[.]?[0-9]*$/;
   }
 
-  return new RegExp(`^[0-9]*[.]?[0-9]{0,${props.decimals}}$`);
+  return new RegExp(`^[0-9]+[.]?[0-9]{0,${props.decimals}}$`);
 });
 
 function handleInput(event: Event) {


### PR DESCRIPTION
### Summary

Before we allowed "." as input value and it was causing issues as it's not a number.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1850

### How to test

1. Go to http://localhost:8080/#/auction/sep:141
2. You cannot type "." without proceeding digit.
