### PR TITLE
fix: fix guest connector not reacting to url change

### DIFF
--- a/apps/ui/src/helpers/connectors/guest.ts
+++ b/apps/ui/src/helpers/connectors/guest.ts
@@ -71,13 +71,14 @@ export default class Guest extends Connector {
     super(options);
 
     const router = useRouter();
+    const { login } = useWeb3();
 
     watch(
       () => router.currentRoute.value.query.as,
       async address => {
         if (!address) return;
 
-        await this.connect();
+        await login(this);
 
         const query = { ...router.currentRoute.value.query };
         delete query.as;


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix an issue where the guest connector is not reacting to url change, and needed a full page load with the `?as=` query params to connect to the specified address.

### How to test

1. Append `?as=less.eth` to any url (as logged in/out)
2. It will connect to the less.eth account as guest