### PR TITLE
fix(ci): install starknet-devnet with --locked, re-enable l1 test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo
-          key: ${{ runner.os }}-cargo-${{ env.STARKNET_DEVNET_VERSION }}
+          key: ${{ runner.os }}-cargo-${{ env.STARKNET_DEVNET_VERSION }}-locked
       - name: Install Starknet Devnet
-        run: cargo install starknet-devnet@${{ env.STARKNET_DEVNET_VERSION }}
+        run: cargo install --locked starknet-devnet@${{ env.STARKNET_DEVNET_VERSION }}
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - run: bun install --frozen-lockfile

--- a/packages/sx.js/test/integration/starknet/index.test.ts
+++ b/packages/sx.js/test/integration/starknet/index.test.ts
@@ -598,9 +598,7 @@ describe('sx-starknet', () => {
       expect(receipt.transaction_hash).toBeDefined();
     }, 60_000);
 
-    // TODO: for some reason this fails on CI.
-    // We should revisit it when we update starknet-devnet.
-    it.skip('should execute on l1', async () => {
+    it('should execute on l1', async () => {
       const flushL2Response = await flush();
       const message_payload = flushL2Response.messages_to_l1[0].payload;
 


### PR DESCRIPTION
## Summary

The starknet l1 integration test (`should execute on l1`) was disabled in e520f426 because it consistently failed in CI. Root cause was that CI installs `starknet-devnet@0.4.2` without `--locked`, so cargo resolves transitive dependencies fresh — which over time diverged from the set that 0.4.2 was published with. The drifted build returns a different shape from `/postman/flush` (no top-level `messages_to_l1`), causing `Cannot read properties of undefined (reading '0')`.

The cached artifact under cache key `Linux-cargo-0.4.2` was already poisoned with that drifted build, so even successful `cargo install` invocations short-circuited to the bad binary.

## Changes

- `cargo install --locked starknet-devnet@…` — builds devnet against its published `Cargo.lock` so transitive deps don't drift between runs.
- Cache key bumped to `…-locked` to invalidate the existing poisoned cache entry.
- Re-enable `should execute on l1` (revert of the `it.skip` from e520f426).

## Test plan

- [x] Reproduced the original failure locally by inspecting devnet's actual `/postman/flush` response.
- [x] Confirmed `cargo install --locked starknet-devnet@0.4.2` produces a binary whose response includes `messages_to_l1` as expected.
- [x] Ran full `bun run test:integration:starknet` locally — all 24 tests pass, including the re-enabled `should execute on l1`.
- [ ] CI green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)