### PR TITLE
fix(api): store lifecycle values as BigInt

### DIFF
--- a/apps/api/src/evm/protocols/governor-bravo/writers.ts
+++ b/apps/api/src/evm/protocols/governor-bravo/writers.ts
@@ -335,12 +335,12 @@ export function createWriters(
       });
 
     proposal.start = await getTimestampFromBlock(event.args.startBlock);
-    proposal.start_block_number = Number(event.args.startBlock);
+    proposal.start_block_number = event.args.startBlock;
     proposal.min_end = await getTimestampFromBlock(event.args.endBlock);
-    proposal.min_end_block_number = Number(event.args.endBlock);
+    proposal.min_end_block_number = event.args.endBlock;
     proposal.max_end = proposal.min_end;
     proposal.max_end_block_number = proposal.min_end_block_number;
-    proposal.snapshot = proposal.start_block_number;
+    proposal.snapshot = event.args.startBlock;
     proposal.treasuries = spaceMetadataItem?.treasuries || [];
     proposal.quorum = executionStrategy.quorum;
     proposal.strategies = space.strategies;
@@ -454,7 +454,7 @@ export function createWriters(
     if (!proposal) return;
 
     proposal.executed = true;
-    proposal.execution_time = Number(event.args.eta);
+    proposal.execution_time = event.args.eta;
 
     await proposal.save();
   };

--- a/apps/api/src/evm/protocols/governor-bravo/writers.ts
+++ b/apps/api/src/evm/protocols/governor-bravo/writers.ts
@@ -476,8 +476,8 @@ export function createWriters(
     proposal.execution_settled = true;
     proposal.completed = true;
     proposal.execution_tx = rawEvent.transactionHash;
-    proposal.executed_at = Number(block?.timestamp ?? getCurrentTimestamp());
-    proposal.executed_at_block_number = blockNumber;
+    proposal.executed_at = block?.timestamp ?? BigInt(getCurrentTimestamp());
+    proposal.executed_at_block_number = BigInt(blockNumber);
 
     await proposal.save();
   };

--- a/apps/api/src/evm/protocols/openzeppelin/writers.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/writers.ts
@@ -369,12 +369,12 @@ export function createWriters(
       });
 
     proposal.start = await getTimestampFromBlock(event.args.voteStart);
-    proposal.start_block_number = Number(event.args.voteStart);
+    proposal.start_block_number = event.args.voteStart;
     proposal.min_end = await getTimestampFromBlock(event.args.voteEnd);
-    proposal.min_end_block_number = Number(event.args.voteEnd);
+    proposal.min_end_block_number = event.args.voteEnd;
     proposal.max_end = proposal.min_end;
     proposal.max_end_block_number = proposal.min_end_block_number;
-    proposal.snapshot = proposal.start_block_number;
+    proposal.snapshot = event.args.voteStart;
     proposal.treasuries = spaceMetadataItem?.treasuries || [];
     proposal.quorum = executionStrategy.quorum;
     proposal.strategies = space.strategies;
@@ -479,7 +479,7 @@ export function createWriters(
     if (!proposal) return;
 
     proposal.executed = true;
-    proposal.execution_time = Number(event.args.etaSeconds);
+    proposal.execution_time = event.args.etaSeconds;
 
     await proposal.save();
   };
@@ -630,7 +630,7 @@ export function createWriters(
     const space = await Space.loadEntity(spaceAddress, config.indexerName);
     if (!space) return;
 
-    space.voting_delay = Number(event.args.newVotingDelay);
+    space.voting_delay = event.args.newVotingDelay;
 
     await space.save();
   };
@@ -649,7 +649,7 @@ export function createWriters(
     const space = await Space.loadEntity(spaceAddress, config.indexerName);
     if (!space) return;
 
-    space.min_voting_period = Number(event.args.newVotingPeriod);
+    space.min_voting_period = event.args.newVotingPeriod;
     space.max_voting_period = space.min_voting_period;
 
     await space.save();
@@ -763,11 +763,11 @@ export function createWriters(
     const proposal = await Proposal.loadEntity(proposalId, config.indexerName);
     if (!proposal) return;
 
-    const extendedDeadlineBlock = Number(event.args.extendedDeadline);
+    const extendedDeadlineBlock = event.args.extendedDeadline;
 
     const extendedDeadlineTimestamp = await _getTimestampFromBlock({
       networkId: config.indexerName,
-      blockNumber: extendedDeadlineBlock,
+      blockNumber: Number(extendedDeadlineBlock),
       currentBlockNumber: blockNumber,
       currentTimestamp: Number(block?.timestamp ?? getCurrentTimestamp()),
       client

--- a/apps/api/src/evm/protocols/openzeppelin/writers.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/writers.ts
@@ -501,8 +501,8 @@ export function createWriters(
     proposal.execution_settled = true;
     proposal.completed = true;
     proposal.execution_tx = rawEvent.transactionHash;
-    proposal.executed_at = Number(block?.timestamp ?? getCurrentTimestamp());
-    proposal.executed_at_block_number = blockNumber;
+    proposal.executed_at = block?.timestamp ?? BigInt(getCurrentTimestamp());
+    proposal.executed_at_block_number = BigInt(blockNumber);
 
     await proposal.save();
   };

--- a/apps/api/src/evm/protocols/snapshot-x/writers.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/writers.ts
@@ -251,9 +251,9 @@ export function createWriters(
     space.turbo = false;
     space.metadata = null;
     space.controller = getAddress(event.args.input.owner);
-    space.voting_delay = event.args.input.votingDelay;
-    space.min_voting_period = event.args.input.minVotingDuration;
-    space.max_voting_period = event.args.input.maxVotingDuration;
+    space.voting_delay = BigInt(event.args.input.votingDelay);
+    space.min_voting_period = BigInt(event.args.input.minVotingDuration);
+    space.max_voting_period = BigInt(event.args.input.maxVotingDuration);
     space.proposal_threshold = '0';
     space.strategies_indices = votingStrategies.map((_, i) => i);
     space.strategies = votingStrategies.map(s => getAddress(s.addr));
@@ -391,7 +391,7 @@ export function createWriters(
     const space = await Space.loadEntity(spaceId, config.indexerName);
     if (!space) return;
 
-    space.min_voting_period = event.args.newMinVotingDuration;
+    space.min_voting_period = BigInt(event.args.newMinVotingDuration);
 
     await space.save();
   };
@@ -409,7 +409,7 @@ export function createWriters(
     const space = await Space.loadEntity(spaceId, config.indexerName);
     if (!space) return;
 
-    space.max_voting_period = event.args.newMaxVotingDuration;
+    space.max_voting_period = BigInt(event.args.newMaxVotingDuration);
 
     await space.save();
   };
@@ -427,7 +427,7 @@ export function createWriters(
     const space = await Space.loadEntity(spaceId, config.indexerName);
     if (!space) return;
 
-    space.voting_delay = event.args.newVotingDelay;
+    space.voting_delay = BigInt(event.args.newVotingDelay);
 
     await space.save();
   };
@@ -657,16 +657,20 @@ export function createWriters(
     proposal.start = await getTimestampFromBlock(
       event.args.proposal.startBlockNumber
     );
-    proposal.start_block_number = event.args.proposal.startBlockNumber;
+    proposal.start_block_number = BigInt(event.args.proposal.startBlockNumber);
     proposal.min_end = await getTimestampFromBlock(
       event.args.proposal.minEndBlockNumber
     );
-    proposal.min_end_block_number = event.args.proposal.minEndBlockNumber;
+    proposal.min_end_block_number = BigInt(
+      event.args.proposal.minEndBlockNumber
+    );
     proposal.max_end = await getTimestampFromBlock(
       event.args.proposal.maxEndBlockNumber
     );
-    proposal.max_end_block_number = event.args.proposal.maxEndBlockNumber;
-    proposal.snapshot = event.args.proposal.startBlockNumber;
+    proposal.max_end_block_number = BigInt(
+      event.args.proposal.maxEndBlockNumber
+    );
+    proposal.snapshot = BigInt(event.args.proposal.startBlockNumber);
     proposal.type = 'basic';
     proposal.scores_1 = '0';
     proposal.scores_1_parsed = 0;
@@ -691,7 +695,7 @@ export function createWriters(
     proposal.execution_strategy = getAddress(
       event.args.proposal.executionStrategy
     );
-    proposal.execution_time = 0;
+    proposal.execution_time = 0n;
     proposal.executed = false;
     proposal.vetoed = false;
     proposal.execution_settled = false;
@@ -800,8 +804,9 @@ export function createWriters(
       : [];
 
     if (apeGasStrategiesIndices.length) {
-      proposal.start += protocolConfig.apeGasStrategyDelay;
-      proposal.min_end = Math.max(proposal.start, proposal.min_end);
+      proposal.start += BigInt(protocolConfig.apeGasStrategyDelay);
+      proposal.min_end =
+        proposal.min_end > proposal.start ? proposal.min_end : proposal.start;
     }
 
     for (const [, i] of apeGasStrategiesIndices) {
@@ -819,7 +824,7 @@ export function createWriters(
         await registerApeGasProposal(
           {
             viewId,
-            snapshot: proposal.snapshot
+            snapshot: Number(proposal.snapshot)
           },
           protocolConfig
         );
@@ -981,7 +986,7 @@ export function createWriters(
           break;
         case 'SimpleQuorumTimelock':
           proposal.execution_time =
-            now + Number(executionStrategy.timelock_delay);
+            BigInt(now) + executionStrategy.timelock_delay;
           break;
       }
     }

--- a/apps/api/src/evm/protocols/snapshot-x/writers.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/writers.ts
@@ -981,8 +981,8 @@ export function createWriters(
           proposal.execution_settled = true;
           proposal.completed = true;
           proposal.execution_tx = txId;
-          proposal.executed_at = now;
-          proposal.executed_at_block_number = blockNumber;
+          proposal.executed_at = BigInt(now);
+          proposal.executed_at_block_number = BigInt(blockNumber);
           break;
         case 'SimpleQuorumTimelock':
           proposal.execution_time =
@@ -1130,8 +1130,8 @@ export function createWriters(
     proposal.execution_settled = true;
     proposal.completed = true;
     proposal.execution_tx = txId;
-    proposal.executed_at = Number(block?.timestamp ?? getCurrentTimestamp());
-    proposal.executed_at_block_number = blockNumber;
+    proposal.executed_at = block?.timestamp ?? BigInt(getCurrentTimestamp());
+    proposal.executed_at_block_number = BigInt(blockNumber);
     await proposal.save();
   };
 

--- a/apps/api/src/evm/utils.test.ts
+++ b/apps/api/src/evm/utils.test.ts
@@ -108,7 +108,7 @@ describe('getTimestampFromBlock', () => {
       client
     });
 
-    expect(actual).toBe(1744967610);
+    expect(actual).toBe(1744967610n);
   });
 
   it('should return timestamp for networks with foreign block.number', async () => {
@@ -124,6 +124,6 @@ describe('getTimestampFromBlock', () => {
       client
     });
 
-    expect(actual).toBe(1753466114);
+    expect(actual).toBe(1753466114n);
   });
 });

--- a/apps/api/src/evm/utils.ts
+++ b/apps/api/src/evm/utils.ts
@@ -130,7 +130,9 @@ export async function getTimestampFromBlock({
 
   const blockDifference = blockNumber - Number(actualCurrentBlockNumber);
 
-  return Math.round(
-    currentTimestamp + blockDifference * evmNetworks[networkId].Meta.blockTime
+  return BigInt(
+    Math.round(
+      currentTimestamp + blockDifference * evmNetworks[networkId].Meta.blockTime
+    )
   );
 }

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -317,9 +317,9 @@ type Proposal {
   "Whether proposal has been cancelled"
   cancelled: Boolean!
   "Timestamp when the proposal execution was finalized"
-  executed_at: Int
+  executed_at: BigInt
   "Block number when the proposal execution was finalized (EVM only)"
-  executed_at_block_number: Int
+  executed_at_block_number: BigInt
   "Historical scores"
   scores_ticks: [ScoresTick!]! @derivedFrom(field: "proposal")
 }

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -22,11 +22,11 @@ type Space {
   "Address of the space controller/owner"
   controller: String!
   "Delay before voting starts after proposal creation (blocks on EVM, seconds on Starknet)"
-  voting_delay: Int!
+  voting_delay: BigInt!
   "Minimum voting period duration (blocks on EVM, seconds on Starknet)"
-  min_voting_period: Int!
+  min_voting_period: BigInt!
   "Maximum voting period duration (blocks on EVM, seconds on Starknet)"
-  max_voting_period: Int!
+  max_voting_period: BigInt!
   "Minimum voting power required to create a proposal"
   proposal_threshold: BigDecimalVP!
   "Index for the next strategy to be added"
@@ -228,21 +228,21 @@ type Proposal {
   "Proposal metadata containing title, body, and choices"
   metadata: ProposalMetadataItem
   "Timestamp when proposal starts"
-  start: Int!
+  start: BigInt!
   "When voting starts (only defined on EVM)"
-  start_block_number: Int
+  start_block_number: BigInt
   "Minimum timestamp when voting can end"
-  min_end: Int!
+  min_end: BigInt!
   "Minimum block number when voting can end (only defined on EVM)"
-  min_end_block_number: Int
+  min_end_block_number: BigInt
   "Maximum timestamp when voting must end"
-  max_end: Int!
+  max_end: BigInt!
   "Maximum block number when voting must end (only defined on EVM)"
-  max_end_block_number: Int
+  max_end_block_number: BigInt
   "Timepoint used for voting power calculation (blocks on EVM, seconds on Starknet)"
-  snapshot: Int!
+  snapshot: BigInt!
   "Timestamp when proposal can be executed"
-  execution_time: Int!
+  execution_time: BigInt!
   "Address of the execution strategy contract"
   execution_strategy: String!
   # Note: in the future move this field to execution_strategy

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -95,13 +95,9 @@ export function createWriters(config: FullConfig) {
     space.turbo = false;
     space.metadata = null;
     space.controller = validateAndParseAddress(event.owner);
-    space.voting_delay = Number(BigInt(event.voting_delay).toString());
-    space.min_voting_period = Number(
-      BigInt(event.min_voting_duration).toString()
-    );
-    space.max_voting_period = Number(
-      BigInt(event.max_voting_duration).toString()
-    );
+    space.voting_delay = BigInt(event.voting_delay);
+    space.min_voting_period = BigInt(event.min_voting_duration);
+    space.max_voting_period = BigInt(event.max_voting_duration);
     space.proposal_threshold = '0';
     space.strategies_indices = strategies.map((_, i) => i);
     space.strategies = strategies;
@@ -198,9 +194,7 @@ export function createWriters(config: FullConfig) {
     const space = await Space.loadEntity(spaceId, config.indexerName);
     if (!space) return;
 
-    space.min_voting_period = Number(
-      BigInt(event.min_voting_duration).toString()
-    );
+    space.min_voting_period = BigInt(event.min_voting_duration);
 
     await space.save();
   };
@@ -218,9 +212,7 @@ export function createWriters(config: FullConfig) {
     const space = await Space.loadEntity(spaceId, config.indexerName);
     if (!space) return;
 
-    space.max_voting_period = Number(
-      BigInt(event.max_voting_duration).toString()
-    );
+    space.max_voting_period = BigInt(event.max_voting_duration);
 
     await space.save();
   };
@@ -256,7 +248,7 @@ export function createWriters(config: FullConfig) {
     const space = await Space.loadEntity(spaceId, config.indexerName);
     if (!space) return;
 
-    space.voting_delay = Number(BigInt(event.voting_delay).toString());
+    space.voting_delay = BigInt(event.voting_delay);
 
     await space.save();
   };
@@ -466,15 +458,11 @@ export function createWriters(config: FullConfig) {
     proposal.author = author.address;
     proposal.metadata = null;
     proposal.execution_hash = event.proposal.execution_payload_hash;
-    proposal.start = parseInt(startTimestamp.toString());
-    proposal.min_end = parseInt(minEnd.toString());
-    proposal.max_end = parseInt(
-      BigInt(event.proposal.max_end_timestamp).toString()
-    );
-    proposal.snapshot = parseInt(
-      BigInt(event.proposal.start_timestamp).toString()
-    );
-    proposal.execution_time = 0;
+    proposal.start = startTimestamp;
+    proposal.min_end = minEnd;
+    proposal.max_end = BigInt(event.proposal.max_end_timestamp);
+    proposal.snapshot = BigInt(event.proposal.start_timestamp);
+    proposal.execution_time = 0n;
     proposal.execution_strategy = validateAndParseAddress(
       event.proposal.execution_strategy
     );
@@ -621,7 +609,7 @@ export function createWriters(config: FullConfig) {
           {
             l1TokenAddress,
             strategyAddress: strategy,
-            snapshotTimestamp: proposal.snapshot
+            snapshotTimestamp: Number(proposal.snapshot)
           },
           config
         );

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -754,7 +754,7 @@ export function createWriters(config: FullConfig) {
     proposal.execution_settled = true;
     proposal.completed = true;
     proposal.execution_tx = txId ?? null;
-    proposal.executed_at = block?.timestamp ?? getCurrentTimestamp();
+    proposal.executed_at = BigInt(block?.timestamp ?? getCurrentTimestamp());
 
     await proposal.save();
   };

--- a/apps/ui/codegen.ts
+++ b/apps/ui/codegen.ts
@@ -8,6 +8,11 @@ const baseConfig: CodegenConfig['config'] = {
     avoidOptionals: {
       field: true,
       inputValue: false
+    },
+    scalars: {
+      BigInt: 'string',
+      Bytes: 'string',
+      BigDecimal: 'string'
     }
   },
   presetConfig: {
@@ -28,15 +33,7 @@ const config: CodegenConfig = {
       schema:
         'https://subgrapher.snapshot.org/subgraph/arbitrum/6EcQPEFwfCiAq45qUKk4Wnajp5vCUFuxq4r5xSBiya1d',
       documents: ['src/helpers/auction/queries.ts'],
-      ...baseConfig,
-      config: {
-        ...baseConfig.config,
-        scalars: {
-          BigInt: 'string',
-          Bytes: 'string',
-          BigDecimal: 'string'
-        }
-      }
+      ...baseConfig
     },
     './src/helpers/auction/referral/gql/': {
       schema: 'https://api.brokester.box',


### PR DESCRIPTION
### Summary

Some values use `uint32` and they overflow `integer` database type. Those need to be stored as bigint.

## Test plan

1. Apply diff from below.
2. Run `bun run dev:interactive` with API.
3. It syncs to the end.

```diff
diff --git a/apps/api/src/evm/protocols/snapshot-x/config.ts b/apps/api/src/evm/protocols/snapshot-x/config.ts
index 39df800ae..006cd0eac 100644
--- a/apps/api/src/evm/protocols/snapshot-x/config.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/config.ts
@@ -12,7 +12,7 @@ import { NetworkID, SnapshotXConfig } from '../../types';
 
 const START_BLOCKS: Record<NetworkID, number> = {
   eth: 18962278,
-  sep: 4519171,
+  sep: 10504005,
   oeth: 118359200,
   matic: 50858232,
   arb1: 157825417,
@@ -47,7 +47,7 @@ export function createConfig(networkId: NetworkID): Config {
   if (networkId === 'sep') {
     sources.push({
       contract: '0x27981a29ec87f2fbf873a2dcb0325405648ffce1',
-      start: 6106288,
+      start: 10504005,
       abi: 'L1AvatarExecutionStrategyFactory',
       events: [
         {
diff --git a/scripts/dev-interactive.ts b/scripts/dev-interactive.ts
index 0bf43b10e..5ad8df127 100644
--- a/scripts/dev-interactive.ts
+++ b/scripts/dev-interactive.ts
@@ -14,7 +14,7 @@ const SERVICES: Record<ServiceType, Service> = {
   api: {
     env: {
       UI_URL: 'http://localhost:8080',
-      ENABLED_NETWORKS: 'sep,sn-sep',
+      ENABLED_NETWORKS: 'sep',
       VITE_ENABLED_NETWORKS: 's-tn,sep,sn-sep',
       VITE_METADATA_NETWORK: 's-tn',
       VITE_API_TESTNET_URL: 'http://localhost:3000'

```