### PR TITLE
fix(ui): make useRelativeTime recompute if source changes

### DIFF
--- a/apps/ui/src/composables/useRelativeTime.ts
+++ b/apps/ui/src/composables/useRelativeTime.ts
@@ -11,5 +11,12 @@ export function useRelativeTime(
     relativeTime.value = _rt(toValue(time), withoutSuffix);
   }, 1000);
 
+  watch(
+    () => toValue(time),
+    time => {
+      relativeTime.value = _rt(time, withoutSuffix);
+    }
+  );
+
   return relativeTime;
 }


### PR DESCRIPTION
### Summary

Before relative time was computed only on init and on interval. If component was updated with different value it would display old value until interval updates it.

With this change all sources to time result in instant update.