### PR TITLE
fix(ui): ecosystem card alignment, fresh data, internal links, blog URL

### DIFF
--- a/apps/ui/src/components/AppsListItem.vue
+++ b/apps/ui/src/components/AppsListItem.vue
@@ -6,8 +6,8 @@ defineProps<{ app: any }>();
 
 <template>
   <AppLink
-    :to="app.link || app.website"
-    class="border rounded-lg p-3 leading-6 relative group"
+    :to="{ name: 'site-app', params: { app: app.id } }"
+    class="border rounded-lg p-3 leading-6 relative group block text-left w-full"
   >
     <img :src="getUrl(app.avatar) || ''" class="size-[32px] rounded-lg mb-2" />
     <IH-arrow-sm-right

--- a/apps/ui/src/components/Site/Footer.vue
+++ b/apps/ui/src/components/Site/Footer.vue
@@ -58,7 +58,7 @@ const SOCIALS = [
               </AppLink>
             </div>
             <div>
-              <AppLink to="https://snapshot.mirror.xyz">
+              <AppLink to="https://blog.snapshot.box">
                 Blog
                 <IH-arrow-sm-right class="inline-block -rotate-45" />
               </AppLink>

--- a/apps/ui/src/components/Site/Topnav.vue
+++ b/apps/ui/src/components/Site/Topnav.vue
@@ -35,7 +35,7 @@ const { toggleTheme, currentTheme } = useTheme();
         </AppLink>
       </li>
       <li>
-        <AppLink to="https://snapshot.mirror.xyz">
+        <AppLink to="https://blog.snapshot.box">
           Blog
           <IH-arrow-sm-right class="inline-block -rotate-45" />
         </AppLink>

--- a/apps/ui/src/composables/useApps.ts
+++ b/apps/ui/src/composables/useApps.ts
@@ -5,7 +5,8 @@ const APPS_SHEET_GID = '0';
 
 async function getSpreadsheet(id: string, gid: string = '0'): Promise<any[]> {
   const res = await fetch(
-    `https://docs.google.com/spreadsheets/d/e/${id}/pub?output=csv&gid=${gid}&cb=${Math.random()}}`
+    `https://docs.google.com/spreadsheets/d/e/${id}/pub?output=csv&gid=${gid}&cb=${Date.now()}`,
+    { cache: 'no-store' }
   );
   const text = await res.text();
 
@@ -64,7 +65,7 @@ const loaded: Ref<boolean> = ref(false);
 
 export function useApps() {
   async function load() {
-    if (loading.value || loaded.value) return;
+    if (loading.value) return;
 
     loading.value = true;
 

--- a/apps/ui/src/views/App.vue
+++ b/apps/ui/src/views/App.vue
@@ -43,7 +43,12 @@ onMounted(() => load());
                 <div v-text="app.category" />
               </div>
             </div>
-            <UiButton v-if="app.link" :to="app.link" primary class="w-full">
+            <UiButton
+              v-if="app.link"
+              :to="app.link"
+              primary
+              class="w-full md:w-auto"
+            >
               Use integration
             </UiButton>
           </div>


### PR DESCRIPTION
## Summary

A handful of small ecosystem-page tweaks bundled together.

- **Ecosystem card alignment** — `AppLink` falls back to `<button>` when there's no URL, which inherits the browser's centered text-align. Added `block text-left w-full` so cards render the same regardless of the underlying element ([AppsListItem.vue](apps/ui/src/components/AppsListItem.vue)).
- **Internal link** — ecosystem cards now route to the in-app detail page (`/ecosystem/:app`) instead of jumping straight to the external website ([AppsListItem.vue](apps/ui/src/components/AppsListItem.vue)).
- **Fresh data on each load** — the apps Google Sheet fetch now uses `cache: 'no-store'` and the in-memory `loaded` guard no longer short-circuits subsequent loads (the `loading` guard still prevents concurrent fetches). The cache-buster query param is a `Date.now()` instead of `Math.random()` (also fixes a stray `}` typo) ([useApps.ts](apps/ui/src/composables/useApps.ts)).
- **"Use integration" button overlap** — the button had `w-full` on desktop and overflowed onto the title. Switched to `w-full md:w-auto` ([App.vue](apps/ui/src/views/App.vue)).
- **Blog URL** — `https://snapshot.mirror.xyz` → `https://blog.snapshot.box` in topnav and footer.

Note: Google's "Publish to web" CSV has its own ~5-minute server-side cache that the client can't bypass; sheet edits still take a few minutes to reach end users.

## Test plan

- [ ] `/ecosystem` cards are all left-aligned (avatar, title, category) regardless of which app has or lacks a website
- [ ] Clicking a card opens the in-app detail page, not an external site
- [ ] Editing the apps sheet and navigating back to `/ecosystem` shows the change without a hard refresh (after Google republishes)
- [ ] On `/ecosystem/:id`, the "Use integration" button sits to the right of the title on desktop and stretches full-width on mobile
- [ ] Topnav and footer "Blog" links point to `blog.snapshot.box`

🤖 Generated with [Claude Code](https://claude.com/claude-code)