### PR TITLE
chore(lint): lint all non-ignored files and respect .gitignore

### DIFF
--- a/.changeset/cuddly-sheep-warn.md
+++ b/.changeset/cuddly-sheep-warn.md
@@ -1,0 +1,5 @@
+---
+'@snapshot-labs/eslint-config': patch
+---
+
+automatically ignore git-ignored files

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "codegen": "checkpoint generate",
-    "lint": "eslint src/ --rule 'no-console: error'",
+    "lint": "eslint . --rule 'no-console: error'",
     "lint:fix": "bun run lint --fix",
     "build": "tsc",
     "dev": "nodemon src/index.ts",

--- a/apps/highlight/package.json
+++ b/apps/highlight/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "codegen": "checkpoint generate -o ./src/api/overrides.json -s ./src/api/schema.gql",
-    "lint": "eslint src/ test/",
+    "lint": "eslint .",
     "lint:fix": "bun run lint --fix",
     "test": "vitest",
     "build": "tsc",

--- a/apps/ui/.storybook/main.ts
+++ b/apps/ui/.storybook/main.ts
@@ -1,6 +1,5 @@
+import { dirname, join } from 'path';
 import { StorybookConfig } from '@storybook/vue3-vite';
-
-import { join, dirname } from 'path';
 
 /**
  * This function is used to resolve the absolute path of a package.

--- a/apps/ui/.storybook/preview.ts
+++ b/apps/ui/.storybook/preview.ts
@@ -1,10 +1,9 @@
-import { Preview, Decorator, setup } from '@storybook/vue3-vite';
-import { createRouter, createMemoryHistory } from 'vue-router';
 import { withThemeByClassName } from '@storybook/addon-themes';
-
+import { Decorator, Preview, setup } from '@storybook/vue3-vite';
+import { h } from 'vue';
+import { createMemoryHistory, createRouter } from 'vue-router';
 import '../src/style.scss';
 import './style.css';
-import { h } from 'vue';
 
 setup(app => {
   app.use(

--- a/apps/ui/main.cjs
+++ b/apps/ui/main.cjs
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { app, BrowserWindow, shell } = require('electron');
 
 function createWindow() {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -15,7 +15,7 @@
     "build": "vite build",
     "typecheck": "vue-tsc --noEmit",
     "codegen": "graphql-codegen",
-    "lint": "eslint src/",
+    "lint": "eslint .",
     "lint:fix": "bun run lint --fix",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/ui/tailwind.config.ts
+++ b/apps/ui/tailwind.config.ts
@@ -1,5 +1,5 @@
-import { Config } from 'tailwindcss';
 import tunePreset from '@snapshot-labs/tune/tailwind-preset';
+import { Config } from 'tailwindcss';
 
 const ELECTRON_TITLEBAR_HEIGHT = !!process.env.ELECTRON ? 32 : 0;
 const APP_TOPNAV_HEIGHT = 72;

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'module';
 import path from 'path';
-import vue from '@vitejs/plugin-vue';
 import { TuneResolver } from '@snapshot-labs/tune/resolver';
+import vue from '@vitejs/plugin-vue';
 import { visualizer } from 'rollup-plugin-visualizer';
 import AutoImport from 'unplugin-auto-import/vite';
 import { FileSystemIconLoader } from 'unplugin-icons/loaders';

--- a/bun.lock
+++ b/bun.lock
@@ -238,6 +238,7 @@
       "name": "@snapshot-labs/eslint-config",
       "version": "0.1.0",
       "dependencies": {
+        "@eslint/compat": "^2.0.5",
         "eslint-config-prettier": "^10.1.1",
         "eslint-plugin-import-x": "^4.16.1",
         "eslint-plugin-prettier": "^5.2.6",
@@ -658,6 +659,8 @@
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
     "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/compat": ["@eslint/compat@2.0.5", "", { "dependencies": { "@eslint/core": "^1.2.1" }, "peerDependencies": { "eslint": "^8.40 || 9 || 10" }, "optionalPeers": ["eslint"] }, "sha512-IbHDbHJfkVNv6xjlET8AIVo/K1NQt7YT4Rp6ok/clyBGcpRx1l6gv0Rq3vBvYfPJIZt6ODf66Zq08FJNDpnzgg=="],
 
     "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
 
@@ -3898,6 +3901,8 @@
     "@emotion/babel-plugin/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/compat/@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
 
     "@eslint/eslintrc/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,8 +1,17 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { includeIgnoreFile } from '@eslint/compat';
 import importPlugin from 'eslint-plugin-import-x';
 import prettierPlugin from 'eslint-plugin-prettier/recommended';
 import tseslint from 'typescript-eslint';
 
+const gitignorePath = path.resolve(process.cwd(), '.gitignore');
+const gitignoreConfig = fs.existsSync(gitignorePath)
+  ? [includeIgnoreFile(gitignorePath)]
+  : [];
+
 export default [
+  ...gitignoreConfig,
   {
     ignores: ['**/dist/**']
   },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -21,6 +21,7 @@
     "typescript": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
+    "@eslint/compat": "^2.0.5",
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-import-x": "^4.16.1",
     "eslint-plugin-prettier": "^5.2.6",

--- a/packages/sx.js/package.json
+++ b/packages/sx.js/package.json
@@ -24,7 +24,7 @@
     "dev": "tsc -w -p tsconfig.esnext.json",
     "build": "tsc -p tsconfig.esnext.json && tsc -p tsconfig.cjs.json",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint ./src ./test",
+    "lint": "eslint .",
     "lint:fix": "bun run lint --fix",
     "prepare": "bun run build",
     "prepublishOnly": "bun run lint",


### PR DESCRIPTION
### Summary

Standardize per-package `lint` scripts to `eslint .` instead of narrow `src/`-only targets, so config files at the package root (codegen.ts, vite.config.ts, tailwind.config.ts, .storybook/*, etc.) are covered.

ESLint 9 does not respect .gitignore by default, so wire up @eslint/compat's includeIgnoreFile in the shared base config against the consumer's cwd — each package's own .gitignore now drives what eslint skips (gql/, .checkpoint/, dist/, storybook-static/, ...).

Fix the lint violations exposed in newly-covered files.

### How to test

1. CI passes.
