### PR TITLE
feat(auction): add View on block explorer link to orders

### DIFF
--- a/apps/ui/src/components/AuctionBid.vue
+++ b/apps/ui/src/components/AuctionBid.vue
@@ -2,14 +2,19 @@
 import { formatPrice, Order } from '@/helpers/auction';
 import { AuctionDetailFragment } from '@/helpers/auction/gql/graphql';
 import { _c, _n, _t, shortenAddress } from '@/helpers/utils';
+import { getNetwork } from '@/networks';
+import { NetworkID } from '@/types';
 
 const props = defineProps<{
+  networkId: NetworkID;
   auctionId: string;
   auction: AuctionDetailFragment;
   order: Order;
   biddingTokenPrice: number;
   totalSupply: bigint;
 }>();
+
+const network = computed(() => getNetwork(props.networkId));
 
 const amountValue = computed(
   () =>
@@ -106,7 +111,11 @@ const fdvValue = computed(() => fdv.value * props.biddingTokenPrice);
           </button>
         </template>
         <template #items>
-          <UiDropdownItem disabled>
+          <UiDropdownItem
+            :to="
+              network.helpers.getExplorerUrl(order.transactionId, 'transaction')
+            "
+          >
             <IH-arrow-sm-right class="-rotate-45" :width="16" />
             View on block explorer
           </UiDropdownItem>

--- a/apps/ui/src/components/AuctionUserBid.vue
+++ b/apps/ui/src/components/AuctionUserBid.vue
@@ -2,8 +2,11 @@
 import { formatPrice, Order } from '@/helpers/auction';
 import { AuctionDetailFragment } from '@/helpers/auction/gql/graphql';
 import { _c, _n, _t } from '@/helpers/utils';
+import { getNetwork } from '@/networks';
+import { NetworkID } from '@/types';
 
 const props = defineProps<{
+  networkId: NetworkID;
   auctionId: string;
   auction: AuctionDetailFragment;
   order: Order;
@@ -15,6 +18,8 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'cancel', order: Order): void;
 }>();
+
+const network = computed(() => getNetwork(props.networkId));
 
 const isCancellable = computed(() => {
   return Number(props.auction.orderCancellationEndDate) * 1000 > Date.now();
@@ -123,6 +128,14 @@ const fdvValue = computed(() => fdv.value * props.biddingTokenPrice);
           >
             <IS-x-mark :width="16" />
             Cancel bid
+          </UiDropdownItem>
+          <UiDropdownItem
+            :to="
+              network.helpers.getExplorerUrl(order.transactionId, 'transaction')
+            "
+          >
+            <IH-arrow-sm-right class="-rotate-45" :width="16" />
+            View on block explorer
           </UiDropdownItem>
         </template>
       </UiDropdown>

--- a/apps/ui/src/helpers/auction/queries.ts
+++ b/apps/ui/src/helpers/auction/queries.ts
@@ -45,6 +45,7 @@ gql(`
     price
     volume
     timestamp
+    transactionId
   }
 `);
 

--- a/apps/ui/src/views/Auction/Overview.vue
+++ b/apps/ui/src/views/Auction/Overview.vue
@@ -538,10 +538,11 @@ function handleScrollEvent(target: HTMLElement) {
                 <AuctionUserBid
                   v-for="order in userOrders"
                   :key="order.id"
-                  :order-status="userOrdersSummary.statuses[order.id]"
+                  :network-id="network"
                   :auction-id="auctionId"
                   :auction="auction"
                   :order="order"
+                  :order-status="userOrdersSummary.statuses[order.id]"
                   :bidding-token-price="biddingTokenPrice"
                   :total-supply="totalSupply"
                   @cancel="handleCancelSellOrder"
@@ -613,6 +614,7 @@ function handleScrollEvent(target: HTMLElement) {
               <AuctionBid
                 v-for="order in allOrders?.pages.flat()"
                 :key="order.id"
+                :network-id="network"
                 :auction-id="auctionId"
                 :auction="auction"
                 :order="order"


### PR DESCRIPTION
### Summary

`transactionId` is already indexed on the subgraph.

Here we add link to explorer on all orders (including on My bids).


Closes: https://github.com/snapshot-labs/workflow/issues/720

### How to test

1. Go to http://localhost:8080/#/auction/sep:105 as boorger.eth
2. Check `My bids` and `Bids` tabs.
3. All orders have links to explorer in three dot menu.
