### PR TITLE
fix: update block explorer Starknet networks

### DIFF
--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -33,7 +33,7 @@ export const METADATA: Partial<Record<NetworkID, Metadata>> = {
     rpcUrl: 'https://rpc.snapshot.org/sn',
     ethRpcUrl: 'https://rpc.snapshot.org/1',
     apiUrl: API_URL,
-    explorerUrl: 'https://starkscan.co',
+    explorerUrl: 'https://voyager.online',
     avatar: 'ipfs://bafkreihbjafyh7eud7r6e5743esaamifcttsvbspfwcrfoc5ykodjdi67m'
   },
   'sn-sep': {
@@ -44,7 +44,7 @@ export const METADATA: Partial<Record<NetworkID, Metadata>> = {
     rpcUrl: 'https://rpc.snapshot.org/sn-sep',
     ethRpcUrl: 'https://rpc.snapshot.org/11155111',
     apiUrl: API_TESTNET_URL,
-    explorerUrl: 'https://sepolia.starkscan.co',
+    explorerUrl: 'https://sepolia.voyager.online',
     avatar: 'ipfs://bafkreihbjafyh7eud7r6e5743esaamifcttsvbspfwcrfoc5ykodjdi67m'
   }
 };


### PR DESCRIPTION
### Summary

Switch the Starknet block explorer from Starkscan to Voyager for both mainnet and Sepolia, Starkscan doesn't resolve anymore. 