### PR TITLE
chore(eslint): enfore 'event' over 'e' for event params

### DIFF
--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -60,8 +60,8 @@ const searchConfig = computed(() => {
   return null;
 });
 
-function handleSearchSubmit(e: Event) {
-  e.preventDefault();
+function handleSearchSubmit(event: Event) {
+  event.preventDefault();
 
   if (!searchConfig.value) return;
 

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -32,8 +32,8 @@ const { space: currentSpace } = useCurrentSpace();
 const { organization } = useOrganization();
 const { login, web3 } = useWeb3();
 const { isSwiping, direction } = useSwipe(el, {
-  onSwipe(e: TouchEvent) {
-    const noSideBarSwipe = (e.target as Element)?.closest(
+  onSwipe(event: TouchEvent) {
+    const noSideBarSwipe = (event.target as Element)?.closest(
       '[data-no-sidebar-swipe]'
     );
     sidebarSwipeEnabled.value =

--- a/apps/ui/src/components/ProposalScoresChart.vue
+++ b/apps/ui/src/components/ProposalScoresChart.vue
@@ -207,12 +207,12 @@ const displayedDate = computed(() =>
         .replace(',', ' ·')
 );
 
-function handleMouseMove(e: MouseEvent) {
+function handleMouseMove(event: MouseEvent) {
   if (!containerRef.value) return;
   const rect = containerRef.value.getBoundingClientRect();
   const ratio = Math.max(
     0,
-    Math.min(1, (e.clientX - rect.left - PADDING.left) / drawingWidth.value)
+    Math.min(1, (event.clientX - rect.left - PADDING.left) / drawingWidth.value)
   );
   hoveredTimestamp.value = props.start + ratio * duration.value;
 }

--- a/apps/ui/src/components/Ui/InputStamp.vue
+++ b/apps/ui/src/components/Ui/InputStamp.vue
@@ -33,9 +33,9 @@ function openFilePicker() {
   fileInput.value?.click();
 }
 
-async function handleFileChange(e: Event) {
+async function handleFileChange(event: Event) {
   try {
-    const file = (e.target as HTMLInputElement).files?.[0];
+    const file = (event.target as HTMLInputElement).files?.[0];
 
     isUploading.value = true;
 

--- a/apps/ui/src/components/Ui/InputStampCover.vue
+++ b/apps/ui/src/components/Ui/InputStampCover.vue
@@ -30,9 +30,9 @@ function openFilePicker() {
   fileInput.value?.click();
 }
 
-async function handleFileChange(e: Event) {
+async function handleFileChange(event: Event) {
   try {
-    const file = (e.target as HTMLInputElement).files?.[0];
+    const file = (event.target as HTMLInputElement).files?.[0];
 
     isUploading.value = true;
 

--- a/apps/ui/src/components/Ui/NftImage.vue
+++ b/apps/ui/src/components/Ui/NftImage.vue
@@ -18,8 +18,8 @@ const fallbackUrl = computed(() =>
 );
 const url = computed(() => props.item.image || fallbackUrl.value);
 
-function handleError(e: Event) {
-  (e.target as HTMLImageElement).src = fallbackUrl.value;
+function handleError(event: Event) {
+  (event.target as HTMLImageElement).src = fallbackUrl.value;
 }
 </script>
 

--- a/apps/ui/src/composables/useMarkdownEditor.ts
+++ b/apps/ui/src/composables/useMarkdownEditor.ts
@@ -164,10 +164,10 @@ export function useMarkdownEditor(
   watch(editorRef, el => {
     if (!el) return;
 
-    el.addEventListener('keydown', (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && shortcuts[e.key]) {
-        e.preventDefault();
-        shortcuts[e.key]();
+    el.addEventListener('keydown', (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && shortcuts[event.key]) {
+        event.preventDefault();
+        shortcuts[event.key]();
       }
     });
   });

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -25,6 +25,11 @@ export default [
           selector: 'CatchClause > Identifier[name=/^(e|error)$/]',
           message:
             "Use 'err' instead of 'e', 'error', or use more descriptive name."
+        },
+        {
+          selector:
+            'Identifier[name=/^(e|evt)$/][typeAnnotation.typeAnnotation.typeName.name=/Event$/]',
+          message: "Use 'event' instead of 'e' or 'evt' for event parameters."
         }
       ],
       'sort-imports': [


### PR DESCRIPTION
### Summary

Context: https://github.com/snapshot-labs/sx-monorepo/pull/2023#discussion_r3073563421

- Add `no-restricted-syntax` rule to flag event handler parameters named `e` or `evt` — enforces using `event` instead
- Rename existing violations across `apps/ui` to match the new rule
- Follows the same pattern as the existing `err` rule for catch clauses


### How to test

- `bun run lint` passes in apps/ui
- Adding a new function `foo(e: Event)` anywhere in apps/ui fails lint with the expected message or edit a file from the changes