### PR TITLE
feat(ui): rename Arbitrum Signals to Offchain voting

### DIFF
--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -126,7 +126,7 @@ const ORGANIZATIONS: Record<string, OrganizationConfig> = {
     ],
     navItems: {
       proposals: {
-        name: 'Treasury governor',
+        name: 'Onchain treasury',
         icon: IHNewspaper,
         link: {
           name: 'space-proposals',

--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -126,7 +126,7 @@ const ORGANIZATIONS: Record<string, OrganizationConfig> = {
     ],
     navItems: {
       proposals: {
-        name: 'Onchain treasury',
+        name: 'Treasury governor',
         icon: IHNewspaper,
         link: {
           name: 'space-proposals',
@@ -167,6 +167,9 @@ const ORGANIZATIONS: Record<string, OrganizationConfig> = {
           name: 'space-discussions',
           params: { space: 's:arbitrumfoundation.eth' }
         }
+      },
+      treasury: {
+        name: 'Onchain treasury'
       },
       docs: {
         name: 'Docs',

--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -149,7 +149,7 @@ const ORGANIZATIONS: Record<string, OrganizationConfig> = {
         position: 3
       },
       signals: {
-        name: 'Signals',
+        name: 'Offchain voting',
         icon: IHWifi,
         link: {
           name: 'space-proposals',


### PR DESCRIPTION
## Summary
- Rename the Arbitrum organization nav item from 'Signals' to 'Offchain voting'.
- Keep ENS organization label unchanged.

## Test plan
- [x] Verified config now shows 'Offchain voting' for 's:arbitrumfoundation.eth'.
- [x] Confirmed 'Signals' still exists for ENS offchain nav item.
