### PR TITLE
feat(ui): add quorum amount tooltip with space symbol

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -46,8 +46,8 @@ const quorumAmountTooltip = computed(() => {
   const required = _vp(props.proposal.quorum / 10 ** props.decimals);
 
   return symbol
-    ? `Current: ${current} ${symbol}\nRequired: ${required} ${symbol}`
-    : `Current: ${current}\nRequired: ${required}`;
+    ? `${current} ${symbol} / ${required} ${symbol}`
+    : `${current} / ${required}`;
 });
 
 const placeholderResults = computed(() =>

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -36,18 +36,13 @@ const displayAllChoices = ref(false);
 
 const totalProgress = computed(() => quorumProgress(props.proposal));
 
-const currentQuorum = computed(() =>
-  getProposalCurrentQuorum(props.proposal.network, props.proposal)
-);
-
-const currentQuorumDisplay = computed(() =>
-  _vp(currentQuorum.value / 10 ** props.decimals)
-);
-
-const quorumAmountTooltip = computed(() => {
-  const required = _vp(props.proposal.quorum / 10 ** props.decimals);
-
-  return `Required: ${required}`;
+const quorumAmount = computed(() => {
+  const current = getProposalCurrentQuorum(
+    props.proposal.network,
+    props.proposal
+  );
+  const format = (n: number) => _vp(n / 10 ** props.decimals);
+  return `${format(current)} / ${format(props.proposal.quorum)}`;
 });
 
 const placeholderResults = computed(() =>
@@ -161,15 +156,14 @@ onMounted(() => {
       All votes are encrypted and will be decrypted only after the voting period
       is over, making the results visible.
     </div>
-    <div v-if="proposal.quorum">
-      <UiTooltip :title="quorumAmountTooltip">
-        <span>
-          {{ quorumLabel(proposal.quorum_type) }}:
-          <span class="text-skin-link">
-            {{ currentQuorumDisplay }} {{ formatQuorum(totalProgress) }}
-          </span>
-        </span>
-      </UiTooltip>
+    <div v-if="proposal.quorum" class="flex items-center justify-between">
+      <span class="text-skin-link">
+        {{ quorumLabel(proposal.quorum_type) }}
+      </span>
+      <div class="flex items-center gap-2">
+        <span>{{ quorumAmount }}</span>
+        <span class="text-skin-heading">{{ formatQuorum(totalProgress) }}</span>
+      </div>
     </div>
   </div>
   <template v-else>
@@ -249,15 +243,16 @@ onMounted(() => {
           See all <IH-arrow-down class="size-[16px]" />
         </div>
       </button>
-      <div v-if="proposal.quorum">
-        <UiTooltip :title="quorumAmountTooltip">
-          <span>
-            {{ quorumLabel(proposal.quorum_type) }}:
-            <span class="text-skin-link">
-              {{ currentQuorumDisplay }} {{ formatQuorum(totalProgress) }}
-            </span>
+      <div v-if="proposal.quorum" class="flex items-center justify-between">
+        <span class="text-skin-link">
+          {{ quorumLabel(proposal.quorum_type) }}
+        </span>
+        <div class="flex items-center gap-2">
+          <span>{{ quorumAmount }}</span>
+          <span class="text-skin-heading">
+            {{ formatQuorum(totalProgress) }}
           </span>
-        </UiTooltip>
+        </div>
       </div>
     </div>
     <div

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -2,6 +2,7 @@
 import { useQueryClient } from '@tanstack/vue-query';
 import {
   formatQuorum,
+  getProposalCurrentQuorum,
   quorumChoiceProgress,
   quorumLabel,
   quorumProgress
@@ -35,11 +36,18 @@ const displayAllChoices = ref(false);
 
 const totalProgress = computed(() => quorumProgress(props.proposal));
 
+const currentQuorum = computed(() =>
+  getProposalCurrentQuorum(props.proposal.network, props.proposal)
+);
+
 const quorumAmountTooltip = computed(() => {
   const symbol = props.proposal.space.voting_power_symbol;
-  const amount = _vp(props.proposal.quorum / 10 ** props.decimals);
+  const current = _vp(currentQuorum.value / 10 ** props.decimals);
+  const required = _vp(props.proposal.quorum / 10 ** props.decimals);
 
-  return symbol ? `${amount} ${symbol}` : amount;
+  return symbol
+    ? `Current: ${current} ${symbol}\nRequired: ${required} ${symbol}`
+    : `Current: ${current}\nRequired: ${required}`;
 });
 
 const placeholderResults = computed(() =>

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -2,6 +2,7 @@
 import { useQueryClient } from '@tanstack/vue-query';
 import {
   formatQuorum,
+  getProposalCurrentQuorum,
   quorumChoiceProgress,
   quorumLabel,
   quorumProgress
@@ -34,6 +35,17 @@ const queryClient = useQueryClient();
 const displayAllChoices = ref(false);
 
 const totalProgress = computed(() => quorumProgress(props.proposal));
+
+const currentQuorum = computed(() =>
+  getProposalCurrentQuorum(props.proposal.network, props.proposal)
+);
+
+const quorumAmountTooltip = computed(() => {
+  const symbol = props.proposal.space.voting_power_symbol;
+  const amount = _vp(currentQuorum.value / 10 ** props.decimals);
+
+  return symbol ? `${amount} ${symbol}` : amount;
+});
 
 const placeholderResults = computed(() =>
   props.proposal.choices.map((_, i) => ({
@@ -148,7 +160,9 @@ onMounted(() => {
     </div>
     <div v-if="proposal.quorum">
       {{ quorumLabel(proposal.quorum_type) }}:
-      <span class="text-skin-link">{{ formatQuorum(totalProgress) }}</span>
+      <UiTooltip :title="quorumAmountTooltip">
+        <span class="text-skin-link">{{ formatQuorum(totalProgress) }}</span>
+      </UiTooltip>
     </div>
   </div>
   <template v-else>
@@ -230,7 +244,9 @@ onMounted(() => {
       </button>
       <div v-if="proposal.quorum">
         {{ quorumLabel(proposal.quorum_type) }}:
-        <span class="text-skin-link">{{ formatQuorum(totalProgress) }}</span>
+        <UiTooltip :title="quorumAmountTooltip">
+          <span class="text-skin-link">{{ formatQuorum(totalProgress) }}</span>
+        </UiTooltip>
       </div>
     </div>
     <div

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -40,14 +40,14 @@ const currentQuorum = computed(() =>
   getProposalCurrentQuorum(props.proposal.network, props.proposal)
 );
 
+const currentQuorumDisplay = computed(() =>
+  _vp(currentQuorum.value / 10 ** props.decimals)
+);
+
 const quorumAmountTooltip = computed(() => {
-  const symbol = props.proposal.space.voting_power_symbol;
-  const current = _vp(currentQuorum.value / 10 ** props.decimals);
   const required = _vp(props.proposal.quorum / 10 ** props.decimals);
 
-  return symbol
-    ? `${current} ${symbol} / ${required} ${symbol}`
-    : `${current} / ${required}`;
+  return `Required: ${required}`;
 });
 
 const placeholderResults = computed(() =>
@@ -162,9 +162,13 @@ onMounted(() => {
       is over, making the results visible.
     </div>
     <div v-if="proposal.quorum">
-      {{ quorumLabel(proposal.quorum_type) }}:
       <UiTooltip :title="quorumAmountTooltip">
-        <span class="text-skin-link">{{ formatQuorum(totalProgress) }}</span>
+        <span>
+          {{ quorumLabel(proposal.quorum_type) }}:
+          <span class="text-skin-link">
+            {{ currentQuorumDisplay }} {{ formatQuorum(totalProgress) }}
+          </span>
+        </span>
       </UiTooltip>
     </div>
   </div>
@@ -246,9 +250,13 @@ onMounted(() => {
         </div>
       </button>
       <div v-if="proposal.quorum">
-        {{ quorumLabel(proposal.quorum_type) }}:
         <UiTooltip :title="quorumAmountTooltip">
-          <span class="text-skin-link">{{ formatQuorum(totalProgress) }}</span>
+          <span>
+            {{ quorumLabel(proposal.quorum_type) }}:
+            <span class="text-skin-link">
+              {{ currentQuorumDisplay }} {{ formatQuorum(totalProgress) }}
+            </span>
+          </span>
         </UiTooltip>
       </div>
     </div>

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -2,7 +2,6 @@
 import { useQueryClient } from '@tanstack/vue-query';
 import {
   formatQuorum,
-  getProposalCurrentQuorum,
   quorumChoiceProgress,
   quorumLabel,
   quorumProgress
@@ -36,13 +35,9 @@ const displayAllChoices = ref(false);
 
 const totalProgress = computed(() => quorumProgress(props.proposal));
 
-const currentQuorum = computed(() =>
-  getProposalCurrentQuorum(props.proposal.network, props.proposal)
-);
-
 const quorumAmountTooltip = computed(() => {
   const symbol = props.proposal.space.voting_power_symbol;
-  const amount = _vp(currentQuorum.value / 10 ** props.decimals);
+  const amount = _vp(props.proposal.quorum / 10 ** props.decimals);
 
   return symbol ? `${amount} ${symbol}` : amount;
 });

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -32,14 +32,12 @@ const currentQuorum = computed(() =>
   getProposalCurrentQuorum(props.proposal.network, props.proposal)
 );
 
+const currentQuorumDisplay = computed(() => _vp(currentQuorum.value));
+
 const quorumAmountTooltip = computed(() => {
-  const symbol = props.proposal.space.voting_power_symbol;
-  const current = _vp(currentQuorum.value);
   const required = _vp(props.proposal.quorum);
 
-  return symbol
-    ? `${current} ${symbol} / ${required} ${symbol}`
-    : `${current} / ${required}`;
+  return `Required: ${required}`;
 });
 
 const hasVoted = computed(
@@ -145,9 +143,8 @@ const hasVoted = computed(
       <span v-if="proposal.quorum" class="lowercase">
         ·
         <UiTooltip :title="quorumAmountTooltip">
-          <span>{{ formatQuorum(totalProgress) }}</span>
+          <span>{{ quorumLabel(proposal.quorum_type) }}: {{ currentQuorumDisplay }} {{ formatQuorum(totalProgress) }}</span>
         </UiTooltip>
-        {{ quorumLabel(proposal.quorum_type) }}
       </span>
       ·
       <button

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -38,8 +38,8 @@ const quorumAmountTooltip = computed(() => {
   const required = _vp(props.proposal.quorum);
 
   return symbol
-    ? `Current: ${current} ${symbol}\nRequired: ${required} ${symbol}`
-    : `Current: ${current}\nRequired: ${required}`;
+    ? `${current} ${symbol} / ${required} ${symbol}`
+    : `${current} / ${required}`;
 });
 
 const hasVoted = computed(

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import { formatQuorum, quorumLabel, quorumProgress } from '@/helpers/quorum';
+import {
+  formatQuorum,
+  getProposalCurrentQuorum,
+  quorumLabel,
+  quorumProgress
+} from '@/helpers/quorum';
 import { _n, _vp, getProposalId, shortenAddress } from '@/helpers/utils';
 import { Proposal as ProposalType } from '@/types';
 
@@ -23,11 +28,18 @@ const modalOpenTimeline = ref(false);
 
 const totalProgress = computed(() => quorumProgress(props.proposal));
 
+const currentQuorum = computed(() =>
+  getProposalCurrentQuorum(props.proposal.network, props.proposal)
+);
+
 const quorumAmountTooltip = computed(() => {
   const symbol = props.proposal.space.voting_power_symbol;
-  const amount = _vp(props.proposal.quorum);
+  const current = _vp(currentQuorum.value);
+  const required = _vp(props.proposal.quorum);
 
-  return symbol ? `${amount} ${symbol}` : amount;
+  return symbol
+    ? `Current: ${current} ${symbol}\nRequired: ${required} ${symbol}`
+    : `Current: ${current}\nRequired: ${required}`;
 });
 
 const hasVoted = computed(

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -34,6 +34,12 @@ const currentQuorum = computed(() =>
 
 const currentQuorumDisplay = computed(() => _vp(currentQuorum.value));
 
+const quorumAmountTooltip = computed(() => {
+  const required = _vp(props.proposal.quorum);
+
+  return `Required: ${required}`;
+});
+
 const hasVoted = computed(
   () =>
     props.showVotedIndicator &&
@@ -135,8 +141,10 @@ const hasVoted = computed(
         </AppLink>
       </template>
       <span v-if="proposal.quorum" class="lowercase">
-        · {{ quorumLabel(proposal.quorum_type) }}:
-        {{ currentQuorumDisplay }} {{ formatQuorum(totalProgress) }}
+        ·
+        <UiTooltip :title="quorumAmountTooltip">
+          <span>{{ quorumLabel(proposal.quorum_type) }}: {{ currentQuorumDisplay }} {{ formatQuorum(totalProgress) }}</span>
+        </UiTooltip>
       </span>
       ·
       <button

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -1,11 +1,6 @@
 <script setup lang="ts">
-import {
-  formatQuorum,
-  getProposalCurrentQuorum,
-  quorumLabel,
-  quorumProgress
-} from '@/helpers/quorum';
-import { _n, _vp, getProposalId, shortenAddress } from '@/helpers/utils';
+import { formatQuorum, quorumLabel, quorumProgress } from '@/helpers/quorum';
+import { _n, getProposalId, shortenAddress } from '@/helpers/utils';
 import { Proposal as ProposalType } from '@/types';
 
 const props = withDefaults(
@@ -27,18 +22,6 @@ const { votes } = useAccount();
 const modalOpenTimeline = ref(false);
 
 const totalProgress = computed(() => quorumProgress(props.proposal));
-
-const currentQuorum = computed(() =>
-  getProposalCurrentQuorum(props.proposal.network, props.proposal)
-);
-
-const currentQuorumDisplay = computed(() => _vp(currentQuorum.value));
-
-const quorumAmountTooltip = computed(() => {
-  const required = _vp(props.proposal.quorum);
-
-  return `Required: ${required}`;
-});
 
 const hasVoted = computed(
   () =>
@@ -141,10 +124,8 @@ const hasVoted = computed(
         </AppLink>
       </template>
       <span v-if="proposal.quorum" class="lowercase">
-        ·
-        <UiTooltip :title="quorumAmountTooltip">
-          <span>{{ quorumLabel(proposal.quorum_type) }}: {{ currentQuorumDisplay }} {{ formatQuorum(totalProgress) }}</span>
-        </UiTooltip>
+        · {{ formatQuorum(totalProgress) }}
+        {{ quorumLabel(proposal.quorum_type) }}
       </span>
       ·
       <button

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -34,12 +34,6 @@ const currentQuorum = computed(() =>
 
 const currentQuorumDisplay = computed(() => _vp(currentQuorum.value));
 
-const quorumAmountTooltip = computed(() => {
-  const required = _vp(props.proposal.quorum);
-
-  return `Required: ${required}`;
-});
-
 const hasVoted = computed(
   () =>
     props.showVotedIndicator &&
@@ -141,10 +135,8 @@ const hasVoted = computed(
         </AppLink>
       </template>
       <span v-if="proposal.quorum" class="lowercase">
-        ·
-        <UiTooltip :title="quorumAmountTooltip">
-          <span>{{ quorumLabel(proposal.quorum_type) }}: {{ currentQuorumDisplay }} {{ formatQuorum(totalProgress) }}</span>
-        </UiTooltip>
+        · {{ quorumLabel(proposal.quorum_type) }}:
+        {{ currentQuorumDisplay }} {{ formatQuorum(totalProgress) }}
       </span>
       ·
       <button

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
-import { formatQuorum, quorumLabel, quorumProgress } from '@/helpers/quorum';
-import { _n, getProposalId, shortenAddress } from '@/helpers/utils';
+import {
+  formatQuorum,
+  getProposalCurrentQuorum,
+  quorumLabel,
+  quorumProgress
+} from '@/helpers/quorum';
+import { _n, _vp, getProposalId, shortenAddress } from '@/helpers/utils';
 import { Proposal as ProposalType } from '@/types';
 
 const props = withDefaults(
@@ -22,6 +27,17 @@ const { votes } = useAccount();
 const modalOpenTimeline = ref(false);
 
 const totalProgress = computed(() => quorumProgress(props.proposal));
+
+const currentQuorum = computed(() =>
+  getProposalCurrentQuorum(props.proposal.network, props.proposal)
+);
+
+const quorumAmountTooltip = computed(() => {
+  const symbol = props.proposal.space.voting_power_symbol;
+  const amount = _vp(currentQuorum.value);
+
+  return symbol ? `${amount} ${symbol}` : amount;
+});
 
 const hasVoted = computed(
   () =>
@@ -124,7 +140,10 @@ const hasVoted = computed(
         </AppLink>
       </template>
       <span v-if="proposal.quorum" class="lowercase">
-        · {{ formatQuorum(totalProgress) }}
+        ·
+        <UiTooltip :title="quorumAmountTooltip">
+          <span>{{ formatQuorum(totalProgress) }}</span>
+        </UiTooltip>
         {{ quorumLabel(proposal.quorum_type) }}
       </span>
       ·

--- a/apps/ui/src/components/ProposalsListItemHeading.vue
+++ b/apps/ui/src/components/ProposalsListItemHeading.vue
@@ -1,10 +1,5 @@
 <script setup lang="ts">
-import {
-  formatQuorum,
-  getProposalCurrentQuorum,
-  quorumLabel,
-  quorumProgress
-} from '@/helpers/quorum';
+import { formatQuorum, quorumLabel, quorumProgress } from '@/helpers/quorum';
 import { _n, _vp, getProposalId, shortenAddress } from '@/helpers/utils';
 import { Proposal as ProposalType } from '@/types';
 
@@ -28,13 +23,9 @@ const modalOpenTimeline = ref(false);
 
 const totalProgress = computed(() => quorumProgress(props.proposal));
 
-const currentQuorum = computed(() =>
-  getProposalCurrentQuorum(props.proposal.network, props.proposal)
-);
-
 const quorumAmountTooltip = computed(() => {
   const symbol = props.proposal.space.voting_power_symbol;
-  const amount = _vp(currentQuorum.value);
+  const amount = _vp(props.proposal.quorum);
 
   return symbol ? `${amount} ${symbol}` : amount;
 });


### PR DESCRIPTION
## Summary
- add a tooltip on quorum percentage in the proposal list item heading
- add a tooltip on quorum percentage in proposal results (both encrypted and standard sections)
- tooltip displays the current quorum amount with the space voting power symbol (e.g. `12.3k VP`)

## Testing
- `bun run lint` *(fails in this environment due to missing ESLint dependency `@eslint/compat`)*
- `bun run --filter ui typecheck` *(fails due to existing workspace dependency/type issues unrelated to this change)*