### PR TITLE
fix(sequencer): correct scores_total_value inflation for approval voting

### DIFF
--- a/apps/sequencer/docs/cb-flow.md
+++ b/apps/sequencer/docs/cb-flow.md
@@ -2,15 +2,15 @@
 
 ## CB States
 
-| Value | Constant | Proposals | Votes |
-|------:|----------|-----------|-------|
-| 0 | `PENDING_SYNC` | Default. Waiting for strategy values from Overlord | N/A |
-| -1 | `PENDING_COMPUTE` | Strategy values synced. Waiting for `scores_total_value` computation | Default. Waiting for `vp_value` computation |
-| -2 | `PENDING_FINAL` | Score value computed, but proposal still active | Value computed, but `vp_state` not final |
-| 1 | `FINAL` | Fully computed | Fully computed |
-| -3 | `PENDING_DELETE` | N/A | Proposal deleted, vote awaiting async cleanup |
-| -10 | `INELIGIBLE` | Invalid payload format, cannot compute (permanent) | Invalid data, cannot compute (permanent) |
-| -11 | `ERROR_SYNC` | Overlord sync failed, will be retried | N/A |
+| Value | Constant          | Proposals                                                            | Votes                                         |
+| ----: | ----------------- | -------------------------------------------------------------------- | --------------------------------------------- |
+|     0 | `PENDING_SYNC`    | Default. Waiting for strategy values from Overlord                   | N/A                                           |
+|    -1 | `PENDING_COMPUTE` | Strategy values synced. Waiting for `scores_total_value` computation | Default. Waiting for `vp_value` computation   |
+|    -2 | `PENDING_FINAL`   | Score value computed, but waiting for scores or votes to finalize    | Value computed, but `vp_state` not final      |
+|     1 | `FINAL`           | Fully computed                                                       | Fully computed                                |
+|    -3 | `PENDING_DELETE`  | N/A                                                                  | Proposal deleted, vote awaiting async cleanup |
+|   -10 | `INELIGIBLE`      | Invalid payload format, cannot compute (permanent)                   | Invalid data, cannot compute (permanent)      |
+|   -11 | `ERROR_SYNC`      | Overlord sync failed, will be retried                                | N/A                                           |
 
 > 🟦 Blue = user action &nbsp;&nbsp; 🟧 Orange = async background script
 
@@ -27,20 +27,23 @@ flowchart TD
     D -->|proposalsScoresValue.ts<br>computes scores_total_value| F{Valid payload?}
     F -->|No| G["cb = -10<br>INELIGIBLE"]
     F -->|Yes| H{scores_state<br>final?}
-    H -->|Yes| I["cb = 1<br>FINAL"]
+    H -->|Yes| K{All votes<br>finalized?}
+    K -->|Yes| I["cb = 1<br>FINAL"]
+    K -->|No| J
     H -->|No| J["cb = -2<br>PENDING_FINAL"]
     J -->|New vote arrives<br>scores.ts| D
+    J -->|"scores_state = final<br>proposalsScoresValue.ts<br>retries finalization"| F
 
     classDef user fill:#4a90d9,color:#fff
     classDef async fill:#e8833a,color:#fff
 
     class A user
-    class C,F,H async
+    class C,F,H,K async
     class B,D,E,G,I,J default
 
     linkStyle 0 stroke:#4a90d9
-    linkStyle 1,2,3,4,5,6,7,8,9,10 stroke:#e8833a
-    linkStyle 11 stroke:#4a90d9
+    linkStyle 1,2,3,4,5,6,7,8,9,10,11,12 stroke:#e8833a
+    linkStyle 13 stroke:#4a90d9
 ```
 
 ## Votes State Diagram

--- a/apps/sequencer/src/helpers/proposalsScoresValue.ts
+++ b/apps/sequencer/src/helpers/proposalsScoresValue.ts
@@ -6,6 +6,7 @@ import { CB } from '../constants';
 
 type Proposal = {
   id: string;
+  type: string;
   scoresState: string;
   vpValueByStrategy: number[];
   scoresByStrategy: number[][];
@@ -17,6 +18,7 @@ const BATCH_SIZE = 25;
 const proposalSchema = z
   .object({
     id: z.string(),
+    type: z.string(),
     scoresState: z.string(),
     vpValueByStrategy: z.array(z.number().finite()),
     scoresByStrategy: z.array(z.array(z.number().finite()))
@@ -42,19 +44,21 @@ const proposalSchema = z
 
 async function getProposals(): Promise<Proposal[]> {
   const query = `
-    SELECT id, scores_state, vp_value_by_strategy, scores_by_strategy
+    SELECT id, type, scores_state, vp_value_by_strategy, scores_by_strategy
     FROM proposals
-    WHERE cb = ?
+    WHERE cb = ? OR (cb = ? AND scores_state = 'final')
     ORDER BY created ASC
     LIMIT ?
   `;
   const proposals = await db.queryAsync(query, [
     CB.PENDING_COMPUTE,
+    CB.PENDING_FINAL,
     BATCH_SIZE
   ]);
 
   return proposals.map((p: any) => ({
     id: p.id,
+    type: p.type,
     scoresState: p.scores_state,
     vpValueByStrategy: JSON.parse(p.vp_value_by_strategy),
     scoresByStrategy: JSON.parse(p.scores_by_strategy)
@@ -77,27 +81,57 @@ export function getScoresTotalValue(proposal: Proposal): number {
   );
 }
 
+// For approval voting, scores_by_strategy counts a voter's VP once per approved choice,
+// inflating scores_total_value. Instead, we sum vp_value directly from votes, which
+// counts each voter's VP exactly once regardless of how many choices they approved.
+async function getVotesVpValueSum(proposalId: string): Promise<number> {
+  const [{ total }] = await db.queryAsync(
+    'SELECT COALESCE(SUM(vp_value), 0) as total FROM votes WHERE proposal = ?',
+    [proposalId]
+  );
+
+  return total;
+}
+
+// Both this job and votesVpValue trigger on cb = PENDING_COMPUTE, creating a race condition
+// where this job could finalize the proposal before all votes have their vp_value computed.
+// We check that all votes are in a terminal state (FINAL or INELIGIBLE) before allowing
+// the proposal to transition to FINAL.
+async function allVotesFinalized(proposalId: string): Promise<boolean> {
+  const [{ pending }] = await db.queryAsync(
+    'SELECT COUNT(*) as pending FROM votes WHERE proposal = ? AND cb NOT IN (?)',
+    [proposalId, [CB.FINAL, CB.INELIGIBLE]]
+  );
+
+  return pending === 0;
+}
+
 async function refreshProposalsScoresTotalValue(proposals: Proposal[]) {
   const query: string[] = [];
   const params: any[] = [];
 
-  proposals.forEach(proposal => {
+  for (const proposal of proposals) {
     query.push(
       'UPDATE proposals SET scores_total_value = ?, cb = ? WHERE id = ? LIMIT 1'
     );
 
     try {
-      const scoresTotalValue = getScoresTotalValue(proposal);
-      params.push(
-        scoresTotalValue,
-        proposal.scoresState === 'final' ? CB.FINAL : CB.PENDING_FINAL,
-        proposal.id
-      );
+      const scoresTotalValue =
+        proposal.type === 'approval'
+          ? await getVotesVpValueSum(proposal.id)
+          : getScoresTotalValue(proposal);
+
+      const canFinalize =
+        proposal.scoresState === 'final' &&
+        (await allVotesFinalized(proposal.id));
+      const cb = canFinalize ? CB.FINAL : CB.PENDING_FINAL;
+
+      params.push(scoresTotalValue, cb, proposal.id);
     } catch (err) {
       capture(err);
       params.push(0, CB.INELIGIBLE, proposal.id);
     }
-  });
+  }
 
   if (query.length) {
     await db.queryAsync(query.join(';'), params);

--- a/apps/sequencer/src/helpers/proposalsScoresValue.ts
+++ b/apps/sequencer/src/helpers/proposalsScoresValue.ts
@@ -103,7 +103,7 @@ async function allVotesFinalized(proposalId: string): Promise<boolean> {
     [proposalId, [CB.FINAL, CB.INELIGIBLE]]
   );
 
-  return pending === 0;
+  return Number(pending) === 0;
 }
 
 async function refreshProposalsScoresTotalValue(proposals: Proposal[]) {

--- a/apps/sequencer/src/helpers/proposalsScoresValue.ts
+++ b/apps/sequencer/src/helpers/proposalsScoresValue.ts
@@ -90,7 +90,7 @@ async function getVotesVpValueSum(proposalId: string): Promise<number> {
     [proposalId]
   );
 
-  return total;
+  return Number(total);
 }
 
 // Both this job and votesVpValue trigger on cb = PENDING_COMPUTE, creating a race condition


### PR DESCRIPTION
## Summary

Migrated from snapshot-labs/snapshot-sequencer#628 — sequencer now lives in `apps/sequencer`.

For approval voting proposals, `scores_total_value` was inflated because the computation summed `scores_by_strategy` across all choices — counting each voter's VP once per approved choice instead of once per voter. For example, a voter with 5 VP approving 3 choices would contribute 15 instead of 5 to `scores_total_value`. This caused an ~$8B mismatch (3.3% of total) between `SUM(votes.vp_value)` and `SUM(proposals.scores_total_value)`, with 99.2% of the gap coming from just 3,508 approval voting proposals.

We cannot compute the correct value from the proposals table alone for approval voting with multiple strategies. The proposal only stores `scores_by_strategy` (per-choice, inflated) and `scores_total` (a single number, not broken down by strategy). With multiple strategies, we need per-strategy VP totals that are not inflated by the number of approved choices, and this data only exists on the individual votes as `vp_value`. This is why we are forced to use `SUM(vp_value)` from the votes table for approval proposals.

**Performance impact**: `SUM(vp_value)` on votes has no covering index, so it requires scanning all matching rows. For the 3,508 approval proposals this is acceptable — the largest has ~16K votes (max ~2s), and the average is 159 votes. This is orders of magnitude smaller than the largest non-approval proposals (2.7M votes, which would take ~4 minutes). Non-approval proposals continue to use the existing formula from proposal data, unaffected.

The fix also adds a finalization gate for all proposal types: proposals only transition to `cb=FINAL` when all votes are in a terminal state, preventing a race condition between the `proposalsScoresValue` and `votesVpValue` background jobs.

## Migration

After deploying, run the following query to reset existing approval proposals for recomputation:

```sql
UPDATE proposals SET cb = -1 WHERE type = 'approval' AND cb = 1;
```

This will reset **3,479 proposals** back to `PENDING_COMPUTE` so the new logic recalculates their `scores_total_value` using `SUM(vp_value)` from votes. At a batch size of 25 every 10 seconds, reprocessing will take ~23 minutes.

## Verification

After reprocessing completes, run the following query to verify that approval proposals now match their votes:

```sql
SELECT
  p.id,
  p.scores_total_value,
  COALESCE(SUM(v.vp_value), 0) AS votes_vp_sum,
  p.scores_total_value - COALESCE(SUM(v.vp_value), 0) AS diff
FROM proposals p
LEFT JOIN votes v ON v.proposal = p.id
WHERE p.type = 'approval' AND p.cb = 1 AND p.scores_total_value > 0
GROUP BY p.id
HAVING ABS(diff) > 1
ORDER BY ABS(diff) DESC
LIMIT 10;
```

This should return no rows if all approval proposals have been correctly recomputed.

## Changes

- 🐛 Fix `scores_total_value` for approval voting by using `SUM(vp_value)` from votes instead of summing inflated `scores_by_strategy`
- 🔒 Add finalization gate: proposals only reach `cb=FINAL` when all votes are finalized (`cb=FINAL` or `cb=INELIGIBLE`)
- 🔄 Retry closed `PENDING_FINAL` proposals (`scores_state = 'final'`) to prevent stuck proposals after votes are processed
- 📝 Update CB flow documentation with new state transitions

## Test plan

- [ ] Verify approval voting proposals get correct `scores_total_value` (should match `SUM(vp_value)` from votes)
- [ ] Verify non-approval proposals are unaffected (still use `scores_by_strategy` formula)
- [ ] Verify proposals don't transition to `FINAL` before all votes are processed
- [ ] Verify `PENDING_FINAL` proposals with `scores_state = 'final'` are retried and eventually reach `FINAL`
- [ ] Verify active `PENDING_FINAL` proposals (`scores_state != 'final'`) are not reprocessed every loop

## Note

As the votes and proposals script are async, the proposals scores update may be triggered before a votes has been updated, making it undervalued, until the proposal closed.
