### PR TITLE
fix: close dropdown menu on page change

### DIFF
--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -154,7 +154,7 @@ onUnmounted(() => {
 
     <div class="flex space-x-2 shrink-0">
       <UiButton v-if="web3.authLoading" loading />
-      <UiDropdown v-else-if="web3.account">
+      <UiDropdown :key="route.fullPath" v-else-if="web3.account">
         <template #button>
           <UiButton class="sm:w-auto !px-0 sm:!px-3">
             <span


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1746

This PR will close the topnav (user) dropdown menu on page change not triggered from within the dropdown menu

### How to test

1. Go to http://localhost:8080/#/
2. Open the user dropdown menu in the top right nav (as logged in user
3. Click on a link, such as settings
4. It should navigate and close the dropdown menu
5. Open the menu again
6. Navigate back using the browser BACK history
7. The menu should close
8. Open the menu again
9. Navigate to another route by editing the url manually 
10. It should navigate to the new url, and close the menu


<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
