### PR TITLE
feat(ui): support multi-chain delegate registry

### DIFF
--- a/apps/ui/src/components/Modal/Delegate.vue
+++ b/apps/ui/src/components/Modal/Delegate.vue
@@ -2,8 +2,8 @@
 import { getAddress } from '@ethersproject/address';
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { h, VNode } from 'vue';
-import { DELEGATE_REGISTRY_STRATEGIES } from '@/helpers/constants';
 import {
+  getDelegateRegistryChainIds,
   isValidDelegation,
   ValidSpaceMetadataDelegation
 } from '@/helpers/delegation';
@@ -24,11 +24,6 @@ type Delegatee = {
 };
 
 const SPLIT_DELEGATION_SUPPORTED_CHAIN_IDS = [1, 100];
-// chain ids from https://github.com/snapshot-labs/snapshot-subgraph
-const DELEGATE_REGISTRY_SUPPORTED_CHAIN_IDS = [
-  1, 42161, 8453, 84532, 81457, 56, 250, 100, 59144, 5000, 137, 10, 146,
-  11155111
-];
 
 const DEFAULT_FORM_STATE = {
   delegatees: [{ id: '', share: 100 }],
@@ -122,30 +117,16 @@ const chainIds = computed(() => {
     return SPLIT_DELEGATION_SUPPORTED_CHAIN_IDS;
   }
 
-  const delegateRegistryStrategies = props.space.strategies_params.filter(
-    (_, index) =>
-      DELEGATE_REGISTRY_STRATEGIES.includes(props.space.strategies[index])
+  const chainIds = getDelegateRegistryChainIds(
+    props.space.strategies,
+    props.space.strategies_params
   );
 
-  if (!delegateRegistryStrategies.length) {
+  if (!chainIds.length) {
     return [form.chainId];
   }
 
-  const chainIds = delegateRegistryStrategies
-    .flatMap(params => {
-      return [
-        params.network,
-        ...(params.params?.strategies?.flatMap(p => [
-          p.network,
-          p.params?.network
-        ]) || [])
-      ];
-    })
-    .filter(Boolean)
-    .map(Number)
-    .filter(chainId => DELEGATE_REGISTRY_SUPPORTED_CHAIN_IDS.includes(chainId));
-
-  return Array.from(new Set(chainIds));
+  return chainIds;
 });
 
 function delegationConnectors(

--- a/apps/ui/src/components/SpaceDelegates.vue
+++ b/apps/ui/src/components/SpaceDelegates.vue
@@ -4,7 +4,10 @@ import removeMarkdown from 'remove-markdown';
 import { isValidDelegation } from '@/helpers/delegation';
 import { getGenericExplorerUrl } from '@/helpers/generic';
 import { _n, _p, _vp, compareAddresses, shorten } from '@/helpers/utils';
-import { useDelegateesQuery } from '@/queries/delegatees';
+import {
+  getDelegateesQueryKey,
+  useDelegateesQuery
+} from '@/queries/delegatees';
 import { useDelegatesQuery } from '@/queries/delegates';
 import { Space, SpaceMetadataDelegation } from '@/types';
 
@@ -138,11 +141,11 @@ function handleUndelegateConfirmed() {
   });
 
   queryClient.invalidateQueries({
-    queryKey: [
-      'delegatees',
-      props.delegation.contractAddress,
-      web3.value.account
-    ]
+    queryKey: getDelegateesQueryKey(
+      web3.value.account,
+      props.space,
+      props.delegation
+    )
   });
 
   isUndelegating.value = false;

--- a/apps/ui/src/helpers/delegation.test.ts
+++ b/apps/ui/src/helpers/delegation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { getDelegateRegistryChainIds } from './delegation';
+
+describe('delegation helpers', () => {
+  describe('getDelegateRegistryChainIds', () => {
+    it('returns supported direct strategy networks', () => {
+      expect(
+        getDelegateRegistryChainIds(['with-delegation'], [{ network: 1 }])
+      ).toEqual([1]);
+    });
+
+    it('returns supported nested strategy networks', () => {
+      expect(
+        getDelegateRegistryChainIds(
+          ['with-delegation'],
+          [
+            {
+              params: {
+                strategies: [{ network: 1 }, { params: { network: 42161 } }]
+              }
+            }
+          ]
+        )
+      ).toEqual([1, 42161]);
+    });
+
+    it('converts numeric strings and preserves first-seen order', () => {
+      expect(
+        getDelegateRegistryChainIds(
+          ['with-delegation', 'with-delegation'],
+          [{ network: '42161' }, { network: '1' }]
+        )
+      ).toEqual([42161, 1]);
+    });
+
+    it('filters unsupported chains', () => {
+      expect(
+        getDelegateRegistryChainIds(['with-delegation'], [{ network: 999999 }])
+      ).toEqual([]);
+    });
+
+    it('removes duplicate chains', () => {
+      expect(
+        getDelegateRegistryChainIds(
+          ['with-delegation'],
+          [
+            {
+              network: 1,
+              params: {
+                strategies: [
+                  { network: '1' },
+                  { params: { network: 42161 } },
+                  { params: { network: '42161' } }
+                ]
+              }
+            }
+          ]
+        )
+      ).toEqual([1, 42161]);
+    });
+
+    it('returns an empty list without Delegate Registry strategies', () => {
+      expect(
+        getDelegateRegistryChainIds(['erc20-balance-of'], [{ network: 1 }])
+      ).toEqual([]);
+    });
+  });
+});

--- a/apps/ui/src/helpers/delegation.ts
+++ b/apps/ui/src/helpers/delegation.ts
@@ -1,7 +1,22 @@
 import { enabledNetworks, evmNetworks } from '@/networks';
 import { METADATA } from '@/networks/starknet/metadata';
 import { ChainId, NetworkID, SpaceMetadataDelegation } from '@/types';
+import { DELEGATE_REGISTRY_STRATEGIES } from './constants';
 import { getChainIdKind } from './utils';
+
+// Chain ids from https://github.com/snapshot-labs/snapshot-subgraph
+export const DELEGATE_REGISTRY_SUPPORTED_CHAIN_IDS = [
+  1, 42161, 8453, 84532, 81457, 56, 250, 100, 59144, 5000, 137, 10, 146,
+  11155111
+];
+
+type StrategyParams = {
+  network?: string | number | null;
+  params?: {
+    network?: string | number | null;
+    strategies?: StrategyParams[];
+  };
+};
 
 export function getDelegationNetwork(chainId: ChainId) {
   // NOTE: any EVM network can be used for delegation on EVMs (it will switch chainId as needed).
@@ -35,4 +50,30 @@ export function isValidDelegation(
     delegation.apiType &&
     delegation.contractAddress
   );
+}
+
+function getStrategyNetworkIds(params: StrategyParams | undefined) {
+  return [
+    params?.network,
+    ...(params?.params?.strategies?.flatMap(strategy => [
+      strategy.network,
+      strategy.params?.network
+    ]) || [])
+  ];
+}
+
+export function getDelegateRegistryChainIds(
+  strategies: string[],
+  strategiesParams: StrategyParams[]
+): number[] {
+  const chainIds = strategiesParams
+    .filter((_, index) =>
+      DELEGATE_REGISTRY_STRATEGIES.includes(strategies[index])
+    )
+    .flatMap(getStrategyNetworkIds)
+    .filter(Boolean)
+    .map(Number)
+    .filter(chainId => DELEGATE_REGISTRY_SUPPORTED_CHAIN_IDS.includes(chainId));
+
+  return Array.from(new Set(chainIds));
 }

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -3,11 +3,13 @@ import {
   createHttpLink,
   InMemoryCache
 } from '@apollo/client/core';
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import {
   CHAIN_IDS,
   DELEGATE_REGISTRY_STRATEGIES,
   DELEGATION_TYPES_NAMES
 } from '@/helpers/constants';
+import { getDelegateRegistryChainIds } from '@/helpers/delegation';
 import { parseOSnapTransaction } from '@/helpers/osnap/transactions';
 import { getProposalCurrentQuorum } from '@/helpers/quorum';
 import { parseSafeSnapTransaction } from '@/helpers/safesnap/transactions';
@@ -88,6 +90,10 @@ const DELEGATE_REGISTRY_URLS: Partial<Record<NetworkID, string>> = {
 
 const SCORES_TICKS_LIMIT = 1000;
 export const SCORES_TICKS_MAX_VOTES = 4000;
+
+function getNetworkName(chainId: string | number) {
+  return networks[String(chainId)]?.name || `Chain ${chainId}`;
+}
 
 function getProposalState(
   networkId: NetworkID,
@@ -489,7 +495,7 @@ function formatVote(vote: ApiVote): Vote {
   };
 }
 
-function formatDelegations(
+export function formatDelegations(
   space: ApiSpace,
   networkId: NetworkID
 ): SpaceMetadataDelegation[] {
@@ -519,16 +525,27 @@ function formatDelegations(
   }
 
   if (basicDelegationStrategy) {
-    const chainId = space.network;
-
     const apiUrl = DELEGATE_REGISTRY_URLS[networkId];
     if (apiUrl) {
-      delegations.push({
-        name: DELEGATION_TYPES_NAMES['delegate-registry'],
-        apiType: 'delegate-registry',
-        apiUrl,
-        contractAddress: space.id,
-        chainId
+      const chainIds = getDelegateRegistryChainIds(
+        space.strategies.map(strategy => strategy.name),
+        space.strategies
+      );
+      const delegationChainIds = chainIds.length ? chainIds : [space.network];
+      const hasMultipleDelegateRegistryChains = delegationChainIds.length > 1;
+
+      delegationChainIds.forEach(chainId => {
+        const name = hasMultipleDelegateRegistryChains
+          ? `${DELEGATION_TYPES_NAMES['delegate-registry']} - ${getNetworkName(chainId)}`
+          : DELEGATION_TYPES_NAMES['delegate-registry'];
+
+        delegations.push({
+          name,
+          apiType: 'delegate-registry',
+          apiUrl,
+          contractAddress: space.id,
+          chainId
+        });
       });
     }
   }

--- a/apps/ui/src/networks/offchain/index.test.ts
+++ b/apps/ui/src/networks/offchain/index.test.ts
@@ -1,11 +1,52 @@
 import * as sx from '@snapshot-labs/sx';
 import { describe, expect, it, vi } from 'vitest';
 import { getNetwork } from '../index';
+import { formatDelegations } from './api';
+import { ApiSpace } from './api/types';
 
 const network = getNetwork('s');
 const voter = '0xf1f09AdC06aAB740AA16004D62Dbd89484d3Be90';
 
 describe('offchain network', () => {
+  describe('formatDelegations', () => {
+    it('generates one Delegate Registry delegation per supported strategy chain', () => {
+      const space = {
+        id: 'visionfoundation.eth',
+        network: '1',
+        delegationPortal: null,
+        strategies: [
+          {
+            name: 'with-delegation',
+            network: '1',
+            params: {
+              strategies: [
+                { network: '1', params: {} },
+                { network: '42161', params: {} }
+              ]
+            }
+          }
+        ]
+      } as unknown as ApiSpace;
+
+      expect(formatDelegations(space, 's')).toEqual([
+        {
+          name: 'Delegate registry - Ethereum',
+          apiType: 'delegate-registry',
+          apiUrl: 'https://delegate-registry-api.snapshot.box',
+          contractAddress: 'visionfoundation.eth',
+          chainId: 1
+        },
+        {
+          name: 'Delegate registry - Arbitrum One',
+          apiType: 'delegate-registry',
+          apiUrl: 'https://delegate-registry-api.snapshot.box',
+          contractAddress: 'visionfoundation.eth',
+          chainId: 42161
+        }
+      ]);
+    });
+  });
+
   describe('getVotingPower', () => {
     describe('vote validation', () => {
       it.each([['invalid address', 'invalid-address']])(

--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -1,6 +1,6 @@
 import { getAddress, isAddress } from '@ethersproject/address';
 import { useQuery } from '@tanstack/vue-query';
-import { MaybeRefOrGetter } from 'vue';
+import { computed, MaybeRefOrGetter, toValue } from 'vue';
 import { getProvider } from '@/helpers/provider';
 import { getNames } from '@/helpers/stamp';
 import { formatAddress } from '@/helpers/utils';
@@ -23,6 +23,22 @@ const FETCH_DELEGATEES_FN = {
   'delegate-registry': fetchDelegateRegistryDelegatees,
   'split-delegation': fetchSplitDelegationDelegatees
 } as const;
+
+export function getDelegateesQueryKey(
+  account: string | undefined,
+  space: Space,
+  delegation: SpaceMetadataDelegation | null
+) {
+  return [
+    'delegatees',
+    delegation?.apiType,
+    delegation?.contractAddress,
+    delegation?.chainId,
+    space.network,
+    space.id,
+    account
+  ];
+}
 
 async function fetchGovernorSubgraphDelegatees(
   account: string,
@@ -285,7 +301,13 @@ export function useDelegateesQuery(
   delegation: MaybeRefOrGetter<SpaceMetadataDelegation | null>
 ) {
   return useQuery({
-    queryKey: ['delegatees', delegation, account],
+    queryKey: computed(() =>
+      getDelegateesQueryKey(
+        toValue(account),
+        toValue(space),
+        toValue(delegation)
+      )
+    ),
     queryFn: () =>
       FETCH_DELEGATEES_FN[
         toValue(delegation)!.apiType as keyof typeof FETCH_DELEGATEES_FN


### PR DESCRIPTION
### Summary

Offchain spaces with Delegate Registry strategies on multiple supported chains previously generated a single delegation entry tied to `space.network`, so spaces like `gnosis.eth` and `cow.eth` exposed an Ethereum-only Delegates page and hid Arbitrum delegations.

Emit one `SpaceMetadataDelegation` per detected supported chain so the Delegates route renders separate tabs, each reading and clearing delegatees on the matching chain. Extract chain detection into a shared helper reused by the offchain formatter and the Delegate modal, and switch the delegatees query key to include chain so same-contract entries on different chains do not share cached results.

### How to test

1. Open a space with Delegate Registry strategies on both Ethereum and Arbitrum (e.g., `gnosis.eth` or `cow.eth`) and navigate to its Delegates page.
2. Confirm two Delegate Registry tabs are shown — one for Ethereum, one for Arbitrum.
3. With a wallet that has no existing delegation, confirm both tabs show an empty "Delegating to" state.
4. Click "Delegate" on the Ethereum tab and confirm the modal's Network field defaults to Ethereum; cancel.
5. Click "Delegate" on the Arbitrum tab and confirm the modal's Network field defaults to Arbitrum; delegate to `vitalik.eth` and approve the transaction.
6. Reload the page and confirm the Arbitrum tab shows the new delegatee while the Ethereum tab remains empty.
7. From the Arbitrum tab, click "Undelegate" and confirm the wallet transaction targets Arbitrum.
8. Open a single-chain Delegate Registry space and confirm only one Delegate Registry tab is shown (no regression).

### Other details
Discussion about the issue on Discord:
https://discord.com/channels/707079246388133940/728646188252921956/1501442365141811362

Demo video:
[Screencast_20260507_203720.webm](https://github.com/user-attachments/assets/bc9dc1f1-32d3-4fc4-a21a-975a40253b3a)