### PR TITLE
chore: hardcode Arbitrum org overview description in UI

### DIFF
--- a/apps/ui/src/views/Organization/Overview.vue
+++ b/apps/ui/src/views/Organization/Overview.vue
@@ -29,7 +29,7 @@ const proposalQueries = useQueries({
 
 const space = computed(() => organization.value?.spaces[0]);
 const spaces = computed(() => organization.value?.spaces ?? []);
-const orgOverviewDescription = computed(() => {
+const description = computed(() => {
   if (organization.value?.id === 'arbitrum') {
     return 'Powering the programmable economy';
   }
@@ -148,9 +148,9 @@ watchEffect(() => {
           </template>
         </div>
         <div
-          v-if="orgOverviewDescription"
+          v-if="description"
           class="max-w-[540px] text-skin-link text-md leading-[26px] mb-3 break-words"
-          v-html="autoLinkText(orgOverviewDescription)"
+          v-html="autoLinkText(description)"
         />
         <div v-if="socials.length > 0" class="gap-x-2 flex">
           <AppLink

--- a/apps/ui/src/views/Organization/Overview.vue
+++ b/apps/ui/src/views/Organization/Overview.vue
@@ -29,6 +29,13 @@ const proposalQueries = useQueries({
 
 const space = computed(() => organization.value?.spaces[0]);
 const spaces = computed(() => organization.value?.spaces ?? []);
+const orgOverviewDescription = computed(() => {
+  if (organization.value?.id === 'arbitrum') {
+    return 'Powering the programmable economy';
+  }
+
+  return space.value?.about;
+});
 
 const totalProposalCount = computed(() =>
   spaces.value.reduce((sum, s) => sum + s.proposal_count, 0)
@@ -141,9 +148,9 @@ watchEffect(() => {
           </template>
         </div>
         <div
-          v-if="space.about"
+          v-if="orgOverviewDescription"
           class="max-w-[540px] text-skin-link text-md leading-[26px] mb-3 break-words"
-          v-html="autoLinkText(space.about)"
+          v-html="autoLinkText(orgOverviewDescription)"
         />
         <div v-if="socials.length > 0" class="gap-x-2 flex">
           <AppLink


### PR DESCRIPTION
## Summary
- hardcode the Arbitrum organization overview description in the UI as:
  - "Powering the programmable economy"
- keep existing behavior for all other organizations (fallback to `space.about`)

## Implementation
- add `orgOverviewDescription` computed in `apps/ui/src/views/Organization/Overview.vue`
- use `orgOverviewDescription` in the overview description render block

## Validation
- attempted to run:
  - `bunx eslint apps/ui/src/views/Organization/Overview.vue`
- local environment error:
  - `Cannot find package '@eslint/compat'` from `packages/eslint-config/index.js`
