### PR TITLE
feat(ui): add support for BNB, Arbitrum and GMX governors

### DIFF
--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -31,6 +31,7 @@ export const CHAIN_IDS: Record<Exclude<NetworkID, 's' | 's-tn'>, ChainId> = {
   // EVM
   eth: 1,
   oeth: 10,
+  bnb: 56,
   matic: 137,
   base: 8453,
   arb1: 42161,

--- a/apps/ui/src/helpers/quorum.test.ts
+++ b/apps/ui/src/helpers/quorum.test.ts
@@ -29,6 +29,16 @@ describe('getProposalCurrentQuorum', () => {
 
     expect(currentQuorum).toBe(20);
   });
+
+  it('should only use for votes for for_only quorum type', () => {
+    const currentQuorum = getProposalCurrentQuorum('eth', {
+      scores: [11, 20, 100],
+      scores_total: 131,
+      quorum_type: 'for_only'
+    });
+
+    expect(currentQuorum).toBe(11);
+  });
 });
 
 describe('formatQuorum', () => {

--- a/apps/ui/src/helpers/quorum.ts
+++ b/apps/ui/src/helpers/quorum.ts
@@ -17,6 +17,10 @@ export function getProposalCurrentQuorum(
       : Number(proposal.scores_total);
   }
 
+  if (proposal.quorum_type === 'for_only') {
+    return Number(proposal.scores[0]);
+  }
+
   // Only For and Abstain votes are counted towards quorum progress in SX spaces.
   return Number(proposal.scores[0]) + Number(proposal.scores[2]);
 }

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -118,7 +118,8 @@ function getProposalState(
   const quorum = BigInt(proposal.quorum);
   const currentQuorum = getProposalCurrentQuorum(networkId, {
     scores: [proposal.scores_1, proposal.scores_2, proposal.scores_3],
-    scores_total: proposal.scores_total
+    scores_total: proposal.scores_total,
+    quorum_type: proposal.quorum_type ?? undefined
   });
   const scoresFor = BigInt(proposal.scores_1);
   const scoresAgainst = BigInt(proposal.scores_2);
@@ -423,6 +424,7 @@ function formatProposal(
     network: networkId,
     privacy: 'none',
     quorum: Number(proposal.execution_strategy_details?.quorum || 0),
+    quorum_type: proposal.quorum_type as Proposal['quorum_type'],
     flagged: false,
     flag_code: 0,
     completed: ['passed', 'rejected', 'queued', 'vetoed', 'executed'].includes(

--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -105,6 +105,7 @@ gql(`
       address_type
     }
     quorum
+    quorum_type
     execution_hash
     metadata {
       id

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -8,6 +8,7 @@ import {
   evmApe,
   evmArbitrum,
   evmBase,
+  evmBnb,
   evmCurtis,
   evmMainnet,
   evmMantle,
@@ -66,6 +67,7 @@ import { EDITOR_APP_NAME } from '../common/constants';
 
 const CONFIGS: Record<number, EvmNetworkConfig> = {
   10: evmOptimism,
+  56: evmBnb,
   137: evmPolygon,
   5000: evmMantle,
   8453: evmBase,

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -55,6 +55,13 @@ export const METADATA: Record<string, Metadata> = {
     apiUrl: API_URL,
     avatar: 'ipfs://bafkreidkucwfn4mzo2gtydrt2wogk3je5xpugom67vhi4h4comaxxjzoz4'
   },
+  bnb: {
+    name: 'BNB Chain',
+    ticker: 'BNB',
+    chainId: 56,
+    apiUrl: API_URL,
+    avatar: 'ipfs://bafkreibll4la7wqerzs7zwxjne2j7ayynbg2wlenemssoahxxj5rbt6c64'
+  },
   eth: {
     name: 'Ethereum',
     chainId: 1,
@@ -182,6 +189,7 @@ export function createEvmNetwork(networkId: NetworkID): Network {
       'matic',
       'base',
       'mnt',
+      'bnb',
       'arb1',
       'ape',
       'curtis'

--- a/apps/ui/src/networks/index.ts
+++ b/apps/ui/src/networks/index.ts
@@ -12,6 +12,7 @@ const polygonNetwork = createEvmNetwork('matic');
 const arbitrumNetwork = createEvmNetwork('arb1');
 const baseNetwork = createEvmNetwork('base');
 const mantleNetwork = createEvmNetwork('mnt');
+const bnbNetwork = createEvmNetwork('bnb');
 const optimismNetwork = createEvmNetwork('oeth');
 const ethereumNetwork = createEvmNetwork('eth');
 const apeNetwork = createEvmNetwork('ape');
@@ -30,6 +31,7 @@ export const enabledNetworks: NetworkID[] = import.meta.env
       'base',
       'mnt',
       'oeth',
+      'bnb',
       'ape',
       'curtis',
       'sep',
@@ -44,6 +46,7 @@ export const evmNetworks: NetworkID[] = [
   'mnt',
   'base',
   'oeth',
+  'bnb',
   'ape',
   'curtis',
   'sep'
@@ -64,6 +67,7 @@ export const getNetwork = (id: NetworkID) => {
   if (id === 'arb1') return arbitrumNetwork;
   if (id === 'base') return baseNetwork;
   if (id === 'mnt') return mantleNetwork;
+  if (id === 'bnb') return bnbNetwork;
   if (id === 'oeth') return optimismNetwork;
   if (id === 'eth') return ethereumNetwork;
   if (id === 'ape') return apeNetwork;

--- a/apps/ui/src/networks/index.ts
+++ b/apps/ui/src/networks/index.ts
@@ -114,7 +114,7 @@ export const explorePageProtocols: Record<ExplorePageProtocol, ProtocolConfig> =
       key: 'governor',
       label: 'Governor',
       apiNetwork: 'eth',
-      networks: ['eth'],
+      networks: ['eth', 'arb1', 'bnb'],
       protocols: ['governor-bravo', '@openzeppelin/governor'],
       limit: 18
     }

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -36,6 +36,7 @@ export type NetworkID =
   | 'oeth'
   | 'base'
   | 'mnt'
+  | 'bnb'
   | 'ape'
   | 'curtis'
   | 'sep'

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -273,7 +273,7 @@ export type Proposal = {
   vp_decimals: number;
   type: VoteType;
   quorum: number;
-  quorum_type?: 'default' | 'rejection';
+  quorum_type?: 'default' | 'rejection' | 'for_only';
   space: {
     id: string;
     protocol: string;


### PR DESCRIPTION
### Summary

UI related changes extracted from https://github.com/snapshot-labs/sx-monorepo/pull/1995

This includes:
 - addition of BNB network
 - showing of BNB, Arbitrum networks in Explore page.
 - proper handling of Bravo-style quorumType.

### How to test

1. TBD


