### PR TITLE
feat(api): use HyperSync indexer for Arb1

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,7 @@
     "@as-integrations/express4": "^1.1.2",
     "@faker-js/faker": "^7.4.0",
     "@logtail/pino": "^0.5.5",
-    "@snapshot-labs/checkpoint": "^0.1.0-beta.67",
+    "@snapshot-labs/checkpoint": "^0.1.0-beta.69",
     "@snapshot-labs/sx": "^0.1.0",
     "@types/node": "^22.6.0",
     "cors": "^2.8.5",

--- a/apps/api/src/evm/index.ts
+++ b/apps/api/src/evm/index.ts
@@ -67,7 +67,11 @@ const ethIndexer = new evm.EvmIndexer(createWriters(ethConfig));
 const sepIndexer = new evm.EvmIndexer(createWriters(sepConfig));
 const oethIndexer = new evm.EvmIndexer(createWriters(oethConfig));
 const maticIndexer = new evm.EvmIndexer(createWriters(maticConfig));
-const arb1Indexer = new evm.EvmIndexer(createWriters(arb1Config));
+const arb1Indexer = process.env.HYPERSYNC_API_TOKEN
+  ? new evm.HyperSyncEvmIndexer(createWriters(arb1Config), {
+      apiToken: process.env.HYPERSYNC_API_TOKEN
+    })
+  : new evm.EvmIndexer(createWriters(arb1Config));
 const baseIndexer = new evm.EvmIndexer(createWriters(baseConfig));
 const mntIndexer = new evm.EvmIndexer(createWriters(mntConfig));
 const bnbIndexer = new evm.EvmIndexer(createWriters(bnbConfig));

--- a/apps/api/src/evm/protocols/openzeppelin/governances.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/governances.ts
@@ -83,7 +83,6 @@ export const GOVERNANCES: Partial<
       startBlock: 37959559
     }
   },
-  /*
   arb1: {
     'Arbitrum Treasury': {
       name: 'Arbitrum Treasury',
@@ -112,7 +111,8 @@ export const GOVERNANCES: Partial<
         'OpenZeppelinAuthenticatorSignatureV4'
       ],
       startBlock: 70398215
-    },
+    }
+    /*
     GMX: {
       name: 'GMX',
       about:
@@ -131,8 +131,8 @@ export const GOVERNANCES: Partial<
       quorumType: 'for_only',
       startBlock: 204249812
     }
+    */
   },
-  */
   sep: {
     Sekhmet: {
       name: 'Sekhmet',

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
         "@as-integrations/express4": "^1.1.2",
         "@faker-js/faker": "^7.4.0",
         "@logtail/pino": "^0.5.5",
-        "@snapshot-labs/checkpoint": "^0.1.0-beta.67",
+        "@snapshot-labs/checkpoint": "^0.1.0-beta.69",
         "@snapshot-labs/sx": "^0.1.0",
         "@types/node": "^22.6.0",
         "cors": "^2.8.5",
@@ -1249,7 +1249,7 @@
 
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
-    "@snapshot-labs/checkpoint": ["@snapshot-labs/checkpoint@0.1.0-beta.68", "", { "dependencies": { "@graphql-tools/schema": "^8.5.1", "@starknet-io/types-js": "^0.9.2", "connection-string": "^4.3.5", "dataloader": "^2.1.0", "express-graphql": "^0.12.0", "graphql": "^16.5.0", "graphql-fields": "^2.0.3", "graphql-parse-resolve-info": "^4.14.1", "json-to-graphql-query": "^2.2.4", "knex": "^3.1.0", "object-hash": "^3.0.0", "pg": "^8.10.0", "pino": "^9.9.0", "pino-pretty": "^13.1.1", "pluralize": "^8.0.0", "starknet": "~5.19.3", "viem": "^2.36.0", "yargs": "^17.7.2", "zod": "^3.21.4" }, "bin": { "checkpoint": "dist/src/bin/index.js" } }, "sha512-sdOY8DNlKPbJ5ww573OyswuhMWeEcmfCewUHbK5TDv4JDdr1GydLFPFHAYdE1d9Ds6BcV7GZD4TV5xKflIfJOA=="],
+    "@snapshot-labs/checkpoint": ["@snapshot-labs/checkpoint@0.1.0-beta.69", "", { "dependencies": { "@graphql-tools/schema": "^8.5.1", "@starknet-io/types-js": "^0.9.2", "connection-string": "^4.3.5", "dataloader": "^2.1.0", "express-graphql": "^0.12.0", "graphql": "^16.5.0", "graphql-fields": "^2.0.3", "graphql-parse-resolve-info": "^4.14.1", "json-to-graphql-query": "^2.2.4", "knex": "^3.1.0", "object-hash": "^3.0.0", "pg": "^8.10.0", "pino": "^9.9.0", "pino-pretty": "^13.1.1", "pluralize": "^8.0.0", "starknet": "~5.19.3", "viem": "^2.36.0", "yargs": "^17.7.2", "zod": "^3.21.4" }, "bin": { "checkpoint": "dist/src/bin/index.js" } }, "sha512-auihsqT8Dhl741A0yVM2uc0mak83DAZwMD234iTxzDuVGSEcn4S2uwY85sdcD7fmh1mIGFwsQ1qcp+pmYL9Ewg=="],
 
     "@snapshot-labs/eslint-config": ["@snapshot-labs/eslint-config@workspace:packages/eslint-config"],
 
@@ -4297,6 +4297,8 @@
 
     "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
+    "highlight/@snapshot-labs/checkpoint": ["@snapshot-labs/checkpoint@0.1.0-beta.68", "", { "dependencies": { "@graphql-tools/schema": "^8.5.1", "@starknet-io/types-js": "^0.9.2", "connection-string": "^4.3.5", "dataloader": "^2.1.0", "express-graphql": "^0.12.0", "graphql": "^16.5.0", "graphql-fields": "^2.0.3", "graphql-parse-resolve-info": "^4.14.1", "json-to-graphql-query": "^2.2.4", "knex": "^3.1.0", "object-hash": "^3.0.0", "pg": "^8.10.0", "pino": "^9.9.0", "pino-pretty": "^13.1.1", "pluralize": "^8.0.0", "starknet": "~5.19.3", "viem": "^2.36.0", "yargs": "^17.7.2", "zod": "^3.21.4" }, "bin": { "checkpoint": "dist/src/bin/index.js" } }, "sha512-sdOY8DNlKPbJ5ww573OyswuhMWeEcmfCewUHbK5TDv4JDdr1GydLFPFHAYdE1d9Ds6BcV7GZD4TV5xKflIfJOA=="],
+
     "highlight/@types/express": ["@types/express@4.17.25", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^4.17.33", "@types/qs": "*", "@types/serve-static": "^1" } }, "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw=="],
 
     "highlight/nodemon": ["nodemon@2.0.22", "", { "dependencies": { "chokidar": "^3.5.2", "debug": "^3.2.7", "ignore-by-default": "^1.0.1", "minimatch": "^3.1.2", "pstree.remy": "^1.1.8", "semver": "^5.7.1", "simple-update-notifier": "^1.0.7", "supports-color": "^5.5.0", "touch": "^3.1.0", "undefsafe": "^2.0.5" }, "bin": { "nodemon": "bin/nodemon.js" } }, "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ=="],
@@ -4867,6 +4869,10 @@
 
     "graphql-config/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
+    "highlight/@snapshot-labs/checkpoint/@graphql-tools/schema": ["@graphql-tools/schema@8.5.1", "", { "dependencies": { "@graphql-tools/merge": "8.3.1", "@graphql-tools/utils": "8.9.0", "tslib": "^2.4.0", "value-or-promise": "1.0.11" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg=="],
+
+    "highlight/@snapshot-labs/checkpoint/starknet": ["starknet@5.19.6", "", { "dependencies": { "@noble/curves": "~1.2.0", "@scure/starknet": "~0.3.0", "abi-wan-kanabi": "^1.0.3", "isomorphic-fetch": "^3.0.0", "lossless-json": "^2.0.8", "pako": "^2.0.4", "url-join": "^4.0.1" } }, "sha512-MyO48QKu+d8CBH/7ruI/RPrDwoFRNV/uxql2nBeA4ccqBXs698FkeGkMhZv++VIwf1MRajHcTM91KuyZQMyMLw=="],
+
     "highlight/@types/express/@types/express-serve-static-core": ["@types/express-serve-static-core@4.19.8", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA=="],
 
     "highlight/@types/express/@types/serve-static": ["@types/serve-static@1.15.10", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw=="],
@@ -5277,6 +5283,18 @@
 
     "graphql-config/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "highlight/@snapshot-labs/checkpoint/@graphql-tools/schema/@graphql-tools/merge": ["@graphql-tools/merge@8.3.1", "", { "dependencies": { "@graphql-tools/utils": "8.9.0", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg=="],
+
+    "highlight/@snapshot-labs/checkpoint/@graphql-tools/schema/@graphql-tools/utils": ["@graphql-tools/utils@8.9.0", "", { "dependencies": { "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg=="],
+
+    "highlight/@snapshot-labs/checkpoint/starknet/@noble/curves": ["@noble/curves@1.2.0", "", { "dependencies": { "@noble/hashes": "1.3.2" } }, "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw=="],
+
+    "highlight/@snapshot-labs/checkpoint/starknet/@scure/starknet": ["@scure/starknet@0.3.0", "", { "dependencies": { "@noble/curves": "~1.2.0", "@noble/hashes": "~1.3.2" } }, "sha512-Ma66yZlwa5z00qI5alSxdWtIpky5LBhy22acVFdoC5kwwbd9uDyMWEYzWHdNyKmQg9t5Y2UOXzINMeb3yez+Gw=="],
+
+    "highlight/@snapshot-labs/checkpoint/starknet/abi-wan-kanabi": ["abi-wan-kanabi@1.0.3", "", { "dependencies": { "abi-wan-kanabi": "^1.0.1", "fs-extra": "^10.0.0", "rome": "^12.1.3", "typescript": "^4.9.5", "yargs": "^17.7.2" }, "bin": { "generate": "dist/generate.js" } }, "sha512-Xwva0AnhXx/IVlzo3/kwkI7Oa7ZX7codtcSn+Gmoa2PmjGPF/0jeVud9puasIPtB7V50+uBdUj4Mh3iATqtBvg=="],
+
+    "highlight/@snapshot-labs/checkpoint/starknet/lossless-json": ["lossless-json@2.0.11", "", {}, "sha512-BP0vn+NGYvzDielvBZaFain/wgeJ1hTvURCqtKvhr1SCPePdaaTanmmcplrHfEJSJOUql7hk4FHwToNJjWRY3g=="],
+
     "highlight/@types/express/@types/serve-static/@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
 
     "highlight/nodemon/simple-update-notifier/semver": ["semver@7.0.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="],
@@ -5555,6 +5573,12 @@
 
     "graphql-config/@graphql-tools/url-loader/@graphql-tools/wrap/@graphql-tools/delegate/@graphql-tools/batch-execute": ["@graphql-tools/batch-execute@10.0.7", "", { "dependencies": { "@graphql-tools/utils": "^11.0.0", "@whatwg-node/promise-helpers": "^1.3.2", "dataloader": "^2.2.3", "tslib": "^2.8.1" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-vKo9XUiy2sc5tzMupXoxZbu5afVY/9yJ0+yLrM5Dhh38yHYULf3z9VC1eAwW0kj8pWpOo8d8CV3jpleGwv83PA=="],
 
+    "highlight/@snapshot-labs/checkpoint/starknet/@noble/curves/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
+
+    "highlight/@snapshot-labs/checkpoint/starknet/abi-wan-kanabi/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
+
+    "highlight/@snapshot-labs/checkpoint/starknet/abi-wan-kanabi/typescript": ["typescript@4.9.5", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="],
+
     "qrcode/yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "read-pkg-up/find-up/locate-path/p-locate/p-limit": ["p-limit@1.3.0", "", { "dependencies": { "p-try": "^1.0.0" } }, "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q=="],
@@ -5578,6 +5602,10 @@
     "@reown/appkit-ui/qrcode/yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "@walletconnect/modal-ui/qrcode/yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "highlight/@snapshot-labs/checkpoint/starknet/abi-wan-kanabi/fs-extra/jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
+
+    "highlight/@snapshot-labs/checkpoint/starknet/abi-wan-kanabi/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "read-pkg-up/find-up/locate-path/p-locate/p-limit/p-try": ["p-try@1.0.0", "", {}, "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww=="],
   }

--- a/turbo.json
+++ b/turbo.json
@@ -39,6 +39,7 @@
         "ENABLE_SNAPSHOT_X",
         "ENABLE_GOVERNOR_BRAVO",
         "ENABLE_OPENZEPPELIN",
+        "HYPERSYNC_API_TOKEN",
         "VITE_MANA_URL"
       ]
     },


### PR DESCRIPTION
### Summary

This PR enables [HyperSync indexer](https://github.com/snapshot-labs/checkpoint/pull/381) for Arb1 if `HYPERSYNC_API_TOKEN` is specified. Otherwise regular indexer is used.
This improves syncing time a lot (maybe we could consider using it for other networks as well in the future).

Syncing Arb1 on SnapshotX takes just few minutes now.

### How to test

1. Run `cd apps/api && HYPERSYNC_API_TOKEN=YOUR_TOKEN ENABLED_NETWORKS=arb1 bun dev`.
2. Within few minutes it should be all synced up.

