### PR TITLE
fix(ui): use checksummed addresses for delegate profile links

### DIFF
--- a/apps/ui/src/composables/useDelegates.ts
+++ b/apps/ui/src/composables/useDelegates.ts
@@ -5,7 +5,7 @@ import {
 } from '@apollo/client/core';
 import gql from 'graphql-tag';
 import { getNames } from '@/helpers/stamp';
-import { compareAddresses } from '@/helpers/utils';
+import { compareAddresses, formatAddress } from '@/helpers/utils';
 import { getNetwork, metadataNetwork as metadataNetworkId } from '@/networks';
 import {
   RequiredProperty,
@@ -219,6 +219,7 @@ export function useDelegates(
         return {
           name: names[delegate.user] || null,
           ...delegate,
+          user: formatAddress(delegate.user),
           delegatorsPercentage,
           votesPercentage,
           statement: indexedStatements[delegate.user.toLowerCase()]

--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/vue-query';
 import { MaybeRefOrGetter } from 'vue';
 import { getProvider } from '@/helpers/provider';
 import { getNames } from '@/helpers/stamp';
+import { formatAddress } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
 import { RequiredProperty, Space, SpaceMetadataDelegation } from '@/types';
 
@@ -39,7 +40,7 @@ async function fetchGovernorSubgraphDelegatees(
 
     return [
       {
-        id: delegateeData.address,
+        id: formatAddress(delegateeData.address),
         balance: Number(delegateeData.balance) / 10 ** delegateeData.decimals,
         delegatedVotePercentage: 1,
         name: names[delegateeData.address],
@@ -69,7 +70,7 @@ async function fetchGovernorSubgraphDelegatees(
 
   return [
     {
-      id: delegateeData.address,
+      id: formatAddress(delegateeData.address),
       balance: Number(delegateeData.balance) / 10 ** delegateeData.decimals,
       delegatedVotePercentage:
         apiDelegate && apiDelegate.delegatedVotesRaw !== '0'
@@ -114,7 +115,7 @@ async function fetchApeChainDelegatees(
 
   return [
     {
-      id: accountDelegation.delegate,
+      id: formatAddress(accountDelegation.delegate),
       balance: Number(balance.toBigInt()) / 1e18,
       delegatedVotePercentage:
         apiDelegate && apiDelegate.delegatedVotesRaw !== '0'
@@ -172,7 +173,7 @@ async function fetchDelegateRegistryDelegatees(
 
   return [
     {
-      id: accountDelegation.delegate,
+      id: formatAddress(accountDelegation.delegate),
       balance,
       delegatedVotePercentage: apiDelegate
         ? balance / Number(apiDelegate.delegatedVotes)
@@ -269,7 +270,7 @@ async function fetchSplitDelegationDelegatees(
       : 0;
 
     return {
-      id: delegate,
+      id: formatAddress(delegate),
       balance: delegatedPower,
       delegatedVotePercentage: delegatedVpPercentage,
       name: names[delegate],


### PR DESCRIPTION
## What

Clicking a delegate from `/delegates` opened the profile at a lowercased URL. Other entry points (proposals, leaderboard) already use checksummed addresses.

## Why

Delegation subgraphs return lowercased addresses. `SpaceDelegates.vue` rendered them directly, unlike `proposal.author.id` / `leaderboard.user.id` which arrive checksummed from the Snapshot API.

## Fix

Normalize at the data layer with `formatAddress`:
- `useDelegates.ts` — `delegate.user`
- `delegatees.ts` — `delegatee.id` (covers governor-subgraph, apechain, delegate-registry, split-delegation)

`SpaceDelegates.vue` is unchanged. Companion safety net for hand-typed URLs: #2061.

## Test

Open each pair and hover the first delegate row; compare the link target.

### Governor-subgraph (Arbitrum Treasury)

- ❌ prod: https://snapshot.org/#/arb1:0x789fC99093B09aD01C34DC7251D0C89ce743e5a4/delegates
- ✅ local: http://localhost:8080/#/arb1:0x789fC99093B09aD01C34DC7251D0C89ce743e5a4/delegates

Prod first row href ends in `0xb4c064f466931b8d0f637654c916e3f203c46f13`. Local ends in `0xb4c064f466931B8d0F637654c916E3F203c46f13`.

### Governor-subgraph (alt arbitrum space)

- ❌ prod: https://snapshot.org/#/arb1:0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/delegates
- ✅ local: http://localhost:8080/#/arb1:0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/delegates

### Delegate-registry (Gitcoin)

- ❌ prod: https://snapshot.org/#/s:gitcoindao.eth/delegates
- ✅ local: http://localhost:8080/#/s:gitcoindao.eth/delegates

Prod first row ends in `0x5743e35477363241300fcedc2f5eb0195f300817`. Local should be checksummed.

### Split-delegation (SafeDAO)

- prod: https://snapshot.org/#/s:safe.eth/delegates
- local: http://localhost:8080/#/s:safe.eth/delegates

Note: SafeDAO's split-delegation API already returns checksummed; prod hrefs may already be mixed case here, but local must still be mixed case (no regression).

### Regression

- [ ] ENS names still resolve on rows (Arbitrum: `blockworksres.eth`, `yoav.eth`, `griff.eth`; Gitcoin: `kev.eth`, `lefteris.eth`, `austingriffith.eth`)
- [ ] Statement column still renders for delegates that have one
- [ ] Excluded delegates still filtered out
- [ ] Delegate / Undelegate / Edit-delegation actions still work for current account

🤖 Generated with [Claude Code](https://claude.com/claude-code)