### PR TITLE
feat(ui): add BNB testnet network support

### DIFF
--- a/.changeset/thick-knives-nail.md
+++ b/.changeset/thick-knives-nail.md
@@ -1,0 +1,5 @@
+---
+'@snapshot-labs/sx': patch
+---
+
+Add BNB Testnet network support

--- a/apps/mana/src/eth/rpc.ts
+++ b/apps/mana/src/eth/rpc.ts
@@ -5,6 +5,7 @@ import {
   evmArbitrum,
   evmBase,
   evmBnb,
+  evmBnbt,
   evmCurtis,
   evmMainnet,
   evmMantle,
@@ -36,6 +37,7 @@ const BROKESTER_API_URL =
 const NETWORKS = new Map<number, EvmNetworkConfig>([
   [10, evmOptimism],
   [56, evmBnb],
+  [97, evmBnbt],
   [137, evmPolygon],
   [8453, evmBase],
   [5000, evmMantle],

--- a/apps/ui/src/helpers/alchemy/index.ts
+++ b/apps/ui/src/helpers/alchemy/index.ts
@@ -11,6 +11,7 @@ export const ALCHEMY_SUPPORTED_CHAIN_IDS = [
   '1', // Ethereum,
   '10', // Optimism,
   '56', // Binance Smart Chain
+  '97', // Binance Smart Chain Testnet
   '100', // Gnosis Safe
   '137', // Polygon,
   '324', // ZkSync Era
@@ -39,6 +40,7 @@ const NETWORKS: Record<(typeof ALCHEMY_SUPPORTED_CHAIN_IDS)[number], string> = {
   '1': 'eth-mainnet',
   '10': 'opt-mainnet',
   '56': 'bnb-mainnet',
+  '97': 'bnb-testnet',
   '100': 'gnosis-mainnet',
   '137': 'polygon-mainnet',
   '324': 'zksync-mainnet',

--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -32,6 +32,7 @@ export const CHAIN_IDS: Record<Exclude<NetworkID, 's' | 's-tn'>, ChainId> = {
   eth: 1,
   oeth: 10,
   bnb: 56,
+  bnbt: 97,
   matic: 137,
   base: 8453,
   arb1: 42161,

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -9,6 +9,7 @@ import {
   evmArbitrum,
   evmBase,
   evmBnb,
+  evmBnbt,
   evmCurtis,
   evmMainnet,
   evmMantle,
@@ -65,6 +66,7 @@ import { EDITOR_APP_NAME } from '../common/constants';
 const CONFIGS: Record<number, EvmNetworkConfig> = {
   10: evmOptimism,
   56: evmBnb,
+  97: evmBnbt,
   137: evmPolygon,
   5000: evmMantle,
   8453: evmBase,

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -110,6 +110,7 @@ export function createEvmNetwork(networkId: NetworkID): Network {
       'base',
       'mnt',
       'bnb',
+      'bnbt',
       'arb1',
       'ape',
       'curtis'

--- a/apps/ui/src/networks/evm/metadata.ts
+++ b/apps/ui/src/networks/evm/metadata.ts
@@ -50,6 +50,13 @@ export const METADATA: Record<string, Metadata> = {
     apiUrl: API_URL,
     avatar: 'ipfs://bafkreibll4la7wqerzs7zwxjne2j7ayynbg2wlenemssoahxxj5rbt6c64'
   },
+  bnbt: {
+    name: 'BNB Chain Testnet',
+    ticker: 'BNB',
+    chainId: 97,
+    apiUrl: API_TESTNET_URL,
+    avatar: 'ipfs://bafkreibll4la7wqerzs7zwxjne2j7ayynbg2wlenemssoahxxj5rbt6c64'
+  },
   eth: {
     name: 'Ethereum',
     chainId: 1,

--- a/apps/ui/src/networks/index.ts
+++ b/apps/ui/src/networks/index.ts
@@ -13,6 +13,7 @@ const arbitrumNetwork = createEvmNetwork('arb1');
 const baseNetwork = createEvmNetwork('base');
 const mantleNetwork = createEvmNetwork('mnt');
 const bnbNetwork = createEvmNetwork('bnb');
+const bnbtNetwork = createEvmNetwork('bnbt');
 const optimismNetwork = createEvmNetwork('oeth');
 const ethereumNetwork = createEvmNetwork('eth');
 const apeNetwork = createEvmNetwork('ape');
@@ -32,6 +33,7 @@ export const enabledNetworks: NetworkID[] = import.meta.env
       'mnt',
       'oeth',
       'bnb',
+      'bnbt',
       'ape',
       'curtis',
       'sep',
@@ -47,13 +49,20 @@ export const evmNetworks: NetworkID[] = [
   'base',
   'oeth',
   'bnb',
+  'bnbt',
   'ape',
   'curtis',
   'sep'
 ];
 export const offchainNetworks: NetworkID[] = ['s', 's-tn'];
 export const starknetNetworks: NetworkID[] = ['sn', 'sn-sep'];
-export const governorNetworks: NetworkID[] = ['eth', 'arb1', 'bnb', 'sep'];
+export const governorNetworks: NetworkID[] = [
+  'eth',
+  'arb1',
+  'bnb',
+  'bnbt',
+  'sep'
+];
 // This network is used for aliases/follows/profiles/explore page.
 export const metadataNetwork: NetworkID =
   import.meta.env.VITE_METADATA_NETWORK || 's';
@@ -69,6 +78,7 @@ export const getNetwork = (id: NetworkID) => {
   if (id === 'base') return baseNetwork;
   if (id === 'mnt') return mantleNetwork;
   if (id === 'bnb') return bnbNetwork;
+  if (id === 'bnbt') return bnbtNetwork;
   if (id === 'oeth') return optimismNetwork;
   if (id === 'eth') return ethereumNetwork;
   if (id === 'ape') return apeNetwork;

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -37,6 +37,7 @@ export type NetworkID =
   | 'base'
   | 'mnt'
   | 'bnb'
+  | 'bnbt'
   | 'ape'
   | 'curtis'
   | 'sep'

--- a/packages/sx.js/src/evmNetworks.ts
+++ b/packages/sx.js/src/evmNetworks.ts
@@ -176,5 +176,6 @@ export const evmArbitrum = createEvmConfig('arb1');
 export const evmBase = createEvmConfig('base');
 export const evmMantle = createEvmConfig('mnt');
 export const evmBnb = createEvmConfig('bnb');
+export const evmBnbt = createEvmConfig('bnbt');
 export const evmApe = createEvmConfig('ape');
 export const evmCurtis = createEvmConfig('curtis');


### PR DESCRIPTION
### Summary

This PR adds support in UI for `bnbt` (BNB Chain testnet) network.

### How to test

1. Run `VITE_API_TESTNET_URL=https://testnet-api-2.snapshot.box bun dev`.
2. Go to http://localhost:8080/#/bnbt:0x0000000000000000000000000000000000002004
3. You see testnet space.