### PR TITLE
fix(sx.js): use getPastVotes for historical VP on non-native-block L2s

### DIFF
--- a/packages/sx.js/src/strategies/evm/ozVotes.ts
+++ b/packages/sx.js/src/strategies/evm/ozVotes.ts
@@ -19,9 +19,10 @@ export default function createOzVotesStrategy(): Strategy {
     ): Promise<bigint> {
       const votesContract = new Contract(params, IVotes, provider);
 
-      const votingPower = await votesContract.getVotes(voterAddress, {
-        blockTag: block ?? 'latest'
-      });
+      const votingPower =
+        block !== null
+          ? await votesContract.getPastVotes(voterAddress, block)
+          : await votesContract.getVotes(voterAddress);
 
       return BigInt(votingPower.toString());
     }

--- a/packages/sx.js/test/unit/strategies/evm/ozVotes.test.ts
+++ b/packages/sx.js/test/unit/strategies/evm/ozVotes.test.ts
@@ -11,28 +11,26 @@ describe('ozVotes', () => {
   beforeAll(() => {
     vi.mock('@ethersproject/contracts', () => ({
       Contract: class {
-        async getVotes(
-          voterAddress: string,
-          { blockTag }: { blockTag: number | string }
-        ) {
+        async getPastVotes(voterAddress: string, block: number) {
           if (
             voterAddress === '0xa40839f84cf98ee6f4fdb84c1bb1a448e7835efe' &&
-            blockTag === 8388733
+            block === 8388733
           ) {
             return '1000000000000000000';
           }
 
           if (
             voterAddress === '0x000000000000000000000000000000000000dead' &&
-            blockTag === 8388733
+            block === 8388733
           ) {
             return '0';
           }
 
-          if (
-            voterAddress === '0xa40839f84cf98ee6f4fdb84c1bb1a448e7835efe' &&
-            blockTag === 'latest'
-          ) {
+          return '0';
+        }
+
+        async getVotes(voterAddress: string) {
+          if (voterAddress === '0xa40839f84cf98ee6f4fdb84c1bb1a448e7835efe') {
             return '3000000000000000000';
           }
 


### PR DESCRIPTION
## Summary
- Querying `getVotes` with `blockTag = proposal.snapshot` fails on Arbitrum (and other `hasNonNativeBlockNumbers: true` chains) because the indexer stores `proposal.snapshot` as the **L1** block number (what the contract emits via Solidity's `block.number`), while the RPC interprets `blockTag` as the **L2** block. An L1 value used as an L2 tag points to an unrelated, very old L2 block, and voting power comes back as `0`.
- Switch to `getPastVotes(account, block)` against `latest` state. The contract's internal checkpoint lookup is keyed by the same block the indexer stored, so it resolves correctly on both L1 and non-native-block L2s.
- Falls back to `getVotes(account)` when `block` is `null` (pending on-chain proposals).

Repro: https://snapshot.box/#/arb1:0x789fC99093B09aD01C34DC7251D0C89ce743e5a4/proposal/86654545843645364200491220873325841239317939837732580673532485559601859962180/votes — voters show their 13.6m / 41.3k / … ARB voting power in the list (computed by the indexer) but the user's own VP panel returned 0 / errored.

Verified against the ARB token on Arbitrum at the proposal's snapshot block: `getPastVotes(DZack23.eth, 24943772)` → `13,558,444,408,645,441,373,639,325` wei (≈ 13.6m ARB), matching the displayed voter row.

## Test plan
- [ ] Open an [Arbitrum OZ Governor proposal](http://localhost:8080/#/arb1:0x789fC99093B09aD01C34DC7251D0C89ce743e5a4/proposal/86654545843645364200491220873325841239317939837732580673532485559601859962180) with a real EVM wallet and confirm "Your voting power" renders a non-zero value (where applicable).
- [ ] Open an Ethereum mainnet ozVotes space and confirm VP still renders as before (no regression on native-block chains).
- [ ] Open proposals page and confirm the code still falls through to `getVotes` (block is `null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)