### PR TITLE
fix(ui): fix avatar alignment

### DIFF
--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -109,7 +109,7 @@ watchEffect(() => setTitle(props.space.name));
               <SpaceAvatar
                 :space="space.parent"
                 :size="22"
-                class="rounded-md"
+                class="rounded-md !block"
               />
               <span>{{ space.parent.name }}</span>
             </AppLink>


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

This PR fix the parent space avatar alignment, it's 2px too low

Before

<img width="914" height="196" alt="image" src="https://github.com/user-attachments/assets/88dd2edd-3a87-41ed-8137-6d176e3ddf5e" />

After

<img width="1014" height="182" alt="image" src="https://github.com/user-attachments/assets/9e8dc94c-4bbb-46fc-bd8d-77787eb25b85" />


### How to test

1. Go to http://localhost:8080/#/s:beanstalkfarms.eth
2. The parent space avatar should be verticall centered with the space name