### PR TITLE
chore(lock): bump version to 0.3.0

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -43,7 +43,7 @@
     "@headlessui/vue": "^1.7.23",
     "@reown/walletkit": "^1.2.11",
     "@snapshot-labs/highlight": "^0.1.0-beta.2",
-    "@snapshot-labs/lock": "0.1.0",
+    "@snapshot-labs/lock": "0.3.0",
     "@snapshot-labs/tune": "0.1.0",
     "@snapshot-labs/pineapple": "^1.2.1",
     "@snapshot-labs/snapshot.js": "^0.14.20",

--- a/bun.lock
+++ b/bun.lock
@@ -134,7 +134,7 @@
         "@headlessui/vue": "^1.7.23",
         "@reown/walletkit": "^1.2.11",
         "@snapshot-labs/highlight": "^0.1.0-beta.2",
-        "@snapshot-labs/lock": "0.1.0",
+        "@snapshot-labs/lock": "0.3.0",
         "@snapshot-labs/pineapple": "^1.2.1",
         "@snapshot-labs/snapshot.js": "^0.14.20",
         "@snapshot-labs/sx": "^0.1.0",
@@ -257,7 +257,7 @@
     },
     "packages/lock": {
       "name": "@snapshot-labs/lock",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
         "0xsequence": "^2.2.10",
         "@coinbase/wallet-sdk": "^4.3.0",

--- a/packages/lock/package.json
+++ b/packages/lock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/lock",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/snapshot-labs/sx-monorepo.git",


### PR DESCRIPTION
Bumps `@snapshot-labs/lock` version from 0.1.0 to 0.3.0.

Closes https://github.com/snapshot-labs/workflow/issues/805

## Publish

After merging, publish from `packages/lock`:

```sh
cd packages/lock && bun publish
```

## Test plan
- [ ] CI passes