### PR TITLE
fix: hide depth chart when no there are no orders

### DIFF
--- a/apps/ui/src/views/Auction/Overview.vue
+++ b/apps/ui/src/views/Auction/Overview.vue
@@ -273,7 +273,7 @@ const transactionProgressFn = computed<() => Promise<string | null>>(() => {
 async function invalidateQueries() {
   await sleep(5000);
 
-  await queryClient.invalidateQueries({
+  queryClient.invalidateQueries({
     queryKey: AUCTION_KEYS.auction(props.network, props.auction)
   });
 }
@@ -320,18 +320,13 @@ function handleClaimOrders() {
   isModalTransactionProgressOpen.value = true;
 }
 
-async function handleTransactionConfirmed() {
+function handleTransactionConfirmed() {
   if (transactionProgressType.value === 'place-order') {
     return moveToNextStep();
   }
 
+  invalidateQueries();
   resetTransactionProgress();
-
-  await invalidateQueries();
-
-  if (volume.value === 0 && chartType.value !== DEFAULT_CHART_TYPE) {
-    chartType.value = DEFAULT_CHART_TYPE;
-  }
 }
 
 function handleAllOrdersEndReached() {
@@ -343,6 +338,12 @@ function handleAllOrdersEndReached() {
 function handleScrollEvent(target: HTMLElement) {
   bidsHeaderX.value = target.scrollLeft;
 }
+
+watch(volume, () => {
+  if (volume.value === 0 && chartType.value !== DEFAULT_CHART_TYPE) {
+    chartType.value = DEFAULT_CHART_TYPE;
+  }
+});
 </script>
 
 <template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/workflow/issues/715
Depends on https://github.com/snapshot-labs/sx-monorepo/pull/1870

This PR will hide the depth chart when the auction has no orders, to prevent showing a blank depth chart, with buggy Y-axis.

On auction without bids, the depth chart TAB is not show

<img width="2088" height="818" alt="image" src="https://github.com/user-attachments/assets/ebf5dc1e-4bb5-4d10-83c5-a465b27bff40" />

Condition is dynamic, so after placing the first bid, or deleting the only existing bid, the tab should hide/show based on the new orders count

### How to test

1. Go to an auction without orders (e.g http://localhost:8080/#/auction/eth:1)
2. The DEPTH CHART tab option is missing