### PR TITLE
fix: properly convert route params to refs

### DIFF
--- a/apps/ui/src/views/Auction.vue
+++ b/apps/ui/src/views/Auction.vue
@@ -24,8 +24,8 @@ const {
   error
 } = useQuery({
   queryKey: AUCTION_KEYS.auction(
-    toRef(params.value.network),
-    toRef(params.value.id)
+    () => params.value.network,
+    () => params.value.id
   ),
   queryFn: () => getAuction(params.value.id, params.value.network),
   enabled: computed(() => !!params.value.id)


### PR DESCRIPTION
### Summary

toRef(value) doesn't create toRef from non-reactive values.

Regression from https://github.com/snapshot-labs/sx-monorepo/pull/1870

### How to test

1. Go to http://localhost:8080/#/auction/sep:145
2. Change `145` to `140` in the URL and submit.
3. New auction loads (before it would stay on old one unless you force refresh).