### PR TITLE
feat: add vocdoni privacy type

### DIFF
--- a/apps/sequencer/src/helpers/utils.ts
+++ b/apps/sequencer/src/helpers/utils.ts
@@ -328,6 +328,15 @@ async function updateWalletConnectWhitelist(
   return true;
 }
 
+// Privacy values that send an encrypted, opaque choice on the wire.
+// - shutter: encrypted at vote time, decrypted server-side after the proposal closes
+// - vocdoni: encrypted at vote time, never decrypted (private forever)
+export function isEncryptedPrivacy(
+  privacy: string | null | undefined
+): boolean {
+  return privacy === 'shutter' || privacy === 'vocdoni';
+}
+
 export function getSpaceController(space: string, network = NETWORK) {
   const tld = space.split('.').slice(-1)[0];
   const tldMapping = {

--- a/apps/sequencer/src/ingestor.ts
+++ b/apps/sequencer/src/ingestor.ts
@@ -12,7 +12,7 @@ import log from './helpers/log';
 import { timeIngestorProcess } from './helpers/metrics';
 import { flaggedIps } from './helpers/moderation';
 import relayer, { issueReceipt } from './helpers/relayer';
-import { getIp, jsonParse, sha256 } from './helpers/utils';
+import { getIp, isEncryptedPrivacy, jsonParse, sha256 } from './helpers/utils';
 import writer from './writer';
 
 const NETWORK_METADATA = {
@@ -194,7 +194,7 @@ export default async function ingestor(req) {
       if (type === 'vote-string') {
         const proposal = await getProposal(message.space, message.proposal);
         if (!proposal) return Promise.reject('unknown proposal');
-        if (proposal.privacy !== 'shutter') {
+        if (!isEncryptedPrivacy(proposal.privacy)) {
           try {
             choice = JSON.parse(message.choice);
           } catch {

--- a/apps/sequencer/src/scores.ts
+++ b/apps/sequencer/src/scores.ts
@@ -186,17 +186,36 @@ export async function updateProposalAndVotes(
     }
 
     // Get results
-    const voting = new snapshot.utils.voting[proposal.type](
-      proposal,
-      votes,
-      proposal.strategies
-    );
-    const results = {
-      scores_state: proposal.state === 'closed' ? 'final' : 'pending',
-      scores: voting.getScores(),
-      scores_by_strategy: voting.getScoresByStrategy(),
-      scores_total: voting.getScoresTotal()
-    };
+    let results;
+    if (proposal.privacy === 'vocdoni') {
+      // For vocdoni, choices are never decrypted. Expose aggregate
+      // participation (total VP) so quorum can still be evaluated, but keep
+      // per-choice scores at zero — they are private forever.
+      const scoresTotal = votes.reduce(
+        (sum: number, v: any) => sum + (v.balance || 0),
+        0
+      );
+      results = {
+        scores_state: proposal.state === 'closed' ? 'final' : 'pending',
+        scores: proposal.choices.map(() => 0),
+        scores_by_strategy: proposal.choices.map(() =>
+          proposal.strategies.map(() => 0)
+        ),
+        scores_total: scoresTotal
+      };
+    } else {
+      const voting = new snapshot.utils.voting[proposal.type](
+        proposal,
+        votes,
+        proposal.strategies
+      );
+      results = {
+        scores_state: proposal.state === 'closed' ? 'final' : 'pending',
+        scores: voting.getScores(),
+        scores_by_strategy: voting.getScoresByStrategy(),
+        scores_total: voting.getScoresTotal()
+      };
+    }
 
     // Check if voting power is final
     const withOverride = hasStrategyOverride(proposal.strategies);

--- a/apps/sequencer/src/writer/vote.ts
+++ b/apps/sequencer/src/writer/vote.ts
@@ -3,7 +3,12 @@ import { CB } from '../constants';
 import { getProposal } from '../helpers/actions';
 import log from '../helpers/log';
 import db from '../helpers/mysql';
-import { captureError, hasStrategyOverride, jsonParse } from '../helpers/utils';
+import {
+  captureError,
+  hasStrategyOverride,
+  isEncryptedPrivacy,
+  jsonParse
+} from '../helpers/utils';
 import { updateProposalAndVotes } from '../scores';
 
 const scoreAPIUrl = process.env.SCORE_API_URL || 'https://score.snapshot.org';
@@ -40,9 +45,11 @@ export async function verify(body): Promise<any> {
   )
     return Promise.reject('not in voting window');
 
-  if (proposal.privacy === 'shutter') {
+  if (isEncryptedPrivacy(proposal.privacy)) {
     if (msg.payload.reason)
-      return Promise.reject('reason not allowed with shutter');
+      return Promise.reject(
+        `reason not allowed with ${proposal.privacy} privacy`
+      );
     if (
       typeof msg.payload.choice !== 'string' ||
       !msg.payload.choice.startsWith('0x')

--- a/apps/sequencer/test/unit/writer/proposal.test.ts
+++ b/apps/sequencer/test/unit/writer/proposal.test.ts
@@ -442,6 +442,41 @@ describe('writer/proposal', () => {
           ).rejects.toMatch('not allowed to set privacy');
         });
       });
+
+      describe('when the space is using VOCDONI privacy', () => {
+        beforeEach(() => {
+          mockGetSpace.mockResolvedValueOnce({
+            ...spacesGetSpaceFixtures,
+            voting: { privacy: 'vocdoni' }
+          });
+        });
+
+        it('accepts a proposal with vocdoni privacy', () => {
+          return expect(
+            writer.verify(updateInputPayload(input, { privacy: 'vocdoni' }))
+          ).resolves.toBeUndefined();
+        });
+
+        it('accepts a proposal with undefined privacy', () => {
+          return expect(
+            writer.verify(updateInputPayload(input, { privacy: undefined }))
+          ).resolves.toBeUndefined();
+        });
+
+        it('rejects a proposal with shutter privacy', async () => {
+          expect.assertions(1);
+          await expect(
+            writer.verify(updateInputPayload(input, { privacy: 'shutter' }))
+          ).rejects.toMatch('not allowed to set privacy');
+        });
+
+        it('rejects a proposal with privacy empty string', async () => {
+          expect.assertions(1);
+          await expect(
+            writer.verify(updateInputPayload(input, { privacy: '' }))
+          ).rejects.toMatch('not allowed to set privacy');
+        });
+      });
     });
 
     it('rejects if the snapshot is in the future', async () => {

--- a/apps/ui/src/components/Modal/SelectPrivacy.vue
+++ b/apps/ui/src/components/Modal/SelectPrivacy.vue
@@ -2,7 +2,7 @@
 import { PRIVACY_TYPES_INFO } from '@/helpers/constants';
 import { SpacePrivacy } from '@/types';
 
-const votingTypes: SpacePrivacy[] = ['any', 'shutter', 'none'];
+const votingTypes: SpacePrivacy[] = ['any', 'shutter', 'vocdoni', 'none'];
 
 defineProps<{
   open: boolean;

--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -103,8 +103,21 @@ const otherResultsSummary = computed(() => {
   );
 });
 
+const isPermanentlyPrivate = computed(
+  () => props.proposal.privacy === 'vocdoni'
+);
+
+// Per-choice results are hidden while a shutter proposal is still open, and
+// hidden forever for vocdoni proposals (the choice is never decrypted).
+const resultsHidden = computed(
+  () =>
+    isPermanentlyPrivate.value ||
+    (props.proposal.privacy !== 'none' && !props.proposal.completed)
+);
+
 const isFinalizing = computed(() => {
   return (
+    !isPermanentlyPrivate.value &&
     offchainNetworks.includes(props.proposal.network) &&
     !props.proposal.completed &&
     ['passed', 'executed', 'rejected', 'closed'].includes(props.proposal.state)
@@ -146,13 +159,18 @@ onMounted(() => {
   </div>
   <div
     v-else-if="
-      props.proposal.privacy !== 'none' &&
-      props.proposal.state === 'active' &&
-      withDetails
+      withDetails &&
+      (isPermanentlyPrivate ||
+        (props.proposal.privacy !== 'none' &&
+          props.proposal.state === 'active'))
     "
     class="space-y-1"
   >
-    <div>
+    <div v-if="isPermanentlyPrivate">
+      Choices are encrypted and never revealed. Only the list of voters and
+      their voting power are public.
+    </div>
+    <div v-else>
       All votes are encrypted and will be decrypted only after the voting period
       is over, making the results visible.
     </div>
@@ -208,10 +226,7 @@ onMounted(() => {
           :content="proposal.choices[result.choice - 1]"
           class="grow"
         />
-        <IH-lock-closed
-          v-if="proposal.privacy !== 'none' && !proposal.completed"
-          class="size-[16px] shrink-0"
-        />
+        <IH-lock-closed v-if="resultsHidden" class="size-[16px] shrink-0" />
         <template v-else>
           <div>
             {{ _vp(result.score / 10 ** decimals) }}
@@ -255,10 +270,7 @@ onMounted(() => {
         </div>
       </div>
     </div>
-    <div
-      v-else-if="props.proposal.privacy === 'none' || props.proposal.completed"
-      class="h-full flex items-center"
-    >
+    <div v-else-if="!resultsHidden" class="h-full flex items-center">
       <div
         class="rounded-full h-[6px] overflow-hidden"
         :style="{

--- a/apps/ui/src/composables/useEditor.ts
+++ b/apps/ui/src/composables/useEditor.ts
@@ -158,6 +158,9 @@ export function useEditor() {
         id,
         space.privacy === 'any' ? ['none', 'shutter'] : [space.privacy]
       );
+      // NOTE: 'vocdoni' is intentionally excluded from 'any' — vocdoni is a
+      // space-level commitment ("private forever") that the author cannot
+      // opt out of on a per-proposal basis.
       spaceDelays.set(id, space.voting_delay);
       spaceMinPeriods.set(id, space.min_voting_period);
       spaceMaxPeriods.set(id, space.max_voting_period);

--- a/apps/ui/src/composables/useSharing.ts
+++ b/apps/ui/src/composables/useSharing.ts
@@ -98,7 +98,7 @@ export function useSharing() {
     const choiceText = getChoiceText(proposal.choices, choice);
     const isSingleChoice =
       proposal.type === 'single-choice' || proposal.type === 'basic';
-    const hasPrivacy = proposal.privacy === 'shutter';
+    const hasPrivacy = proposal.privacy !== 'none';
     const votedText =
       isSingleChoice && !hasPrivacy
         ? `I just voted "${choiceText}"`

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -472,7 +472,7 @@ export function useSpaceSettings(space: Ref<Space>) {
   }
 
   function getInitialVotingProperties(space: Space) {
-    const validPrivacyTypes = ['shutter', 'any'];
+    const validPrivacyTypes = ['shutter', 'vocdoni', 'any'];
     const spaceVoteType = space.additionalRawData?.voting.type;
     const privacyValue = space.privacy;
 

--- a/apps/ui/src/helpers/constants.ts
+++ b/apps/ui/src/helpers/constants.ts
@@ -185,6 +185,11 @@ export const PRIVACY_TYPES_INFO: Record<
     description:
       'Choices are encrypted and only visible once the voting period is over.'
   },
+  vocdoni: {
+    label: 'Private voting',
+    description:
+      'Choices are encrypted and never revealed. Only the list of voters and their voting power are public.'
+  },
   any: {
     label: 'Any',
     description: 'Author can choose between no privacy and shielded voting.'

--- a/apps/ui/src/networks/offchain/actions.ts
+++ b/apps/ui/src/networks/offchain/actions.ts
@@ -172,7 +172,7 @@ export function createActions(
         type,
         discussion,
         choices,
-        privacy: privacy === 'shutter' ? 'shutter' : '',
+        privacy: privacy === 'none' ? '' : privacy,
         labels,
         start,
         end: min_end,
@@ -215,7 +215,7 @@ export function createActions(
         type,
         discussion,
         choices,
-        privacy: privacy === 'shutter' ? 'shutter' : '',
+        privacy: privacy === 'none' ? '' : privacy,
         labels,
         plugins: JSON.stringify(plugins),
         from: account

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -56,7 +56,7 @@ export type ApiSpace = {
     type: VoteType | '' | null;
     quorum: number | null;
     quorumType?: 'default' | 'rejection';
-    privacy: '' | 'shutter' | 'any';
+    privacy: '' | 'shutter' | 'vocdoni' | 'any';
     hideAbstain: boolean;
   };
   strategies: { network: string; params: Record<string, any>; name: string }[];
@@ -135,7 +135,7 @@ export type ApiProposal = {
   created: number;
   updated: number | null;
   votes: number;
-  privacy: 'shutter' | '';
+  privacy: 'shutter' | 'vocdoni' | '';
   plugins: Record<string, any>;
   flagged: boolean;
   flagCode: number;

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -54,7 +54,7 @@ export type Choice =
   | number[]
   | Record<string, number>;
 
-export type Privacy = 'shutter' | 'none';
+export type Privacy = 'shutter' | 'vocdoni' | 'none';
 export type SpacePrivacy = Privacy | 'any';
 
 export type VoteType =

--- a/packages/sx.js/src/clients/offchain/utils.ts
+++ b/packages/sx.js/src/clients/offchain/utils.ts
@@ -13,7 +13,10 @@ export async function encryptChoices(
   proposalId: string,
   choice: string
 ): Promise<string> {
-  if (privacy === 'shutter') {
+  // Vocdoni reuses the shutter encryption primitive on the wire; the
+  // never-decrypt semantic is enforced by the hub/sequencer, which never
+  // request a decryption key for vocdoni proposals.
+  if (privacy === 'shutter' || privacy === 'vocdoni') {
     return encryptShutterChoice(choice, proposalId);
   }
 

--- a/packages/sx.js/src/types/index.ts
+++ b/packages/sx.js/src/types/index.ts
@@ -14,7 +14,7 @@ export enum Choice {
   Abstain = 2
 }
 
-export type Privacy = 'shutter' | 'none';
+export type Privacy = 'shutter' | 'vocdoni' | 'none';
 
 // NOTE: This is shared between starknet and offchain clients.
 // Maybe we should find a way to unify it more or split it.

--- a/packages/sx.js/test/unit/clients/offchain/ethereum-sig/__snapshots__/index.test.ts.snap
+++ b/packages/sx.js/test/unit/clients/offchain/ethereum-sig/__snapshots__/index.test.ts.snap
@@ -285,6 +285,127 @@ exports[`EthereumSig > should create propose envelope with shutter 1`] = `
 }
 `;
 
+exports[`EthereumSig > should create propose envelope with vocdoni 1`] = `
+{
+  "data": {
+    "app": "snapshot-v2",
+    "body": "Dummy body",
+    "choices": [
+      "For",
+      "Against",
+      "Abstain",
+    ],
+    "discussion": "https://snapshot.org",
+    "end": 1705798800,
+    "labels": [
+      "1234e",
+    ],
+    "plugins": "{}",
+    "privacy": "vocdoni",
+    "snapshot": 19283932,
+    "space": "wan-test.eth",
+    "start": 1705795200,
+    "title": "Creation test",
+    "type": "basic",
+  },
+  "signatureData": {
+    "address": "0xf1f09AdC06aAB740AA16004D62Dbd89484d3Be90",
+    "domain": {
+      "name": "snapshot",
+      "version": "0.1.4",
+    },
+    "message": {
+      "app": "snapshot-v2",
+      "body": "Dummy body",
+      "choices": [
+        "For",
+        "Against",
+        "Abstain",
+      ],
+      "discussion": "https://snapshot.org",
+      "end": 1705798800,
+      "from": "0xf1f09AdC06aAB740AA16004D62Dbd89484d3Be90",
+      "labels": [
+        "1234e",
+      ],
+      "plugins": "{}",
+      "privacy": "vocdoni",
+      "snapshot": 19283932,
+      "space": "wan-test.eth",
+      "start": 1705795200,
+      "timestamp": 1705795200,
+      "title": "Creation test",
+      "type": "basic",
+    },
+    "signature": "0x78e889d63a9ac510dd5b50ecd3319068a39461fa8aee956fefaa8d1f2953ec5d0b91c84a48a7a68799faa7f6974da2546a322cc8c0f77b8629e56a5bb18dc8401c",
+    "types": {
+      "Proposal": [
+        {
+          "name": "from",
+          "type": "string",
+        },
+        {
+          "name": "space",
+          "type": "string",
+        },
+        {
+          "name": "timestamp",
+          "type": "uint64",
+        },
+        {
+          "name": "type",
+          "type": "string",
+        },
+        {
+          "name": "title",
+          "type": "string",
+        },
+        {
+          "name": "body",
+          "type": "string",
+        },
+        {
+          "name": "discussion",
+          "type": "string",
+        },
+        {
+          "name": "choices",
+          "type": "string[]",
+        },
+        {
+          "name": "labels",
+          "type": "string[]",
+        },
+        {
+          "name": "start",
+          "type": "uint64",
+        },
+        {
+          "name": "end",
+          "type": "uint64",
+        },
+        {
+          "name": "snapshot",
+          "type": "uint64",
+        },
+        {
+          "name": "plugins",
+          "type": "string",
+        },
+        {
+          "name": "privacy",
+          "type": "string",
+        },
+        {
+          "name": "app",
+          "type": "string",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`EthereumSig > should create vote envelope 1`] = `
 {
   "data": {

--- a/packages/sx.js/test/unit/clients/offchain/ethereum-sig/index.test.ts
+++ b/packages/sx.js/test/unit/clients/offchain/ethereum-sig/index.test.ts
@@ -94,6 +94,31 @@ describe('EthereumSig', () => {
     expect(envelope).toMatchSnapshot();
   });
 
+  it('should create propose envelope with vocdoni', async () => {
+    const payload = {
+      space: 'wan-test.eth',
+      title: 'Creation test',
+      body: 'Dummy body',
+      type: 'basic',
+      discussion: 'https://snapshot.org',
+      choices: ['For', 'Against', 'Abstain'],
+      labels: ['1234e'],
+      privacy: 'vocdoni',
+      start: Math.floor(Date.now() / 1000),
+      end: Math.floor(Date.now() / 1000) + 60 * 60,
+      snapshot: 19283932,
+      plugins: '{}',
+      app: 'snapshot-v2'
+    };
+
+    const envelope = await client.propose({
+      signer,
+      data: payload
+    });
+
+    expect(envelope).toMatchSnapshot();
+  });
+
   it('should create cancelProposal envelope', async () => {
     const payload = {
       space: 'test.eth',


### PR DESCRIPTION
## Summary
- Adds a new offchain privacy mode `vocdoni` alongside `shutter`. Vocdoni votes are encrypted on the wire (reusing the shutter encryption primitive) but the sequencer never requests a decryption key — the choice is private forever. The voter list + voting power remain public so quorum can still be evaluated.
- `sx.js` adds `'vocdoni'` to the `Privacy` union; `encryptChoices` accepts vocdoni and routes through the existing shutter encryption helper.
- `apps/ui` surfaces vocdoni in the `SelectPrivacy` modal, in draft/space settings, and in the offchain wire types. `ProposalResults` stays locked for vocdoni proposals even after they close, with copy that calls out the "private forever" semantic. Vocdoni is intentionally excluded from the existing `'any'` shutter-or-none toggle — it's a space-level commitment, not a per-proposal choice.
- `apps/sequencer` treats vocdoni like shutter when validating encrypted choices (writer/vote, ingestor) via a new `isEncryptedPrivacy()` helper. `scores.ts` skips per-choice voting math for vocdoni and writes only the aggregate total VP, leaving per-choice scores at zero. The shutter-specific decryption hook is untouched.
- `apps/hub` needed no changes — the schema's `privacy VARCHAR(24)` and GraphQL `privacy: String` are already permissive.

## Design notes
- Encryption: this PR reuses the shutter encryption primitive for vocdoni payloads. The never-decrypt guarantee is enforced by the sequencer (which never calls `getDecryptionKey` for vocdoni proposals), not by the cryptographic primitive. A future PR can swap in a vocdoni-native SDK without touching the privacy plumbing added here.
- Results UI: for vocdoni, per-choice scores stay at 0 forever, but `scores_total` (sum of VP) is still computed so quorum bars work.
- Validation: a vocdoni space rejects shutter/empty privacy proposals, mirroring the existing shutter strict-match logic in `writer/proposal.ts` and `writer/update-proposal.ts`.

## Test plan
- [x] `bun run test` in `packages/sx.js` (new vocdoni propose-envelope snapshot added)
- [x] `bun run typecheck` in `apps/ui` (only pre-existing `townhall/gql/graphql` codegen error remains, unrelated)
- [x] `bun run lint` clean in `apps/ui`, `apps/sequencer`, `packages/sx.js`
- [x] `bun run test:unit -- test/unit/writer/proposal.test.ts` in `apps/sequencer` — 4 new vocdoni cases mirror the existing shutter cases (existing test-infra failures on master are unrelated and reproduce on `master` head)
- [ ] Manual: configure an offchain space with `privacy = vocdoni`, create a proposal, submit a vote, confirm UI shows the lock + "private forever" copy and the sequencer never triggers `shutter_set_proposal_key`
- [ ] Manual: configure an `any` space, confirm shutter toggle still works and vocdoni is not offered there
- [ ] Manual: change a space from `vocdoni` to another privacy mode in space settings and confirm the diff round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)