### PR TITLE
fix: hide negative y-axis labels

### DIFF
--- a/apps/ui/src/components/Ui/ChartPriceDepth.vue
+++ b/apps/ui/src/components/Ui/ChartPriceDepth.vue
@@ -109,7 +109,8 @@ const { chartContainer, chart } = useChart({
     localization: {
       ...CHART_DEFAULT_OPTIONS.localization,
       // Format the x-axis time as price
-      timeFormatter: (time: number) => formatNumber(time, priceDelta.value)
+      timeFormatter: (time: number) => formatNumber(time, priceDelta.value),
+      priceFormatter: (price: number) => (price < 0 ? '' : formatNumber(price))
     },
     timeScale: {
       ...CHART_DEFAULT_OPTIONS.timeScale,


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/715

This PR will hide the negative values on the auction depth chart Y-axis

The charting library has some limitation on how we can customize the y-axis. The current fix will only hide the negative labels, without rescaling the chart, ideally we want the line to be closer to the bottom, but there's no control over that.

BEFORE

<img width="2092" height="782" alt="image" src="https://github.com/user-attachments/assets/ba291ff8-230a-4bc2-a198-53c3cb679f92" />

AFTER

<img width="2090" height="806" alt="image" src="https://github.com/user-attachments/assets/ee61548b-e24e-48c5-931a-044df53fb59e" />


### How to test

1. Go to http://localhost:8080/#/auction/sep:144
2. No more negative prices on the Y axis
