### PR TITLE
feat(ui): redirect explore rows to org overview when a space is part of one

### DIFF
--- a/apps/ui/src/components/SpacesListItem.vue
+++ b/apps/ui/src/components/SpacesListItem.vue
@@ -1,15 +1,23 @@
 <script lang="ts" setup>
+import { RouteLocationRaw } from 'vue-router';
 import { _n } from '@/helpers/utils';
 import { offchainNetworks } from '@/networks';
 import { RelatedSpace, Space } from '@/types';
 
-const props = defineProps<{ space: Space | RelatedSpace }>();
+const props = defineProps<{
+  space: Space | RelatedSpace;
+  to?: RouteLocationRaw;
+}>();
 const compositeSpaceId = `${props.space.network}:${props.space.id}`;
+const linkTo = computed<RouteLocationRaw>(
+  () =>
+    props.to ?? { name: 'space-overview', params: { space: compositeSpaceId } }
+);
 </script>
 
 <template>
   <AppLink
-    :to="{ name: 'space-overview', params: { space: compositeSpaceId } }"
+    :to="linkTo"
     class="text-skin-text mx-4 group overflow-hidden flex border-b items-center py-[18px] space-x-3"
   >
     <div class="grow flex items-center">

--- a/apps/ui/src/components/SpacesListItem.vue
+++ b/apps/ui/src/components/SpacesListItem.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import { RouteLocationRaw } from 'vue-router';
 import { OrganizationConfig } from '@/helpers/organizations';
 import { _n } from '@/helpers/utils';
 import { offchainNetworks } from '@/networks';
@@ -7,26 +6,21 @@ import { RelatedSpace, Space } from '@/types';
 
 const props = defineProps<{
   space: Space | RelatedSpace;
-  to?: RouteLocationRaw;
   org?: OrganizationConfig | null;
 }>();
-const compositeSpaceId = `${props.space.network}:${props.space.id}`;
-const linkTo = computed<RouteLocationRaw>(
-  () =>
-    props.to ?? { name: 'space-overview', params: { space: compositeSpaceId } }
+const linkTo = computed(() =>
+  props.org
+    ? { name: 'org', params: { org: props.org.id } }
+    : {
+        name: 'space-overview',
+        params: { space: `${props.space.network}:${props.space.id}` }
+      }
 );
-const displayName = computed(() => props.org?.name ?? props.space.name);
-const orgSpaceCount = computed(() => props.org?.spaceIds.length ?? 0);
-const avatarSpace = computed(() => {
-  if (!props.org) return props.space;
-  const primary = props.org.spaceIds[0];
-  return {
-    id: primary.id,
-    network: primary.network,
-    avatar: '',
-    active_proposals: 0
-  };
-});
+const avatarSpace = computed(() =>
+  props.org
+    ? { ...props.org.spaceIds[0], avatar: '', active_proposals: 0 }
+    : props.space
+);
 </script>
 
 <template>
@@ -42,7 +36,7 @@ const avatarSpace = computed(() => {
       >
         <SpaceAvatar :space="avatarSpace" :size="32" class="rounded-md" />
       </UiBadgeNetwork>
-      <h3 class="truncate" v-text="displayName" />
+      <h3 class="truncate" v-text="org?.name ?? space.name" />
       <UiBadgeSpace
         class="ml-1"
         :verified="space.verified"
@@ -52,11 +46,9 @@ const avatarSpace = computed(() => {
           false
         "
       />
-      <span v-if="org" class="ml-2 shrink-0">
-        {{ _n(orgSpaceCount) }}
-        <span class="text-skin-text">
-          {{ orgSpaceCount === 1 ? 'space' : 'spaces' }}
-        </span>
+      <span v-if="org" class="ml-2 shrink-0 text-skin-text">
+        {{ org.spaceIds.length }}
+        {{ org.spaceIds.length === 1 ? 'space' : 'spaces' }}
       </span>
     </div>
     <ButtonFollow :space="space" class="hidden group-hover:block -my-2" />

--- a/apps/ui/src/components/SpacesListItem.vue
+++ b/apps/ui/src/components/SpacesListItem.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { RouteLocationRaw } from 'vue-router';
+import { OrganizationConfig } from '@/helpers/organizations';
 import { _n } from '@/helpers/utils';
 import { offchainNetworks } from '@/networks';
 import { RelatedSpace, Space } from '@/types';
@@ -7,12 +8,25 @@ import { RelatedSpace, Space } from '@/types';
 const props = defineProps<{
   space: Space | RelatedSpace;
   to?: RouteLocationRaw;
+  org?: OrganizationConfig | null;
 }>();
 const compositeSpaceId = `${props.space.network}:${props.space.id}`;
 const linkTo = computed<RouteLocationRaw>(
   () =>
     props.to ?? { name: 'space-overview', params: { space: compositeSpaceId } }
 );
+const displayName = computed(() => props.org?.name ?? props.space.name);
+const orgSpaceCount = computed(() => props.org?.spaceIds.length ?? 0);
+const avatarSpace = computed(() => {
+  if (!props.org) return props.space;
+  const primary = props.org.spaceIds[0];
+  return {
+    id: primary.id,
+    network: primary.network,
+    avatar: '',
+    active_proposals: 0
+  };
+});
 </script>
 
 <template>
@@ -20,15 +34,15 @@ const linkTo = computed<RouteLocationRaw>(
     :to="linkTo"
     class="text-skin-text mx-4 group overflow-hidden flex border-b items-center py-[18px] space-x-3"
   >
-    <div class="grow flex items-center">
+    <div class="grow flex items-center min-w-0">
       <UiBadgeNetwork
-        :id="space.network"
+        :id="avatarSpace.network"
         class="mr-2.5 shrink-0"
-        :size="!offchainNetworks.includes(space.network) ? 16 : 0"
+        :size="!org && !offchainNetworks.includes(avatarSpace.network) ? 16 : 0"
       >
-        <SpaceAvatar :space="space" :size="32" class="rounded-md" />
+        <SpaceAvatar :space="avatarSpace" :size="32" class="rounded-md" />
       </UiBadgeNetwork>
-      <h3 class="truncate" v-text="space.name" />
+      <h3 class="truncate" v-text="displayName" />
       <UiBadgeSpace
         class="ml-1"
         :verified="space.verified"
@@ -38,6 +52,12 @@ const linkTo = computed<RouteLocationRaw>(
           false
         "
       />
+      <span v-if="org" class="ml-2 shrink-0">
+        {{ _n(orgSpaceCount) }}
+        <span class="text-skin-text">
+          {{ orgSpaceCount === 1 ? 'space' : 'spaces' }}
+        </span>
+      </span>
     </div>
     <ButtonFollow :space="space" class="hidden group-hover:block -my-2" />
     <div class="text-[21px] font-bold flex text-center">

--- a/apps/ui/src/helpers/organizations.test.ts
+++ b/apps/ui/src/helpers/organizations.test.ts
@@ -104,16 +104,8 @@ describe('getOrgProposalLabel', () => {
 });
 
 describe('getOrganizationConfigBySpace', () => {
-  it('returns the org config when the space is part of one', () => {
+  it('returns the org for a member space, null otherwise', () => {
     expect(getOrganizationConfigBySpace('s:ens.eth')?.id).toBe('ens');
-    expect(
-      getOrganizationConfigBySpace(
-        'eth:0x323A76393544d5ecca80cd6ef2A560C6a395b7E3'
-      )?.id
-    ).toBe('ens');
-  });
-
-  it('returns null when the space is not part of any org', () => {
     expect(getOrganizationConfigBySpace('s:not-an-org.eth')).toBeNull();
   });
 });

--- a/apps/ui/src/helpers/organizations.test.ts
+++ b/apps/ui/src/helpers/organizations.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { getOrgProposalLabel } from './organizations';
+import {
+  getOrganizationConfigBySpace,
+  getOrgProposalLabel
+} from './organizations';
 
 function org(navItems: any) {
   return { navItems } as any;
@@ -97,5 +100,20 @@ describe('getOrgProposalLabel', () => {
     };
 
     expect(getOrgProposalLabel(org(navItems), 'eth:0xABC')).toBeUndefined();
+  });
+});
+
+describe('getOrganizationConfigBySpace', () => {
+  it('returns the org config when the space is part of one', () => {
+    expect(getOrganizationConfigBySpace('s:ens.eth')?.id).toBe('ens');
+    expect(
+      getOrganizationConfigBySpace(
+        'eth:0x323A76393544d5ecca80cd6ef2A560C6a395b7E3'
+      )?.id
+    ).toBe('ens');
+  });
+
+  it('returns null when the space is not part of any org', () => {
+    expect(getOrganizationConfigBySpace('s:not-an-org.eth')).toBeNull();
   });
 });

--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -270,6 +270,14 @@ export function getOrganizationConfigById(
   return ORGANIZATIONS[id] ?? null;
 }
 
+export function getOrganizationConfigBySpace(
+  spaceId: string
+): OrganizationConfig | null {
+  return (
+    Object.values(ORGANIZATIONS).find(org => isOrgSpace(org, spaceId)) ?? null
+  );
+}
+
 export function isOrgSpace(
   org: OrganizationConfig,
   spaceParam?: string | string[]

--- a/apps/ui/src/helpers/organizations/index.ts
+++ b/apps/ui/src/helpers/organizations/index.ts
@@ -1,6 +1,7 @@
 export {
   getOrganizationConfigByDomain,
   getOrganizationConfigById,
+  getOrganizationConfigBySpace,
   getOrgProposalLabel,
   type Organization,
   type OrganizationConfig

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -110,12 +110,19 @@ function handleEndReached() {
   fetchNextPage();
 }
 
+function getSpaceOrg(space: Space | RelatedSpace) {
+  if (protocol.value !== 'snapshot') return null;
+  return getOrganizationConfigBySpace(`${space.network}:${space.id}`);
+}
+
 function getSpaceLink(space: Space | RelatedSpace): RouteLocationRaw {
-  const compositeId = `${space.network}:${space.id}`;
-  const org = getOrganizationConfigBySpace(compositeId);
+  const org = getSpaceOrg(space);
   if (org) return { name: 'org', params: { org: org.id } };
 
-  return { name: 'space-overview', params: { space: compositeId } };
+  return {
+    name: 'space-overview',
+    params: { space: `${space.network}:${space.id}` }
+  };
 }
 
 watch([protocol, category, network], ([p, c, n]) => {
@@ -233,6 +240,7 @@ watchEffect(() => setTitle('Explore'));
             :key="space.id"
             :space="space"
             :to="getSpaceLink(space)"
+            :org="getSpaceOrg(space)"
           />
         </UiContainerInfiniteScroll>
         <UiStateWarning v-else class="px-4 py-3">

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+import { RouteLocationRaw } from 'vue-router';
 import { SPACE_CATEGORIES } from '@/helpers/constants';
+import { getOrganizationConfigBySpace } from '@/helpers/organizations';
 import { getUrl } from '@/helpers/utils';
 import { explorePageProtocols, getNetwork, metadataNetwork } from '@/networks';
 import { ExplorePageProtocol, ProtocolConfig } from '@/networks/types';
 import { useExploreSpacesQuery } from '@/queries/spaces';
-import { SelectItem } from '@/types';
+import { RelatedSpace, SelectItem, Space } from '@/types';
 
 defineOptions({ inheritAttrs: false });
 
@@ -106,6 +108,14 @@ function handleEndReached() {
   if (!hasNextPage.value) return;
 
   fetchNextPage();
+}
+
+function getSpaceLink(space: Space | RelatedSpace): RouteLocationRaw {
+  const compositeId = `${space.network}:${space.id}`;
+  const org = getOrganizationConfigBySpace(compositeId);
+  if (org) return { name: 'org', params: { org: org.id } };
+
+  return { name: 'space-overview', params: { space: compositeId } };
 }
 
 watch([protocol, category, network], ([p, c, n]) => {
@@ -222,6 +232,7 @@ watchEffect(() => setTitle('Explore'));
             v-for="space in data.pages.flat()"
             :key="space.id"
             :space="space"
+            :to="getSpaceLink(space)"
           />
         </UiContainerInfiniteScroll>
         <UiStateWarning v-else class="px-4 py-3">

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { RouteLocationRaw } from 'vue-router';
 import { SPACE_CATEGORIES } from '@/helpers/constants';
 import { getOrganizationConfigBySpace } from '@/helpers/organizations';
 import { getUrl } from '@/helpers/utils';
@@ -113,16 +112,6 @@ function handleEndReached() {
 function getSpaceOrg(space: Space | RelatedSpace) {
   if (protocol.value !== 'snapshot') return null;
   return getOrganizationConfigBySpace(`${space.network}:${space.id}`);
-}
-
-function getSpaceLink(space: Space | RelatedSpace): RouteLocationRaw {
-  const org = getSpaceOrg(space);
-  if (org) return { name: 'org', params: { org: org.id } };
-
-  return {
-    name: 'space-overview',
-    params: { space: `${space.network}:${space.id}` }
-  };
 }
 
 watch([protocol, category, network], ([p, c, n]) => {
@@ -239,7 +228,6 @@ watchEffect(() => setTitle('Explore'));
             v-for="space in data.pages.flat()"
             :key="space.id"
             :space="space"
-            :to="getSpaceLink(space)"
             :org="getSpaceOrg(space)"
           />
         </UiContainerInfiniteScroll>

--- a/apps/ui/src/views/Organization/Overview.vue
+++ b/apps/ui/src/views/Organization/Overview.vue
@@ -123,7 +123,7 @@ watchEffect(() => {
             v-if="!isWhiteLabel"
             class="top-0.5"
             :verified="space.verified"
-            :turbo="space.turbo"
+            :turbo="spaces.some(s => s.turbo)"
             :flagged="space.additionalRawData?.flagged || false"
           />
         </div>


### PR DESCRIPTION
## Summary
- On the Explore page (Snapshot protocol only), spaces that belong to a configured organization now link to the org overview (`/org/:id`) instead of the space.
- Their row is restyled to show the org's name, the org's primary space avatar (no network bullet), and an "N spaces" member count.
- SX and Governor lists are unchanged.
- On the Organization overview, the gold (turbo) badge now reflects any member space having `turbo`, not just the first space.

<img width="1470" height="829" alt="image" src="https://github.com/user-attachments/assets/066531e8-dac2-427c-9cc6-3d0936a93066" />

## Test plan
- [ ] On `/explore?p=snapshot`, ENS / Starknet / Arbitrum / Snapshot rows show the org name, "N spaces" label, and clicking them lands on `/org/:id`.
- [ ] Switching the protocol filter to Snapshot X or Governor shows the unchanged master layout (no org redirect, no org styling).
- [ ] Other places using `SpacesListItem` (Settings → Spaces, related spaces on a space overview) keep the original space behavior.
- [ ] Visiting an org overview shows the gold badge when at least one member space has `turbo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)