### PR TITLE
fix:  handle favicon with theme

### DIFF
--- a/apps/ui/src/composables/useFavicon.ts
+++ b/apps/ui/src/composables/useFavicon.ts
@@ -1,12 +1,15 @@
-const DEFAULT_FAVICON = '/favicon.svg';
+const DEFAULT_FAVICONS: Record<string, string> = {
+  '(prefers-color-scheme: dark)': '/favicon.svg',
+  '(prefers-color-scheme: light)': '/favicon-dark.svg'
+};
 
 export function useFavicon(favicon?: string) {
   const setFavicon = (newFavicon: string | null) => {
-    if (!newFavicon) return setFavicon(DEFAULT_FAVICON);
-
     document.head
       .querySelectorAll<HTMLLinkElement>('link[rel="icon"]')
-      .forEach(el => (el.href = newFavicon));
+      .forEach(el => {
+        el.href = newFavicon || DEFAULT_FAVICONS[el.media] || '/favicon.svg';
+      });
   };
 
   if (favicon) {


### PR DESCRIPTION
### Summary
- improved favicon setting logic to fallback based on media queries

### How to test

1. Go to any http://localhost:8080
2. Change the system theme from dark to light and vice versa
3. Notice favicon change with theme
4. Regression test: Go to any space page, it should still show space favicon 


https://github.com/user-attachments/assets/4404e8a4-9f8e-4c60-ad5d-322ff9acbafe


