### PR TITLE
fix(lock): address review feedback on extracted package

### DIFF
--- a/packages/lock/README.md
+++ b/packages/lock/README.md
@@ -1,30 +1,15 @@
 # @snapshot-labs/lock
 
-Web3 connector library. Bundles a base `Connector` class, concrete
+Web3 connector library for Snapshot's Vue app. It bundles concrete
 implementations for common wallets (injected, WalletConnect, Coinbase,
-Safe, Sequence, Argent X, Unicorn) and a `Guest` connector backed by
-`GuestProvider`, plus an EIP-6963 provider discovery helper.
+Safe, Sequence, Argent X, Unicorn) plus a `Guest` connector and an
+EIP-6963 provider discovery helper used internally by the Vue composable.
 
 Heavy wallet SDKs are loaded on demand inside each connector's
 `connect()` method, so consumers only pay the download cost for the
 connector the user actually picks.
 
 ## Usage
-
-```ts
-import { connectors } from '@snapshot-labs/lock';
-
-const walletconnect = new connectors.walletconnect({
-  id: 'walletconnect',
-  type: 'walletconnect',
-  info: { name: 'WalletConnect' },
-  options: { projectId: '...' },
-  provider: undefined,
-  autoConnectOnly: false
-});
-
-await walletconnect.connect();
-```
 
 ### Vue
 
@@ -43,3 +28,10 @@ const { connectors } = useLock(CONNECTOR_DETAILS);
 
 `useLock` handles EIP-6963 discovery of injected wallets and returns a
 reactive list of instantiated connectors ready for login flows.
+
+The package root currently exposes only the shared `Connector` and
+`ConnectorType` types:
+
+```ts
+import type { Connector, ConnectorType } from '@snapshot-labs/lock';
+```

--- a/packages/lock/package.json
+++ b/packages/lock/package.json
@@ -15,12 +15,12 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
     "./vue": {
-      "import": "./dist/vue/index.js",
-      "types": "./dist/vue/index.d.ts"
+      "types": "./dist/vue/index.d.ts",
+      "import": "./dist/vue/index.js"
     }
   },
   "peerDependencies": {

--- a/packages/lock/src/connectors/argentx.ts
+++ b/packages/lock/src/connectors/argentx.ts
@@ -8,7 +8,8 @@ const getWebwallet = (): Promise<any> =>
 
 export default class Argentx extends Connector {
   async connect() {
-    const modalTheme = this.options.getTheme?.() ?? 'light';
+    const { getTheme, ...options } = this.options;
+    const modalTheme = getTheme?.() ?? 'light';
 
     try {
       const injected = (window as any).starknet_argentX;
@@ -21,8 +22,6 @@ export default class Argentx extends Connector {
 
       const [argentx, { InjectedConnector }, { WebWalletConnector }] =
         await Promise.all([get(), getInjected(), getWebwallet()]);
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { getTheme, ...options } = this.options;
       const starknet = await argentx.connect({
         ...options,
         connectors: [

--- a/packages/lock/src/connectors/guest.ts
+++ b/packages/lock/src/connectors/guest.ts
@@ -7,7 +7,7 @@ const ADDRESS_KEY = 'connector:guest:address';
 const CHAIN_ID_KEY = 'connector:guest:chainId';
 const DEFAULT_CHAIN_ID = 1;
 
-export class GuestProvider extends EventEmitter {
+class GuestProvider extends EventEmitter {
   public selectedAddress: string;
   public chainId: number;
 
@@ -55,7 +55,7 @@ export class GuestProvider extends EventEmitter {
   }
 }
 
-export function formatAddress(address: string): string {
+function formatAddress(address: string): string {
   try {
     return address.length === 42
       ? getAddress(address)

--- a/packages/lock/src/connectors/sequence.ts
+++ b/packages/lock/src/connectors/sequence.ts
@@ -9,13 +9,12 @@ export default class Sequence extends Connector {
   }
 
   async connect() {
-    const theme = this.options.getTheme?.() ?? 'light';
+    const { getTheme, ...options } = this.options;
+    const theme = getTheme?.() ?? 'light';
 
     try {
       const wallet = await this.getWallet();
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { getTheme, ...options } = this.options;
       const connectDetails = await wallet.connect({
         ...options,
         authorize: true,

--- a/packages/lock/src/connectors/walletconnect.ts
+++ b/packages/lock/src/connectors/walletconnect.ts
@@ -38,7 +38,8 @@ export default class Walletconnect extends Connector {
   private modal: AppKit | null = null;
 
   async connect(isAutoConnect = false) {
-    const themeMode = this.options.getTheme?.() ?? 'light';
+    const { projectId, getTheme, ...metadata } = this.options;
+    const themeMode = getTheme?.() ?? 'light';
 
     try {
       const { createAppKit } = await import('@reown/appkit');
@@ -59,9 +60,6 @@ export default class Walletconnect extends Connector {
         celo,
         linea
       } = await import('@reown/appkit/networks');
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { projectId, getTheme, ...metadata } = this.options;
 
       this.modal = createAppKit({
         networks: [

--- a/packages/lock/src/index.ts
+++ b/packages/lock/src/index.ts
@@ -1,5 +1,1 @@
-export { default as connectors } from './connectors';
-export { default as ConnectorClass } from './connectors/connector';
-export { default as Eip6963 } from './eip6963';
-export { GuestProvider, formatAddress } from './connectors/guest';
 export type { Connector, ConnectorType } from './types';


### PR DESCRIPTION
## Summary
- remove the temporary eslint suppressions by destructuring `getTheme` before the connector-specific option objects are built
- reorder `types` before `import` in `packages/lock/package.json` exports
- trim the root package public API down to the types that are actually consumed externally and update the README accordingly

## Test plan
- [x] `cd packages/lock && bun run typecheck`
- [x] `cd packages/lock && bun run build`
- [ ] `cd packages/lock && bun run lint` *(fails in this env because the workspace eslint config imports missing package `eslint-plugin-import-x` before it reaches this change set)*

Refs: #2038
