### PR TITLE
fix: fix label picker hidden behind sticky title

### DIFF
--- a/apps/ui/src/components/PickerLabel.vue
+++ b/apps/ui/src/components/PickerLabel.vue
@@ -58,7 +58,7 @@ const filteredLabels = computed(() =>
     >
       <PopoverPanel
         focus
-        class="absolute z-[11] left-0 -mt-2 mx-4 pb-3"
+        class="absolute z-30 left-0 -mt-2 mx-4 pb-3"
         style="width: calc(100% - 48px)"
         v-bind="panelProps"
       >


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix a z-index issue where the label picker is hidden behind the sticky SectionHeader element

<img width="1180" height="742" alt="image" src="https://github.com/user-attachments/assets/c7d62b1b-28bb-4d23-bb3b-7461e7790202" />

### How to test

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth/proposals
2. Open the label filters
3. It should not be hidden behind the SectionHeader element
