### PR TITLE
feat(ui): support org-level treasuries

### DIFF
--- a/apps/ui/src/composables/useNav/org.ts
+++ b/apps/ui/src/composables/useNav/org.ts
@@ -17,7 +17,8 @@ function getOrgConfig(context: NavContext): NavConfig | null {
 
   const hasDelegates = primarySpace.delegations?.length;
   const hasDiscussions = SPACES_DISCUSSIONS[spaceId];
-  const hasTreasury = primarySpace.treasuries?.length;
+  const hasTreasury =
+    context.organization?.treasuries?.length || primarySpace.treasuries?.length;
 
   // Canonical order matching space.ts
   const allItems: [string, NavItem | null][] = [

--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -1,5 +1,5 @@
 import { NavItem } from '@/composables/useNav/types';
-import { NetworkID, Space } from '@/types';
+import { NetworkID, Space, SpaceMetadataTreasury } from '@/types';
 import IHAnnotation from '~icons/heroicons-outline/annotation';
 import IHCheckCircle from '~icons/heroicons-outline/check-circle';
 import IHDocumentText from '~icons/heroicons-outline/document-text';
@@ -24,6 +24,8 @@ export type OrganizationConfig = {
   spaceIds: { network: NetworkID; id: string }[];
   routes?: SpaceRoute[];
   navItems?: Record<string, Partial<NavItem>>;
+  /** Org-level treasuries (read-only display). */
+  treasuries?: SpaceMetadataTreasury[];
 };
 
 export type Organization = OrganizationConfig & {
@@ -92,6 +94,13 @@ const ORGANIZATIONS: Record<string, OrganizationConfig> = {
       {
         network: 's',
         id: 'arbitrumfoundation.eth'
+      }
+    ],
+    treasuries: [
+      {
+        name: 'Treasury',
+        address: '0xF3FC178157fb3c87548bAA86F9d24BA38E649B58',
+        chainId: '42161'
       }
     ],
     routes: [

--- a/apps/ui/src/views/Space/Treasury.vue
+++ b/apps/ui/src/views/Space/Treasury.vue
@@ -5,18 +5,21 @@ import { Space } from '@/types';
 const props = defineProps<{ space: Space }>();
 
 const { setTitle } = useTitle();
+const { organization } = useOrganization();
 const route = useRoute();
 const router = useRouter();
 const treasuriesList = ref<HTMLElement | null>(null);
+
+const treasuries = computed(
+  () => organization.value?.treasuries ?? props.space.treasuries
+);
 
 const activeTreasuryId = computed(() => {
   if (!route.params.index) return 0;
   return parseInt(route.params.index as string) - 1;
 });
 
-const treasuryData = computed(
-  () => props.space.treasuries[activeTreasuryId.value]
-);
+const treasuryData = computed(() => treasuries.value[activeTreasuryId.value]);
 
 // scroll to treasury tab
 watch(
@@ -33,7 +36,7 @@ watchEffect(() => setTitle(`Treasury - ${props.space.name}`));
 watchEffect(() => {
   const { index, tab } = route.params;
 
-  if (!props.space.treasuries.length) return;
+  if (!treasuries.value.length) return;
 
   const isValidTab = ['tokens', 'nfts'].includes(tab as string);
   if (!index || !tab || !isValidTab) {
@@ -51,7 +54,7 @@ watchEffect(() => {
 <template>
   <div>
     <UiScrollerHorizontal
-      v-if="props.space.treasuries.length !== 1"
+      v-if="treasuries.length !== 1"
       ref="treasuriesList"
       class="z-40 sticky top-header-height-with-offset lg:top-header-height"
       with-buttons
@@ -59,7 +62,7 @@ watchEffect(() => {
     >
       <div class="flex px-4 space-x-3 bg-skin-bg border-b min-w-max">
         <AppLink
-          v-for="(treasury, i) in props.space.treasuries"
+          v-for="(treasury, i) in treasuries"
           :key="i"
           :to="{
             name: 'space-treasury',
@@ -82,7 +85,7 @@ watchEffect(() => {
       :key="activeTreasuryId"
       :space="space"
       :treasury-data="treasuryData"
-      :extra-contacts="props.space.treasuries"
+      :extra-contacts="treasuries"
     />
     <UiStateWarning v-else class="px-4 py-3">
       Treasury not found.


### PR DESCRIPTION
## Summary
- Adds an optional `treasuries` field to the organization config.
- When an org defines `treasuries`, the Treasury tab renders that list instead of the primary space's treasuries.
- Applies it to Arbitrum so the Treasury tab shows the DAO Treasury (`0xF3FC178157fb3c87548bAA86F9d24BA38E649B58` on Arbitrum One) instead of the Treasury governor's timelock.
- Org treasuries are read-only: they don't match any `executors_strategies`, so `SpaceTreasury` automatically renders them as read-only (no proposal execution wiring).

## Why
Arbitrum's Treasury governor lists its timelock as the treasury, but the DAO's actual treasury contract is elsewhere. We need a way for an org to point the Treasury tab at a specific contract without touching per-space settings or API data.

## Approach
- `OrganizationConfig.treasuries?: SpaceMetadataTreasury[]` (new field, optional).
- No mutation of space objects — the override happens at display time in [useNav/org.ts](apps/ui/src/composables/useNav/org.ts) (tab visibility) and [views/Space/Treasury.vue](apps/ui/src/views/Space/Treasury.vue) (rendered list) via `organization.treasuries ?? space.treasuries`.

## How to test
- [ ] Visit http://localhost:8080/#/org/arbitrum and confirm:
- [ ] Treasury tab appears in the org sidebar.
- [ ] Clicking Treasury shows the DAO Treasury `0xF3FC...9B58` on Arbitrum One (not the timelock `0xbFc1...EF58`).
- [ ] The treasury is read-only — no Send/Stake/WalletConnect actions appear.
- [ ] Token and NFT balances load for the DAO Treasury.
- [ ] Other orgs (e.g. http://localhost:8080/#/org/ens, http://localhost:8080/#/org/starknet) are unaffected — their Treasury tab still reflects their primary space's treasuries.
- [ ] Visiting a regular space outside of an org context still shows that space's own treasuries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)