### PR TITLE
fix: delegation auto-detection not working

### DIFF
--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -29,10 +29,6 @@ async function fetchGovernorSubgraphDelegatees(
   space: Space
 ): Promise<Delegatee[]> {
   const { getDelegatee } = useActions();
-  const { getDelegates } = useDelegates(
-    delegation as RequiredProperty<typeof delegation>,
-    space
-  );
 
   const delegateeData = await getDelegatee(delegation, account);
 
@@ -51,6 +47,11 @@ async function fetchGovernorSubgraphDelegatees(
       }
     ];
   }
+
+  const { getDelegates } = useDelegates(
+    delegation as RequiredProperty<typeof delegation>,
+    space
+  );
 
   const [names, [apiDelegate]] = await Promise.all([
     getNames([delegateeData.address]),

--- a/apps/ui/src/queries/delegates.ts
+++ b/apps/ui/src/queries/delegates.ts
@@ -15,16 +15,15 @@ export function useDelegatesQuery(
     | 'tokenHoldersRepresentedAmount-asc'
   >
 ) {
-  const { getDelegates } = useDelegates(
-    toValue(delegation) as RequiredProperty<SpaceMetadataDelegation>,
-    toValue(space)
-  );
-
   return useInfiniteQuery({
     initialPageParam: 0,
     queryKey: ['delegates', delegation, sortBy],
     enabled: () => !!toValue(delegation)?.apiUrl,
     queryFn: ({ pageParam }) => {
+      const { getDelegates } = useDelegates(
+        toValue(delegation) as RequiredProperty<SpaceMetadataDelegation>,
+        toValue(space)
+      );
       const [orderBy, orderDirection] = toValue(sortBy).split('-');
 
       return getDelegates({


### PR DESCRIPTION
## Issue:
https://snapshot.box/#/s:dgendao.eth/delegates Doesn't work

### Summary
Root cause: When an `erc20-votes space` (e.g. dgendao.eth) has `apiUrl: null`, `createHttpLink({ uri: null })` crashes inside useDelegates(). The enabled guard only prevents queryFn execution — it doesn't prevent setup-time code from running.

### Fix: 
Move both `useDelegates` after the guards, so these can be called only if apiUrl exist

### How to test:
- Go to http://localhost:8080/#/s:dgendao.eth/delegates
- You should see delegation page now with `Delegation dashboard is not configured.` message