### PR TITLE
fix(sx.js): use getPriorVotes for comp historical VP

### DIFF
--- a/packages/sx.js/src/strategies/evm/comp.ts
+++ b/packages/sx.js/src/strategies/evm/comp.ts
@@ -19,9 +19,10 @@ export default function createCompStrategy(): Strategy {
     ): Promise<bigint> {
       const compContract = new Contract(params, ICompAbi, provider);
 
-      const votingPower = await compContract.getCurrentVotes(voterAddress, {
-        blockTag: block ?? 'latest'
-      });
+      const votingPower =
+        block !== null
+          ? await compContract.getPriorVotes(voterAddress, block)
+          : await compContract.getCurrentVotes(voterAddress);
 
       return BigInt(votingPower.toString());
     }

--- a/packages/sx.js/test/unit/strategies/evm/comp.test.ts
+++ b/packages/sx.js/test/unit/strategies/evm/comp.test.ts
@@ -11,28 +11,26 @@ describe('compStrategy', () => {
   beforeAll(() => {
     vi.mock('@ethersproject/contracts', () => ({
       Contract: class {
-        async getCurrentVotes(
-          voterAddress: string,
-          { blockTag }: { blockTag: number | string }
-        ) {
+        async getPriorVotes(voterAddress: string, block: number) {
           if (
             voterAddress === '0xa40839f84cf98ee6f4fdb84c1bb1a448e7835efe' &&
-            blockTag === 8388714
+            block === 8388714
           ) {
             return '150000000';
           }
 
           if (
             voterAddress === '0x000000000000000000000000000000000000dead' &&
-            blockTag === 8388714
+            block === 8388714
           ) {
             return '0';
           }
 
-          if (
-            voterAddress === '0xa40839f84cf98ee6f4fdb84c1bb1a448e7835efe' &&
-            blockTag === 'latest'
-          ) {
+          return '0';
+        }
+
+        async getCurrentVotes(voterAddress: string) {
+          if (voterAddress === '0xa40839f84cf98ee6f4fdb84c1bb1a448e7835efe') {
             return '300000000';
           }
 


### PR DESCRIPTION
## Summary
- switch the `comp` strategy to `getPriorVotes(account, block)` for historical voting power lookups
- keep `getCurrentVotes(account)` for live/pending proposal lookups when `block` is `null`
- update the comp unit test mocks to match the new historical/live split

## Why
Issue #2050 follows up on #2049. `comp` had the same non-native-block L2 problem as `ozVotes`: passing a proposal snapshot as an RPC `blockTag` can point at the wrong block domain on chains where the indexed snapshot block and RPC block numbers differ.

Using `getPriorVotes(account, block)` asks the governor token for the checkpoint at the proposal snapshot block directly, which matches how Compound-style tokens expose historical voting power.

## Test plan
- [x] `bun run --cwd packages/sx.js test`
- [x] `bun run --cwd packages/sx.js typecheck`
- [x] `bun run --cwd packages/sx.js lint src/strategies/evm/comp.ts test/unit/strategies/evm/comp.test.ts`

Closes #2050