### PR TITLE
refactor: extract referral reward to its own component

### DIFF
--- a/apps/ui/src/components/FormAuctionReferral.vue
+++ b/apps/ui/src/components/FormAuctionReferral.vue
@@ -1,52 +1,16 @@
 <script setup lang="ts">
 import { AuctionNetworkId } from '@/helpers/auction';
 import { AuctionDetailFragment } from '@/helpers/auction/gql/graphql';
-import { compareOrders, decodeOrder } from '@/helpers/auction/orders';
-import {
-  DEFAULT_AUCTION_TAG,
-  REFERRAL_SHARE
-} from '@/helpers/auction/referral';
-import { _n, formatAddress, shortenAddress } from '@/helpers/utils';
-import { useBidsSummaryQuery } from '@/queries/auction';
-import {
-  usePartnerStatisticsQuery,
-  useUserInvitesQuery
-} from '@/queries/referral';
+import { DEFAULT_AUCTION_TAG } from '@/helpers/auction/referral';
+import { formatAddress, shortenAddress } from '@/helpers/utils';
+import { usePartnerStatisticsQuery } from '@/queries/referral';
 
 const props = defineProps<{
   network: AuctionNetworkId;
-  auction: AuctionDetailFragment;
+  auction?: AuctionDetailFragment;
 }>();
 
 const { web3Account } = useWeb3();
-
-const {
-  data: userInvites,
-  isError: isUserInvitesError,
-  isPending: isUserInvitesPending
-} = useUserInvitesQuery({
-  networkId: toRef(props, 'network'),
-  account: web3Account,
-  auctionTag: () => DEFAULT_AUCTION_TAG
-});
-
-const {
-  data: userBuyersOrders,
-  isError: isUserBuyersOrdersError,
-  isLoading: isUserBuyersOrdersLoading
-} = useBidsSummaryQuery({
-  network: () => props.network,
-  auction: () => props.auction,
-  where: () => ({
-    userAddress_in: userInvites.value?.map(r => r.buyer.toLowerCase()) ?? []
-  }),
-  orderBy: 'price',
-  orderDirection: 'desc',
-  enabled: () =>
-    web3Account.value !== null &&
-    !!userInvites.value &&
-    userInvites.value.length > 0
-});
 
 const {
   data: partnerStatisticsData,
@@ -63,134 +27,74 @@ const {
 const partnerStatistics = computed(
   () => partnerStatisticsData.value?.pages.flat() ?? []
 );
-
-const userBuyersOrdersTotal = computed(() => {
-  let totalVolume = 0n;
-
-  const clearingPriceOrderDecoded = props.auction.clearingPriceOrder
-    ? decodeOrder(props.auction.clearingPriceOrder)
-    : null;
-
-  for (const order of userBuyersOrders.value ?? []) {
-    const orderComparison = compareOrders(
-      {
-        userId: order.userId,
-        buyAmount: order.buyAmount,
-        sellAmount: order.sellAmount
-      },
-      // Until auction is cleared we are missing userId for clearing price order.
-      // If our referee has order with the same price, buyAmount and sellAmount as the (last) clearing order
-      // it might be or not be included in the total.
-      // This might not be a huge deal as for open auctions last clearing order might be changing often.
-      clearingPriceOrderDecoded ?? {
-        userId: order.userId,
-        buyAmount: props.auction.currentClearingOrderBuyAmount,
-        sellAmount: props.auction.currentClearingOrderSellAmount
-      }
-    );
-
-    if (orderComparison > 0) {
-      totalVolume += BigInt(order.sellAmount);
-    } else if (orderComparison === 0) {
-      totalVolume += BigInt(props.auction.currentVolume);
-    }
-  }
-
-  return totalVolume;
-});
-
-const rewards = computed(() => {
-  const sellAmountShare =
-    (REFERRAL_SHARE * Number(userBuyersOrdersTotal.value)) /
-    10 ** Number(props.auction.decimalsBiddingToken);
-
-  return sellAmountShare * Number(props.auction.currentClearingPrice);
-});
 </script>
 
 <template>
-  <div class="s-box p-4 space-y-3">
-    <div v-if="web3Account">
-      <h4 class="pb-2">Your rewards</h4>
-      <UiLoading
-        v-if="isUserInvitesPending || isUserBuyersOrdersLoading"
-        class="py-3 block"
-      />
-      <UiStateWarning
-        v-else-if="isUserInvitesError || isUserBuyersOrdersError"
-        class="py-3"
+  <div class="divide-y divide-skin-border mb-4">
+    <ReferralReward
+      v-if="web3Account && auction"
+      :network="network"
+      :auction="auction"
+      class="p-4"
+    />
+
+    <div>
+      <h4 class="px-4 py-2">Leaderboard</h4>
+
+      <UiColumnHeader
+        class="overflow-hidden gap-3 !top-header-height-with-offset"
       >
-        Failed to load your rewards.
-      </UiStateWarning>
-      <div v-else>
-        <div
-          class="flex gap-1 items-baseline font-medium text-skin-link leading-9"
-        >
-          <span class="text-[32px]">
-            {{ _n(rewards) }}
-          </span>
-          <span class="text-md">{{ props.auction.symbolAuctioningToken }}</span>
-        </div>
-      </div>
-    </div>
-  </div>
+        <div class="flex-1 min-w-0 truncate">Referee</div>
+        <div class="w-[80px] text-right truncate">Referrals</div>
+      </UiColumnHeader>
 
-  <div class="border-t border-skin-border">
-    <h4 class="px-4 py-2">Leaderboard</h4>
+      <div class="px-4">
+        <UiLoading v-if="isPartnerStatisticsPending" class="py-3 block" />
 
-    <UiColumnHeader
-      class="overflow-hidden gap-3 !top-header-height-with-offset"
-    >
-      <div class="flex-1 min-w-0 truncate">Referee</div>
-      <div class="w-[80px] text-right truncate">Referrals</div>
-    </UiColumnHeader>
+        <UiStateWarning v-else-if="isPartnerStatisticsError" class="py-3">
+          Failed to load leaderboard.
+        </UiStateWarning>
 
-    <div class="px-4">
-      <UiLoading v-if="isPartnerStatisticsPending" class="py-3 block" />
+        <UiStateWarning v-else-if="partnerStatistics.length === 0" class="py-3">
+          No referees yet.
+        </UiStateWarning>
 
-      <UiStateWarning v-else-if="isPartnerStatisticsError" class="py-3">
-        Failed to load leaderboard.
-      </UiStateWarning>
-
-      <UiStateWarning v-else-if="partnerStatistics.length === 0" class="py-3">
-        No referees yet.
-      </UiStateWarning>
-
-      <UiContainerInfiniteScroll
-        v-else
-        :loading-more="isFetchingNextPage"
-        @end-reached="() => hasNextPage && fetchNextPage()"
-      >
-        <div
-          class="divide-y divide-skin-border flex flex-col justify-center border-b"
+        <UiContainerInfiniteScroll
+          v-else
+          :loading-more="isFetchingNextPage"
+          @end-reached="() => hasNextPage && fetchNextPage()"
         >
           <div
-            v-for="entry in partnerStatistics"
-            :key="entry.id"
-            class="flex items-center gap-3 py-3"
+            class="divide-y divide-skin-border flex flex-col justify-center border-b"
           >
-            <div class="flex-1 min-w-0 flex items-center gap-3 truncate">
-              <UiStamp :id="entry.partner" :size="32" />
-              <div class="flex flex-col truncate">
-                <h4
-                  class="truncate"
-                  v-text="entry.name || shortenAddress(entry.partner)"
-                />
-                <UiAddress
-                  :address="formatAddress(entry.partner)"
-                  class="text-[17px] text-skin-text truncate"
-                />
+            <div
+              v-for="entry in partnerStatistics"
+              :key="entry.id"
+              class="flex items-center gap-3 py-3"
+            >
+              <div class="flex-1 min-w-0 flex items-center gap-3 truncate">
+                <UiStamp :id="entry.partner" :size="32" />
+                <div class="flex flex-col truncate">
+                  <h4
+                    class="truncate"
+                    v-text="entry.name || shortenAddress(entry.partner)"
+                  />
+                  <UiAddress
+                    :address="formatAddress(entry.partner)"
+                    class="text-[17px] text-skin-text truncate"
+                  />
+                </div>
+              </div>
+              <div class="w-[80px] text-right">
+                <h4 class="text-skin-link">{{ entry.buyer_count }}</h4>
               </div>
             </div>
-            <div class="w-[80px] text-right">
-              <h4 class="text-skin-link">{{ entry.buyer_count }}</h4>
-            </div>
           </div>
-        </div>
-        <template #loading>
-          <UiLoading class="py-3 block" />
-        </template>
-      </UiContainerInfiniteScroll>
+          <template #loading>
+            <UiLoading class="py-3 block" />
+          </template>
+        </UiContainerInfiniteScroll>
+      </div>
     </div>
   </div>
 </template>

--- a/apps/ui/src/components/ReferralReward.vue
+++ b/apps/ui/src/components/ReferralReward.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { AuctionNetworkId } from '@/helpers/auction';
+import { AuctionDetailFragment } from '@/helpers/auction/gql/graphql';
+import { compareOrders, decodeOrder } from '@/helpers/auction/orders';
+import {
+  DEFAULT_AUCTION_TAG,
+  REFERRAL_SHARE
+} from '@/helpers/auction/referral';
+import { _n } from '@/helpers/utils';
+import { useBidsSummaryQuery } from '@/queries/auction';
+import { useUserInvitesQuery } from '@/queries/referral';
+
+const props = defineProps<{
+  network: AuctionNetworkId;
+  auction: AuctionDetailFragment;
+}>();
+
+const { web3Account } = useWeb3();
+
+const {
+  data: userInvites,
+  isError: isUserInvitesError,
+  isPending: isUserInvitesPending
+} = useUserInvitesQuery({
+  networkId: toRef(props, 'network'),
+  account: web3Account,
+  auctionTag: () => DEFAULT_AUCTION_TAG
+});
+
+const {
+  data: userBuyersOrders,
+  isError: isUserBuyersOrdersError,
+  isLoading: isUserBuyersOrdersLoading
+} = useBidsSummaryQuery({
+  network: () => props.network,
+  auction: () => props.auction,
+  where: () => ({
+    userAddress_in: userInvites.value?.map(r => r.buyer.toLowerCase()) ?? []
+  }),
+  orderBy: 'price',
+  orderDirection: 'desc',
+  enabled: () =>
+    web3Account.value !== null &&
+    !!userInvites.value &&
+    userInvites.value.length > 0
+});
+
+const userBuyersOrdersTotal = computed(() => {
+  let totalVolume = 0n;
+
+  const clearingPriceOrderDecoded = props.auction.clearingPriceOrder
+    ? decodeOrder(props.auction.clearingPriceOrder)
+    : null;
+
+  for (const order of userBuyersOrders.value ?? []) {
+    const orderComparison = compareOrders(
+      {
+        userId: order.userId,
+        buyAmount: order.buyAmount,
+        sellAmount: order.sellAmount
+      },
+      // Until auction is cleared we are missing userId for clearing price order.
+      // If our referee has order with the same price, buyAmount and sellAmount as the (last) clearing order
+      // it might be or not be included in the total.
+      // This might not be a huge deal as for open auctions last clearing order might be changing often.
+      clearingPriceOrderDecoded ?? {
+        userId: order.userId,
+        buyAmount: props.auction.currentClearingOrderBuyAmount,
+        sellAmount: props.auction.currentClearingOrderSellAmount
+      }
+    );
+
+    if (orderComparison > 0) {
+      totalVolume += BigInt(order.sellAmount);
+    } else if (orderComparison === 0) {
+      totalVolume += BigInt(props.auction.currentVolume);
+    }
+  }
+
+  return totalVolume;
+});
+
+const rewards = computed(() => {
+  const sellAmountShare =
+    (REFERRAL_SHARE * Number(userBuyersOrdersTotal.value)) /
+    10 ** Number(props.auction.decimalsBiddingToken);
+
+  return sellAmountShare * Number(props.auction.currentClearingPrice);
+});
+</script>
+
+<template>
+  <div>
+    <h4 class="pb-2">Your rewards</h4>
+    <UiLoading
+      v-if="isUserInvitesPending || isUserBuyersOrdersLoading"
+      class="py-2 block"
+    />
+    <UiStateWarning
+      v-else-if="isUserInvitesError || isUserBuyersOrdersError"
+      class="py-2"
+    >
+      Failed to load your rewards.
+    </UiStateWarning>
+    <div
+      v-else
+      class="flex gap-1 items-baseline font-medium text-skin-link leading-9"
+    >
+      <span class="text-[32px]">
+        {{ _n(rewards) }}
+      </span>
+      <span class="text-md">{{ props.auction.symbolAuctioningToken }}</span>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION

### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Blocking https://github.com/snapshot-labs/sx-monorepo/pull/1843

This refactor will allow the FormAuctionReferral component to be used without an auction, so it can be used in the upcoming page

### How to test

1. Go to an active auction page
2. You should see your reward and the leaderboard in the referral tab if logged
3. You should only see the leaderboard it logged out
