### PR TITLE
chore(ui): explicitly convert lifecycle values to Number

### DIFF
--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -129,7 +129,7 @@ function getProposalState(
     return proposal.execution_settled ? 'executed' : 'queued';
   }
 
-  if ((proposal.max_end_block_number ?? proposal.max_end) <= current) {
+  if (Number(proposal.max_end_block_number ?? proposal.max_end) <= current) {
     if (currentQuorum < quorum) return 'rejected';
     return scoresFor > scoresAgainst ? 'passed' : 'rejected';
   }
@@ -313,6 +313,9 @@ function formatSpace(
 ): Space {
   return {
     ...space,
+    voting_delay: Number(space.voting_delay),
+    min_voting_period: Number(space.min_voting_period),
+    max_voting_period: Number(space.max_voting_period),
     turbo_expiration: 0,
     network: space._indexer as NetworkID,
     name: space.metadata.name,
@@ -378,6 +381,10 @@ function formatProposal(
 
   return {
     ...proposal,
+    min_end: Number(proposal.min_end),
+    max_end: Number(proposal.max_end),
+    snapshot: Number(proposal.snapshot),
+    execution_time: Number(proposal.execution_time),
     isInvalid:
       proposal.metadata === null ||
       (proposal.metadata.execution === null &&
@@ -417,8 +424,8 @@ function formatProposal(
     has_execution_window_opened: ['Axiom', 'EthRelayer'].includes(
       proposal.execution_strategy_type
     )
-      ? (proposal.max_end_block_number ?? proposal.max_end) <= current
-      : (proposal.min_end_block_number ?? proposal.min_end) <= current,
+      ? Number(proposal.max_end_block_number ?? proposal.max_end) <= current
+      : Number(proposal.min_end_block_number ?? proposal.min_end) <= current,
     execution_settled: proposal.execution_settled,
     state,
     network: networkId,

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -134,7 +134,7 @@ function getProposalState(
     return scoresFor > scoresAgainst ? 'passed' : 'rejected';
   }
 
-  if ((proposal.start_block_number ?? proposal.start) > current) {
+  if (Number(proposal.start_block_number ?? proposal.start) > current) {
     return 'pending';
   }
 

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -381,6 +381,7 @@ function formatProposal(
 
   return {
     ...proposal,
+    start: Number(proposal.start),
     min_end: Number(proposal.min_end),
     max_end: Number(proposal.max_end),
     snapshot: Number(proposal.snapshot),


### PR DESCRIPTION
### Summary

Those values will soon be re-indexed as bigint and returned as string from API (https://github.com/snapshot-labs/sx-monorepo/pull/2024)

We need to be able to convert those no matter if they are returned as number or string and this change gives us that.

Once deployed we will be able to switch API with bigint storage.

### How to test

1. Go to http://localhost:8080/#/sn:0x009fedaf0d7a480d21a27683b0965c0f8ded35b3f1cac39827a25a06a8a682a4
2. Go to http://localhost:8080/#/base:0x282d013BF31374D0046F04D6a7644d97751ed339
3. Everything loads as before.

