### PR TITLE
feat(ui): list enabled supported networks in Governor protocol

### DIFF
--- a/apps/ui/src/networks/index.ts
+++ b/apps/ui/src/networks/index.ts
@@ -53,6 +53,7 @@ export const evmNetworks: NetworkID[] = [
 ];
 export const offchainNetworks: NetworkID[] = ['s', 's-tn'];
 export const starknetNetworks: NetworkID[] = ['sn', 'sn-sep'];
+export const governorNetworks: NetworkID[] = ['eth', 'arb1', 'bnb', 'sep'];
 // This network is used for aliases/follows/profiles/explore page.
 export const metadataNetwork: NetworkID =
   import.meta.env.VITE_METADATA_NETWORK || 's';
@@ -90,6 +91,9 @@ export const enabledReadWriteNetworks: NetworkID[] = enabledNetworks.filter(
   id => !getNetwork(id).readOnly
 );
 
+const onchainApiNetwork =
+  enabledNetworks.find(network => !offchainNetworks.includes(network)) || 'eth';
+
 export const explorePageProtocols: Record<ExplorePageProtocol, ProtocolConfig> =
   {
     snapshot: {
@@ -102,9 +106,7 @@ export const explorePageProtocols: Record<ExplorePageProtocol, ProtocolConfig> =
     'snapshot-x': {
       key: 'snapshot-x',
       label: 'Snapshot X',
-      apiNetwork:
-        enabledNetworks.find(network => !offchainNetworks.includes(network)) ||
-        'eth',
+      apiNetwork: onchainApiNetwork,
       networks: enabledNetworks.filter(
         network => !offchainNetworks.includes(network)
       ),
@@ -113,8 +115,10 @@ export const explorePageProtocols: Record<ExplorePageProtocol, ProtocolConfig> =
     governor: {
       key: 'governor',
       label: 'Governor',
-      apiNetwork: 'eth',
-      networks: ['eth'],
+      apiNetwork: onchainApiNetwork,
+      networks: enabledNetworks.filter(network =>
+        governorNetworks.includes(network)
+      ),
       protocols: ['governor-bravo', '@openzeppelin/governor'],
       limit: 18
     }


### PR DESCRIPTION
### Summary

List of networks in Governor will now include only enabled networks from predefined list.

Also the same detection will be used for apiNetwork as for Snapshot X, so spaces will be fetched from testnet API on testnet UI.

### How to test

1. Run `bun dev`.
2. You see Ethereum/Arbitrum/BNB (and Sepolia) as possible networks for Governor.
3. Run `VITE_ENABLED_NETWORKS=s,sep,curtis bun dev`.
4. You see Sepolia as possible network.

## Screenshot
<img width="436" height="351" alt="image" src="https://github.com/user-attachments/assets/f1ffd43e-e535-4fba-8be6-322537e146ea" />
