### PR TITLE
fix(ux): disable the submit button when the form is empty

### DIFF
--- a/apps/ui/src/components/Modal/StakeToken.vue
+++ b/apps/ui/src/components/Modal/StakeToken.vue
@@ -186,7 +186,11 @@ watch(
       </template>
     </div>
     <template v-if="stakingContract" #footer>
-      <UiButton class="w-full" :disabled="!formValid" @click="handleSubmit">
+      <UiButton
+        class="w-full"
+        :disabled="!formValid || !form.amount"
+        @click="handleSubmit"
+      >
         Confirm
       </UiButton>
     </template>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR will disable the stake token form when empty

### How to test

1. Go to http://localhost:8080/#/s:test.wa0x6e.eth/treasury/1/tokens
2. Click on "stake token", next to the ETH row
3. The form "confirm" button should be disabled when the form is empty
