### PR TITLE
fix(auction): use loading state if account is still loading

### DIFF
--- a/apps/ui/src/composables/useAuctionVerification.ts
+++ b/apps/ui/src/composables/useAuctionVerification.ts
@@ -45,7 +45,7 @@ export function useAuctionVerification({
     isPrivateAuction: boolean;
   }>;
 }) {
-  const { web3Account } = useWeb3();
+  const { web3, web3Account } = useWeb3();
   const { modalAccountOpen } = useModal();
   const uiStore = useUiStore();
 
@@ -179,7 +179,7 @@ export function useAuctionVerification({
 
   return {
     verificationProvider,
-    status,
+    status: computed(() => (web3.value.authLoading ? 'loading' : status.value)),
     isVerified,
     verificationUrl,
     error,


### PR DESCRIPTION
### Issue:
https://discord.com/channels/955773041898573854/1443196270423445504/1462775106106294437

### Summary
use loading state if web3 account is still loading

### How to test

1. Apply this to add extra time to load account
```ts
diff --git a/apps/ui/src/composables/useWeb3.ts b/apps/ui/src/composables/useWeb3.ts
index cb1de958..7be639a2 100644
--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -125,6 +125,7 @@ export function useWeb3() {
             web3.getNetwork(),
             web3.listAccounts()
           ]);
+          await new Promise(resolve => setTimeout(resolve, 10000));
         }
       } catch (e) {
         console.log(e);

```
- Go to http://localhost:8080/#/auction/sep:141?as=boorger.eth
- Before fix: you will see verify button when account is still loading
<img width="273" height="181" alt="image" src="https://github.com/user-attachments/assets/2cd053f8-472f-40de-8c32-0cab79c3fe92" />

- After fix: you should still see loading icon
