### PR TITLE
feat(ui): batch approve and pay via EIP-5792

### DIFF
--- a/apps/ui/src/composables/usePayment.ts
+++ b/apps/ui/src/composables/usePayment.ts
@@ -140,7 +140,8 @@ export default function usePayment(network: MaybeRefOrGetter<ChainId>) {
   async function batchedApproveAndPay(
     token: Token,
     amount: number,
-    barcode: string
+    barcode: string,
+    includeApprove: boolean
   ) {
     if (!auth.value) {
       modalAccountOpen.value = true;
@@ -155,20 +156,23 @@ export default function usePayment(network: MaybeRefOrGetter<ChainId>) {
     const erc20 = new Interface(abis.erc20);
     const payment = new Interface(PAYMENT_CONTRACT_ABI);
 
-    const calls: Eip5792Call[] = [
-      {
+    const calls: Eip5792Call[] = [];
+
+    if (includeApprove) {
+      calls.push({
         to: token.contractAddress,
         data: erc20.encodeFunctionData('approve', [spender, weiAmount])
-      },
-      {
-        to: spender,
-        data: payment.encodeFunctionData('payWithERC20Token', [
-          token.contractAddress,
-          weiAmount,
-          barcode
-        ])
-      }
-    ];
+      });
+    }
+
+    calls.push({
+      to: spender,
+      data: payment.encodeFunctionData('payWithERC20Token', [
+        token.contractAddress,
+        weiAmount,
+        barcode
+      ])
+    });
 
     const bundleId = await sendBatchedCalls(
       auth.value.provider,

--- a/apps/ui/src/composables/usePayment.ts
+++ b/apps/ui/src/composables/usePayment.ts
@@ -139,10 +139,10 @@ export default function usePayment(network: MaybeRefOrGetter<ChainId>) {
     token: Token,
     amount: number,
     barcode: string
-  ): Promise<{ hash: string }> {
+  ) {
     if (!auth.value) {
       modalAccountOpen.value = true;
-      throw new Error('wallet not connected');
+      return;
     }
 
     await verifyNetwork(auth.value.provider, Number(toValue(network)));

--- a/apps/ui/src/composables/usePayment.ts
+++ b/apps/ui/src/composables/usePayment.ts
@@ -67,6 +67,8 @@ function getWeiAmount(token: Token, amount: number): bigint {
 export default function usePayment(network: MaybeRefOrGetter<ChainId>) {
   const { auth } = useWeb3();
   const { modalAccountOpen } = useModal();
+  const abortController = new AbortController();
+  onScopeDispose(() => abortController.abort());
 
   async function getIsApproved(
     token: Token,
@@ -175,7 +177,9 @@ export default function usePayment(network: MaybeRefOrGetter<ChainId>) {
       calls
     );
 
-    const hash = await waitForCallsBundle(auth.value.provider, bundleId);
+    const hash = await waitForCallsBundle(auth.value.provider, bundleId, {
+      signal: abortController.signal
+    });
 
     return { hash };
   }

--- a/apps/ui/src/composables/usePayment.ts
+++ b/apps/ui/src/composables/usePayment.ts
@@ -1,6 +1,14 @@
+import { Interface } from '@ethersproject/abi';
 import { BigNumber } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
 import { MaybeRefOrGetter } from 'vue';
+import { abis } from '@/helpers/abis';
+import {
+  Eip5792Call,
+  hasAtomicBatchSupport,
+  sendBatchedCalls,
+  waitForCallsBundle
+} from '@/helpers/eip5792';
 import { approve as approveToken, getTokenAllowance } from '@/helpers/token';
 import { verifyNetwork } from '@/helpers/walletNetworks';
 import { ChainId } from '@/types';
@@ -117,9 +125,66 @@ export default function usePayment(network: MaybeRefOrGetter<ChainId>) {
     );
   }
 
+  async function getHasBatchSupport(): Promise<boolean> {
+    if (!auth.value) return false;
+
+    return hasAtomicBatchSupport(
+      auth.value.provider,
+      auth.value.account,
+      Number(toValue(network))
+    );
+  }
+
+  async function batchedApproveAndPay(
+    token: Token,
+    amount: number,
+    barcode: string
+  ): Promise<{ hash: string }> {
+    if (!auth.value) {
+      modalAccountOpen.value = true;
+      throw new Error('wallet not connected');
+    }
+
+    await verifyNetwork(auth.value.provider, Number(toValue(network)));
+
+    const spender = PAYMENT_CONTRACT_ADDRESSES[toValue(network)];
+    const weiAmount = getWeiAmount(token, amount);
+
+    const erc20 = new Interface(abis.erc20);
+    const payment = new Interface(PAYMENT_CONTRACT_ABI);
+
+    const calls: Eip5792Call[] = [
+      {
+        to: token.contractAddress,
+        data: erc20.encodeFunctionData('approve', [spender, weiAmount])
+      },
+      {
+        to: spender,
+        data: payment.encodeFunctionData('payWithERC20Token', [
+          token.contractAddress,
+          weiAmount,
+          barcode
+        ])
+      }
+    ];
+
+    const bundleId = await sendBatchedCalls(
+      auth.value.provider,
+      auth.value.account,
+      Number(toValue(network)),
+      calls
+    );
+
+    const hash = await waitForCallsBundle(auth.value.provider, bundleId);
+
+    return { hash };
+  }
+
   return {
     getIsApproved,
+    getHasBatchSupport,
     approve,
-    pay
+    pay,
+    batchedApproveAndPay
   };
 }

--- a/apps/ui/src/composables/usePaymentFactory.ts
+++ b/apps/ui/src/composables/usePaymentFactory.ts
@@ -114,9 +114,7 @@ export default function usePaymentFactory(network: MaybeRefOrGetter<ChainId>) {
 
   const currentStep = computed<Step>(() => STEPS.value[currentStepId.value]);
 
-  const isLastStep = computed<boolean>(
-    () => currentStep.value.nextStep() === false
-  );
+  const isLastStep = computed<boolean>(() => !currentStep.value.nextStep());
 
   function goToNextStep() {
     const nextStep = currentStep.value.nextStep();

--- a/apps/ui/src/composables/usePaymentFactory.ts
+++ b/apps/ui/src/composables/usePaymentFactory.ts
@@ -9,7 +9,7 @@ export type BarcodePayload = {
   params: Record<string, any>;
 };
 
-type StepId = 'prepare' | 'approve' | 'pay' | 'batched_pay';
+type StepId = 'prepare' | 'approve' | 'pay';
 
 type Step = {
   messages: {
@@ -64,9 +64,9 @@ export default function usePaymentFactory(network: MaybeRefOrGetter<ChainId>) {
         failTitle: 'Unable to prepare payment'
       },
       nextStep: () => {
-        if (isBatchSupported.value) return 'batched_pay';
+        if (isBatchSupported.value || isApproved.value) return 'pay';
 
-        return isApproved.value ? 'pay' : 'approve';
+        return 'approve';
       },
       execute: async (token, amount) => {
         const [approved, batchSupported] = await Promise.all([
@@ -105,28 +105,12 @@ export default function usePaymentFactory(network: MaybeRefOrGetter<ChainId>) {
           throw new Error('barcode payload is missing');
         }
 
-        return wrapPromise(
-          pay(token, amount, await getBarcode(payload)),
-          toValue(network)
-        );
-      }
-    },
-    batched_pay: {
-      messages: {
-        approveTitle: 'Confirm payment',
-        confirmingTitle: 'Confirming payment',
-        successTitle: 'Payment successful'
-      },
-      nextStep: () => false,
-      execute: async (token, amount, payload) => {
-        if (!payload) {
-          throw new Error('barcode payload is missing');
-        }
+        const barcode = await getBarcode(payload);
+        const promise = isBatchSupported.value
+          ? batchedApproveAndPay(token, amount, barcode)
+          : pay(token, amount, barcode);
 
-        return wrapPromise(
-          batchedApproveAndPay(token, amount, await getBarcode(payload)),
-          toValue(network)
-        );
+        return wrapPromise(promise, toValue(network));
       }
     }
   });

--- a/apps/ui/src/composables/usePaymentFactory.ts
+++ b/apps/ui/src/composables/usePaymentFactory.ts
@@ -9,7 +9,7 @@ export type BarcodePayload = {
   params: Record<string, any>;
 };
 
-type StepId = 'check_approval' | 'approve' | 'pay';
+type StepId = 'prepare' | 'approve' | 'pay' | 'batched_pay';
 
 type Step = {
   messages: {
@@ -31,7 +31,7 @@ type Step = {
 
 const BARCODE_VERSION = '0.1';
 
-const FIRST_STEP: StepId = 'check_approval';
+const FIRST_STEP: StepId = 'prepare';
 
 async function getBarcode(contents: BarcodePayload): Promise<string> {
   const receipt = await pin({
@@ -45,27 +45,43 @@ async function getBarcode(contents: BarcodePayload): Promise<string> {
 export default function usePaymentFactory(network: MaybeRefOrGetter<ChainId>) {
   const uiStore = useUiStore();
 
-  const { getIsApproved, approve, pay } = usePayment(network);
+  const {
+    getIsApproved,
+    getHasBatchSupport,
+    approve,
+    pay,
+    batchedApproveAndPay
+  } = usePayment(network);
   const currentStepId = ref<StepId>(FIRST_STEP);
-  const stepExecuteResults = ref<Map<StepId, boolean>>(new Map());
+  const stepExecuteResults = ref<Map<string, boolean>>(new Map());
 
   const STEPS = ref<Record<StepId, Step>>({
-    check_approval: {
+    prepare: {
       messages: {
-        approveTitle: 'Checking token allowance',
+        approveTitle: 'Preparing payment',
         approveSubtitle: 'Please wait...',
-        failTitle: 'Unable to check token allowance'
+        failTitle: 'Unable to prepare payment'
       },
-      nextStep: () =>
-        stepExecuteResults.value.get('check_approval') ? 'pay' : 'approve',
-      execute: async (token, amount) => {
-        const result = await getIsApproved(token, amount);
+      nextStep: () => {
+        if (stepExecuteResults.value.get('batched_pay_supported')) {
+          return 'batched_pay';
+        }
 
-        if (result === undefined) {
+        return stepExecuteResults.value.get('check_approval')
+          ? 'pay'
+          : 'approve';
+      },
+      execute: async (token, amount) => {
+        const isApproved = await getIsApproved(token, amount);
+
+        if (isApproved === undefined) {
           throw new Error('wallet not found');
         }
 
-        stepExecuteResults.value.set('check_approval', result);
+        stepExecuteResults.value.set('check_approval', isApproved);
+
+        const isBatchSupported = await getHasBatchSupport();
+        stepExecuteResults.value.set('batched_pay_supported', isBatchSupported);
 
         return null;
       }
@@ -75,7 +91,7 @@ export default function usePaymentFactory(network: MaybeRefOrGetter<ChainId>) {
         approveTitle: 'Setting token allowance',
         confirmingTitle: 'Waiting for token allowance'
       },
-      nextStep: () => 'check_approval',
+      nextStep: () => 'prepare',
       execute: async (token, amount) =>
         wrapPromise(approve(token, amount), toValue(network))
     },
@@ -96,13 +112,31 @@ export default function usePaymentFactory(network: MaybeRefOrGetter<ChainId>) {
           toValue(network)
         );
       }
+    },
+    batched_pay: {
+      messages: {
+        approveTitle: 'Confirm payment',
+        confirmingTitle: 'Confirming payment',
+        successTitle: 'Payment successful'
+      },
+      nextStep: () => false,
+      execute: async (token, amount, payload) => {
+        if (!payload) {
+          throw new Error('barcode payload is missing');
+        }
+
+        return wrapPromise(
+          batchedApproveAndPay(token, amount, await getBarcode(payload)),
+          toValue(network)
+        );
+      }
     }
   });
 
   const currentStep = computed<Step>(() => STEPS.value[currentStepId.value]);
 
   const isLastStep = computed<boolean>(() => {
-    return currentStepId.value === Object.keys(STEPS.value).pop();
+    return currentStep.value.nextStep() === false;
   });
 
   function goToNextStep() {

--- a/apps/ui/src/composables/usePaymentFactory.ts
+++ b/apps/ui/src/composables/usePaymentFactory.ts
@@ -104,7 +104,7 @@ export default function usePaymentFactory(network: MaybeRefOrGetter<ChainId>) {
 
         const barcode = await getBarcode(payload);
         const promise = isBatchSupported.value
-          ? batchedApproveAndPay(token, amount, barcode)
+          ? batchedApproveAndPay(token, amount, barcode, !isApproved.value)
           : pay(token, amount, barcode);
 
         return wrapPromise(promise, toValue(network));

--- a/apps/ui/src/composables/usePaymentFactory.ts
+++ b/apps/ui/src/composables/usePaymentFactory.ts
@@ -63,11 +63,8 @@ export default function usePaymentFactory(network: MaybeRefOrGetter<ChainId>) {
         approveSubtitle: 'Please wait...',
         failTitle: 'Unable to prepare payment'
       },
-      nextStep: () => {
-        if (isBatchSupported.value || isApproved.value) return 'pay';
-
-        return 'approve';
-      },
+      nextStep: () =>
+        isBatchSupported.value || isApproved.value ? 'pay' : 'approve',
       execute: async (token, amount) => {
         const [approved, batchSupported] = await Promise.all([
           getIsApproved(token, amount),

--- a/apps/ui/src/composables/usePaymentFactory.ts
+++ b/apps/ui/src/composables/usePaymentFactory.ts
@@ -53,7 +53,8 @@ export default function usePaymentFactory(network: MaybeRefOrGetter<ChainId>) {
     batchedApproveAndPay
   } = usePayment(network);
   const currentStepId = ref<StepId>(FIRST_STEP);
-  const stepExecuteResults = ref<Map<string, boolean>>(new Map());
+  const isApproved = ref(false);
+  const isBatchSupported = ref(false);
 
   const STEPS = ref<Record<StepId, Step>>({
     prepare: {
@@ -63,25 +64,22 @@ export default function usePaymentFactory(network: MaybeRefOrGetter<ChainId>) {
         failTitle: 'Unable to prepare payment'
       },
       nextStep: () => {
-        if (stepExecuteResults.value.get('batched_pay_supported')) {
-          return 'batched_pay';
-        }
+        if (isBatchSupported.value) return 'batched_pay';
 
-        return stepExecuteResults.value.get('check_approval')
-          ? 'pay'
-          : 'approve';
+        return isApproved.value ? 'pay' : 'approve';
       },
       execute: async (token, amount) => {
-        const isApproved = await getIsApproved(token, amount);
+        const [approved, batchSupported] = await Promise.all([
+          getIsApproved(token, amount),
+          getHasBatchSupport()
+        ]);
 
-        if (isApproved === undefined) {
+        if (approved === undefined) {
           throw new Error('wallet not found');
         }
 
-        stepExecuteResults.value.set('check_approval', isApproved);
-
-        const isBatchSupported = await getHasBatchSupport();
-        stepExecuteResults.value.set('batched_pay_supported', isBatchSupported);
+        isApproved.value = approved;
+        isBatchSupported.value = batchSupported;
 
         return null;
       }
@@ -159,7 +157,8 @@ export default function usePaymentFactory(network: MaybeRefOrGetter<ChainId>) {
 
   function start() {
     currentStepId.value = FIRST_STEP;
-    stepExecuteResults.value.clear();
+    isApproved.value = false;
+    isBatchSupported.value = false;
   }
 
   return { start, goToNextStep, isLastStep, currentStep };

--- a/apps/ui/src/composables/usePaymentFactory.ts
+++ b/apps/ui/src/composables/usePaymentFactory.ts
@@ -114,9 +114,9 @@ export default function usePaymentFactory(network: MaybeRefOrGetter<ChainId>) {
 
   const currentStep = computed<Step>(() => STEPS.value[currentStepId.value]);
 
-  const isLastStep = computed<boolean>(() => {
-    return currentStep.value.nextStep() === false;
-  });
+  const isLastStep = computed<boolean>(
+    () => currentStep.value.nextStep() === false
+  );
 
   function goToNextStep() {
     const nextStep = currentStep.value.nextStep();

--- a/apps/ui/src/helpers/eip5792.test.ts
+++ b/apps/ui/src/helpers/eip5792.test.ts
@@ -132,6 +132,14 @@ describe('waitForCallsBundle', () => {
 
     await expect(
       waitForCallsBundle({ send } as any, '0xBUNDLE', { pollIntervalMs: 0 })
-    ).rejects.toThrow(/failed/i);
+    ).rejects.toThrow(/failed.*500/i);
+  });
+
+  it('throws when status is 3xx (partial revert)', async () => {
+    const send = vi.fn().mockResolvedValue({ status: 300, receipts: [] });
+
+    await expect(
+      waitForCallsBundle({ send } as any, '0xBUNDLE', { pollIntervalMs: 0 })
+    ).rejects.toThrow(/failed.*300/i);
   });
 });

--- a/apps/ui/src/helpers/eip5792.test.ts
+++ b/apps/ui/src/helpers/eip5792.test.ts
@@ -178,4 +178,17 @@ describe('waitForCallsBundle', () => {
       waitForCallsBundle({ send } as any, '0xBUNDLE', { pollIntervalMs: 0 })
     ).rejects.toThrow(/failed.*300/i);
   });
+
+  it('throws when signal is aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const send = vi.fn().mockResolvedValue({ status: 100, receipts: [] });
+
+    await expect(
+      waitForCallsBundle({ send } as any, '0xBUNDLE', {
+        pollIntervalMs: 0,
+        signal: controller.signal
+      })
+    ).rejects.toThrow(/aborted/i);
+  });
 });

--- a/apps/ui/src/helpers/eip5792.test.ts
+++ b/apps/ui/src/helpers/eip5792.test.ts
@@ -49,6 +49,42 @@ describe('hasAtomicBatchSupport', () => {
     );
   });
 
+  it('returns true when atomic is a JSON-encoded string (Safe Wallet format)', async () => {
+    const provider = makeProvider({
+      '0x1': { atomic: '{"status":"supported"}' }
+    });
+
+    expect(await hasAtomicBatchSupport(provider as any, '0xabc', 1)).toBe(true);
+  });
+
+  it('returns true when capability uses legacy atomicBatch.supported (Safe iframe)', async () => {
+    const provider = makeProvider({
+      '0x1': { atomicBatch: { supported: true } }
+    });
+
+    expect(await hasAtomicBatchSupport(provider as any, '0xabc', 1)).toBe(true);
+  });
+
+  it('returns false when legacy atomicBatch.supported is false', async () => {
+    const provider = makeProvider({
+      '0x1': { atomicBatch: { supported: false } }
+    });
+
+    expect(await hasAtomicBatchSupport(provider as any, '0xabc', 1)).toBe(
+      false
+    );
+  });
+
+  it('returns false when atomic is an unparseable string', async () => {
+    const provider = makeProvider({
+      '0x1': { atomic: 'not json' }
+    });
+
+    expect(await hasAtomicBatchSupport(provider as any, '0xabc', 1)).toBe(
+      false
+    );
+  });
+
   it('returns false when capability key is missing', async () => {
     const provider = makeProvider({ '0x1': {} });
 

--- a/apps/ui/src/helpers/eip5792.test.ts
+++ b/apps/ui/src/helpers/eip5792.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import { hasAtomicBatchSupport } from './eip5792';
+import {
+  Eip5792Call,
+  hasAtomicBatchSupport,
+  sendBatchedCalls,
+  waitForCallsBundle
+} from './eip5792';
 
 function makeProvider(response: unknown, error?: Error) {
   return {
@@ -58,5 +63,75 @@ describe('hasAtomicBatchSupport', () => {
     expect(await hasAtomicBatchSupport(provider as any, '0xabc', 1)).toBe(
       false
     );
+  });
+});
+
+describe('sendBatchedCalls', () => {
+  it('sends wallet_sendCalls with hex chain id and returns the bundle id', async () => {
+    const provider = makeProvider({ id: '0xBUNDLE' });
+
+    const calls: Eip5792Call[] = [
+      { to: '0xToken', data: '0xapprove' },
+      { to: '0xPay', data: '0xpay' }
+    ];
+
+    const bundleId = await sendBatchedCalls(
+      provider as any,
+      '0xACCOUNT',
+      1,
+      calls
+    );
+
+    expect(bundleId).toBe('0xBUNDLE');
+    expect(provider.send).toHaveBeenCalledWith('wallet_sendCalls', [
+      {
+        version: '2.0.0',
+        chainId: '0x1',
+        from: '0xACCOUNT',
+        atomicRequired: true,
+        calls
+      }
+    ]);
+  });
+
+  it('accepts a string bundle id (legacy wallet shape)', async () => {
+    const provider = makeProvider('0xLEGACY');
+
+    const bundleId = await sendBatchedCalls(
+      provider as any,
+      '0xACCOUNT',
+      1,
+      []
+    );
+
+    expect(bundleId).toBe('0xLEGACY');
+  });
+});
+
+describe('waitForCallsBundle', () => {
+  it('polls until status is CONFIRMED and returns the first tx hash', async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 100, receipts: [] })
+      .mockResolvedValueOnce({
+        status: 200,
+        receipts: [{ transactionHash: '0xTX1' }, { transactionHash: '0xTX2' }]
+      });
+
+    const hash = await waitForCallsBundle({ send } as any, '0xBUNDLE', {
+      pollIntervalMs: 0
+    });
+
+    expect(hash).toBe('0xTX1');
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenCalledWith('wallet_getCallsStatus', ['0xBUNDLE']);
+  });
+
+  it('throws when status indicates failure', async () => {
+    const send = vi.fn().mockResolvedValue({ status: 500, receipts: [] });
+
+    await expect(
+      waitForCallsBundle({ send } as any, '0xBUNDLE', { pollIntervalMs: 0 })
+    ).rejects.toThrow(/failed/i);
   });
 });

--- a/apps/ui/src/helpers/eip5792.test.ts
+++ b/apps/ui/src/helpers/eip5792.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { hasAtomicBatchSupport } from './eip5792';
+
+function makeProvider(response: unknown, error?: Error) {
+  return {
+    send: vi.fn(async () => {
+      if (error) throw error;
+
+      return response;
+    })
+  };
+}
+
+describe('hasAtomicBatchSupport', () => {
+  it('returns true when atomic status is "supported"', async () => {
+    const provider = makeProvider({
+      '0x1': { atomic: { status: 'supported' } }
+    });
+
+    const result = await hasAtomicBatchSupport(provider as any, '0xabc', 1);
+
+    expect(result).toBe(true);
+    expect(provider.send).toHaveBeenCalledWith('wallet_getCapabilities', [
+      '0xabc',
+      ['0x1']
+    ]);
+  });
+
+  it('returns true when atomic status is "ready"', async () => {
+    const provider = makeProvider({
+      '0x1': { atomic: { status: 'ready' } }
+    });
+
+    expect(await hasAtomicBatchSupport(provider as any, '0xabc', 1)).toBe(true);
+  });
+
+  it('returns false when atomic status is "unsupported"', async () => {
+    const provider = makeProvider({
+      '0x1': { atomic: { status: 'unsupported' } }
+    });
+
+    expect(await hasAtomicBatchSupport(provider as any, '0xabc', 1)).toBe(
+      false
+    );
+  });
+
+  it('returns false when capability key is missing', async () => {
+    const provider = makeProvider({ '0x1': {} });
+
+    expect(await hasAtomicBatchSupport(provider as any, '0xabc', 1)).toBe(
+      false
+    );
+  });
+
+  it('returns false when wallet rejects the RPC method', async () => {
+    const provider = makeProvider(undefined, new Error('Method not found'));
+
+    expect(await hasAtomicBatchSupport(provider as any, '0xabc', 1)).toBe(
+      false
+    );
+  });
+});

--- a/apps/ui/src/helpers/eip5792.ts
+++ b/apps/ui/src/helpers/eip5792.ts
@@ -12,7 +12,7 @@ type SendCallsResult = string | { id: string };
 
 type CallsStatusResponse = {
   status: number;
-  receipts: { transactionHash: string }[];
+  receipts?: { transactionHash: string }[];
 };
 
 type CapabilitiesResponse = Record<
@@ -21,7 +21,7 @@ type CapabilitiesResponse = Record<
 >;
 
 const STATUS_CONFIRMED_MIN = 200;
-const STATUS_FAILURE_MIN = 400;
+const STATUS_FAILURE_MIN = 300;
 
 export async function hasAtomicBatchSupport(
   provider: Pick<Web3Provider, 'send'>,
@@ -76,7 +76,7 @@ export async function waitForCallsBundle(
     ])) as CallsStatusResponse;
 
     if (result.status >= STATUS_CONFIRMED_MIN && result.status < 300) {
-      const hash = result.receipts[0]?.transactionHash;
+      const hash = result.receipts?.[0]?.transactionHash;
       if (!hash) throw new Error('Bundle confirmed but no receipts returned');
 
       return hash;

--- a/apps/ui/src/helpers/eip5792.ts
+++ b/apps/ui/src/helpers/eip5792.ts
@@ -98,7 +98,10 @@ export async function waitForCallsBundle(
       bundleId
     ])) as CallsStatusResponse;
 
-    if (result.status >= STATUS_CONFIRMED_MIN && result.status < 300) {
+    if (
+      result.status >= STATUS_CONFIRMED_MIN &&
+      result.status < STATUS_FAILURE_MIN
+    ) {
       const hash = result.receipts?.[0]?.transactionHash;
       if (!hash) throw new Error('Bundle confirmed but no receipts returned');
 

--- a/apps/ui/src/helpers/eip5792.ts
+++ b/apps/ui/src/helpers/eip5792.ts
@@ -1,0 +1,29 @@
+import { Web3Provider } from '@ethersproject/providers';
+
+type AtomicStatus = 'supported' | 'ready' | 'unsupported';
+
+type CapabilitiesResponse = Record<
+  string,
+  { atomic?: { status?: AtomicStatus } }
+>;
+
+export async function hasAtomicBatchSupport(
+  provider: Pick<Web3Provider, 'send'>,
+  account: string,
+  chainId: number
+): Promise<boolean> {
+  const chainHex = `0x${chainId.toString(16)}`;
+
+  try {
+    const result = (await provider.send('wallet_getCapabilities', [
+      account,
+      [chainHex]
+    ])) as CapabilitiesResponse | undefined;
+
+    const status = result?.[chainHex]?.atomic?.status;
+
+    return status === 'supported' || status === 'ready';
+  } catch {
+    return false;
+  }
+}

--- a/apps/ui/src/helpers/eip5792.ts
+++ b/apps/ui/src/helpers/eip5792.ts
@@ -15,12 +15,13 @@ type CallsStatusResponse = {
   receipts: { transactionHash: string }[];
 };
 
-const STATUS_CONFIRMED = 200;
-
 type CapabilitiesResponse = Record<
   string,
   { atomic?: { status?: AtomicStatus } }
 >;
+
+const STATUS_CONFIRMED_MIN = 200;
+const STATUS_FAILURE_MIN = 400;
 
 export async function hasAtomicBatchSupport(
   provider: Pick<Web3Provider, 'send'>,
@@ -74,14 +75,14 @@ export async function waitForCallsBundle(
       bundleId
     ])) as CallsStatusResponse;
 
-    if (result.status >= STATUS_CONFIRMED && result.status < 300) {
+    if (result.status >= STATUS_CONFIRMED_MIN && result.status < 300) {
       const hash = result.receipts[0]?.transactionHash;
       if (!hash) throw new Error('Bundle confirmed but no receipts returned');
 
       return hash;
     }
 
-    if (result.status >= 400) {
+    if (result.status >= STATUS_FAILURE_MIN) {
       throw new Error(`Bundle execution failed (status ${result.status})`);
     }
 

--- a/apps/ui/src/helpers/eip5792.ts
+++ b/apps/ui/src/helpers/eip5792.ts
@@ -2,6 +2,21 @@ import { Web3Provider } from '@ethersproject/providers';
 
 type AtomicStatus = 'supported' | 'ready' | 'unsupported';
 
+export type Eip5792Call = {
+  to: string;
+  data: string;
+  value?: string;
+};
+
+type SendCallsResult = string | { id: string };
+
+type CallsStatusResponse = {
+  status: number;
+  receipts: { transactionHash: string }[];
+};
+
+const STATUS_CONFIRMED = 200;
+
 type CapabilitiesResponse = Record<
   string,
   { atomic?: { status?: AtomicStatus } }
@@ -25,5 +40,51 @@ export async function hasAtomicBatchSupport(
     return status === 'supported' || status === 'ready';
   } catch {
     return false;
+  }
+}
+
+export async function sendBatchedCalls(
+  provider: Pick<Web3Provider, 'send'>,
+  account: string,
+  chainId: number,
+  calls: Eip5792Call[]
+): Promise<string> {
+  const result = (await provider.send('wallet_sendCalls', [
+    {
+      version: '2.0.0',
+      chainId: `0x${chainId.toString(16)}`,
+      from: account,
+      atomicRequired: true,
+      calls
+    }
+  ])) as SendCallsResult;
+
+  return typeof result === 'string' ? result : result.id;
+}
+
+export async function waitForCallsBundle(
+  provider: Pick<Web3Provider, 'send'>,
+  bundleId: string,
+  options: { pollIntervalMs?: number } = {}
+): Promise<string> {
+  const interval = options.pollIntervalMs ?? 2000;
+
+  while (true) {
+    const result = (await provider.send('wallet_getCallsStatus', [
+      bundleId
+    ])) as CallsStatusResponse;
+
+    if (result.status >= STATUS_CONFIRMED && result.status < 300) {
+      const hash = result.receipts[0]?.transactionHash;
+      if (!hash) throw new Error('Bundle confirmed but no receipts returned');
+
+      return hash;
+    }
+
+    if (result.status >= 400) {
+      throw new Error(`Bundle execution failed (status ${result.status})`);
+    }
+
+    await new Promise(resolve => setTimeout(resolve, interval));
   }
 }

--- a/apps/ui/src/helpers/eip5792.ts
+++ b/apps/ui/src/helpers/eip5792.ts
@@ -89,11 +89,14 @@ export async function sendBatchedCalls(
 export async function waitForCallsBundle(
   provider: Pick<Web3Provider, 'send'>,
   bundleId: string,
-  options: { pollIntervalMs?: number } = {}
+  options: { pollIntervalMs?: number; signal?: AbortSignal } = {}
 ): Promise<string> {
   const interval = options.pollIntervalMs ?? 2000;
+  const { signal } = options;
 
   while (true) {
+    if (signal?.aborted) throw new Error('Bundle polling aborted');
+
     const result = (await provider.send('wallet_getCallsStatus', [
       bundleId
     ])) as CallsStatusResponse;

--- a/apps/ui/src/helpers/eip5792.ts
+++ b/apps/ui/src/helpers/eip5792.ts
@@ -15,13 +15,32 @@ type CallsStatusResponse = {
   receipts?: { transactionHash: string }[];
 };
 
+type AtomicCapability = { status?: AtomicStatus };
+
+type LegacyAtomicCapability = { supported?: boolean };
+
 type CapabilitiesResponse = Record<
   string,
-  { atomic?: { status?: AtomicStatus } }
+  {
+    atomic?: AtomicCapability | string;
+    atomicBatch?: LegacyAtomicCapability;
+  }
 >;
 
 const STATUS_CONFIRMED_MIN = 200;
 const STATUS_FAILURE_MIN = 300;
+
+function parseAtomicCapability(
+  raw: AtomicCapability | string | undefined
+): AtomicCapability | undefined {
+  if (typeof raw !== 'string') return raw;
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
 
 export async function hasAtomicBatchSupport(
   provider: Pick<Web3Provider, 'send'>,
@@ -36,9 +55,13 @@ export async function hasAtomicBatchSupport(
       [chainHex]
     ])) as CapabilitiesResponse | undefined;
 
-    const status = result?.[chainHex]?.atomic?.status;
+    const capability = result?.[chainHex];
+    const atomic = parseAtomicCapability(capability?.atomic);
+    const status = atomic?.status;
 
-    return status === 'supported' || status === 'ready';
+    if (status === 'supported' || status === 'ready') return true;
+
+    return capability?.atomicBatch?.supported === true;
   } catch {
     return false;
   }


### PR DESCRIPTION
Add EIP-5792 atomic batching so users on Safe and other smart-account wallets sign once instead of twice when paying for or extending a Turbo subscription. Resolves https://github.com/snapshot-labs/workflow/issues/807.

## Summary

- New `eip5792.ts` helper + capability-aware branching in the payment factory; falls back to the existing sequential flow when the wallet doesn't support batching.
- Capability parser handles three response shapes (standard EIP-5792, Safe-via-WC's JSON-encoded string, Safe iframe's legacy `atomicBatch.supported`).
- Approve call is omitted from the bundle when the user already has sufficient allowance.
- Polling is aborted automatically when the payment composable's scope disposes (e.g. modal closes).
- No new dependencies.

## Wallet support

| Wallet | Result |
|---|---|
| Safe (iframe) | ✅ Verified — one Safe proposal containing both calls via MultiSend, one signing round |
| Safe (WalletConnect) | ✅ Verified — same as above |
| MetaMask + EIP-7702 delegation | Should batch (untested) |
| MetaMask plain EOA | Falls back to existing sequential approve → pay (unchanged behavior) |

## Notes

- Mainnet USDT users with a non-zero leftover allowance can hit the legacy "non-zero to non-zero" approve revert when the bundle includes an approve. This is a pre-existing bug in the non-batched flow too — tracked in #2083 — and out of scope for this PR.

## Test plan

### Common setup

1. Create `apps/ui/.env.local` (testnet payments use Sepolia + SNUSDC):
   ```
   VITE_METADATA_NETWORK=s-tn
   VITE_ENABLED_NETWORKS=s-tn,sep,sn-sep
   ```
2. Run `bun run dev` from `apps/ui`.
3. Sepolia 1/1 Safe funded with ~0.01 ETH and ~5 SNUSDC. Mint SNUSDC at https://sepolia.etherscan.io/address/0x8ec1409bf214893aea175c9c00c711593277f1c3#writeContract — send to **the Safe address**, not your owner EOA.

- [x] `bun run test` in `apps/ui` — passes on this branch.

### Safe iframe ✅

Safe requires HTTPS for custom apps, so the dev server must be tunneled. The Netlify testnet preview (https://deploy-preview-2079--snapshot-testnet.netlify.app/) can't be used as the Safe app URL either — its `manifest.json` doesn't include `Access-Control-Allow-Origin: https://app.safe.global`, so Safe rejects it during validation.

1. **HTTPS tunnel** to expose `http://localhost:8080`. Use whichever tool you prefer — `cloudflared`, `ngrok`, `localtunnel`, etc. Note the resulting `https://...` URL and its hostname.

2. **Patch `apps/ui/vite.config.ts`** so Vite accepts the tunnel host and sets CORS for Safe's manifest fetch (replace `<tunnel-host>` with the hostname from step 1, e.g. `.trycloudflare.com` or `.ngrok-free.app`):
   ```ts
   export default defineConfig({
     base: ELECTRON ? './' : undefined,
     server: {
       allowedHosts: ['<tunnel-host>'],
       cors: { origin: 'https://app.safe.global' }
     },
     // ... rest unchanged
   ```

3. Restart `bun run dev`.

4. In `https://app.safe.global` → your Sepolia Safe → Apps → My custom apps → Add custom app → paste the tunnel URL → open it.

5. Inside the iframe, navigate to `#/pro`. Pick SNUSDC, accept terms, click **Pay**.

6. Expect: "Preparing payment" → "Confirm payment" with **one** Safe screen showing both calls → sign once → success. Safe → Transactions → History shows ONE on-chain tx where `execTransaction.operation = 1` (DELEGATECALL) and the calldata is a MultiSend wrapping `approve` + `payWithERC20Token`.

<img width="2440" height="946" alt="image" src="https://github.com/user-attachments/assets/1f3bb371-337c-455e-b427-77d5491949ee" />

See example tx: https://sepolia.etherscan.io/tx/0x792b84876edd6c7b5933571ae1b2c973c51f365027f5f1f8f7d7d72923976175

### Safe via WalletConnect ✅

No tunnel or patches needed — `localhost:8080` works because WC connects over its own protocol.

1. Open `http://localhost:8080/#/pro` in a regular browser tab.

2. Click **Connect** → WalletConnect → copy the URI.

3. In `https://app.safe.global` → your Sepolia Safe → top-right Settings → WalletConnect → paste the URI → approve the session.

4. Confirm Snapshot's top bar now shows the **Safe address** (not your owner EOA) as the connected account.

5. On the Pro page, pick SNUSDC, accept terms, click **Pay**.

6. Expect: same outcome as the iframe path — one bundled Safe proposal containing both calls; history shows ONE MultiSend tx.

### Remaining checks

- [ ] **EOA fallback regression** — connect MetaMask on Sepolia → `http://localhost:8080/#/pro` → Pay with SNUSDC (no prior allowance). Expect: "Preparing payment" → "Setting token allowance" (sign 1) → "Preparing payment" (brief) → "Confirm payment" (sign 2) → success. Two pending tx hashes recorded.
- [ ] **EOA with sufficient allowance** — repeat above. Expect approve step skipped.
- [ ] **Batched with sufficient allowance** — repeat the Safe iframe / WC flow with prior allowance. Expect bundle contains only `payWithERC20Token` (no approve), one signing round.
- [ ] **Modal Close mid-flow** on each scenario — clean dismissal, no unhandled rejections in console; `wallet_getCallsStatus` polling stops within ~2s of close.
- [ ] **DevTools sanity** — `wallet_getCapabilities` sent on every payment; `wallet_sendCalls` only on the batched path.
