### PR TITLE
fix: reduce typing lag in textarea for large whitelist strategies

### DIFF
--- a/apps/ui/src/components/Ui/Textarea.vue
+++ b/apps/ui/src/components/Ui/Textarea.vue
@@ -10,6 +10,33 @@ const props = defineProps<{
 }>();
 
 const { isDirty } = useDirty(model, props.definition);
+
+// Large values (e.g. 61k-line whitelist) cause browser layout thrashing when
+// Vue re-sets the textarea DOM value on every reactive update. For these cases
+// we debounce model sync so typing stays responsive while validation still
+// fires after 500ms.
+const LARGE_VALUE_THRESHOLD = 100_000;
+const textareaRef = ref<HTMLTextAreaElement>();
+
+watch([textareaRef, model], ([el, val]) => {
+  if (el && el.value !== (val ?? '')) {
+    el.value = val ?? '';
+  }
+});
+
+const updateModelDebounced = useDebounceFn((el: HTMLTextAreaElement) => {
+  model.value = el.value;
+}, 500);
+
+function onInput(e: Event) {
+  const el = e.target as HTMLTextAreaElement;
+
+  if (el.value.length > LARGE_VALUE_THRESHOLD) {
+    updateModelDebounced(el);
+  } else {
+    model.value = el.value;
+  }
+}
 </script>
 
 <template>
@@ -23,10 +50,11 @@ const { isDirty } = useDirty(model, props.definition);
   >
     <textarea
       :id="id"
-      v-model="model"
+      ref="textareaRef"
       class="s-input"
       v-bind="$attrs"
       :placeholder="definition.examples && definition.examples[0]"
+      @input="onInput"
     />
   </UiWrapperInput>
 </template>

--- a/apps/ui/src/components/Ui/Textarea.vue
+++ b/apps/ui/src/components/Ui/Textarea.vue
@@ -18,18 +18,12 @@ const { isDirty } = useDirty(model, props.definition);
 const LARGE_VALUE_THRESHOLD = 100_000;
 const textareaRef = ref<HTMLTextAreaElement>();
 
-watch([textareaRef, model], ([el, val]) => {
-  if (el && el.value !== (val ?? '')) {
-    el.value = val ?? '';
-  }
-});
-
 const updateModelDebounced = useDebounceFn((el: HTMLTextAreaElement) => {
   model.value = el.value;
 }, 500);
 
-function onInput(e: Event) {
-  const el = e.target as HTMLTextAreaElement;
+function onInput(event: Event) {
+  const el = event.target as HTMLTextAreaElement;
 
   if (el.value.length > LARGE_VALUE_THRESHOLD) {
     updateModelDebounced(el);
@@ -37,6 +31,12 @@ function onInput(e: Event) {
     model.value = el.value;
   }
 }
+
+watch([textareaRef, model], ([el, val]) => {
+  if (el && el.value !== (val ?? '')) {
+    el.value = val ?? '';
+  }
+});
 </script>
 
 <template>


### PR DESCRIPTION
## Problem

When editing a MerkleWhitelist voting strategy with ~61,925 addresses (~5.4MB), every keystroke triggers Vue's `v-model` to reactively re-set the textarea DOM value, causing ~2.5s delay per keystroke. This makes the edit strategy modal unusable for large whitelists.



## Summary

- Fix typing lag when editing MerkleWhitelist voting strategies with large address lists (~61K addresses)
- Replace `v-model` with manual DOM management that debounces model sync for large content (>100K chars)
- No behavior change for normal-sized textareas

Note: ~800ms of per-keystroke lag remains due to native browser textarea layout cost with 5.4MB content. Fully eliminating this would require a virtualized editor (CodeMirror) or a UX change (file upload).

## How to test
- [ ] Edit a large MerkleWhitelist strategy — typing should be noticeably more responsive:
  1. Go to http://localhost:8080/#/sn:0x009fedaf0d7a480d21a27683b0965c0f8ded35b3f1cac39827a25a06a8a682a4/settings?as=0x0557a9c5f4248a1a06a20180ccf5afc49212143d572bdbea45da7028047a4680
  2. Open Voting Strategies → Edit the Whitelist strategy (61,925 addresses)
  3. Type in the textarea — each keystroke should not freeze the UI for multiple seconds
- [ ] Validation errors still appear while typing (after 500ms debounce for large values)
- [ ] Opening a modal with initial state correctly populates the textarea