### PR TITLE
feat(ui): Spaces filter on proposals page

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -9,7 +9,7 @@ import {
 } from '@/helpers/quorum';
 import { _n, _p, _vp } from '@/helpers/utils';
 import { getNetwork, offchainNetworks } from '@/networks';
-import { PROPOSALS_KEYS } from '@/queries/proposals';
+import { invalidateSpaceProposals } from '@/queries/proposals';
 import { Proposal as ProposalType } from '@/types';
 
 const DEFAULT_MAX_CHOICES = 6;
@@ -121,12 +121,11 @@ async function refreshScores() {
     const result = await response.json();
 
     if (result.result === true) {
-      queryClient.invalidateQueries({
-        queryKey: PROPOSALS_KEYS.space(
-          props.proposal.network,
-          props.proposal.space.id
-        )
-      });
+      invalidateSpaceProposals(
+        queryClient,
+        props.proposal.network,
+        props.proposal.space.id
+      );
     }
   } catch (err) {
     console.warn('Failed to refresh scores', err);

--- a/apps/ui/src/composables/useNav/index.ts
+++ b/apps/ui/src/composables/useNav/index.ts
@@ -23,8 +23,10 @@ function getActiveItemKey(
 
   for (const [key, item] of Object.entries(config.items)) {
     const { prefix, params } = item.activeRoute ?? { prefix: `space-${key}` };
-    const isMatchingRoute = [prefix].flat().some(p => {
+    const prefixes = Array.isArray(prefix) ? prefix : [prefix];
+    const isMatchingRoute = prefixes.some(p => {
       const fullPrefix = p.replace(/^space-/, `${namespace}-`);
+
       return routeName === fullPrefix || routeName.startsWith(`${fullPrefix}-`);
     });
     const isMatchingParams =

--- a/apps/ui/src/composables/useNav/index.ts
+++ b/apps/ui/src/composables/useNav/index.ts
@@ -23,10 +23,7 @@ function getActiveItemKey(
 
   for (const [key, item] of Object.entries(config.items)) {
     const { prefix, params } = item.activeRoute ?? { prefix: `space-${key}` };
-    /** Multiple prefixes let one nav entry highlight under several routes (e.g. a unified
-     *  "Onchain voting" item that's active on both core-gov and treasury-gov routes). */
-    const prefixes = Array.isArray(prefix) ? prefix : [prefix];
-    const isMatchingRoute = prefixes.some(p => {
+    const isMatchingRoute = [prefix].flat().some(p => {
       const fullPrefix = p.replace(/^space-/, `${namespace}-`);
       return routeName === fullPrefix || routeName.startsWith(`${fullPrefix}-`);
     });

--- a/apps/ui/src/composables/useNav/index.ts
+++ b/apps/ui/src/composables/useNav/index.ts
@@ -23,9 +23,13 @@ function getActiveItemKey(
 
   for (const [key, item] of Object.entries(config.items)) {
     const { prefix, params } = item.activeRoute ?? { prefix: `space-${key}` };
-    const fullPrefix = prefix.replace(/^space-/, `${namespace}-`);
-    const isMatchingRoute =
-      routeName === fullPrefix || routeName.startsWith(`${fullPrefix}-`);
+    /** Multiple prefixes let one nav entry highlight under several routes (e.g. a unified
+     *  "Onchain voting" item that's active on both core-gov and treasury-gov routes). */
+    const prefixes = Array.isArray(prefix) ? prefix : [prefix];
+    const isMatchingRoute = prefixes.some(p => {
+      const fullPrefix = p.replace(/^space-/, `${namespace}-`);
+      return routeName === fullPrefix || routeName.startsWith(`${fullPrefix}-`);
+    });
     const isMatchingParams =
       !params ||
       Object.entries(params).every(([k, v]) => route.params[k] === v);

--- a/apps/ui/src/composables/useNav/types.ts
+++ b/apps/ui/src/composables/useNav/types.ts
@@ -10,7 +10,7 @@ export type NavItem = {
   count?: number;
   hidden?: boolean;
   link?: RouteLocationRaw;
-  activeRoute?: { prefix: string; params?: Record<string, string> };
+  activeRoute?: { prefix: string | string[]; params?: Record<string, string> };
   isActive?: boolean;
   /** 1-based insertion index used by org nav to position custom items among defaults */
   position?: number;

--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -1,6 +1,5 @@
 import { RouteLocationRaw } from 'vue-router';
 import { NavItem } from '@/composables/useNav/types';
-import { offchainNetworks } from '@/networks';
 import { NetworkID, RelatedSpace, Space, SpaceMetadataTreasury } from '@/types';
 import IHAnnotation from '~icons/heroicons-outline/annotation';
 import IHCheckCircle from '~icons/heroicons-outline/check-circle';
@@ -28,6 +27,8 @@ export type OrganizationConfig = {
   navItems?: Record<string, Partial<NavItem>>;
   /** Org-level treasuries (read-only display). */
   treasuries?: SpaceMetadataTreasury[];
+  /** Spaces merged by the Spaces filter on the proposals page. */
+  proposalSpaces?: { network: NetworkID; ids: string[] };
 };
 
 export type Organization = OrganizationConfig & {
@@ -105,6 +106,13 @@ const ORGANIZATIONS: Record<string, OrganizationConfig> = {
         chainId: '42161'
       }
     ],
+    proposalSpaces: {
+      network: 'arb1',
+      ids: [
+        '0x789fC99093B09aD01C34DC7251D0C89ce743e5a4',
+        '0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9'
+      ]
+    },
     routes: [
       {
         path: 'treasury-gov',
@@ -325,14 +333,18 @@ export function getCustomRoute(
   return org.routes?.find(r => r.meta.orgSpaceId === spaceId);
 }
 
-export function getOrgOnchainSpaces(
+export function getOrgProposalSpaces(
   organization: Organization | null,
   network: NetworkID
 ): Space[] {
-  if (organization?.id !== 'arbitrum') return [];
-  return organization.spaces.filter(
-    s => s.network === network && !offchainNetworks.includes(s.network)
-  );
+  const group = organization?.proposalSpaces;
+  if (!group || group.network !== network) return [];
+
+  return group.ids
+    .map(id =>
+      organization.spaces.find(s => s.network === network && s.id === id)
+    )
+    .filter((s): s is Space => !!s);
 }
 
 export function getOrgProposalLabel(

--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -127,27 +127,17 @@ const ORGANIZATIONS: Record<string, OrganizationConfig> = {
     ],
     navItems: {
       proposals: {
-        name: 'Treasury governor',
+        name: 'Onchain voting',
         icon: IHNewspaper,
-        link: {
-          name: 'space-proposals',
-          params: { space: 'arb1:0x789fC99093B09aD01C34DC7251D0C89ce743e5a4' }
-        },
-        activeRoute: {
-          prefix: 'space-treasury-gov'
-        }
-      },
-      core: {
-        name: 'Core governor',
-        icon: IHNewspaper,
+        /** Lands on the Core governor route by convention; the Spaces filter on the
+         *  proposals page picks both Core and Treasury by default for Arbitrum. */
         link: {
           name: 'space-proposals',
           params: { space: 'arb1:0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9' }
         },
         activeRoute: {
-          prefix: 'space-core-gov'
-        },
-        position: 3
+          prefix: ['space-core-gov', 'space-treasury-gov']
+        }
       },
       signals: {
         name: 'Offchain voting',

--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -354,6 +354,15 @@ export function getOrgProposalLabel(
   const navItems = organization?.navItems;
   if (!navItems) return undefined;
 
+  // Spaces merged by the proposals-page filter share a single nav item, so
+  // they are distinguished by their own name instead
+  const [network, id] = spaceId.split(':');
+  const group = organization.proposalSpaces;
+  if (group && group.network === network && group.ids.includes(id)) {
+    return organization.spaces.find(s => s.network === network && s.id === id)
+      ?.name;
+  }
+
   const match = Object.values(navItems).find(item => {
     if (typeof item.link !== 'object') return false;
     const link = item.link as NavLink;

--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -1,4 +1,5 @@
 import { NavItem } from '@/composables/useNav/types';
+import { offchainNetworks } from '@/networks';
 import { NetworkID, Space, SpaceMetadataTreasury } from '@/types';
 import IHAnnotation from '~icons/heroicons-outline/annotation';
 import IHCheckCircle from '~icons/heroicons-outline/check-circle';
@@ -285,6 +286,18 @@ export function getCustomRoute(
   spaceId: string
 ): SpaceRoute | undefined {
   return org.routes?.find(r => r.meta.orgSpaceId === spaceId);
+}
+
+/** Onchain spaces in this org on a given network. Drives the Spaces filter on
+ *  proposals; currently only Arbitrum opts in (Core + Treasury governors). */
+export function getOrgOnchainSpaces(
+  organization: Organization | null,
+  network: NetworkID
+): Space[] {
+  if (organization?.id !== 'arbitrum') return [];
+  return (organization.spaces ?? []).filter(
+    s => !offchainNetworks.includes(s.network) && s.network === network
+  );
 }
 
 export function getOrgProposalLabel(

--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -347,28 +347,33 @@ export function getOrgProposalSpaces(
     .filter((s): s is Space => !!s);
 }
 
+/** Org-level label for a space's proposals list. Without a spaceId (e.g. the
+ *  merged multi-space list), resolves to the proposals nav item's name. */
 export function getOrgProposalLabel(
   organization: Organization | null,
-  spaceId: string
+  spaceId?: string
 ): string | undefined {
   const navItems = organization?.navItems;
   if (!navItems) return undefined;
 
-  // Spaces merged by the proposals-page filter share a single nav item, so
-  // they are distinguished by their own name instead
-  const [network, id] = spaceId.split(':');
-  const group = organization.proposalSpaces;
-  if (group && group.network === network && group.ids.includes(id)) {
-    return organization.spaces.find(s => s.network === network && s.id === id)
-      ?.name;
+  if (spaceId) {
+    // Spaces merged by the proposals-page filter share a single nav item, so
+    // they are distinguished by their own name instead
+    const [network, id] = spaceId.split(':');
+    const group = organization.proposalSpaces;
+    if (group && group.network === network && group.ids.includes(id)) {
+      return organization.spaces.find(s => s.network === network && s.id === id)
+        ?.name;
+    }
+
+    const match = Object.values(navItems).find(item => {
+      if (typeof item.link !== 'object') return false;
+      const link = item.link as NavLink;
+
+      return link.name === 'space-proposals' && link.params?.space === spaceId;
+    });
+    if (match?.name) return match.name;
   }
 
-  const match = Object.values(navItems).find(item => {
-    if (typeof item.link !== 'object') return false;
-    const link = item.link as NavLink;
-
-    return link.name === 'space-proposals' && link.params?.space === spaceId;
-  });
-
-  return match?.name ?? navItems.proposals?.name;
+  return navItems.proposals?.name;
 }

--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -1,5 +1,6 @@
 import { RouteLocationRaw } from 'vue-router';
 import { NavItem } from '@/composables/useNav/types';
+import { offchainNetworks } from '@/networks';
 import { NetworkID, RelatedSpace, Space, SpaceMetadataTreasury } from '@/types';
 import IHAnnotation from '~icons/heroicons-outline/annotation';
 import IHCheckCircle from '~icons/heroicons-outline/check-circle';
@@ -324,6 +325,18 @@ export function getCustomRoute(
   spaceId: string
 ): SpaceRoute | undefined {
   return org.routes?.find(r => r.meta.orgSpaceId === spaceId);
+}
+
+/** Onchain spaces in this org on a given network. Drives the Spaces filter on
+ *  proposals; currently only Arbitrum opts in (Core + Treasury governors). */
+export function getOrgOnchainSpaces(
+  organization: Organization | null,
+  network: NetworkID
+): Space[] {
+  if (organization?.id !== 'arbitrum') return [];
+  return (organization.spaces ?? []).filter(
+    s => !offchainNetworks.includes(s.network) && s.network === network
+  );
 }
 
 export function getOrgProposalLabel(

--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -130,8 +130,6 @@ const ORGANIZATIONS: Record<string, OrganizationConfig> = {
       proposals: {
         name: 'Onchain voting',
         icon: IHNewspaper,
-        /** Lands on the Core governor route by convention; the Spaces filter on the
-         *  proposals page picks both Core and Treasury by default for Arbitrum. */
         link: {
           name: 'space-proposals',
           params: { space: 'arb1:0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9' }
@@ -327,15 +325,13 @@ export function getCustomRoute(
   return org.routes?.find(r => r.meta.orgSpaceId === spaceId);
 }
 
-/** Onchain spaces in this org on a given network. Drives the Spaces filter on
- *  proposals; currently only Arbitrum opts in (Core + Treasury governors). */
 export function getOrgOnchainSpaces(
   organization: Organization | null,
   network: NetworkID
 ): Space[] {
   if (organization?.id !== 'arbitrum') return [];
-  return (organization.spaces ?? []).filter(
-    s => !offchainNetworks.includes(s.network) && s.network === network
+  return organization.spaces.filter(
+    s => s.network === network && !offchainNetworks.includes(s.network)
   );
 }
 

--- a/apps/ui/src/helpers/organizations/config.ts
+++ b/apps/ui/src/helpers/organizations/config.ts
@@ -126,27 +126,17 @@ const ORGANIZATIONS: Record<string, OrganizationConfig> = {
     ],
     navItems: {
       proposals: {
-        name: 'Treasury governor',
+        name: 'Onchain voting',
         icon: IHNewspaper,
-        link: {
-          name: 'space-proposals',
-          params: { space: 'arb1:0x789fC99093B09aD01C34DC7251D0C89ce743e5a4' }
-        },
-        activeRoute: {
-          prefix: 'space-treasury-gov'
-        }
-      },
-      core: {
-        name: 'Core governor',
-        icon: IHNewspaper,
+        /** Lands on the Core governor route by convention; the Spaces filter on the
+         *  proposals page picks both Core and Treasury by default for Arbitrum. */
         link: {
           name: 'space-proposals',
           params: { space: 'arb1:0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9' }
         },
         activeRoute: {
-          prefix: 'space-core-gov'
-        },
-        position: 3
+          prefix: ['space-core-gov', 'space-treasury-gov']
+        }
       },
       signals: {
         name: 'Offchain voting',

--- a/apps/ui/src/helpers/organizations/index.ts
+++ b/apps/ui/src/helpers/organizations/index.ts
@@ -2,6 +2,7 @@ export {
   getOrganizationConfigByDomain,
   getOrganizationConfigById,
   getOrganizationConfigBySpace,
+  getOrgOnchainSpaces,
   getOrgProposalLabel,
   resolveSpaceItem,
   type Organization,

--- a/apps/ui/src/helpers/organizations/index.ts
+++ b/apps/ui/src/helpers/organizations/index.ts
@@ -2,6 +2,7 @@ export {
   getOrganizationConfigByDomain,
   getOrganizationConfigById,
   getOrganizationConfigBySpace,
+  getOrgOnchainSpaces,
   getOrgProposalLabel,
   type Organization,
   type OrganizationConfig

--- a/apps/ui/src/helpers/organizations/index.ts
+++ b/apps/ui/src/helpers/organizations/index.ts
@@ -2,8 +2,8 @@ export {
   getOrganizationConfigByDomain,
   getOrganizationConfigById,
   getOrganizationConfigBySpace,
-  getOrgOnchainSpaces,
   getOrgProposalLabel,
+  getOrgProposalSpaces,
   resolveSpaceItem,
   type Organization,
   type OrganizationConfig

--- a/apps/ui/src/queries/proposals.ts
+++ b/apps/ui/src/queries/proposals.ts
@@ -38,7 +38,11 @@ export const PROPOSALS_KEYS = {
       spacesIds,
       { ...filters, query }
     ] as const,
-  multiSpaceList: (
+  spaceSummary: (
+    networkId: MaybeRefOrGetter<NetworkID>,
+    spaceId: MaybeRefOrGetter<string>
+  ) => [...PROPOSALS_KEYS.space(networkId, spaceId), 'summary'] as const,
+  spaceList: (
     networkId: MaybeRefOrGetter<NetworkID>,
     spacesIds: MaybeRefOrGetter<string[]>,
     filters: Filters,
@@ -46,24 +50,9 @@ export const PROPOSALS_KEYS = {
   ) =>
     [
       ...PROPOSALS_KEYS.all,
-      'multiSpaceList',
+      'spaceList',
       networkId,
       spacesIds,
-      { ...filters, query }
-    ] as const,
-  spaceSummary: (
-    networkId: MaybeRefOrGetter<NetworkID>,
-    spaceId: MaybeRefOrGetter<string>
-  ) => [...PROPOSALS_KEYS.space(networkId, spaceId), 'summary'] as const,
-  spaceList: (
-    networkId: MaybeRefOrGetter<NetworkID>,
-    spaceId: MaybeRefOrGetter<string>,
-    filters: Filters,
-    query?: MaybeRefOrGetter<string>
-  ) =>
-    [
-      ...PROPOSALS_KEYS.space(networkId, spaceId),
-      'list',
       { ...filters, query }
     ] as const,
   details: (
@@ -196,29 +185,12 @@ export function useHomeProposalsQuery(
 
 export function useProposalsQuery(
   networkId: MaybeRefOrGetter<NetworkID>,
-  spaceId: MaybeRefOrGetter<string>,
-  filters: Filters,
-  query?: MaybeRefOrGetter<string>
-) {
-  return getProposalsQuery(
-    PROPOSALS_KEYS.spaceList(networkId, spaceId, filters, query),
-    networkId,
-    toRef(() => [toValue(spaceId)]),
-    filters,
-    query
-  );
-}
-
-/** Multi-space variant — used by the Spaces filter in Space/Proposals.vue to merge
- *  proposals across several spaces in the same org / network. */
-export function useMultiSpaceProposalsQuery(
-  networkId: MaybeRefOrGetter<NetworkID>,
   spacesIds: MaybeRefOrGetter<string[]>,
   filters: Filters,
   query?: MaybeRefOrGetter<string>
 ) {
   return getProposalsQuery(
-    PROPOSALS_KEYS.multiSpaceList(networkId, spacesIds, filters, query),
+    PROPOSALS_KEYS.spaceList(networkId, spacesIds, filters, query),
     networkId,
     spacesIds,
     filters,

--- a/apps/ui/src/queries/proposals.ts
+++ b/apps/ui/src/queries/proposals.ts
@@ -75,6 +75,31 @@ export const PROPOSALS_KEYS = {
     ] as const
 };
 
+/** Invalidates all proposals queries related to a space: summary, details,
+ *  and any list (single or merged) that includes the space. */
+export function invalidateSpaceProposals(
+  queryClient: QueryClient,
+  networkId: NetworkID,
+  spaceId: string
+) {
+  queryClient.invalidateQueries({
+    queryKey: PROPOSALS_KEYS.space(networkId, spaceId)
+  });
+  queryClient.invalidateQueries({
+    predicate: ({ queryKey }) => {
+      const [scope, tag, keyNetworkId, spacesIds] = queryKey;
+
+      return (
+        scope === 'proposals' &&
+        tag === 'spaceList' &&
+        keyNetworkId === networkId &&
+        Array.isArray(spacesIds) &&
+        spacesIds.includes(spaceId)
+      );
+    }
+  });
+}
+
 async function withAuthorNames(proposals: Proposal[]) {
   const names = await getNames(proposals.map(proposal => proposal.author.id));
 

--- a/apps/ui/src/queries/proposals.ts
+++ b/apps/ui/src/queries/proposals.ts
@@ -38,6 +38,19 @@ export const PROPOSALS_KEYS = {
       spacesIds,
       { ...filters, query }
     ] as const,
+  multiSpaceList: (
+    networkId: MaybeRefOrGetter<NetworkID>,
+    spacesIds: MaybeRefOrGetter<string[]>,
+    filters: Filters,
+    query?: MaybeRefOrGetter<string>
+  ) =>
+    [
+      ...PROPOSALS_KEYS.all,
+      'multiSpaceList',
+      networkId,
+      spacesIds,
+      { ...filters, query }
+    ] as const,
   spaceSummary: (
     networkId: MaybeRefOrGetter<NetworkID>,
     spaceId: MaybeRefOrGetter<string>
@@ -191,6 +204,23 @@ export function useProposalsQuery(
     PROPOSALS_KEYS.spaceList(networkId, spaceId, filters, query),
     networkId,
     toRef(() => [toValue(spaceId)]),
+    filters,
+    query
+  );
+}
+
+/** Multi-space variant — used by the Spaces filter in Space/Proposals.vue to merge
+ *  proposals across several spaces in the same org / network. */
+export function useMultiSpaceProposalsQuery(
+  networkId: MaybeRefOrGetter<NetworkID>,
+  spacesIds: MaybeRefOrGetter<string[]>,
+  filters: Filters,
+  query?: MaybeRefOrGetter<string>
+) {
+  return getProposalsQuery(
+    PROPOSALS_KEYS.multiSpaceList(networkId, spacesIds, filters, query),
+    networkId,
+    spacesIds,
     filters,
     query
   );

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -11,7 +11,7 @@ import {
 } from '@/helpers/utils';
 import { explorePageProtocols, getNetwork, offchainNetworks } from '@/networks';
 import { SNAPSHOT_URLS } from '@/networks/offchain';
-import { PROPOSALS_KEYS } from '@/queries/proposals';
+import { invalidateSpaceProposals } from '@/queries/proposals';
 import { Proposal } from '@/types';
 
 const WHITELISTED_SPACES: string[] = ['kleros.eth', 'gnosis.eth'];
@@ -235,12 +235,11 @@ async function handleFlagClick() {
   try {
     const result = await flagProposal(props.proposal);
     if (result) {
-      queryClient.invalidateQueries({
-        queryKey: PROPOSALS_KEYS.space(
-          props.proposal.network,
-          props.proposal.space.id
-        )
-      });
+      invalidateSpaceProposals(
+        queryClient,
+        props.proposal.network,
+        props.proposal.space.id
+      );
 
       uiStore.addNotification('success', 'Proposal flagged successfully.');
 
@@ -259,12 +258,11 @@ async function handleCancelClick() {
   try {
     const result = await cancelProposal(props.proposal);
     if (result) {
-      queryClient.invalidateQueries({
-        queryKey: PROPOSALS_KEYS.space(
-          props.proposal.network,
-          props.proposal.space.id
-        )
-      });
+      invalidateSpaceProposals(
+        queryClient,
+        props.proposal.network,
+        props.proposal.space.id
+      );
 
       uiStore.addNotification('success', 'Proposal cancelled successfully.');
 

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -413,7 +413,11 @@ async function handleProposeClick() {
       }
     }
     if (result) {
-      invalidateSpaceProposals(queryClient, props.space.network, props.space.id);
+      invalidateSpaceProposals(
+        queryClient,
+        props.space.network,
+        props.space.id
+      );
     }
 
     if (

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -8,7 +8,7 @@ import { BASIC_CHOICES, DOCS_URL, VERIFIED_URL } from '@/helpers/constants';
 import { omit, prettyConcat } from '@/helpers/utils';
 import { validateForm } from '@/helpers/validation';
 import { explorePageProtocols, getNetwork, offchainNetworks } from '@/networks';
-import { PROPOSALS_KEYS } from '@/queries/proposals';
+import { invalidateSpaceProposals } from '@/queries/proposals';
 import { usePropositionPowerQuery } from '@/queries/propositionPower';
 import { Contact, Space, Transaction, VoteType } from '@/types';
 import { TOTAL_NAV_HEIGHT } from '../../../tailwind.config';
@@ -413,9 +413,7 @@ async function handleProposeClick() {
       }
     }
     if (result) {
-      queryClient.invalidateQueries({
-        queryKey: PROPOSALS_KEYS.space(props.space.network, props.space.id)
-      });
+      invalidateSpaceProposals(queryClient, props.space.network, props.space.id);
     }
 
     if (

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -6,7 +6,7 @@ import {
   getOrgProposalLabel
 } from '@/helpers/organizations';
 import { ProposalsFilter } from '@/networks/types';
-import { useMultiSpaceProposalsQuery } from '@/queries/proposals';
+import { useProposalsQuery } from '@/queries/proposals';
 import { useSpaceVotingPowerQuery } from '@/queries/votingPower';
 import { Space } from '@/types';
 
@@ -86,7 +86,7 @@ const {
   isPending,
   isError,
   isFetchingNextPage
-} = useMultiSpaceProposalsQuery(
+} = useProposalsQuery(
   toRef(() => props.space.network),
   queriedSpaceIds,
   {
@@ -158,7 +158,7 @@ watch(
         delete query.labels;
       }
 
-      if (hasMultiSpaceFilter.value && toSpace !== ANY_SPACE) {
+      if (toSpace !== ANY_SPACE) {
         query.space = toSpace;
       } else {
         delete query.space;

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -368,6 +368,7 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
       :loading="isPending"
       :loading-more="isFetchingNextPage"
       :proposals="data?.pages.flat() ?? []"
+      :show-space="selectedSpaceIds.length > 1"
       @end-reached="handleEndReached"
     />
   </div>

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -1,9 +1,17 @@
 <script setup lang="ts">
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions
+} from '@headlessui/vue';
+import { Float } from '@headlessui-float/vue';
 import { LocationQueryRaw } from 'vue-router';
 import ProposalIconStatus from '@/components/ProposalIconStatus.vue';
 import { getOrgProposalLabel } from '@/helpers/organizations';
+import { offchainNetworks } from '@/networks';
 import { ProposalsFilter } from '@/networks/types';
-import { useProposalsQuery } from '@/queries/proposals';
+import { useMultiSpaceProposalsQuery } from '@/queries/proposals';
 import { useSpaceVotingPowerQuery } from '@/queries/votingPower';
 import { Space } from '@/types';
 
@@ -27,23 +35,64 @@ const {
 const state = ref<NonNullable<ProposalsFilter['state']>>('any');
 const labels = ref<string[]>([]);
 
+/** Other onchain spaces in this org, on the same network as the current space.
+ *  Drives the Spaces filter (hidden when the org has only one such space). */
+const orgOnchainSpaces = computed(() => {
+  const all = organization.value?.spaces ?? [];
+  return all.filter(
+    s =>
+      !offchainNetworks.includes(s.network) &&
+      s.network === props.space.network
+  );
+});
+
+/** Multi-select: which spaces to aggregate proposals from. Defaults to the current
+ *  space; persisted in ?spaces=<csv>. Always a subset of orgOnchainSpaces. */
+const selectedSpaceIds = ref<string[]>([props.space.id]);
+
+const showSpacesFilter = computed(() => orgOnchainSpaces.value.length > 1);
+
+const spacesById = computed(() =>
+  Object.fromEntries(orgOnchainSpaces.value.map(s => [s.id, s]))
+);
+
+/** Chip label: "Any" when nothing selected, the name when one, "Name +N" when many. */
+const spacesButtonLabel = computed(() => {
+  const ids = selectedSpaceIds.value;
+  if (!ids.length) return 'Any';
+  const first = spacesById.value[ids[0]];
+  const firstName = first?.name ?? first?.id ?? ids[0];
+  return ids.length === 1 ? firstName : `${firstName} +${ids.length - 1}`;
+});
+
 const selectIconBaseProps = {
   size: 16
 };
 
-const proposalsLabel = computed(
-  () =>
-    getOrgProposalLabel(
-      organization.value,
-      `${props.space.network}:${props.space.id}`
-    ) ?? 'Proposals'
-);
+const proposalsLabel = computed(() => {
+  /** Single space selected (or no org context): keep the existing per-space label. */
+  if (selectedSpaceIds.value.length <= 1) {
+    return (
+      getOrgProposalLabel(
+        organization.value,
+        `${props.space.network}:${props.space.id}`
+      ) ?? 'Proposals'
+    );
+  }
+  return 'Proposals';
+});
 
 const spaceLabels = computed(() => {
   if (!props.space.labels) return {};
 
   return Object.fromEntries(props.space.labels.map(label => [label.id, label]));
 });
+
+/** Effective spaces to query — falls back to the current space when the multi-select
+ *  is empty (avoids an empty-IN query that would return nothing). */
+const effectiveSpaceIds = computed(() =>
+  selectedSpaceIds.value.length ? selectedSpaceIds.value : [props.space.id]
+);
 
 const {
   data,
@@ -52,9 +101,9 @@ const {
   isPending,
   isError,
   isFetchingNextPage
-} = useProposalsQuery(
+} = useMultiSpaceProposalsQuery(
   toRef(() => props.space.network),
-  toRef(() => props.space.id),
+  effectiveSpaceIds,
   {
     state,
     labels
@@ -76,9 +125,12 @@ async function handleEndReached() {
 watchThrottled(
   [
     () => route.query.state as string,
-    () => route.query.labels as string[] | string
+    () => route.query.labels as string[] | string,
+    () => route.query.spaces as string | undefined,
+    () => props.space.id,
+    () => orgOnchainSpaces.value
   ],
-  ([toState, toLabels]) => {
+  ([toState, toLabels, toSpaces, currentSpaceId, onchainSpaces]) => {
     state.value = ['any', 'active', 'pending', 'closed'].includes(toState)
       ? (toState as NonNullable<ProposalsFilter['state']>)
       : 'any';
@@ -87,17 +139,25 @@ watchThrottled(
       ? normalizedLabels
       : [normalizedLabels];
     labels.value = normalizedLabels.filter(id => spaceLabels.value[id]);
+
+    const validIds = new Set(onchainSpaces.map(s => s.id));
+    const fromQuery = (toSpaces ?? '').split(',').filter(id => validIds.has(id));
+    selectedSpaceIds.value = fromQuery.length ? fromQuery : [currentSpaceId];
   },
   { throttle: 1000, immediate: true }
 );
 
 watch(
-  [() => props.space.id, state, labels],
-  ([toSpaceId, toState, toLabels], [fromSpaceId, fromState, fromLabels]) => {
+  [() => props.space.id, state, labels, selectedSpaceIds],
+  (
+    [toSpaceId, toState, toLabels, toSpaces],
+    [fromSpaceId, fromState, fromLabels, fromSpaces]
+  ) => {
     if (
       toSpaceId !== fromSpaceId ||
       toState !== fromState ||
-      toLabels !== fromLabels
+      toLabels !== fromLabels ||
+      toSpaces !== fromSpaces
     ) {
       const query: LocationQueryRaw = { ...route.query };
 
@@ -111,6 +171,15 @@ watch(
         query.labels = toLabels;
       } else {
         delete query.labels;
+      }
+
+      /** Drop the param when the selection is the current-space default. */
+      const isDefault =
+        toSpaces.length === 1 && toSpaces[0] === toSpaceId;
+      if (toSpaces.length && !isDefault) {
+        query.spaces = toSpaces.join(',');
+      } else {
+        delete query.spaces;
       }
 
       if (JSON.stringify(query) !== JSON.stringify(route.query)) {
@@ -162,6 +231,48 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
             }
           ]"
         />
+        <div v-if="showSpacesFilter" class="sm:relative">
+          <Listbox v-model="selectedSpaceIds" multiple as="div">
+            <Float adaptive-width strategy="fixed" placement="bottom-start">
+              <ListboxButton
+                class="flex items-center gap-2 relative rounded-full leading-[100%] border button px-3 min-w-[110px] h-[42px] top-1 text-skin-link bg-skin-bg"
+              >
+                <div
+                  class="absolute top-[-10px] bg-skin-bg px-1 left-2.5 text-sm text-skin-text"
+                >
+                  Spaces
+                </div>
+                <span class="truncate max-w-[180px]">
+                  {{ spacesButtonLabel }}
+                </span>
+              </ListboxButton>
+              <ListboxOptions
+                class="mt-2 bg-skin-bg rounded-md shadow-bottom overflow-hidden focus:outline-none min-w-[200px] border"
+              >
+                <ListboxOption
+                  v-for="s in orgOnchainSpaces"
+                  :key="s.id"
+                  v-slot="{ selected, active }"
+                  :value="s.id"
+                >
+                  <li
+                    class="px-3 py-2 cursor-pointer flex items-center gap-2 whitespace-nowrap"
+                    :class="active ? 'bg-skin-border' : ''"
+                  >
+                    <IH-check
+                      v-if="selected"
+                      class="text-skin-success size-[16px]"
+                    />
+                    <span v-else class="inline-block size-[16px]" />
+                    <span class="text-skin-link">
+                      {{ s.name ?? s.id }}
+                    </span>
+                  </li>
+                </ListboxOption>
+              </ListboxOptions>
+            </Float>
+          </Listbox>
+        </div>
         <div v-if="space.labels?.length" class="sm:relative">
           <PickerLabel
             v-model="labels"

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -368,8 +368,14 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
       :loading="isPending"
       :loading-more="isFetchingNextPage"
       :proposals="data?.pages.flat() ?? []"
-      :show-space="selectedSpaceIds.length > 1"
       @end-reached="handleEndReached"
-    />
+    >
+      <template
+        v-if="selectedSpaceIds.length > 1"
+        #item-meta="{ proposal }"
+      >
+        {{ proposal.space.name }}
+      </template>
+    </ProposalsList>
   </div>
 </template>

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -46,7 +46,7 @@ const spacesItems = computed(() => [
   { key: ANY_SPACE, label: 'Any' },
   ...orgProposalSpaces.value.map(s => ({
     key: s.id,
-    label: s.name ?? s.id
+    label: s.name
   }))
 ]);
 
@@ -307,7 +307,7 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
                 params: { space: `${space.network}:${s.id}` }
               }"
             >
-              {{ s.name ?? s.id }}
+              {{ s.name }}
             </UiDropdownItem>
           </template>
         </UiDropdown>

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -121,10 +121,9 @@ watchThrottled(
     () => route.query.state as string,
     () => route.query.labels as string[] | string,
     () => route.query.space as string | undefined,
-    () => props.space.id,
-    () => orgProposalSpaces.value
+    orgProposalSpaces
   ],
-  ([toState, toLabels, toSpace, , proposalSpaces]) => {
+  ([toState, toLabels, toSpace]) => {
     state.value = ['any', 'active', 'pending', 'closed'].includes(toState)
       ? (toState as NonNullable<ProposalsFilter['state']>)
       : 'any';
@@ -134,9 +133,9 @@ watchThrottled(
       : [normalizedLabels];
     labels.value = normalizedLabels.filter(id => spaceLabels.value[id]);
 
-    const validIds = new Set(proposalSpaces.map(s => s.id));
-    const next = toSpace && validIds.has(toSpace) ? toSpace : ANY_SPACE;
-    if (next !== selectedSpaceId.value) selectedSpaceId.value = next;
+    const isValidSpace =
+      toSpace && orgProposalSpaces.value.some(s => s.id === toSpace);
+    selectedSpaceId.value = isValidSpace ? toSpace : ANY_SPACE;
   },
   { throttle: 1000, immediate: true }
 );

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -48,9 +48,18 @@ const orgOnchainSpaces = computed(() => {
   );
 });
 
-/** Multi-select: which spaces to aggregate proposals from. Defaults to the current
- *  space; persisted in ?spaces=<csv>. Always a subset of orgOnchainSpaces. */
-const selectedSpaceIds = ref<string[]>([props.space.id]);
+/** Default selection: when the chip is shown (Arbitrum org today), all onchain spaces
+ *  are pre-selected so "Onchain voting" surfaces everything at once. Falls back to the
+ *  current space for any future org that opts in with a single-space sidebar. */
+const defaultSelectedSpaceIds = computed(() =>
+  orgOnchainSpaces.value.length
+    ? orgOnchainSpaces.value.map(s => s.id)
+    : [props.space.id]
+);
+
+/** Multi-select: which spaces to aggregate proposals from. Persisted in ?spaces=<csv>;
+ *  initialized from the default and overridden by URL state in the watcher below. */
+const selectedSpaceIds = ref<string[]>([...defaultSelectedSpaceIds.value]);
 
 const showSpacesFilter = computed(() => orgOnchainSpaces.value.length > 1);
 
@@ -132,7 +141,7 @@ watchThrottled(
     () => props.space.id,
     () => orgOnchainSpaces.value
   ],
-  ([toState, toLabels, toSpaces, currentSpaceId, onchainSpaces]) => {
+  ([toState, toLabels, toSpaces, , onchainSpaces]) => {
     state.value = ['any', 'active', 'pending', 'closed'].includes(toState)
       ? (toState as NonNullable<ProposalsFilter['state']>)
       : 'any';
@@ -144,7 +153,9 @@ watchThrottled(
 
     const validIds = new Set(onchainSpaces.map(s => s.id));
     const fromQuery = (toSpaces ?? '').split(',').filter(id => validIds.has(id));
-    selectedSpaceIds.value = fromQuery.length ? fromQuery : [currentSpaceId];
+    selectedSpaceIds.value = fromQuery.length
+      ? fromQuery
+      : [...defaultSelectedSpaceIds.value];
   },
   { throttle: 1000, immediate: true }
 );
@@ -175,9 +186,12 @@ watch(
         delete query.labels;
       }
 
-      /** Drop the param when the selection is the current-space default. */
+      /** Drop the param when the selection matches the default (so URLs stay clean
+       *  on fresh visits and only show ?spaces= when the user has narrowed). */
+      const def = defaultSelectedSpaceIds.value;
       const isDefault =
-        toSpaces.length === 1 && toSpaces[0] === toSpaceId;
+        toSpaces.length === def.length &&
+        toSpaces.every(id => def.includes(id));
       if (toSpaces.length && !isDefault) {
         query.spaces = toSpaces.join(',');
       } else {

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -19,18 +19,10 @@ const { organization } = useOrganization();
 const router = useRouter();
 const route = useRoute();
 const { web3 } = useWeb3();
-const {
-  data: votingPower,
-  isPending: isVotingPowerPending,
-  isError: isVotingPowerError,
-  refetch: fetchVotingPower
-} = useSpaceVotingPowerQuery(
-  toRef(() => web3.value.account),
-  toRef(props, 'space')
-);
 
 const state = ref<NonNullable<ProposalsFilter['state']>>('any');
 const labels = ref<string[]>([]);
+const selectedSpaceId = ref<string>(ANY_SPACE);
 
 const orgProposalSpaces = computed(() =>
   getOrgProposalSpaces(organization.value, props.space.network)
@@ -38,7 +30,17 @@ const orgProposalSpaces = computed(() =>
 
 const hasMultiSpaceFilter = computed(() => orgProposalSpaces.value.length > 1);
 
-const selectedSpaceId = ref<string>(ANY_SPACE);
+/** The space all space-specific context (voting power, labels, heading) is
+ *  bound to. `null` when showing the merged list. */
+const selectedSpace = computed(() => {
+  if (!hasMultiSpaceFilter.value) return props.space;
+
+  return (
+    orgProposalSpaces.value.find(s => s.id === selectedSpaceId.value) ?? null
+  );
+});
+
+const isMergedList = computed(() => !selectedSpace.value);
 
 const spacesItems = computed(() => [
   { key: ANY_SPACE, label: 'Any' },
@@ -50,34 +52,41 @@ const spacesItems = computed(() => [
 
 const queriedSpaceIds = computed(() => {
   if (!hasMultiSpaceFilter.value) return [props.space.id];
+
   return selectedSpaceId.value === ANY_SPACE
     ? orgProposalSpaces.value.map(s => s.id)
     : [selectedSpaceId.value];
 });
-
-const isMergedList = computed(
-  () => hasMultiSpaceFilter.value && selectedSpaceId.value === ANY_SPACE
-);
 
 const selectIconBaseProps = {
   size: 16
 };
 
 const proposalsLabel = computed(() => {
-  if (isMergedList.value) return 'Proposals';
-  return (
-    getOrgProposalLabel(
-      organization.value,
-      `${props.space.network}:${props.space.id}`
-    ) ?? 'Proposals'
-  );
+  const spaceId = selectedSpace.value
+    ? `${props.space.network}:${selectedSpace.value.id}`
+    : undefined;
+
+  return getOrgProposalLabel(organization.value, spaceId) ?? 'Proposals';
 });
 
 const spaceLabels = computed(() => {
-  if (!props.space.labels) return {};
+  if (!selectedSpace.value?.labels) return {};
 
-  return Object.fromEntries(props.space.labels.map(label => [label.id, label]));
+  return Object.fromEntries(
+    selectedSpace.value.labels.map(label => [label.id, label])
+  );
 });
+
+const {
+  data: votingPower,
+  isPending: isVotingPowerPending,
+  isError: isVotingPowerError,
+  refetch: fetchVotingPower
+} = useSpaceVotingPowerQuery(
+  toRef(() => web3.value.account),
+  toRef(() => selectedSpace.value ?? props.space)
+);
 
 const {
   data,
@@ -180,7 +189,7 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
   <div>
     <div
       class="flex justify-between p-4 gap-2 gap-y-3 flex-row"
-      :class="{ 'flex-col-reverse sm:flex-row': space.labels?.length }"
+      :class="{ 'flex-col-reverse sm:flex-row': selectedSpace?.labels?.length }"
     >
       <div class="flex gap-2">
         <UiSelectDropdown
@@ -221,10 +230,10 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
             }
           ]"
         />
-        <div v-if="space.labels?.length" class="sm:relative">
+        <div v-if="selectedSpace?.labels?.length" class="sm:relative">
           <PickerLabel
             v-model="labels"
-            :labels="space.labels"
+            :labels="selectedSpace.labels"
             :button-props="{
               class: [
                 'flex items-center gap-2 relative rounded-full leading-[100%] min-w-[75px] max-w-[230px] border button h-[42px] top-1 text-skin-link bg-skin-bg'
@@ -274,6 +283,7 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
       </div>
       <div class="flex gap-2 truncate">
         <IndicatorVotingPower
+          v-if="selectedSpace"
           :network-id="space.network"
           :voting-power="votingPower"
           :is-loading="isVotingPowerPending"

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -2,8 +2,8 @@
 import { LocationQueryRaw } from 'vue-router';
 import ProposalIconStatus from '@/components/ProposalIconStatus.vue';
 import {
-  getOrgOnchainSpaces,
-  getOrgProposalLabel
+  getOrgProposalLabel,
+  getOrgProposalSpaces
 } from '@/helpers/organizations';
 import { ProposalsFilter } from '@/networks/types';
 import { useProposalsQuery } from '@/queries/proposals';
@@ -32,17 +32,17 @@ const {
 const state = ref<NonNullable<ProposalsFilter['state']>>('any');
 const labels = ref<string[]>([]);
 
-const orgOnchainSpaces = computed(() =>
-  getOrgOnchainSpaces(organization.value, props.space.network)
+const orgProposalSpaces = computed(() =>
+  getOrgProposalSpaces(organization.value, props.space.network)
 );
 
-const hasMultiSpaceFilter = computed(() => orgOnchainSpaces.value.length > 1);
+const hasMultiSpaceFilter = computed(() => orgProposalSpaces.value.length > 1);
 
 const selectedSpaceId = ref<string>(ANY_SPACE);
 
 const spacesItems = computed(() => [
   { key: ANY_SPACE, label: 'Any' },
-  ...orgOnchainSpaces.value.map(s => ({
+  ...orgProposalSpaces.value.map(s => ({
     key: s.id,
     label: s.name ?? s.id
   }))
@@ -51,7 +51,7 @@ const spacesItems = computed(() => [
 const queriedSpaceIds = computed(() => {
   if (!hasMultiSpaceFilter.value) return [props.space.id];
   return selectedSpaceId.value === ANY_SPACE
-    ? orgOnchainSpaces.value.map(s => s.id)
+    ? orgProposalSpaces.value.map(s => s.id)
     : [selectedSpaceId.value];
 });
 
@@ -113,9 +113,9 @@ watchThrottled(
     () => route.query.labels as string[] | string,
     () => route.query.space as string | undefined,
     () => props.space.id,
-    () => orgOnchainSpaces.value
+    () => orgProposalSpaces.value
   ],
-  ([toState, toLabels, toSpace, , onchainSpaces]) => {
+  ([toState, toLabels, toSpace, , proposalSpaces]) => {
     state.value = ['any', 'active', 'pending', 'closed'].includes(toState)
       ? (toState as NonNullable<ProposalsFilter['state']>)
       : 'any';
@@ -125,7 +125,7 @@ watchThrottled(
       : [normalizedLabels];
     labels.value = normalizedLabels.filter(id => spaceLabels.value[id]);
 
-    const validIds = new Set(onchainSpaces.map(s => s.id));
+    const validIds = new Set(proposalSpaces.map(s => s.id));
     const next = toSpace && validIds.has(toSpace) ? toSpace : ANY_SPACE;
     if (next !== selectedSpaceId.value) selectedSpaceId.value = next;
   },
@@ -290,7 +290,7 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
           </template>
           <template #items>
             <UiDropdownItem
-              v-for="s in orgOnchainSpaces"
+              v-for="s in orgProposalSpaces"
               :key="s.id"
               :to="{
                 name: 'space-editor',

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -127,15 +127,16 @@ watchThrottled(
     state.value = ['any', 'active', 'pending', 'closed'].includes(toState)
       ? (toState as NonNullable<ProposalsFilter['state']>)
       : 'any';
+
+    const isValidSpace =
+      toSpace && orgProposalSpaces.value.some(s => s.id === toSpace);
+    selectedSpaceId.value = isValidSpace ? toSpace : ANY_SPACE;
+
     let normalizedLabels = toLabels || [];
     normalizedLabels = Array.isArray(normalizedLabels)
       ? normalizedLabels
       : [normalizedLabels];
     labels.value = normalizedLabels.filter(id => spaceLabels.value[id]);
-
-    const isValidSpace =
-      toSpace && orgProposalSpaces.value.some(s => s.id === toSpace);
-    selectedSpaceId.value = isValidSpace ? toSpace : ANY_SPACE;
   },
   { throttle: 1000, immediate: true }
 );

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -8,8 +8,7 @@ import {
 import { Float } from '@headlessui-float/vue';
 import { LocationQueryRaw } from 'vue-router';
 import ProposalIconStatus from '@/components/ProposalIconStatus.vue';
-import { getOrgProposalLabel } from '@/helpers/organizations';
-import { offchainNetworks } from '@/networks';
+import { getOrgOnchainSpaces, getOrgProposalLabel } from '@/helpers/organizations';
 import { ProposalsFilter } from '@/networks/types';
 import { useMultiSpaceProposalsQuery } from '@/queries/proposals';
 import { useSpaceVotingPowerQuery } from '@/queries/votingPower';
@@ -35,44 +34,23 @@ const {
 const state = ref<NonNullable<ProposalsFilter['state']>>('any');
 const labels = ref<string[]>([]);
 
-/** Onchain spaces in this org, on the same network as the current space.
- *  Drives the Spaces filter. Gated to Arbitrum for now — the only org with multiple
- *  onchain governors today; revisit when another org needs the same pattern. */
-const orgOnchainSpaces = computed(() => {
-  if (organization.value?.id !== 'arbitrum') return [];
-  const all = organization.value?.spaces ?? [];
-  return all.filter(
-    s =>
-      !offchainNetworks.includes(s.network) &&
-      s.network === props.space.network
-  );
-});
+const orgOnchainSpaces = computed(() =>
+  getOrgOnchainSpaces(organization.value, props.space.network)
+);
 
-/** Default selection: when the chip is shown (Arbitrum org today), all onchain spaces
- *  are pre-selected so "Onchain voting" surfaces everything at once. Falls back to the
- *  current space for any future org that opts in with a single-space sidebar. */
 const defaultSelectedSpaceIds = computed(() =>
   orgOnchainSpaces.value.length
     ? orgOnchainSpaces.value.map(s => s.id)
     : [props.space.id]
 );
 
-/** Multi-select: which spaces to aggregate proposals from. Persisted in ?spaces=<csv>;
- *  initialized from the default and overridden by URL state in the watcher below. */
 const selectedSpaceIds = ref<string[]>([...defaultSelectedSpaceIds.value]);
 
-const showSpacesFilter = computed(() => orgOnchainSpaces.value.length > 1);
-
-const spacesById = computed(() =>
-  Object.fromEntries(orgOnchainSpaces.value.map(s => [s.id, s]))
-);
-
-/** Chip label: "Any" when nothing selected, the name when one, "Name +N" when many. */
 const spacesButtonLabel = computed(() => {
   const ids = selectedSpaceIds.value;
   if (!ids.length) return 'Any';
-  const first = spacesById.value[ids[0]];
-  const firstName = first?.name ?? first?.id ?? ids[0];
+  const first = orgOnchainSpaces.value.find(s => s.id === ids[0]);
+  const firstName = first?.name ?? ids[0];
   return ids.length === 1 ? firstName : `${firstName} +${ids.length - 1}`;
 });
 
@@ -81,16 +59,13 @@ const selectIconBaseProps = {
 };
 
 const proposalsLabel = computed(() => {
-  /** Single space selected (or no org context): keep the existing per-space label. */
-  if (selectedSpaceIds.value.length <= 1) {
-    return (
-      getOrgProposalLabel(
-        organization.value,
-        `${props.space.network}:${props.space.id}`
-      ) ?? 'Proposals'
-    );
-  }
-  return 'Proposals';
+  if (selectedSpaceIds.value.length > 1) return 'Proposals';
+  return (
+    getOrgProposalLabel(
+      organization.value,
+      `${props.space.network}:${props.space.id}`
+    ) ?? 'Proposals'
+  );
 });
 
 const spaceLabels = computed(() => {
@@ -98,12 +73,6 @@ const spaceLabels = computed(() => {
 
   return Object.fromEntries(props.space.labels.map(label => [label.id, label]));
 });
-
-/** Effective spaces to query — falls back to the current space when the multi-select
- *  is empty (avoids an empty-IN query that would return nothing). */
-const effectiveSpaceIds = computed(() =>
-  selectedSpaceIds.value.length ? selectedSpaceIds.value : [props.space.id]
-);
 
 const {
   data,
@@ -114,7 +83,7 @@ const {
   isFetchingNextPage
 } = useMultiSpaceProposalsQuery(
   toRef(() => props.space.network),
-  effectiveSpaceIds,
+  selectedSpaceIds,
   {
     state,
     labels
@@ -131,6 +100,10 @@ async function handleEndReached() {
   if (!hasNextPage.value) return;
 
   fetchNextPage();
+}
+
+function sameIds(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((id, i) => id === b[i]);
 }
 
 watchThrottled(
@@ -153,9 +126,8 @@ watchThrottled(
 
     const validIds = new Set(onchainSpaces.map(s => s.id));
     const fromQuery = (toSpaces ?? '').split(',').filter(id => validIds.has(id));
-    selectedSpaceIds.value = fromQuery.length
-      ? fromQuery
-      : [...defaultSelectedSpaceIds.value];
+    const next = fromQuery.length ? fromQuery : defaultSelectedSpaceIds.value;
+    if (!sameIds(next, selectedSpaceIds.value)) selectedSpaceIds.value = [...next];
   },
   { throttle: 1000, immediate: true }
 );
@@ -186,12 +158,7 @@ watch(
         delete query.labels;
       }
 
-      /** Drop the param when the selection matches the default (so URLs stay clean
-       *  on fresh visits and only show ?spaces= when the user has narrowed). */
-      const def = defaultSelectedSpaceIds.value;
-      const isDefault =
-        toSpaces.length === def.length &&
-        toSpaces.every(id => def.includes(id));
+      const isDefault = sameIds(toSpaces, defaultSelectedSpaceIds.value);
       if (toSpaces.length && !isDefault) {
         query.spaces = toSpaces.join(',');
       } else {
@@ -247,48 +214,51 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
             }
           ]"
         />
-        <div v-if="showSpacesFilter" class="sm:relative">
-          <Listbox v-model="selectedSpaceIds" multiple as="div">
-            <Float adaptive-width strategy="fixed" placement="bottom-start">
-              <ListboxButton
-                class="flex items-center gap-2 relative rounded-full leading-[100%] border button px-3 min-w-[110px] h-[42px] top-1 text-skin-link bg-skin-bg"
+        <Listbox
+          v-if="orgOnchainSpaces.length > 1"
+          v-model="selectedSpaceIds"
+          multiple
+          as="div"
+        >
+          <Float adaptive-width strategy="fixed" placement="bottom-start">
+            <ListboxButton
+              class="flex items-center gap-2 relative rounded-full leading-[100%] border button px-3 min-w-[110px] h-[42px] top-1 text-skin-link bg-skin-bg"
+            >
+              <div
+                class="absolute top-[-10px] bg-skin-bg px-1 left-2.5 text-sm text-skin-text"
               >
-                <div
-                  class="absolute top-[-10px] bg-skin-bg px-1 left-2.5 text-sm text-skin-text"
-                >
-                  Spaces
-                </div>
-                <span class="truncate max-w-[180px]">
-                  {{ spacesButtonLabel }}
-                </span>
-              </ListboxButton>
-              <ListboxOptions
-                class="mt-2 bg-skin-bg rounded-md shadow-bottom overflow-hidden focus:outline-none min-w-[200px] border"
+                Spaces
+              </div>
+              <span class="truncate max-w-[180px]">
+                {{ spacesButtonLabel }}
+              </span>
+            </ListboxButton>
+            <ListboxOptions
+              class="mt-2 bg-skin-bg rounded-md shadow-bottom overflow-hidden focus:outline-none min-w-[200px] border"
+            >
+              <ListboxOption
+                v-for="s in orgOnchainSpaces"
+                :key="s.id"
+                v-slot="{ selected, active }"
+                :value="s.id"
               >
-                <ListboxOption
-                  v-for="s in orgOnchainSpaces"
-                  :key="s.id"
-                  v-slot="{ selected, active }"
-                  :value="s.id"
+                <li
+                  class="px-3 py-2 cursor-pointer flex items-center gap-2 whitespace-nowrap"
+                  :class="active ? 'bg-skin-border' : ''"
                 >
-                  <li
-                    class="px-3 py-2 cursor-pointer flex items-center gap-2 whitespace-nowrap"
-                    :class="active ? 'bg-skin-border' : ''"
-                  >
-                    <IH-check
-                      v-if="selected"
-                      class="text-skin-success size-[16px]"
-                    />
-                    <span v-else class="inline-block size-[16px]" />
-                    <span class="text-skin-link">
-                      {{ s.name ?? s.id }}
-                    </span>
-                  </li>
-                </ListboxOption>
-              </ListboxOptions>
-            </Float>
-          </Listbox>
-        </div>
+                  <IH-check
+                    v-if="selected"
+                    class="text-skin-success size-[16px]"
+                  />
+                  <span v-else class="inline-block size-[16px]" />
+                  <span class="text-skin-link">
+                    {{ s.name ?? s.id }}
+                  </span>
+                </li>
+              </ListboxOption>
+            </ListboxOptions>
+          </Float>
+        </Listbox>
         <div v-if="space.labels?.length" class="sm:relative">
           <PickerLabel
             v-model="labels"

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -35,9 +35,11 @@ const {
 const state = ref<NonNullable<ProposalsFilter['state']>>('any');
 const labels = ref<string[]>([]);
 
-/** Other onchain spaces in this org, on the same network as the current space.
- *  Drives the Spaces filter (hidden when the org has only one such space). */
+/** Onchain spaces in this org, on the same network as the current space.
+ *  Drives the Spaces filter. Gated to Arbitrum for now — the only org with multiple
+ *  onchain governors today; revisit when another org needs the same pattern. */
 const orgOnchainSpaces = computed(() => {
+  if (organization.value?.id !== 'arbitrum') return [];
   const all = organization.value?.spaces ?? [];
   return all.filter(
     s =>

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -1,18 +1,16 @@
 <script setup lang="ts">
-import {
-  Listbox,
-  ListboxButton,
-  ListboxOption,
-  ListboxOptions
-} from '@headlessui/vue';
-import { Float } from '@headlessui-float/vue';
 import { LocationQueryRaw } from 'vue-router';
 import ProposalIconStatus from '@/components/ProposalIconStatus.vue';
-import { getOrgOnchainSpaces, getOrgProposalLabel } from '@/helpers/organizations';
+import {
+  getOrgOnchainSpaces,
+  getOrgProposalLabel
+} from '@/helpers/organizations';
 import { ProposalsFilter } from '@/networks/types';
 import { useMultiSpaceProposalsQuery } from '@/queries/proposals';
 import { useSpaceVotingPowerQuery } from '@/queries/votingPower';
 import { Space } from '@/types';
+
+const ANY_SPACE = 'any';
 
 const props = defineProps<{ space: Space }>();
 
@@ -38,28 +36,35 @@ const orgOnchainSpaces = computed(() =>
   getOrgOnchainSpaces(organization.value, props.space.network)
 );
 
-const defaultSelectedSpaceIds = computed(() =>
-  orgOnchainSpaces.value.length
+const hasMultiSpaceFilter = computed(() => orgOnchainSpaces.value.length > 1);
+
+const selectedSpaceId = ref<string>(ANY_SPACE);
+
+const spacesItems = computed(() => [
+  { key: ANY_SPACE, label: 'Any' },
+  ...orgOnchainSpaces.value.map(s => ({
+    key: s.id,
+    label: s.name ?? s.id
+  }))
+]);
+
+const queriedSpaceIds = computed(() => {
+  if (!hasMultiSpaceFilter.value) return [props.space.id];
+  return selectedSpaceId.value === ANY_SPACE
     ? orgOnchainSpaces.value.map(s => s.id)
-    : [props.space.id]
-);
-
-const selectedSpaceIds = ref<string[]>([...defaultSelectedSpaceIds.value]);
-
-const spacesButtonLabel = computed(() => {
-  const ids = selectedSpaceIds.value;
-  if (!ids.length) return 'Any';
-  const first = orgOnchainSpaces.value.find(s => s.id === ids[0]);
-  const firstName = first?.name ?? ids[0];
-  return ids.length === 1 ? firstName : `${firstName} +${ids.length - 1}`;
+    : [selectedSpaceId.value];
 });
+
+const isMergedList = computed(
+  () => hasMultiSpaceFilter.value && selectedSpaceId.value === ANY_SPACE
+);
 
 const selectIconBaseProps = {
   size: 16
 };
 
 const proposalsLabel = computed(() => {
-  if (selectedSpaceIds.value.length > 1) return 'Proposals';
+  if (isMergedList.value) return 'Proposals';
   return (
     getOrgProposalLabel(
       organization.value,
@@ -83,7 +88,7 @@ const {
   isFetchingNextPage
 } = useMultiSpaceProposalsQuery(
   toRef(() => props.space.network),
-  selectedSpaceIds,
+  queriedSpaceIds,
   {
     state,
     labels
@@ -102,19 +107,15 @@ async function handleEndReached() {
   fetchNextPage();
 }
 
-function sameIds(a: string[], b: string[]): boolean {
-  return a.length === b.length && a.every((id, i) => id === b[i]);
-}
-
 watchThrottled(
   [
     () => route.query.state as string,
     () => route.query.labels as string[] | string,
-    () => route.query.spaces as string | undefined,
+    () => route.query.space as string | undefined,
     () => props.space.id,
     () => orgOnchainSpaces.value
   ],
-  ([toState, toLabels, toSpaces, , onchainSpaces]) => {
+  ([toState, toLabels, toSpace, , onchainSpaces]) => {
     state.value = ['any', 'active', 'pending', 'closed'].includes(toState)
       ? (toState as NonNullable<ProposalsFilter['state']>)
       : 'any';
@@ -125,24 +126,23 @@ watchThrottled(
     labels.value = normalizedLabels.filter(id => spaceLabels.value[id]);
 
     const validIds = new Set(onchainSpaces.map(s => s.id));
-    const fromQuery = (toSpaces ?? '').split(',').filter(id => validIds.has(id));
-    const next = fromQuery.length ? fromQuery : defaultSelectedSpaceIds.value;
-    if (!sameIds(next, selectedSpaceIds.value)) selectedSpaceIds.value = [...next];
+    const next = toSpace && validIds.has(toSpace) ? toSpace : ANY_SPACE;
+    if (next !== selectedSpaceId.value) selectedSpaceId.value = next;
   },
   { throttle: 1000, immediate: true }
 );
 
 watch(
-  [() => props.space.id, state, labels, selectedSpaceIds],
+  [() => props.space.id, state, labels, selectedSpaceId],
   (
-    [toSpaceId, toState, toLabels, toSpaces],
-    [fromSpaceId, fromState, fromLabels, fromSpaces]
+    [toSpaceId, toState, toLabels, toSpace],
+    [fromSpaceId, fromState, fromLabels, fromSpace]
   ) => {
     if (
       toSpaceId !== fromSpaceId ||
       toState !== fromState ||
       toLabels !== fromLabels ||
-      toSpaces !== fromSpaces
+      toSpace !== fromSpace
     ) {
       const query: LocationQueryRaw = { ...route.query };
 
@@ -158,11 +158,10 @@ watch(
         delete query.labels;
       }
 
-      const isDefault = sameIds(toSpaces, defaultSelectedSpaceIds.value);
-      if (toSpaces.length && !isDefault) {
-        query.spaces = toSpaces.join(',');
+      if (hasMultiSpaceFilter.value && toSpace !== ANY_SPACE) {
+        query.space = toSpace;
       } else {
-        delete query.spaces;
+        delete query.space;
       }
 
       if (JSON.stringify(query) !== JSON.stringify(route.query)) {
@@ -184,6 +183,14 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
       :class="{ 'flex-col-reverse sm:flex-row': space.labels?.length }"
     >
       <div class="flex gap-2">
+        <UiSelectDropdown
+          v-if="hasMultiSpaceFilter"
+          v-model="selectedSpaceId"
+          title="Spaces"
+          gap="12"
+          placement="start"
+          :items="spacesItems"
+        />
         <UiSelectDropdown
           v-model="state"
           title="Status"
@@ -214,51 +221,6 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
             }
           ]"
         />
-        <Listbox
-          v-if="orgOnchainSpaces.length > 1"
-          v-model="selectedSpaceIds"
-          multiple
-          as="div"
-        >
-          <Float adaptive-width strategy="fixed" placement="bottom-start">
-            <ListboxButton
-              class="flex items-center gap-2 relative rounded-full leading-[100%] border button px-3 min-w-[110px] h-[42px] top-1 text-skin-link bg-skin-bg"
-            >
-              <div
-                class="absolute top-[-10px] bg-skin-bg px-1 left-2.5 text-sm text-skin-text"
-              >
-                Spaces
-              </div>
-              <span class="truncate max-w-[180px]">
-                {{ spacesButtonLabel }}
-              </span>
-            </ListboxButton>
-            <ListboxOptions
-              class="mt-2 bg-skin-bg rounded-md shadow-bottom overflow-hidden focus:outline-none min-w-[200px] border"
-            >
-              <ListboxOption
-                v-for="s in orgOnchainSpaces"
-                :key="s.id"
-                v-slot="{ selected, active }"
-                :value="s.id"
-              >
-                <li
-                  class="px-3 py-2 cursor-pointer flex items-center gap-2 whitespace-nowrap"
-                  :class="active ? 'bg-skin-border' : ''"
-                >
-                  <IH-check
-                    v-if="selected"
-                    class="text-skin-success size-[16px]"
-                  />
-                  <span v-else class="inline-block size-[16px]" />
-                  <span class="text-skin-link">
-                    {{ s.name ?? s.id }}
-                  </span>
-                </li>
-              </ListboxOption>
-            </ListboxOptions>
-          </Float>
-        </Listbox>
         <div v-if="space.labels?.length" class="sm:relative">
           <PickerLabel
             v-model="labels"
@@ -318,7 +280,28 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
           :is-error="isVotingPowerError"
           @fetch="fetchVotingPower"
         />
-        <UiTooltip title="New proposal">
+        <UiDropdown v-if="hasMultiSpaceFilter" gap="12" placement="end">
+          <template #button>
+            <UiTooltip title="New proposal">
+              <UiButton type="button" uniform>
+                <IH-pencil-alt />
+              </UiButton>
+            </UiTooltip>
+          </template>
+          <template #items>
+            <UiDropdownItem
+              v-for="s in orgOnchainSpaces"
+              :key="s.id"
+              :to="{
+                name: 'space-editor',
+                params: { space: `${space.network}:${s.id}` }
+              }"
+            >
+              {{ s.name ?? s.id }}
+            </UiDropdownItem>
+          </template>
+        </UiDropdown>
+        <UiTooltip v-else title="New proposal">
           <UiButton
             :to="{
               name: 'space-editor',
@@ -340,10 +323,7 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
       :proposals="data?.pages.flat() ?? []"
       @end-reached="handleEndReached"
     >
-      <template
-        v-if="selectedSpaceIds.length > 1"
-        #item-meta="{ proposal }"
-      >
+      <template v-if="isMergedList" #item-meta="{ proposal }">
         {{ proposal.space.name }}
       </template>
     </ProposalsList>


### PR DESCRIPTION
## Summary

Some orgs run more than one onchain governor on the same network (Arbitrum's Core + Treasury), and today each one is a separate nav item and a separate proposals page. This adds a single Spaces dropdown on `Space/Proposals.vue` so you can look at one governor or all of them from the same list.

The dropdown only shows up when the org has more than one onchain proposal space configured for the current network (set via `proposalSpaces` in the org config). Options are "Any" plus one entry per space, and "Any" is the default. Picking "Any" merges proposals across all the configured spaces into one list sorted by created desc; picking a specific space narrows to just that one. The selection is persisted in the URL as `?space=<id>`, and the param is dropped when it's back on "Any".

A few things follow from the selected space rather than the route: the heading, the Labels filter, and the voting-power indicator all bind to the chosen space. On the merged "Any" view there's no single space to bind to, so the voting-power indicator is hidden, the heading falls back to the org's proposals label, and each row shows which space it belongs to. The New proposal button also becomes a dropdown on multi-space orgs so you can pick which governor to propose in. Status and Labels filters keep working on top of whatever the Spaces dropdown is showing.

Arbitrum's two governors are now a single "Onchain voting" nav item instead of separate Core/Treasury items, since the filter replaces that split.

## Test plan

Verified manually on `http://localhost:8081/#/org/arbitrum`:

- [x] Open the Arbitrum proposals page: Spaces dropdown shows, defaults to "Any", list merges Core + Treasury sorted by created desc, and each row shows its space name.
- [x] Pick "Arbitrum Core": list narrows to Core, heading and Labels filter switch to Core, voting-power indicator appears, and the URL gains `?space=<core id>`.
- [x] Reload on that URL: dropdown and narrowed list restore from the param.
- [x] Switch back to "Any": `?space` is removed from the URL and the merged list comes back.
- [x] Status and Labels filters still narrow correctly in both the merged and single-space views.
- [x] New proposal button on Arbitrum opens a dropdown to choose Core or Treasury; on a single-space org it stays a plain button.
- [x] Org with only one onchain space on the network: no Spaces dropdown, page behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
