### PR TITLE
fix: use hash comparison for voting strategies dirty check

### DIFF
--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -1008,13 +1008,6 @@ export function useSpaceSettings(space: Ref<Space>) {
           return true;
         }
 
-        if (
-          objectHash(votingStrategiesValue) !==
-          initialVotingStrategiesObjectHashValue
-        ) {
-          return true;
-        }
-
         const hasValidationStrategyChanged =
           objectHash(validationStrategyValue) !==
           initialValidationStrategyObjectHashValue;
@@ -1026,6 +1019,26 @@ export function useSpaceSettings(space: Ref<Space>) {
           objectHash(executionStrategiesValue) !==
           initialExecutionStrategiesObjectHashValue;
         if (hasExecutionStrategiesChanged) {
+          return true;
+        }
+
+        // Preliminary check to detect input changes early before expensive
+        // params/metadata generation (e.g. MerkleWhitelist IPFS pin).
+        if (
+          objectHash(votingStrategiesValue) !==
+          initialVotingStrategiesObjectHashValue
+        ) {
+          return true;
+        }
+
+        const [strategiesToAdd, strategiesToRemove] = await processChanges(
+          votingStrategiesValue,
+          space.value.strategies,
+          space.value.strategies_params,
+          space.value.strategies_parsed_metadata
+        );
+
+        if (strategiesToAdd.length || strategiesToRemove.length) {
           return true;
         }
       }

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -162,6 +162,7 @@ export function useSpaceSettings(space: Ref<Space>) {
   const votingStrategies = ref([] as StrategyConfig[]);
   const initialExecutionStrategiesObjectHash = ref(null as string | null);
   const initialValidationStrategyObjectHash = ref(null as string | null);
+  const initialVotingStrategiesObjectHash = ref(null as string | null);
 
   // Offchain properties
   const proposalValidation = ref({ name: 'basic', params: {} } as Validation);
@@ -325,12 +326,6 @@ export function useSpaceSettings(space: Ref<Space>) {
 
     if (objectHash(coreMetadata) !== objectHash(previousCoreMetadata)) {
       return true;
-    }
-    if (strategy.type === 'MerkleWhitelist') {
-      // NOTE: MerkleWhitelist params are expensive to compute so we try to skip this step if possible.
-      // If metadata has changed then we already know strategy has changed, if metadata is the same
-      // we can assume params are the same as well as they use the same source params.
-      return false;
     }
 
     let params: string[] = [];
@@ -771,6 +766,7 @@ export function useSpaceSettings(space: Ref<Space>) {
 
     authenticators.value = authenticatorsValue;
     votingStrategies.value = votingStrategiesValue;
+    initialVotingStrategiesObjectHash.value = objectHash(votingStrategiesValue);
     validationStrategy.value = validationStrategyValue;
     initialValidationStrategyObjectHash.value = objectHash(
       validationStrategyValue
@@ -829,6 +825,8 @@ export function useSpaceSettings(space: Ref<Space>) {
       const maxVotingPeriodValue = maxVotingPeriod.value;
       const authenticatorsValue = authenticators.value;
       const votingStrategiesValue = votingStrategies.value;
+      const initialVotingStrategiesObjectHashValue =
+        initialVotingStrategiesObjectHash.value;
       const validationStrategyValue = validationStrategy.value;
       const initialValidationStrategyObjectHashValue =
         initialValidationStrategyObjectHash.value;
@@ -1010,14 +1008,10 @@ export function useSpaceSettings(space: Ref<Space>) {
           return true;
         }
 
-        const [strategiesToAdd, strategiesToRemove] = await processChanges(
-          votingStrategiesValue,
-          space.value.strategies,
-          space.value.strategies_params,
-          space.value.strategies_parsed_metadata
-        );
-
-        if (strategiesToAdd.length || strategiesToRemove.length) {
+        if (
+          objectHash(votingStrategiesValue) !==
+          initialVotingStrategiesObjectHashValue
+        ) {
           return true;
         }
 

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -327,6 +327,12 @@ export function useSpaceSettings(space: Ref<Space>) {
     if (objectHash(coreMetadata) !== objectHash(previousCoreMetadata)) {
       return true;
     }
+    if (strategy.type === 'MerkleWhitelist') {
+      // NOTE: MerkleWhitelist params are expensive to compute so we try to skip this step if possible.
+      // If metadata has changed then we already know strategy has changed, if metadata is the same
+      // we can assume params are the same as well as they use the same source params.
+      return false;
+    }
 
     let params: string[] = [];
     if (evmNetworks.includes(space.value.network)) {


### PR DESCRIPTION
### Context
https://discord.com/channels/955773041898573854/1031838169282392144/1491786887248216155


## Problem

On spaces with large MerkleWhitelist voting strategies (e.g. 61,925 addresses), the save toolbar took 20-30 seconds to appear after editing. 

The `isModified` computed was calling `processChanges()` → `hasStrategyChanged()` → `generateMetadata()` which pins the entire whitelist tree to IPFS on every reactive update.


## Summary

- Replace expensive `processChanges()` call in `isModified` with `objectHash` comparison for voting strategies
- Follows the existing pattern used by `initialExecutionStrategiesObjectHash` and `initialValidationStrategyObjectHash`
- Removes the partial MerkleWhitelist workaround in `hasStrategyChanged` (no longer needed since it's not called during dirty-checking)


## Fix

Store the initial `objectHash` of voting strategies at load time and compare against it in `isModified` — the same approach already used for execution strategies and validation strategy.

The full `processChanges` path is still used at save time (`saveOnchain`) where `generateMetadata` / `generateParams` are actually needed.

## How to test

- [ ] Navigate to a space with a large MerkleWhitelist voting strategy http://localhost:8080/#/sn:0x009fedaf0d7a480d21a27683b0965c0f8ded35b3f1cac39827a25a06a8a682a4/settings/voting-strategies?as=0x0557a9c5f4248a1a06a20180ccf5afc49212143d572bdbea45da7028047a4680
- [ ] Add/remove an address, click Confirm (if you experience delay while typing, it is bcz of https://github.com/snapshot-labs/sx-monorepo/pull/2023)
- [ ] Verify the save toolbar appears immediately (<1 second)
- [ ] Verify saving the settings still works correctly
