### PR TITLE
refactor: always use no-cache for ApolloClient

### DIFF
--- a/apps/ui/src/composables/useDelegates.ts
+++ b/apps/ui/src/composables/useDelegates.ts
@@ -309,7 +309,12 @@ export function useDelegates(
 
     const client = new ApolloClient({
       uri: delegationSubgraph,
-      cache: new InMemoryCache()
+      cache: new InMemoryCache(),
+      defaultOptions: {
+        query: {
+          fetchPolicy: 'no-cache'
+        }
+      }
     });
 
     const isApeChainDelegateRegistry =

--- a/apps/ui/src/helpers/auction/index.ts
+++ b/apps/ui/src/helpers/auction/index.ts
@@ -92,7 +92,12 @@ function getClient(network: AuctionNetworkId) {
 
   return new ApolloClient({
     uri: subgraphUrl,
-    cache: new InMemoryCache()
+    cache: new InMemoryCache(),
+    defaultOptions: {
+      query: {
+        fetchPolicy: 'no-cache'
+      }
+    }
   });
 }
 

--- a/apps/ui/src/helpers/auction/referral/index.ts
+++ b/apps/ui/src/helpers/auction/referral/index.ts
@@ -28,7 +28,12 @@ export type Invite = NonNullable<UserInviteQuery['invite']>;
 
 const client = new ApolloClient({
   uri: import.meta.env.VITE_BROKESTER_API_URL || 'https://api.brokester.box',
-  cache: new InMemoryCache()
+  cache: new InMemoryCache(),
+  defaultOptions: {
+    query: {
+      fetchPolicy: 'no-cache'
+    }
+  }
 });
 
 export async function getPartnerStatistics(
@@ -40,8 +45,7 @@ export async function getPartnerStatistics(
 
   const { data } = await client.query({
     query: PartnerStatisticsDocument,
-    variables: { indexer: networkId, tag, first, skip },
-    fetchPolicy: 'no-cache'
+    variables: { indexer: networkId, tag, first, skip }
   });
 
   return data.partnerstatistics;
@@ -56,8 +60,7 @@ export async function getUserInvite(
 
   const { data } = await client.query({
     query: UserInviteDocument,
-    variables: { indexer: networkId, id },
-    fetchPolicy: 'no-cache'
+    variables: { indexer: networkId, id }
   });
 
   return data.invite;
@@ -79,8 +82,7 @@ export async function getUserInvites(
       partner: partner.toLowerCase(),
       first,
       skip
-    },
-    fetchPolicy: 'no-cache'
+    }
   });
 
   return data.invites;

--- a/apps/ui/src/helpers/boost.ts
+++ b/apps/ui/src/helpers/boost.ts
@@ -87,7 +87,12 @@ async function getBoosts(proposalIds: string[]) {
   async function query(chainId: string) {
     const client = new ApolloClient({
       uri: SUBGRAPH_URLS[chainId],
-      cache: new InMemoryCache()
+      cache: new InMemoryCache(),
+      defaultOptions: {
+        query: {
+          fetchPolicy: 'no-cache'
+        }
+      }
     });
 
     const { data } = await client.query({


### PR DESCRIPTION
### Summary

None of this was breaking, because those were single use instances, but as we never depend on Apollo's cache to set reference for other usages we always disable cache so when this code gets reused it's prevent us from using basically forever cache.
