### PR TITLE
feat(api): index BNB governor on testnet

### DIFF
--- a/apps/api/src/evm/index.ts
+++ b/apps/api/src/evm/index.ts
@@ -27,6 +27,7 @@ const arb1Config = createConfig('arb1', protocols);
 const baseConfig = createConfig('base', protocols);
 const mntConfig = createConfig('mnt', protocols);
 const bnbConfig = createConfig('bnb', protocols);
+const bnbtConfig = createConfig('bnbt', protocols);
 const apeConfig = createConfig('ape', protocols);
 const curtisConfig = createConfig('curtis', protocols);
 
@@ -75,6 +76,7 @@ const arb1Indexer = process.env.HYPERSYNC_API_TOKEN
 const baseIndexer = new evm.EvmIndexer(createWriters(baseConfig));
 const mntIndexer = new evm.EvmIndexer(createWriters(mntConfig));
 const bnbIndexer = new evm.EvmIndexer(createWriters(bnbConfig));
+const bnbtIndexer = new evm.EvmIndexer(createWriters(bnbtConfig));
 const apeIndexer = new evm.EvmIndexer(createWriters(apeConfig));
 const curtisIndexer = new evm.EvmIndexer(createWriters(curtisConfig));
 
@@ -92,6 +94,7 @@ export function addEvmIndexers(checkpoint: Checkpoint) {
   registerIndexer(checkpoint, baseConfig.indexerName, baseConfig, baseIndexer);
   registerIndexer(checkpoint, mntConfig.indexerName, mntConfig, mntIndexer);
   registerIndexer(checkpoint, bnbConfig.indexerName, bnbConfig, bnbIndexer);
+  registerIndexer(checkpoint, bnbtConfig.indexerName, bnbtConfig, bnbtIndexer);
   registerIndexer(checkpoint, apeConfig.indexerName, apeConfig, apeIndexer);
   registerIndexer(
     checkpoint,

--- a/apps/api/src/evm/protocols/openzeppelin/governances.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/governances.ts
@@ -83,6 +83,23 @@ export const GOVERNANCES: Partial<
       startBlock: 37959559
     }
   },
+  bnbt: {
+    BNB: {
+      name: 'BNB Chain',
+      avatar:
+        'ipfs://bafkreibll4la7wqerzs7zwxjne2j7ayynbg2wlenemssoahxxj5rbt6c64',
+      externalUrl: 'https://www.bnbchain.org',
+      github: 'bnb-chain',
+      twitter: 'BNBChain',
+      address: '0x0000000000000000000000000000000000002004',
+      authenticators: [
+        'OpenZeppelinAuthenticator',
+        'OpenZeppelinAuthenticatorSignatureV4'
+      ],
+      quorumType: 'for_only',
+      startBlock: 38475089
+    }
+  },
   arb1: {
     'Arbitrum Treasury': {
       name: 'Arbitrum Treasury',

--- a/apps/api/src/evm/protocols/snapshot-x/config.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/config.ts
@@ -19,6 +19,7 @@ const START_BLOCKS: Record<NetworkID, number> = {
   base: 23524251,
   mnt: 75662182,
   bnb: Infinity,
+  bnbt: Infinity,
   ape: 12100384,
   curtis: 16682282
 };

--- a/apps/api/src/evm/types.ts
+++ b/apps/api/src/evm/types.ts
@@ -9,6 +9,7 @@ export type NetworkID =
   | 'base'
   | 'mnt'
   | 'bnb'
+  | 'bnbt'
   | 'ape'
   | 'curtis';
 

--- a/packages/sx.js/src/evmNetworks.ts
+++ b/packages/sx.js/src/evmNetworks.ts
@@ -144,6 +144,9 @@ export const evmNetworks = {
   bnb: createStandardConfig(56, {
     blockTime: 0.45
   }),
+  bnbt: createStandardConfig(97, {
+    blockTime: 0.45
+  }),
   mnt: createStandardConfig(5000, {
     blockTime: 2,
     // https://docs.mantle.xyz/network/system-information/fee-mechanism/eip-1559-support#application-of-eip-1559-in-mantle-v2-tectonic


### PR DESCRIPTION
### Summary

This will index BNB governor on BNB network testnet.

### How to test

1. Diff from below.
2. `bun run dev:interactive` with API.

```diff
diff --git a/scripts/dev-interactive.ts b/scripts/dev-interactive.ts
index 0bf43b10e..0ddd69c96 100644
--- a/scripts/dev-interactive.ts
+++ b/scripts/dev-interactive.ts
@@ -14,10 +14,11 @@ const SERVICES: Record<ServiceType, Service> = {
   api: {
     env: {
       UI_URL: 'http://localhost:8080',
-      ENABLED_NETWORKS: 'sep,sn-sep',
+      ENABLED_NETWORKS: 'bnbt',
       VITE_ENABLED_NETWORKS: 's-tn,sep,sn-sep',
       VITE_METADATA_NETWORK: 's-tn',
-      VITE_API_TESTNET_URL: 'http://localhost:3000'
+      VITE_API_TESTNET_URL: 'http://localhost:3000',
+      ENABLE_OPENZEPPELIN: 'true'
     }
   },
   mana: {

```