### PR TITLE
fix(ui): show AVT token in treasury list

### DIFF
--- a/apps/ui/src/helpers/contracts.test.ts
+++ b/apps/ui/src/helpers/contracts.test.ts
@@ -25,4 +25,14 @@ describe('getTokensMetadata', () => {
       }
     ]);
   });
+
+  it('should resolve symbol for legacy bytes32 tokens (e.g. AVT)', async () => {
+    const [avt] = await getTokensMetadata('1', [
+      '0x0d88ed6e74bbfd96b831231638b66c05571e824f'
+    ]);
+
+    expect(avt.address).toBe('0x0d88ed6e74bbfd96b831231638b66c05571e824f');
+    expect(avt.symbol).toBe('AVT');
+    expect(avt.decimals).toBe(18);
+  });
 });

--- a/apps/ui/src/helpers/contracts.ts
+++ b/apps/ui/src/helpers/contracts.ts
@@ -4,6 +4,22 @@ import { EIP7702_DELEGATION_INDICATOR } from './constants';
 import Multicaller from './multicaller';
 import { getProvider } from './provider';
 
+// Pre-EIP-20 tokens declare name/symbol as bytes32 and the standard ERC-20
+// ABI fails to decode them, so they would otherwise be dropped from the
+// treasury list. Override the known cases manually.
+const HARDCODED_TOKEN_METADATA: Record<
+  string,
+  Record<string, { name: string; symbol: string; decimals: number }>
+> = {
+  '1': {
+    '0x0d88ed6e74bbfd96b831231638b66c05571e824f': {
+      name: 'Aventus',
+      symbol: 'AVT',
+      decimals: 18
+    }
+  }
+};
+
 export async function getIsContract(provider: Provider, address: string) {
   const code = await provider.getCode(address);
 
@@ -27,10 +43,15 @@ export async function getTokensMetadata(chainId: string, tokens: string[]) {
     allowFailure: true
   });
 
-  return tokens.map(token => ({
-    address: token,
-    name: result[token].name,
-    symbol: result[token].symbol,
-    decimals: result[token].decimals ?? 0
-  }));
+  return tokens.map(token => {
+    const hardcoded = HARDCODED_TOKEN_METADATA[chainId]?.[token.toLowerCase()];
+    if (hardcoded) return { address: token, ...hardcoded };
+
+    return {
+      address: token,
+      name: result[token].name,
+      symbol: result[token].symbol,
+      decimals: result[token].decimals ?? 0
+    };
+  });
 }


### PR DESCRIPTION
Reported on https://app.intercom.com/a/inbox/n9dmxtcs/inbox/shared/all/conversation/215474202169701?view=List

Supersedes #2074.

## Summary

Some pre-EIP-20 ERC-20 tokens declare `name()` and `symbol()` as `bytes32` instead of `string` (e.g. **AVT**). The standard ERC-20 ABI fails to decode them, so the tokens were silently dropped from the treasury list — even though Alchemy correctly returned their balances.

Per @bonustrack's feedback on #2074, we go with the simpler approach: hardcode the metadata for the known case (AVT) rather than add a generic `bytes32` fallback path. Adding more legacy tokens later is a one-line entry in the map.

```ts
const HARDCODED_TOKEN_METADATA: Record<
  string,
  Record<string, { name: string; symbol: string; decimals: number }>
> = {
  '1': {
    '0x0d88ed6e74bbfd96b831231638b66c05571e824f': {
      name: 'Aventus',
      symbol: 'AVT',
      decimals: 18
    }
  }
};
```

Keys are chainId → lowercased token address. `getTokensMetadata` consults the map after the multicall and overrides the (failed-to-decode) result with the hardcoded values.

## How to test

**Before (broken — on https://snapshot.org)**
- [ ] Visit https://snapshot.org/#/s:aventus-gov.eth/treasury/1/tokens
- [ ] Confirm the AVT token (`0x0d88ed6e74bbfd96b831231638b66c05571e824f`) is **missing** from the list, even though Alchemy returns a balance for it.

**After (fixed — on http://localhost:8080)**
- [ ] `cd apps/ui && bun run dev`
- [ ] Visit http://localhost:8080/#/s:aventus-gov.eth/treasury/1/tokens
- [ ] Confirm AVT now appears with `symbol = "AVT"`, `decimals = 18`, and a correct USD value.
- [ ] Regression check: visit normal treasuries on multiple chains (e.g. `arbitrumfoundation.eth`, `ovncommunity.eth`, `hodldance.eth`, `justaveryintelligentsystem.eth`, `uuu-community.eth`) — all non-AVT tokens still display correctly.
- [ ] `bun run vitest run src/helpers/contracts.test.ts` — both tests pass (USDC/LINK case and the new AVT regression case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)