### PR TITLE
feat: add vp_value to leaderboard

### DIFF
--- a/apps/ui/src/components/AuctionBidsList.vue
+++ b/apps/ui/src/components/AuctionBidsList.vue
@@ -81,29 +81,26 @@ function handleSortChange(field: Order_OrderBy) {
         >
           <div class="flex-1 min-w-[168px] truncate">Bidder</div>
           <UiColumnHeaderItemSortable
-            class="w-[200px] max-w-[200px]"
+            class="w-[200px] max-w-[200px] !justify-start uppercase"
             :is-ordered="orderBy === 'timestamp'"
             :order-direction="orderDirection"
+            label="Created"
             @sort-change="handleSortChange('timestamp')"
-          >
-            Created
-          </UiColumnHeaderItemSortable>
+          />
           <UiColumnHeaderItemSortable
-            class="w-[200px] max-w-[200px]"
+            class="w-[200px] max-w-[200px] !justify-start uppercase"
             :is-ordered="orderBy === 'sellAmount'"
             :order-direction="orderDirection"
+            label="Amount"
             @sort-change="handleSortChange('sellAmount')"
-          >
-            Amount
-          </UiColumnHeaderItemSortable>
+          />
           <UiColumnHeaderItemSortable
-            class="w-[200px] max-w-[200px]"
+            class="w-[200px] max-w-[200px] !justify-start uppercase"
             :is-ordered="orderBy === 'price'"
             :order-direction="orderDirection"
+            label="Max. price"
             @sort-change="handleSortChange('price')"
-          >
-            Max. price
-          </UiColumnHeaderItemSortable>
+          />
           <div class="w-[200px] max-w-[200px] truncate">Max. FDV</div>
           <div class="w-[200px] max-w-[200px] truncate">Status</div>
           <div class="min-w-[44px] lg:w-[60px]" />

--- a/apps/ui/src/components/Ui/ColumnHeaderItemSortable.vue
+++ b/apps/ui/src/components/Ui/ColumnHeaderItemSortable.vue
@@ -6,15 +6,16 @@ const emit = defineEmits<{
 defineProps<{
   isOrdered: boolean;
   orderDirection: 'asc' | 'desc';
+  label: string;
 }>();
 </script>
 
 <template>
   <button
-    class="flex items-center space-x-1 hover:text-skin-link uppercase truncate"
+    class="flex items-center space-x-1 hover:text-skin-link justify-end truncate"
     @click="emit('sortChange')"
   >
-    <span><slot /></span>
+    <span class="truncate" v-text="label" />
     <template v-if="isOrdered">
       <IH-arrow-sm-down v-if="orderDirection === 'desc'" class="shrink-0" />
       <IH-arrow-sm-up v-else-if="orderDirection === 'asc'" class="shrink-0" />

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -755,7 +755,8 @@ export function createApi(
         id: `${networkId}:${leaderboard.space.id}`,
         spaceId: `${networkId}:${leaderboard.space.id}`,
         vote_count: leaderboard.vote_count,
-        proposal_count: leaderboard.proposal_count
+        proposal_count: leaderboard.proposal_count,
+        vp_value: 0
       }));
     },
     async loadLeaderboard(
@@ -765,7 +766,9 @@ export function createApi(
         | 'vote_count-desc'
         | 'vote_count-asc'
         | 'proposal_count-desc'
-        | 'proposal_count-asc' = 'vote_count-desc',
+        | 'proposal_count-asc'
+        | 'vp_value-desc'
+        | 'vp_value-asc' = 'vote_count-desc',
       user?: string
     ): Promise<UserActivity[]> {
       const [orderBy, orderDirection] = sortBy.split('-') as [
@@ -792,7 +795,8 @@ export function createApi(
         id: leaderboard.user.id,
         spaceId: leaderboard.space.id,
         vote_count: leaderboard.vote_count,
-        proposal_count: leaderboard.proposal_count
+        proposal_count: leaderboard.proposal_count,
+        vp_value: 0
       }));
     },
     loadFollows: async () => {

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -771,7 +771,7 @@ export function createApi(
           variables: {
             first: 1000,
             skip: 0,
-            orderBy: 'proposal_count',
+            orderBy: 'vp_value',
             orderDirection: 'desc',
             where: {
               user: userId
@@ -782,7 +782,8 @@ export function createApi(
           data.leaderboards.map((leaderboard: any) => ({
             spaceId: `${networkId}:${leaderboard.space}`,
             vote_count: leaderboard.votesCount,
-            proposal_count: leaderboard.proposalsCount
+            proposal_count: leaderboard.proposalsCount,
+            vp_value: leaderboard.vpValue
           }))
         );
     },
@@ -793,7 +794,9 @@ export function createApi(
         | 'vote_count-desc'
         | 'vote_count-asc'
         | 'proposal_count-desc'
-        | 'proposal_count-asc' = 'vote_count-desc',
+        | 'proposal_count-asc'
+        | 'vp_value-desc'
+        | 'vp_value-asc' = 'vp_value-desc',
       user?: string
     ): Promise<UserActivity[]> {
       const [orderBy, orderDirection] = sortBy.split('-') as [
@@ -820,7 +823,8 @@ export function createApi(
             id: leaderboard.user,
             spaceId: leaderboard.space,
             vote_count: leaderboard.votesCount,
-            proposal_count: leaderboard.proposalsCount
+            proposal_count: leaderboard.proposalsCount,
+            vp_value: leaderboard.vpValue
           }))
         );
     },

--- a/apps/ui/src/networks/offchain/api/queries.ts
+++ b/apps/ui/src/networks/offchain/api/queries.ts
@@ -362,6 +362,7 @@ export const LEADERBOARD_QUERY = gql`
       space
       proposalsCount
       votesCount
+      vpValue
     }
   }
 `;

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -354,7 +354,9 @@ export type NetworkApi = {
       | 'vote_count-desc'
       | 'vote_count-asc'
       | 'proposal_count-desc'
-      | 'proposal_count-asc',
+      | 'proposal_count-asc'
+      | 'vp_value-desc'
+      | 'vp_value-asc',
     user?: string
   ): Promise<UserActivity[]>;
   loadFollows(userId?: string, spaceId?: string): Promise<Follow[]>;

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -371,6 +371,7 @@ export type UserActivity = {
   spaceId: string;
   proposal_count: number;
   vote_count: number;
+  vp_value: number;
 };
 
 export type Statement = {

--- a/apps/ui/src/views/Space/Leaderboard.vue
+++ b/apps/ui/src/views/Space/Leaderboard.vue
@@ -6,6 +6,8 @@ import { getNetwork, offchainNetworks } from '@/networks';
 import { Space, UserActivity } from '@/types';
 
 type SortableColumn = 'proposal_count' | 'vote_count' | 'vp_value';
+type SortDirection = 'asc' | 'desc';
+type SortByValue = `${SortableColumn}-${SortDirection}`;
 
 const USERS_LIMIT = 20;
 
@@ -19,14 +21,8 @@ const isOffchainNetwork = computed(() =>
   offchainNetworks.includes(props.space.network)
 );
 
-const sortBy = ref(
-  (isOffchainNetwork.value ? 'vp_value-desc' : 'vote_count-desc') as
-    | 'vote_count-desc'
-    | 'vote_count-asc'
-    | 'proposal_count-desc'
-    | 'proposal_count-asc'
-    | 'vp_value-desc'
-    | 'vp_value-asc'
+const sortBy = ref<SortByValue>(
+  isOffchainNetwork.value ? 'vp_value-desc' : 'vote_count-desc'
 );
 
 const {
@@ -88,10 +84,10 @@ function handleSortChange(type: SortableColumn) {
 }
 
 const orderDirection = computed(
-  () => sortBy.value.split('-')[1] as 'asc' | 'desc'
+  () => sortBy.value.split('-')[1] as SortDirection
 );
 
-const orderBy = computed(() => sortBy.value.split('-')[0]);
+const orderBy = computed(() => sortBy.value.split('-')[0] as SortableColumn);
 
 const statsColumn = computed<Partial<Record<SortableColumn, string>>>(() => {
   return {

--- a/apps/ui/src/views/Space/Leaderboard.vue
+++ b/apps/ui/src/views/Space/Leaderboard.vue
@@ -2,8 +2,10 @@
 import { useInfiniteQuery } from '@tanstack/vue-query';
 import { getNames } from '@/helpers/stamp';
 import { _n, _p, shorten } from '@/helpers/utils';
-import { getNetwork } from '@/networks';
+import { getNetwork, offchainNetworks } from '@/networks';
 import { Space, UserActivity } from '@/types';
+
+type SortableColumn = 'proposal_count' | 'vote_count' | 'vp_value';
 
 const USERS_LIMIT = 20;
 
@@ -11,15 +13,21 @@ const props = defineProps<{ space: Space }>();
 
 const { setTitle } = useTitle();
 
+const network = computed(() => getNetwork(props.space.network));
+
+const isOffchainNetwork = computed(() =>
+  offchainNetworks.includes(props.space.network)
+);
+
 const sortBy = ref(
-  'vote_count-desc' as
+  (isOffchainNetwork.value ? 'vp_value-desc' : 'vote_count-desc') as
     | 'vote_count-desc'
     | 'vote_count-asc'
     | 'proposal_count-desc'
     | 'proposal_count-asc'
+    | 'vp_value-desc'
+    | 'vp_value-asc'
 );
-
-const network = computed(() => getNetwork(props.space.network));
 
 const {
   data,
@@ -69,7 +77,7 @@ async function withAuthorNames(users: UserActivity[]): Promise<UserActivity[]> {
   });
 }
 
-function handleSortChange(type: 'vote_count' | 'proposal_count') {
+function handleSortChange(type: SortableColumn) {
   if (sortBy.value.startsWith(type)) {
     sortBy.value = sortBy.value.endsWith('desc')
       ? `${type}-asc`
@@ -78,6 +86,22 @@ function handleSortChange(type: 'vote_count' | 'proposal_count') {
     sortBy.value = `${type}-desc`;
   }
 }
+
+const orderDirection = computed(
+  () => sortBy.value.split('-')[1] as 'asc' | 'desc'
+);
+
+const orderBy = computed(() => sortBy.value.split('-')[0]);
+
+const statsColumn = computed<Partial<Record<SortableColumn, string>>>(() => {
+  return {
+    ...{
+      proposal_count: 'Proposals',
+      vote_count: 'Votes'
+    },
+    ...(isOffchainNetwork.value ? { vp_value: 'VP value' } : {})
+  };
+});
 
 function handleEndReached() {
   if (!hasNextPage.value) return;
@@ -92,37 +116,17 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
   <div>
     <UiSectionHeader label="Leaderboard" sticky />
     <UiColumnHeader>
-      <div class="w-[40%] lg:w-[50%] flex items-center truncate">User</div>
-      <button
-        type="button"
-        class="flex w-[30%] lg:w-[25%] items-center justify-end hover:text-skin-link space-x-1 truncate"
-        @click="handleSortChange('proposal_count')"
-      >
-        <span class="truncate">Proposals</span>
-        <IH-arrow-sm-down
-          v-if="sortBy === 'proposal_count-desc'"
-          class="shrink-0"
+      <div class="w-[40%] flex items-center truncate">User</div>
+      <div class="grid grid-flow-col auto-cols-fr w-[60%]">
+        <UiColumnHeaderItemSortable
+          v-for="(label, key) in statsColumn"
+          :key="key"
+          :is-ordered="orderBy === key"
+          :order-direction="orderDirection"
+          :label="label!"
+          @sort-change="handleSortChange(key as SortableColumn)"
         />
-        <IH-arrow-sm-up
-          v-else-if="sortBy === 'proposal_count-asc'"
-          class="shrink-0"
-        />
-      </button>
-      <button
-        type="button"
-        class="flex justify-end items-center hover:text-skin-link w-[30%] lg:w-[25%] space-x-1 truncate"
-        @click="handleSortChange('vote_count')"
-      >
-        <span class="truncate">Votes</span>
-        <IH-arrow-sm-down
-          v-if="sortBy === 'vote_count-desc'"
-          class="shrink-0"
-        />
-        <IH-arrow-sm-up
-          v-else-if="sortBy === 'vote_count-asc'"
-          class="shrink-0"
-        />
-      </button>
+      </div>
     </UiColumnHeader>
     <UiLoading v-if="isPending" class="px-4 py-3 block" />
     <template v-else>
@@ -146,7 +150,7 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
           class="border-b flex space-x-1"
         >
           <div
-            class="flex items-center py-3 gap-x-3 leading-[22px] w-[40%] lg:w-[50%] truncate"
+            class="flex items-center py-3 gap-x-3 leading-[22px] w-[40%] truncate"
           >
             <UiStamp :id="user.id" :size="32" />
             <AppLink
@@ -166,20 +170,29 @@ watchEffect(() => setTitle(`Leaderboard - ${props.space.name}`));
               />
             </AppLink>
           </div>
-          <div
-            class="flex flex-col items-end justify-center leading-[22px] w-[30%] lg:w-[25%] truncate"
-          >
-            <h4 class="text-skin-link" v-text="_n(user.proposal_count)" />
-            <div class="text-[17px]">
-              {{ _p(user.proposal_count / space.proposal_count) }}
+          <div class="grid grid-flow-col auto-cols-fr w-[60%]">
+            <div
+              class="flex flex-col items-end justify-center leading-[22px] truncate"
+            >
+              <h4 class="text-skin-link" v-text="_n(user.proposal_count)" />
+              <div class="text-[17px]">
+                {{ _p(user.proposal_count / space.proposal_count) }}
+              </div>
             </div>
-          </div>
-          <div
-            class="flex flex-col items-end justify-center leading-[22px] w-[30%] lg:w-[25%] truncate"
-          >
-            <h4 class="text-skin-link" v-text="_n(user.vote_count)" />
-            <div class="text-[17px]">
-              {{ _p(user.vote_count / space.proposal_count) }}
+            <div
+              class="flex flex-col items-end justify-center leading-[22px] truncate"
+            >
+              <h4 class="text-skin-link" v-text="_n(user.vote_count)" />
+              <div class="text-[17px]">
+                {{ _p(user.vote_count / space.proposal_count) }}
+              </div>
+            </div>
+            <div
+              v-if="isOffchainNetwork"
+              class="flex flex-col items-end justify-center leading-[22px] truncate"
+            >
+              <h4 class="text-skin-link" v-text="_n(user.vp_value)" />
+              <div class="text-[17px]">USD</div>
             </div>
           </div>
         </div>

--- a/apps/ui/src/views/User.vue
+++ b/apps/ui/src/views/User.vue
@@ -95,7 +95,9 @@ async function loadActivities(userId: string) {
       .flat()
       .sort(
         (a, b) =>
-          b.proposal_count - a.proposal_count || b.vote_count - a.vote_count
+          b.vp_value - a.vp_value ||
+          b.proposal_count - a.proposal_count ||
+          b.vote_count - a.vote_count
       );
 
     await fetchSpacesAndStore(
@@ -229,9 +231,10 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
     </div>
     <UiSectionHeader label="Activity" sticky />
     <UiColumnHeader class="text-right">
-      <span class="w-[60%] lg:w-[50%] text-left truncate">Space</span>
-      <span class="w-[20%] lg:w-[25%] truncate">Proposals</span>
-      <span class="w-[20%] lg:w-[25%] truncate">Votes</span>
+      <span class="w-[40%] text-left truncate">Space</span>
+      <span class="w-[20%] truncate">Proposals</span>
+      <span class="w-[20%] truncate">Votes</span>
+      <span class="w-[20%] truncate">VP value</span>
     </UiColumnHeader>
     <UiLoading v-if="loadingActivities" class="px-4 py-3 block" />
     <UiStateWarning v-else-if="!activities.length" class="px-4 py-3">
@@ -251,7 +254,7 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
       class="mx-4 border-b flex space-x-1 py-3"
     >
       <div
-        class="flex items-center gap-x-3 leading-[22px] w-[60%] lg:w-[50%] font-semibold text-skin-link truncate"
+        class="flex items-center gap-x-3 leading-[22px] w-[40%] font-semibold text-skin-link truncate"
       >
         <SpaceAvatar
           :space="activity.space"
@@ -261,7 +264,7 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
         <span class="flex-auto w-0 truncate" v-text="activity.space.name" />
       </div>
       <div
-        class="flex flex-col justify-center text-right w-[20%] lg:w-[25%] leading-[22px] truncate"
+        class="flex flex-col justify-center text-right w-[20%] leading-[22px] truncate"
       >
         <h4
           class="text-skin-link truncate"
@@ -273,13 +276,19 @@ watchEffect(() => setTitle(`${user.value?.name || id.value} user profile`));
         />
       </div>
       <div
-        class="flex flex-col justify-center text-right w-[20%] lg:w-[25%] leading-[22px] truncate"
+        class="flex flex-col justify-center text-right w-[20%] leading-[22px] truncate"
       >
         <h4 class="text-skin-link truncate" v-text="_n(activity.vote_count)" />
         <div
           class="text-[17px] truncate"
           v-text="_p(activity.vote_percentage)"
         />
+      </div>
+      <div
+        class="flex flex-col justify-center text-right w-[20%] leading-[22px] truncate"
+      >
+        <h4 class="text-skin-link truncate" v-text="_n(activity.vp_value)" />
+        <div class="text-[17px] truncate">USD</div>
       </div>
     </AppLink>
     <teleport to="#modal">


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Toward https://github.com/snapshot-labs/workflow/issues/625

This PR will add a new "VP value" in offchain spaces leaderboard, and user profile.

<img width="1830" height="1346" alt="image" src="https://github.com/user-attachments/assets/5d7fedce-0c1c-4935-a0bc-d12bb2638b76" />

This PR is technically ready, but data from the hub are still syncing, and not available

### How to test

1. Go to an offchain space leaderboard http://localhost:8080/#/s:cow.eth/leaderboard
2. There should be a vp value column, which is now the default sorted column (you can confirm that inspecting the graphql query)
3. On onchain spaces (http://localhost:8080/#/base:0x282d013BF31374D0046F04D6a7644d97751ed339/leaderboard), leaderboard remain unchanged
4. Go to an user profile http://localhost:8080/#/profile/0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3
5. Inspect the graphql queries in the dev tool network tab
6. The graphql queries to the hub should use sorting by `vp_value`, whereas the one to the onchain api should still use `proposal_count`
