### PR TITLE
fix: update depth chart clearing price color

### DIFF
--- a/apps/ui/src/components/Ui/ChartPriceDepth.vue
+++ b/apps/ui/src/components/Ui/ChartPriceDepth.vue
@@ -31,8 +31,6 @@ const ABOVE_CLEARING_PRICE_SERIES_OPTIONS: AreaSeriesPartialOptions = {
   priceLineVisible: false
 };
 
-const CLEARING_PRICE_COLOR = '#f59e0b';
-
 const props = defineProps<{
   data: SingleValueData[];
   auction: AuctionDetailFragment;
@@ -153,12 +151,7 @@ function formatNumber(value: number, range?: number): string {
       </div>
     </UiChartTooltip>
 
-    <UiChartVerticalLine
-      v-if="chart"
-      :chart="chart"
-      :value="clearingPrice"
-      :color="CLEARING_PRICE_COLOR"
-    >
+    <UiChartVerticalLine v-if="chart" :chart="chart" :value="clearingPrice">
       Clearing:
       {{
         _n(clearingPrice, 'standard', {

--- a/apps/ui/src/components/Ui/ChartVerticalLine.vue
+++ b/apps/ui/src/components/Ui/ChartVerticalLine.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { IChartApi, Time } from 'lightweight-charts';
+import { CHART_SERIES_COLORS } from '@/composables/useChart';
 import { Coordinates, getSmartPosition } from '@/helpers/charts';
 
 type LinePosition = Coordinates & {
@@ -11,7 +12,6 @@ const LABEL_MARGIN = 0;
 const props = defineProps<{
   chart: IChartApi;
   value: number;
-  color: string;
 }>();
 
 const linePosition = ref<LinePosition>({ x: 0, y: 0, height: 0 });
@@ -19,6 +19,10 @@ const labelPosition = ref<Coordinates>({ x: 0, y: 0 });
 const isLineVisible = ref(false);
 const isLabelVisible = ref(false);
 const labelRef = ref<HTMLDivElement>();
+
+const { currentTheme } = useTheme();
+
+const color = computed(() => CHART_SERIES_COLORS[currentTheme.value].lineColor);
 
 const chartContainer = computed(() => {
   return props.chart.chartElement() || null;

--- a/apps/ui/src/composables/useChart.ts
+++ b/apps/ui/src/composables/useChart.ts
@@ -16,7 +16,7 @@ import {
 import { MaybeRef } from 'vue';
 import { getPriceFormat } from '@/helpers/charts';
 
-const CHART_SERIES_COLORS = {
+export const CHART_SERIES_COLORS = {
   light: {
     lineColor: 'rgba(17, 17, 17, 0.8)',
     areaTopColor: 'rgba(17, 17, 17, 0.4)',


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR updates the clearing price line color in the depth chart, from orange to chart basic color (reacting to theme)

<img width="2110" height="778" alt="image" src="https://github.com/user-attachments/assets/54279684-f158-42a0-b194-376c1a0ad77b" />


### How to test

1. Go to http://localhost:8080/#/auction/sep:144
2. The clearing price should be black/white, depending on theme
