### PR TITLE
fix: update auction data on new/deleted orders

### DIFF
--- a/apps/ui/src/queries/auction.ts
+++ b/apps/ui/src/queries/auction.ts
@@ -51,8 +51,16 @@ export const AUCTION_KEYS = {
   ],
   auction: (
     network: MaybeRefOrGetter<AuctionNetworkId>,
-    auction: MaybeRefOrGetter<AuctionDetailFragment>
-  ) => [...AUCTION_KEYS.all, network, 'detail', () => toValue(auction).id],
+    auction: MaybeRefOrGetter<AuctionDetailFragment | string>
+  ) => [
+    ...AUCTION_KEYS.all,
+    network,
+    () => {
+      const auctionValue = toValue(auction);
+
+      return typeof auctionValue === 'string' ? auctionValue : auctionValue.id;
+    }
+  ],
   orders: (
     network: MaybeRefOrGetter<AuctionNetworkId>,
     auction: MaybeRefOrGetter<AuctionDetailFragment>

--- a/apps/ui/src/views/Auction.vue
+++ b/apps/ui/src/views/Auction.vue
@@ -5,6 +5,7 @@ import { abis } from '@/helpers/abis';
 import { AuctionNetworkId, getAuction } from '@/helpers/auction';
 import { getProvider } from '@/helpers/provider';
 import { getNetwork } from '@/networks';
+import { AUCTION_KEYS } from '@/queries/auction';
 
 defineOptions({ inheritAttrs: false });
 
@@ -22,7 +23,10 @@ const {
   isLoading,
   error
 } = useQuery({
-  queryKey: computed(() => ['auction', params.value.network, params.value.id]),
+  queryKey: AUCTION_KEYS.auction(
+    toRef(params.value.network),
+    toRef(params.value.id)
+  ),
   queryFn: () => getAuction(params.value.id, params.value.network),
   enabled: computed(() => !!params.value.id)
 });

--- a/apps/ui/src/views/Auction/Overview.vue
+++ b/apps/ui/src/views/Auction/Overview.vue
@@ -272,11 +272,8 @@ const transactionProgressFn = computed<() => Promise<string | null>>(() => {
 async function invalidateQueries() {
   await sleep(5000);
 
-  queryClient.invalidateQueries({
+  await queryClient.invalidateQueries({
     queryKey: AUCTION_KEYS.auction(props.network, props.auction)
-  });
-  await queryClient.refetchQueries({
-    queryKey: ['auction', props.network, props.auction.id]
   });
 }
 


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

After placing/canceling an order, most of the page section auto-update to reflect the order (bids list, charts), but the main auction is still stale, resulting in a page with mixed fresh and stale data.

In particular, there will be discrepancy between the header stats (current clearing price, volume, etc...) and the charts/bids list. The FDV computation will also be based on stale data.

This PR will invalidate the main auction cache after placing/canceling a bid, so the whole auction page is updated with fresh data.

### How to test

1. Place an order in an auction
2. The header stats should refresh together with all other parts on cache invalidation
3. Same when cancelling an order

### Note

There's an issue when cancelling the only existing bid, subgraph still return the same data (see https://github.com/snapshot-labs/workflow/issues/721)