### PR TITLE
chore+fix: add Arbitrum org and use orgnaization name

### DIFF
--- a/apps/ui/src/components/Breadcrumb.vue
+++ b/apps/ui/src/components/Breadcrumb.vue
@@ -79,7 +79,7 @@ const cb = computed(() => (logo.value ? getCacheHash(logo.value) : undefined));
       <div class="shrink-0">
         <SpaceAvatar :space="space" :size="36" class="!rounded-[4px]" />
       </div>
-      <span class="truncate" v-text="space.name" />
+      <span class="truncate" v-text="organization?.name ?? space.name" />
     </template>
   </AppLink>
 </template>

--- a/apps/ui/src/composables/useWhiteLabel.ts
+++ b/apps/ui/src/composables/useWhiteLabel.ts
@@ -95,6 +95,19 @@ const MAPPING: Record<string, WhiteLabelConfig> = {
       theme: 'light'
     }
   },
+  'arbitrum.stage.box': {
+    skinSettings: {
+      logo: 'ipfs://bafkreid7lqlhqi34op5dppmrt77ewdtedwdc5wodch25slfbjrc2bql3ty',
+      bg_color: '#000000',
+      link_color: '#ffffff',
+      text_color: '#a3a8a8',
+      content_color: '#a3a8a8',
+      border_color: '#353535',
+      heading_color: '#ffffff',
+      primary_color: '#10abff',
+      theme: 'dark'
+    }
+  },
   ...(WHITELABEL_MAPPING
     ? (() => {
         const [localDomain, localSpaceId] = WHITELABEL_MAPPING.split(';');

--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -76,6 +76,64 @@ const ORGANIZATIONS: Record<string, OrganizationConfig> = {
     name: 'Snapshot',
     spaceIds: [{ network: 's', id: 'shot.eth' }]
   },
+  arbitrum: {
+    id: 'arbitrum',
+    name: 'Arbitrum',
+    spaceIds: [
+      {
+        network: 'arb1',
+        id: '0x789fC99093B09aD01C34DC7251D0C89ce743e5a4'
+      },
+      {
+        network: 'arb1',
+        id: '0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9'
+      },
+      {
+        network: 's',
+        id: 'arbitrumfoundation.eth'
+      }
+    ],
+    navItems: {
+      proposals: {
+        name: 'Treasury proposals',
+        link: {
+          name: 'space-proposals',
+          params: { space: 'arb1:0x789fC99093B09aD01C34DC7251D0C89ce743e5a4' }
+        }
+      },
+      core: {
+        name: 'Core proposals',
+        icon: IHDocumentText,
+        link: {
+          name: 'space-proposals',
+          params: { space: 'arb1:0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9' }
+        },
+        position: 3
+      },
+      offchain: {
+        name: 'Offchain proposals',
+        icon: IHCheckCircle,
+        link: {
+          name: 'space-proposals',
+          params: { space: 's:arbitrumfoundation.eth' }
+        },
+        position: 4
+      },
+      discussions: {
+        name: 'Discussions',
+        icon: IHAnnotation,
+        link: {
+          name: 'space-discussions',
+          params: { space: 's:arbitrumfoundation.eth' }
+        }
+      },
+      docs: {
+        name: 'Docs',
+        icon: IHDocumentText,
+        link: 'https://docs.arbitrum.foundation/'
+      }
+    }
+  },
   ens: {
     id: 'ens',
     name: 'ENS',
@@ -148,6 +206,7 @@ const ORGANIZATION_DOMAINS: Record<string, string> = {
   'governance.starknet.io': 'starknet',
   'vote.ensdao.org': 'ens',
   'ens.stage.box': 'ens',
+  'arbitrum.stage.box': 'arbitrum',
   ...(ORGANIZATION_MAPPING
     ? {
         [ORGANIZATION_MAPPING.split(';')[0]]: ORGANIZATION_MAPPING.split(';')[1]

--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -4,6 +4,7 @@ import IHAnnotation from '~icons/heroicons-outline/annotation';
 import IHCheckCircle from '~icons/heroicons-outline/check-circle';
 import IHDocumentText from '~icons/heroicons-outline/document-text';
 import IHLightningBolt from '~icons/heroicons-outline/lightning-bolt';
+import IHNewspaper from '~icons/heroicons-outline/newspaper';
 import IHWifi from '~icons/heroicons-outline/wifi';
 
 type NavLink = { name?: string; params?: Record<string, string> };
@@ -29,7 +30,7 @@ export type Organization = OrganizationConfig & {
   spaces: Space[];
 };
 
-const ENS_SPACE_ROUTES: SpaceRoute['children'] = [
+const DEFAULT_SPACE_ROUTES: SpaceRoute['children'] = [
   { path: '', name: 'space-proposals' },
   { path: 'create/:key?', name: 'space-editor' },
   { path: ':proposal', name: 'space-proposal' }
@@ -93,31 +94,62 @@ const ORGANIZATIONS: Record<string, OrganizationConfig> = {
         id: 'arbitrumfoundation.eth'
       }
     ],
+    routes: [
+      {
+        path: 'treasury-gov',
+        meta: {
+          orgSpaceId: 'arb1:0x789fC99093B09aD01C34DC7251D0C89ce743e5a4'
+        },
+        children: DEFAULT_SPACE_ROUTES
+      },
+      {
+        path: 'core-gov',
+        meta: {
+          orgSpaceId: 'arb1:0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9'
+        },
+        children: DEFAULT_SPACE_ROUTES
+      },
+      {
+        path: 'signals',
+        meta: { orgSpaceId: 's:arbitrumfoundation.eth' },
+        children: DEFAULT_SPACE_ROUTES
+      }
+    ],
     navItems: {
       proposals: {
-        name: 'Treasury proposals',
+        name: 'Treasury governor',
+        icon: IHNewspaper,
         link: {
           name: 'space-proposals',
           params: { space: 'arb1:0x789fC99093B09aD01C34DC7251D0C89ce743e5a4' }
+        },
+        activeRoute: {
+          prefix: 'space-treasury-gov'
         }
       },
       core: {
-        name: 'Core proposals',
-        icon: IHDocumentText,
+        name: 'Core governor',
+        icon: IHNewspaper,
         link: {
           name: 'space-proposals',
           params: { space: 'arb1:0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9' }
         },
+        activeRoute: {
+          prefix: 'space-core-gov'
+        },
         position: 3
       },
-      offchain: {
-        name: 'Offchain proposals',
-        icon: IHCheckCircle,
+      signals: {
+        name: 'Signals',
+        icon: IHWifi,
         link: {
           name: 'space-proposals',
           params: { space: 's:arbitrumfoundation.eth' }
         },
-        position: 4
+        activeRoute: {
+          prefix: 'space-signals'
+        },
+        position: 2
       },
       discussions: {
         name: 'Discussions',
@@ -151,12 +183,12 @@ const ORGANIZATIONS: Record<string, OrganizationConfig> = {
       {
         path: 'onchain',
         meta: { orgSpaceId: 'eth:0x323A76393544d5ecca80cd6ef2A560C6a395b7E3' },
-        children: ENS_SPACE_ROUTES
+        children: DEFAULT_SPACE_ROUTES
       },
       {
         path: 'offchain',
         meta: { orgSpaceId: 's:ens.eth' },
-        children: ENS_SPACE_ROUTES
+        children: DEFAULT_SPACE_ROUTES
       }
     ],
     navItems: {

--- a/apps/ui/src/views/Organization/Overview.vue
+++ b/apps/ui/src/views/Organization/Overview.vue
@@ -74,7 +74,7 @@ const proposals = computed(() =>
 );
 
 watchEffect(() => {
-  if (space.value) setTitle(space.value.name);
+  if (organization.value) setTitle(organization.value.name);
 });
 </script>
 
@@ -111,7 +111,7 @@ watchEffect(() => {
           class="relative mb-2 border-4 border-skin-bg !rounded-lg -left-1"
         />
         <div class="flex items-center gap-1">
-          <h1 data-testid="space-name" v-text="space.name" />
+          <h1 data-testid="space-name" v-text="organization?.name" />
           <UiBadgeSpace
             v-if="!isWhiteLabel"
             class="top-0.5"


### PR DESCRIPTION
## Summary
- Adds Arbitrum org config with 3 spaces: Treasury governor (`arb1:0x789fC...`), Core governor (`arb1:0xf07DeD...`), and offchain space (`s:arbitrumfoundation.eth`).
- Maps `arbitrum.stage.box` to the org.
- Overview + Breadcrumb now show the organization name on org routes (instead of the first space's name).


Closes https://github.com/snapshot-labs/workflow/issues/799

### How to test

- http://localhost:8080/#/org/arbitrum — overview shows "Arbitrum", nav has Overview / Treasury proposals / Core proposals / Offchain proposals / Discussions / Treasury / Docs
- http://localhost:8080/#/org/arbitrum/arb1:0x789fC99093B09aD01C34DC7251D0C89ce743e5a4/proposals — Treasury proposals list
- http://localhost:8080/#/org/arbitrum/arb1:0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/proposals — Core proposals list
- http://localhost:8080/#/org/arbitrum/s:arbitrumfoundation.eth/proposals — Offchain proposals list
- http://localhost:8080/#/org/arbitrum/s:arbitrumfoundation.eth/discussions — Discussions
- Breadcrumb shows "Arbitrum" across all the above; active nav highlights correctly on each page
- Docs link opens https://docs.arbitrum.foundation/
- Sanity-check ENS (`/#/org/ens`) and Starknet (`/#/org/starknet`) still render correctly

### To-Do

- [ ] Point `arbitrum.stage.box` to the org
- [ ] Check names and icons