### PR TITLE
fix: improve price history chart for recent auctions

### DIFF
--- a/apps/ui/src/components/AuctionChartPriceHistory.vue
+++ b/apps/ui/src/components/AuctionChartPriceHistory.vue
@@ -33,8 +33,14 @@ const granularity = computed<ChartGranularity>(() => {
   const auctionDuration =
     Number(props.auction.endTimeTimestamp) -
     Number(props.auction.startingTimeStamp);
+  const auctionSinceStart =
+    Math.floor(Date.now() / 1000) - Number(props.auction.startingTimeStamp);
 
-  if ((offset.value && offset.value <= ONE_DAY) || auctionDuration <= ONE_DAY) {
+  if (
+    (offset.value && offset.value <= ONE_DAY) ||
+    auctionDuration <= ONE_DAY ||
+    auctionSinceStart <= ONE_DAY
+  ) {
     return 'minute';
   }
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/699

This PR improves the chart visual appearance for recently started auctions
While this does not fix the issue completely, it mitigates it.

BEFORE: we use the hour granularity for the ALL time window (if the auction last more than one day). This creates a chart with only a single point, not filling the whole chart, and a chart with 2 points after 2 hours, etc...

![Screenshot 2026-01-19 at 09 42 02](https://github.com/user-attachments/assets/94c87054-554b-4d7b-9b71-65b27170880d)

NOW: We always use the minute granularity when the chart time window is smaller than one day: the chart is creating more points, and filling the chart gradually each minute, and looks like this after 12 minutes into the auction:

<img width="2102" height="784" alt="image" src="https://github.com/user-attachments/assets/fff57427-47f1-4ddb-b1d7-a41be04570e6" />


### How to test

1. Create a new auction (or use http://localhost:8080/#/auction/sep:144, but may not work anymore since time dependent)
2. The price history chart uses the minute granularity if started less than one day ago. The chart contains as much points as minute elapsed since auction start, and gradually fill the chart, instead of always showing a single point for the hour.
