### PR TITLE
fix: add notification on bid cancellation

### DIFF
--- a/apps/ui/src/views/Auction/Overview.vue
+++ b/apps/ui/src/views/Auction/Overview.vue
@@ -324,7 +324,7 @@ function handleTransactionConfirmed() {
   if (transactionProgressType.value === 'place-order') {
     return moveToNextStep();
   } else if (transactionProgressType.value === 'cancel-order') {
-    uiStore.addNotification('success', 'Your bid has been cancelled');
+    uiStore.addNotification('success', 'Your bid has been cancelled.');
   }
   invalidateQueries();
   resetTransactionProgress();


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR adds a success notification on bid successful cancellation.

<img width="676" height="158" alt="image" src="https://github.com/user-attachments/assets/a2e65606-df2f-4b7f-ab2d-f4c627c55c6f" />

### How to test

1. Cancel a bid
2. It should show a success notification after transaction confirmation
