### PR TITLE
chore: migrate RPC traffic to rpc.brovider.xyz with client attribution

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -2,6 +2,11 @@ export const UI_URL = process.env.UI_URL || 'https://snapshot.box';
 
 export const MANA_URL = process.env.VITE_MANA_URL || 'https://mana.box';
 
+export const BROVIDER_URL = 'https://rpc.brovider.xyz';
+
+export const getRpcUrl = (id: string | number) =>
+  `${BROVIDER_URL}/${id}?client=api`;
+
 /**
  * Array of enabled networks. Can be defined using ENABLED_NETWORKS environment variable
  * with comma-separated list of network names.

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -3,7 +3,7 @@ export const UI_URL = process.env.UI_URL || 'https://snapshot.box';
 export const MANA_URL =
   process.env.VITE_MANA_URL || 'https://mana.snapshot.box';
 
-export const BROVIDER_URL = 'https://rpc.brovider.xyz';
+const BROVIDER_URL = 'https://rpc.brovider.xyz';
 
 export const getRpcUrl = (id: string | number) =>
   `${BROVIDER_URL}/${id}?client=api`;

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -3,6 +3,11 @@ export const UI_URL = process.env.UI_URL || 'https://snapshot.box';
 export const MANA_URL =
   process.env.VITE_MANA_URL || 'https://mana.snapshot.box';
 
+export const BROVIDER_URL = 'https://rpc.brovider.xyz';
+
+export const getRpcUrl = (id: string | number) =>
+  `${BROVIDER_URL}/${id}?client=api`;
+
 /**
  * Array of enabled networks. Can be defined using ENABLED_NETWORKS environment variable
  * with comma-separated list of network names.

--- a/apps/api/src/evm/config.ts
+++ b/apps/api/src/evm/config.ts
@@ -1,4 +1,5 @@
 import { evmNetworks } from '@snapshot-labs/sx';
+import { getRpcUrl } from '../config';
 import { createConfig as createGovernorBravoConfig } from './protocols/governor-bravo/config';
 import { createConfig as createOpenZeppelinConfig } from './protocols/openzeppelin/config';
 import { createConfig as createSnapshotXConfig } from './protocols/snapshot-x/config';
@@ -38,7 +39,7 @@ export function createConfig(indexerName: NetworkID): EVMConfig {
 
   return {
     indexerName,
-    network_node_url: `https://rpc.snapshot.org/${network.Meta.eip712ChainId}`,
+    network_node_url: getRpcUrl(network.Meta.eip712ChainId),
     ...partialConfig,
     state_retention_blocks: 5000,
     snapshotXConfig: snapshotXConfig.protocolConfig,

--- a/apps/api/src/evm/config.ts
+++ b/apps/api/src/evm/config.ts
@@ -1,4 +1,5 @@
 import { evmNetworks } from '@snapshot-labs/sx';
+import { getRpcUrl } from '../config';
 import { createConfig as createGovernorBravoConfig } from './protocols/governor-bravo/config';
 import { createConfig as createOpenZeppelinConfig } from './protocols/openzeppelin/config';
 import { createConfig as createSnapshotXConfig } from './protocols/snapshot-x/config';
@@ -54,7 +55,7 @@ export function createConfig(
 
   return {
     indexerName,
-    network_node_url: `https://rpc.snapshot.org/${network.Meta.eip712ChainId}`,
+    network_node_url: getRpcUrl(network.Meta.eip712ChainId),
     ...partialConfig,
     state_retention_blocks: 5000,
     snapshotXConfig: snapshotXConfig?.protocolConfig,

--- a/apps/api/src/evm/utils.test.ts
+++ b/apps/api/src/evm/utils.test.ts
@@ -97,7 +97,7 @@ describe('applyConfig', () => {
 describe('getTimestampFromBlock', () => {
   it('should return real onchain timestamp for past blocks on native-block chains', async () => {
     const client = createPublicClient({
-      transport: http('https://rpc.snapshot.org/1')
+      transport: http('https://rpc.brovider.xyz/1')
     });
 
     const actual = await getTimestampFromBlock({
@@ -113,7 +113,7 @@ describe('getTimestampFromBlock', () => {
 
   it('should return real onchain timestamp for past blocks on non-native-block chains', async () => {
     const client = createPublicClient({
-      transport: http('https://rpc.snapshot.org/42161')
+      transport: http('https://rpc.brovider.xyz/42161')
     });
 
     const actual = await getTimestampFromBlock({

--- a/apps/api/src/evm/utils.ts
+++ b/apps/api/src/evm/utils.ts
@@ -1,6 +1,7 @@
 import { evm } from '@snapshot-labs/checkpoint';
 import { evmNetworks } from '@snapshot-labs/sx';
 import { createPublicClient, http, PublicClient } from 'viem';
+import { getRpcUrl } from '../config';
 import { EVMConfig, NetworkID, PartialConfig } from './types';
 
 type ProtocolConfig = Pick<EVMConfig, 'sources' | 'templates' | 'abis'>;
@@ -148,7 +149,7 @@ export async function getTimestampFromBlock({
   const nonNativeBlockChainId = NON_NATIVE_BLOCK_CHAIN_ID[networkId];
   const blockClient = nonNativeBlockChainId
     ? createPublicClient({
-        transport: http(`https://rpc.snapshot.org/${nonNativeBlockChainId}`)
+        transport: http(getRpcUrl(nonNativeBlockChainId))
       })
     : client;
 

--- a/apps/api/src/starknet/config.ts
+++ b/apps/api/src/starknet/config.ts
@@ -1,14 +1,13 @@
 import { CheckpointConfig } from '@snapshot-labs/checkpoint';
 import { starknetNetworks } from '@snapshot-labs/sx';
 import { validateAndParseAddress } from 'starknet';
-import { MANA_URL } from '../config';
+import { getRpcUrl, MANA_URL } from '../config';
 import spaceAbi from './abis/space.json';
 import spaceFactoryAbi from './abis/spaceFactory.json';
 
-const snNetworkNodeUrl =
-  process.env.NETWORK_NODE_URL_SN || 'https://rpc.snapshot.org/sn';
+const snNetworkNodeUrl = process.env.NETWORK_NODE_URL_SN || getRpcUrl('sn');
 const snSepNetworkNodeUrl =
-  process.env.NETWORK_NODE_URL_SN_SEP || 'https://rpc.snapshot.org/sn-sep';
+  process.env.NETWORK_NODE_URL_SN_SEP || getRpcUrl('sn-sep');
 
 export type FullConfig = {
   indexerName: 'sn' | 'sn-sep';
@@ -19,7 +18,7 @@ const CONFIG = {
   sn: {
     indexerName: 'sn',
     networkNodeUrl: snNetworkNodeUrl,
-    l1NetworkNodeUrl: 'https://rpc.brovider.xyz/1',
+    l1NetworkNodeUrl: getRpcUrl(1),
     contract: starknetNetworks['sn'].Meta.spaceFactory,
     start: 445498,
     verifiedSpaces: [
@@ -32,7 +31,7 @@ const CONFIG = {
   'sn-sep': {
     indexerName: 'sn-sep',
     networkNodeUrl: snSepNetworkNodeUrl,
-    l1NetworkNodeUrl: 'https://rpc.brovider.xyz/11155111',
+    l1NetworkNodeUrl: getRpcUrl(11155111),
     contract: starknetNetworks['sn-sep'].Meta.spaceFactory,
     start: 17960,
     verifiedSpaces: [

--- a/apps/auction/src/helpers/provider.ts
+++ b/apps/auction/src/helpers/provider.ts
@@ -3,7 +3,7 @@ import { StaticJsonRpcProvider } from '@ethersproject/providers';
 const providers: Record<number, StaticJsonRpcProvider | undefined> = {};
 
 export function getProvider(networkId: number): StaticJsonRpcProvider {
-  const url = `https://rpc.snapshot.org/${networkId}`;
+  const url = `https://rpc.brovider.xyz/${networkId}?client=auction`;
 
   let provider = providers[networkId];
 

--- a/apps/delegates-api/src/evm/config.ts
+++ b/apps/delegates-api/src/evm/config.ts
@@ -10,8 +10,8 @@ type Source = {
 };
 
 const NETWORK_NODE_URLS: Record<NetworkID, string> = {
-  eth: 'https://rpc.snapshot.org/1'
-  // arb1: 'https://rpc.snapshot.org/42161'
+  eth: 'https://rpc.brovider.xyz/1?client=delegates-api'
+  // arb1: 'https://rpc.brovider.xyz/42161?client=delegates-api'
 };
 
 const TOKEN_SOURCES: Record<NetworkID, Source[]> = {

--- a/apps/delegates-api/src/starknet/config.ts
+++ b/apps/delegates-api/src/starknet/config.ts
@@ -11,7 +11,7 @@ type Source = {
 };
 
 const NETWORK_NODE_URLS: Record<NetworkID, string> = {
-  sn: 'https://rpc.snapshot.org/sn'
+  sn: 'https://rpc.brovider.xyz/sn?client=delegates-api'
 };
 
 const TOKEN_SOURCES: Record<NetworkID, Source[]> = {

--- a/apps/highlight/src/agents/aliases.test.ts
+++ b/apps/highlight/src/agents/aliases.test.ts
@@ -8,7 +8,7 @@ import Process from '../highlight/process';
 
 const CHAIN_ID = '11155111';
 
-const provider = new StaticJsonRpcProvider('https://rpc.snapshot.org/11155111');
+const provider = new StaticJsonRpcProvider('https://rpc.brovider.xyz/11155111');
 const adapter = new MemoryAdapter();
 const wallet = getWallet();
 

--- a/apps/highlight/src/highlight/signatures.ts
+++ b/apps/highlight/src/highlight/signatures.ts
@@ -88,7 +88,7 @@ async function verifyEip1271SignatureWithAbi(
   let returnValue: string;
   try {
     const provider = new StaticJsonRpcProvider(
-      `https://rpc.snapshot.org/${chainId}`,
+      `https://rpc.brovider.xyz/${chainId}?client=highlight`,
       Number(chainId)
     );
 

--- a/apps/highlight/test/integration/highlight.test.ts
+++ b/apps/highlight/test/integration/highlight.test.ts
@@ -14,7 +14,7 @@ const ALIASES_ADDRESS = '0x0000000000000000000000000000000000000001';
 const FAKE_SIGNATURE =
   '0x9a40ce5d706efe66cdc1b9075b866ba25385bf083bbc19b7e1ce315ac2a3957f3a6e075762f6f4723006889ed341ce740e023959f6c600e30586f005f5afa64a1c';
 
-const provider = new StaticJsonRpcProvider('https://rpc.snapshot.org/11155111');
+const provider = new StaticJsonRpcProvider('https://rpc.brovider.xyz/11155111');
 const adapter = new MemoryAdapter();
 const highlight = new Highlight({ adapter, agents: AGENTS_MAP });
 const wallet = new Wallet(PRIVATE_KEY, provider);

--- a/apps/mana/scripts/check-starknet-balances.mts
+++ b/apps/mana/scripts/check-starknet-balances.mts
@@ -34,11 +34,11 @@ const STARK_TOKEN_ADDRESS =
 
 const CONFIG: Record<NetworkID, NetworkConfig> = {
   sn: {
-    rpcUrl: 'https://rpc.brovider.xyz/sn',
+    rpcUrl: 'https://rpc.brovider.xyz/sn?client=mana',
     apiUrl: 'https://api.snapshot.box'
   },
   'sn-sep': {
-    rpcUrl: 'https://rpc.brovider.xyz/sn-sep',
+    rpcUrl: 'https://rpc.brovider.xyz/sn-sep?client=mana',
     apiUrl: 'https://testnet-api.snapshot.box'
   }
 };

--- a/apps/mana/scripts/check-starknet-balances.mts
+++ b/apps/mana/scripts/check-starknet-balances.mts
@@ -34,11 +34,11 @@ const STARK_TOKEN_ADDRESS =
 
 const CONFIG: Record<NetworkID, NetworkConfig> = {
   sn: {
-    rpcUrl: 'https://rpc.snapshot.org/sn',
+    rpcUrl: 'https://rpc.brovider.xyz/sn',
     apiUrl: 'https://api.snapshot.box'
   },
   'sn-sep': {
-    rpcUrl: 'https://rpc.snapshot.org/sn-sep',
+    rpcUrl: 'https://rpc.brovider.xyz/sn-sep',
     apiUrl: 'https://testnet-api.snapshot.box'
   }
 };

--- a/apps/mana/src/eth/dependencies.ts
+++ b/apps/mana/src/eth/dependencies.ts
@@ -18,7 +18,7 @@ export function generateSpaceEvmWallet(
 export const createWalletProxy = (chainId: number) => {
   const signers = new Map<string, Wallet>();
   const provider = new StaticJsonRpcProvider(
-    `https://rpc.snapshot.org/${chainId}`,
+    `https://rpc.brovider.xyz/${chainId}?client=mana`,
     chainId
   );
 

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -63,7 +63,7 @@ Creates a Snapshot proposal. Most defaults come from the space itself, so for ty
 | `end` | `number?` | Voting end as a unix timestamp in seconds. Defaults to `start + space.voting.period` (3 days if the space sets none). |
 | `shielded` | `boolean?` | Opt into Shutter-encrypted voting. Only honored when the space's `voting.privacy` is `"any"`; spaces with `voting.privacy === "shutter"` always encrypt. |
 
-The snapshot block is read from `https://rpc.snapshot.org/<chainId>` based on the space's network. Requires a wallet, same as `snapshot-vote`.
+The snapshot block is read from `https://rpc.brovider.xyz/<chainId>` based on the space's network. Requires a wallet, same as `snapshot-vote`.
 
 ### `snapshot-follow`
 

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -79,7 +79,7 @@ Creates a Snapshot proposal. Most defaults come from the space itself, so for ty
 | `end` | `number?` | Voting end as a unix timestamp in seconds. Defaults to `start + space.voting.period` (3 days if the space sets none). |
 | `privacy` | `"shutter" \| "none"?` | Opt into Shutter-encrypted voting with `"shutter"`. Only honored when the space's `voting.privacy` is `"any"`; spaces with `voting.privacy === "shutter"` always encrypt. |
 
-The snapshot block is read from `https://rpc.snapshot.org/<chainId>` based on the space's network. Requires a wallet, same as `snapshot-vote`.
+The snapshot block is read from `https://rpc.brovider.xyz/<chainId>` based on the space's network. Requires a wallet, same as `snapshot-vote`.
 
 ### `snapshot-follow`
 

--- a/apps/mcp/src/hub.ts
+++ b/apps/mcp/src/hub.ts
@@ -7,7 +7,7 @@ const SNAPSHOT_BLOCK_OFFSET = 4;
 export async function getProposalSnapshotBlock(
   chainId: number
 ): Promise<number> {
-  const res = await fetch(`https://rpc.snapshot.org/${chainId}`, {
+  const res = await fetch(`https://rpc.brovider.xyz/${chainId}?client=mcp`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_blockNumber' })

--- a/apps/sequencer/.env.example
+++ b/apps/sequencer/.env.example
@@ -13,7 +13,7 @@ SCHNAPS_API_URL=https://schnaps.snapshot.box
 # If you need unlimited access to score-api, use `https://score.snapshot.org?apiKey=...`
 RATE_LIMIT_DATABASE_URL= # optional
 RATE_LIMIT_KEYS_PREFIX=snapshot-sequencer: # optional
-BROVIDER_URL=https://rpc.snapshot.org # optional
+BROVIDER_URL=https://rpc.brovider.xyz # optional
 # Secret for laser
 AUTH_SECRET=1dfd84a695705665668c260222ded178d1f1d62d251d7bee8148428dac6d0487 # optional
 WALLETCONNECT_PROJECT_ID=e6454bd61aba40b786e866a69bd4c5c6

--- a/apps/sequencer/package.json
+++ b/apps/sequencer/package.json
@@ -22,6 +22,7 @@
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/bytes": "^5.6.1",
     "@ethersproject/hash": "^5.5.0",
+    "@ethersproject/providers": "^5.8.0",
     "@ethersproject/strings": "^5.7.0",
     "@ethersproject/wallet": "^5.6.2",
     "@shutter-network/shutter-crypto": "^1.0.0",

--- a/apps/sequencer/src/helpers/poke.ts
+++ b/apps/sequencer/src/helpers/poke.ts
@@ -1,11 +1,11 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import { addOrUpdateSpace } from './actions';
+import { BROVIDER_URL } from './provider';
 
 type Space = Record<string, any>;
 
 const DEFAULT_NETWORK = process.env.DEFAULT_NETWORK ?? '1';
-const broviderUrl = process.env.BROVIDER_URL || 'https://rpc.snapshot.org';
 
 export default async function poke(id: string): Promise<Space> {
   const space = await getSpaceENS(id);
@@ -26,7 +26,7 @@ export default async function poke(id: string): Promise<Space> {
 
 async function getSpaceENS(id: string): Promise<Space> {
   const uri = await snapshot.utils.getSpaceUri(id, DEFAULT_NETWORK, {
-    broviderUrl
+    broviderUrl: BROVIDER_URL
   });
 
   if (uri) {

--- a/apps/sequencer/src/helpers/provider.ts
+++ b/apps/sequencer/src/helpers/provider.ts
@@ -6,22 +6,31 @@ export const BROVIDER_URL =
   process.env.BROVIDER_URL ?? 'https://rpc.brovider.xyz';
 const providers = new Map<string, StaticJsonRpcProvider>();
 
-export function getProvider(network: string | number): StaticJsonRpcProvider {
+// Loose `any` return type matches snapshot.js: starknet networks return a
+// starknet RpcProvider, not a StaticJsonRpcProvider.
+export function getProvider(network: string | number): any {
+  const key = String(network);
+  const config = (
+    networks as Record<string, { starknet?: boolean } | undefined>
+  )[key];
+  if (!config) {
+    throw new Error(`Network '${key}' is not supported`);
+  }
   // snapshot.js builds the RPC URL without a query string, so EVM providers are
   // created locally to append ?client=sequencer. Starknet networks need
   // snapshot.js (RpcProvider + broviderId mapping) and keep going through it.
-  if (
-    (networks as Record<string, { starknet?: boolean }>)[String(network)]
-      ?.starknet
-  ) {
+  if (config.starknet) {
     return snapshot.utils.getProvider(network, { broviderUrl: BROVIDER_URL });
   }
 
-  const key = String(network);
   let provider = providers.get(key);
   if (!provider) {
     provider = new StaticJsonRpcProvider(
-      { url: `${BROVIDER_URL}/${key}?client=sequencer`, timeout: 25000 },
+      {
+        url: `${BROVIDER_URL}/${key}?client=sequencer`,
+        timeout: 25000,
+        allowGzip: true
+      },
       Number(network)
     );
     providers.set(key, provider);

--- a/apps/sequencer/src/helpers/provider.ts
+++ b/apps/sequencer/src/helpers/provider.ts
@@ -1,0 +1,18 @@
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+
+export const BROVIDER_URL =
+  process.env.BROVIDER_URL ?? 'https://rpc.brovider.xyz';
+const providers = new Map<string, StaticJsonRpcProvider>();
+
+export function getProvider(network: string | number): StaticJsonRpcProvider {
+  const key = String(network);
+  let provider = providers.get(key);
+  if (!provider) {
+    provider = new StaticJsonRpcProvider(
+      { url: `${BROVIDER_URL}/${key}?client=sequencer`, timeout: 25000 },
+      Number(network)
+    );
+    providers.set(key, provider);
+  }
+  return provider;
+}

--- a/apps/sequencer/src/helpers/provider.ts
+++ b/apps/sequencer/src/helpers/provider.ts
@@ -1,10 +1,22 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import snapshot from '@snapshot-labs/snapshot.js';
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 
 export const BROVIDER_URL =
   process.env.BROVIDER_URL ?? 'https://rpc.brovider.xyz';
 const providers = new Map<string, StaticJsonRpcProvider>();
 
 export function getProvider(network: string | number): StaticJsonRpcProvider {
+  // snapshot.js builds the RPC URL without a query string, so EVM providers are
+  // created locally to append ?client=sequencer. Starknet networks need
+  // snapshot.js (RpcProvider + broviderId mapping) and keep going through it.
+  if (
+    (networks as Record<string, { starknet?: boolean }>)[String(network)]
+      ?.starknet
+  ) {
+    return snapshot.utils.getProvider(network, { broviderUrl: BROVIDER_URL });
+  }
+
   const key = String(network);
   let provider = providers.get(key);
   if (!provider) {

--- a/apps/sequencer/src/helpers/turbo.ts
+++ b/apps/sequencer/src/helpers/turbo.ts
@@ -1,6 +1,7 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import db from './mysql';
+import { getProvider } from './provider';
 import { fetchWithKeepAlive } from './utils';
 
 type Space = {
@@ -12,12 +13,7 @@ const SCHNAPS_API_URL = process.env.SCHNAPS_API_URL;
 const NETWORK_PREFIX = process.env.NETWORK === 'mainnet' ? 's:' : 's-tn:';
 const RUN_INTERVAL = 10 * 1e3; // 10 seconds
 
-const provider = snapshot.utils.getProvider(
-  process.env.DEFAULT_NETWORK ?? '1',
-  {
-    broviderUrl: process.env.BROVIDER_URL || 'https://rpc.snapshot.org'
-  }
-);
+const provider = getProvider(process.env.DEFAULT_NETWORK ?? '1');
 
 // Periodically sync the turbo status of spaces with the schnaps-api
 export async function trackTurboStatuses() {

--- a/apps/sequencer/src/helpers/turbo.ts
+++ b/apps/sequencer/src/helpers/turbo.ts
@@ -1,6 +1,7 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import db from './mysql';
+import { getProvider } from './provider';
 import { fetchWithKeepAlive } from './utils';
 
 type Space = {
@@ -13,12 +14,7 @@ const NETWORK_PREFIX = process.env.NETWORK === 'mainnet' ? 's:' : 's-tn:';
 const EVM_INDEXER = process.env.NETWORK === 'mainnet' ? 'eth' : 'sep';
 const RUN_INTERVAL = 10 * 1e3; // 10 seconds
 
-const provider = snapshot.utils.getProvider(
-  process.env.DEFAULT_NETWORK ?? '1',
-  {
-    broviderUrl: process.env.BROVIDER_URL || 'https://rpc.snapshot.org'
-  }
-);
+const provider = getProvider(process.env.DEFAULT_NETWORK ?? '1');
 
 // Periodically sync the turbo status of spaces with the schnaps-api
 export async function trackTurboStatuses() {

--- a/apps/sequencer/src/helpers/utils.ts
+++ b/apps/sequencer/src/helpers/utils.ts
@@ -7,6 +7,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import { Response } from 'express';
 import fetch from 'node-fetch';
+import { BROVIDER_URL, getProvider } from './provider';
 
 const MAINNET_NETWORK_ID_WHITELIST = [
   's',
@@ -25,8 +26,6 @@ const TESTNET_NETWORK_ID_WHITELIST = [
   'linea-testnet',
   'sn-sep'
 ];
-const broviderUrl = process.env.BROVIDER_URL ?? 'https://rpc.snapshot.org';
-
 export const NETWORK_ID_WHITELIST = [
   ...MAINNET_NETWORK_ID_WHITELIST,
   ...TESTNET_NETWORK_ID_WHITELIST
@@ -218,7 +217,7 @@ export const getQuorum = async (
     }
     case 'balance': {
       const { address, methodABI, decimals, quorumModifier = 1 } = options;
-      const provider = snapshot.utils.getProvider(network, { broviderUrl });
+      const provider = getProvider(network);
 
       const votingPower = await snapshot.utils.call(
         provider,
@@ -238,7 +237,7 @@ export const getQuorum = async (
 
     case 'multichainBalance': {
       const { network, strategies, quorumModifier = 1 } = options;
-      const provider = snapshot.utils.getProvider(network, { broviderUrl });
+      const provider = getProvider(network);
       const blocks = await snapshot.utils.getSnapshots(
         network,
         blockTag,
@@ -247,7 +246,7 @@ export const getQuorum = async (
       );
       const requests: Promise<any>[] = strategies.map(s =>
         snapshot.utils.call(
-          snapshot.utils.getProvider(s.network, { broviderUrl }),
+          getProvider(s.network),
           [s.methodABI],
           [s.address, s.methodABI.name],
           {
@@ -341,5 +340,7 @@ export function getSpaceController(space: string, network = NETWORK) {
   };
   const networkId = tldMapping[tld]?.[network] ?? DEFAULT_NETWORK;
 
-  return snapshot.utils.getSpaceController(space, networkId, { broviderUrl });
+  return snapshot.utils.getSpaceController(space, networkId, {
+    broviderUrl: BROVIDER_URL
+  });
 }

--- a/apps/sequencer/src/ingestor.ts
+++ b/apps/sequencer/src/ingestor.ts
@@ -11,6 +11,7 @@ import { doesMessageExist, storeMsg } from './helpers/highlight';
 import log from './helpers/log';
 import { timeIngestorProcess } from './helpers/metrics';
 import { flaggedIps } from './helpers/moderation';
+import { BROVIDER_URL } from './helpers/provider';
 import relayer, { issueReceipt } from './helpers/relayer';
 import { getIp, jsonParse, sha256 } from './helpers/utils';
 import writer from './writer';
@@ -19,13 +20,13 @@ const NETWORK_METADATA = {
   evm: {
     name: 'snapshot',
     version: '0.1.4',
-    broviderUrl: process.env.BROVIDER_URL ?? 'https://rpc.snapshot.org',
+    broviderUrl: BROVIDER_URL,
     defaultNetwork: process.env.DEFAULT_NETWORK ?? '1'
   },
   starknet: {
     name: 'sx-starknet',
     version: '0.1.0',
-    broviderUrl: process.env.BROVIDER_URL ?? 'https://rpc.snapshot.org',
+    broviderUrl: BROVIDER_URL,
     defaultNetwork:
       process.env.NETWORK === 'testnet'
         ? '0x534e5f5345504f4c4941'

--- a/apps/sequencer/src/writer/proposal.ts
+++ b/apps/sequencer/src/writer/proposal.ts
@@ -9,8 +9,8 @@ import { containsFlaggedLinks, flaggedAddresses } from '../helpers/moderation';
 import { isMalicious } from '../helpers/monitoring';
 import db from '../helpers/mysql';
 import { getLimits, getSpaceType } from '../helpers/options';
-import { validateSpaceSettings } from '../helpers/spaceValidation';
 import { getProvider } from '../helpers/provider';
+import { validateSpaceSettings } from '../helpers/spaceValidation';
 import {
   captureError,
   getQuorum,

--- a/apps/sequencer/src/writer/proposal.ts
+++ b/apps/sequencer/src/writer/proposal.ts
@@ -10,6 +10,7 @@ import { isMalicious } from '../helpers/monitoring';
 import db from '../helpers/mysql';
 import { getLimits, getSpaceType } from '../helpers/options';
 import { validateSpaceSettings } from '../helpers/spaceValidation';
+import { getProvider } from '../helpers/provider';
 import {
   captureError,
   getQuorum,
@@ -18,7 +19,6 @@ import {
 } from '../helpers/utils';
 
 const scoreAPIUrl = process.env.SCORE_API_URL || 'https://score.snapshot.org';
-const broviderUrl = process.env.BROVIDER_URL || 'https://rpc.snapshot.org';
 
 export const getProposalsCount = async (space, author) => {
   const query = `
@@ -225,7 +225,7 @@ export async function verify(body): Promise<any> {
     return Promise.reject('proposal snapshot must be after network start');
 
   try {
-    const provider = snapshot.utils.getProvider(space.network, { broviderUrl });
+    const provider = getProvider(space.network);
     const block = await provider.getBlock(msg.payload.snapshot);
     if (!block) return Promise.reject('invalid snapshot block');
   } catch (err: any) {

--- a/apps/ui/src/helpers/provider.ts
+++ b/apps/ui/src/helpers/provider.ts
@@ -1,9 +1,15 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 
+const BROVIDER_URL = 'https://rpc.brovider.xyz';
+
+export function getRpcUrl(path: string | number): string {
+  return `${BROVIDER_URL}/${path}?client=ui`;
+}
+
 const providers: Record<number, StaticJsonRpcProvider | undefined> = {};
 
 export function getProvider(networkId: number): StaticJsonRpcProvider {
-  const url = `https://rpc.snapshot.org/${networkId}`;
+  const url = getRpcUrl(networkId);
 
   let provider = providers[networkId];
 

--- a/apps/ui/src/networks/starknet/metadata.ts
+++ b/apps/ui/src/networks/starknet/metadata.ts
@@ -1,5 +1,6 @@
 import { constants as starknetConstants } from 'starknet';
 import { API_TESTNET_URL, API_URL } from '@/helpers/constants';
+import { getRpcUrl } from '@/helpers/provider';
 import { NetworkID } from '@/types';
 
 type Metadata = {
@@ -20,8 +21,8 @@ export const METADATA: Partial<Record<NetworkID, Metadata>> = {
     chainId: starknetConstants.StarknetChainId.SN_MAIN,
     baseChainId: 1,
     baseNetworkId: 'eth',
-    rpcUrl: 'https://rpc.snapshot.org/sn',
-    ethRpcUrl: 'https://rpc.snapshot.org/1',
+    rpcUrl: getRpcUrl('sn'),
+    ethRpcUrl: getRpcUrl(1),
     apiUrl: API_URL,
     explorerUrl: 'https://voyager.online',
     avatar: 'ipfs://bafkreihbjafyh7eud7r6e5743esaamifcttsvbspfwcrfoc5ykodjdi67m'
@@ -31,8 +32,8 @@ export const METADATA: Partial<Record<NetworkID, Metadata>> = {
     chainId: starknetConstants.StarknetChainId.SN_SEPOLIA,
     baseChainId: 11155111,
     baseNetworkId: 'sep',
-    rpcUrl: 'https://rpc.snapshot.org/sn-sep',
-    ethRpcUrl: 'https://rpc.snapshot.org/11155111',
+    rpcUrl: getRpcUrl('sn-sep'),
+    ethRpcUrl: getRpcUrl(11155111),
     apiUrl: API_TESTNET_URL,
     explorerUrl: 'https://sepolia.voyager.online',
     avatar: 'ipfs://bafkreihbjafyh7eud7r6e5743esaamifcttsvbspfwcrfoc5ykodjdi67m'

--- a/bun.lock
+++ b/bun.lock
@@ -271,6 +271,7 @@
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/hash": "^5.5.0",
+        "@ethersproject/providers": "^5.8.0",
         "@ethersproject/strings": "^5.7.0",
         "@ethersproject/wallet": "^5.6.2",
         "@shutter-network/shutter-crypto": "^1.0.0",

--- a/docs/snapshot-x/services/sx-js.mdx
+++ b/docs/snapshot-x/services/sx-js.mdx
@@ -57,7 +57,7 @@ const ethSigClient = new clients.EthereumSig(clientConfig);
 import { clients } from '@snapshot-labs/sx';
 import { Provider, constants } from 'starknet';
 
-const ethUrl = 'https://rpc.snapshot.org/1';
+const ethUrl = 'https://eth.drpc.org';
 const manaUrl = 'https://mana.pizza';
 
 const starkProvider = new Provider({ sequencer: { network: constants.NetworkName.SN_SEPOLIA } });
@@ -160,7 +160,7 @@ import { Provider, constants } from 'starknet';
 
 const web3 = window.starknet.provider;
 
-const ethUrl = 'https://rpc.snapshot.org/1';
+const ethUrl = 'https://eth.drpc.org';
 const manaUrl = 'https://mana.pizza';
 
 const starkProvider = new Provider({ sequencer: { network: constants.NetworkName.SN_SEPOLIA } });
@@ -202,7 +202,7 @@ import { Provider, constants } from 'starknet';
 
 const web3 = window.starknet.provider;
 
-const ethUrl = 'https://rpc.snapshot.org/1';
+const ethUrl = 'https://eth.drpc.org';
 const manaUrl = 'https://mana.pizza';
 
 const starkProvider = new Provider({ sequencer: { network: constants.NetworkName.SN_SEPOLIA } });
@@ -323,7 +323,7 @@ import { Provider, constants } from 'starknet';
 
 const web3 = window.starknet.provider;
 
-const ethUrl = 'https://rpc.snapshot.org/1';
+const ethUrl = 'https://eth.drpc.org';
 const manaUrl = 'https://mana.pizza';
 
 const starkProvider = new Provider({ sequencer: { network: constants.NetworkName.SN_SEPOLIA } });
@@ -367,7 +367,7 @@ import { Provider, constants } from 'starknet';
 
 const web3 = window.starknet.provider;
 
-const ethUrl = 'https://rpc.snapshot.org/1';
+const ethUrl = 'https://eth.drpc.org';
 const manaUrl = 'https://mana.pizza';
 
 const starkProvider = new Provider({ sequencer: { network: constants.NetworkName.SN_SEPOLIA } });
@@ -482,7 +482,7 @@ import { Provider, constants } from 'starknet';
 
 const web3 = window.starknet.provider;
 
-const ethUrl = 'https://rpc.snapshot.org/1';
+const ethUrl = 'https://eth.drpc.org';
 const manaUrl = 'https://mana.pizza';
 
 const starkProvider = new Provider({ sequencer: { network: constants.NetworkName.SN_SEPOLIA } });
@@ -521,7 +521,7 @@ import { Provider, constants } from 'starknet';
 
 const web3 = window.starknet.provider;
 
-const ethUrl = 'https://rpc.snapshot.org/1';
+const ethUrl = 'https://eth.drpc.org';
 const manaUrl = 'https://mana.pizza';
 
 const starkProvider = new Provider({ sequencer: { network: constants.NetworkName.SN_SEPOLIA } });

--- a/packages/sx.js/package.json
+++ b/packages/sx.js/package.json
@@ -30,7 +30,7 @@
     "prepublishOnly": "bun run lint",
     "node:evm": "anvil",
     "node:starknet": "starknet-devnet --seed 1",
-    "test": "SEPOLIA_NODE_URL=https://rpc.snapshot.org/11155111 vitest run test/unit",
+    "test": "SEPOLIA_NODE_URL=https://rpc.brovider.xyz/11155111 vitest run test/unit",
     "test:integration": "./test/run-integration-tests.sh",
     "test:integration:starknet": "vitest run test/integration/starknet",
     "test:integration:evm": "vitest run test/integration/evm",

--- a/packages/sx.js/src/utils/execution.ts
+++ b/packages/sx.js/src/utils/execution.ts
@@ -9,7 +9,8 @@ import {
 } from '../types';
 
 const BROVIDER_URL = 'https://rpc.brovider.xyz';
-const getRpcUrl = (chainId: number) => `${BROVIDER_URL}/${chainId}?client=sx.js`;
+const getRpcUrl = (chainId: number) =>
+  `${BROVIDER_URL}/${chainId}?client=sx.js`;
 
 type Abi = (Fragment | JsonFragment | string)[];
 
@@ -63,10 +64,7 @@ export async function getAbi(
     const resolver =
       CUSTOM_PROXY_RESOLVERS[address as keyof typeof CUSTOM_PROXY_RESOLVERS];
 
-    const provider = new StaticJsonRpcProvider(
-      getRpcUrl(chainId),
-      chainId
-    );
+    const provider = new StaticJsonRpcProvider(getRpcUrl(chainId), chainId);
 
     const implementationAddress = await resolver(address, provider);
 
@@ -130,10 +128,7 @@ export async function decodeExecution(
       functionFragment.inputs[1]?.type === 'uint256';
 
     if (isErc20Transfer) {
-      const provider = new StaticJsonRpcProvider(
-        getRpcUrl(chainId),
-        chainId
-      );
+      const provider = new StaticJsonRpcProvider(getRpcUrl(chainId), chainId);
 
       const tokenContract = new Contract(target, abi, provider);
 

--- a/packages/sx.js/src/utils/execution.ts
+++ b/packages/sx.js/src/utils/execution.ts
@@ -8,6 +8,9 @@ import {
   Transaction
 } from '../types';
 
+const BROVIDER_URL = 'https://rpc.brovider.xyz';
+const getRpcUrl = (chainId: number) => `${BROVIDER_URL}/${chainId}?client=sx.js`;
+
 type Abi = (Fragment | JsonFragment | string)[];
 
 type CallInfo = {
@@ -61,7 +64,7 @@ export async function getAbi(
       CUSTOM_PROXY_RESOLVERS[address as keyof typeof CUSTOM_PROXY_RESOLVERS];
 
     const provider = new StaticJsonRpcProvider(
-      `https://rpc.snapshot.org/${chainId}`,
+      getRpcUrl(chainId),
       chainId
     );
 
@@ -128,7 +131,7 @@ export async function decodeExecution(
 
     if (isErc20Transfer) {
       const provider = new StaticJsonRpcProvider(
-        `https://rpc.snapshot.org/${chainId}`,
+        getRpcUrl(chainId),
         chainId
       );
 

--- a/packages/sx.js/src/utils/execution.ts
+++ b/packages/sx.js/src/utils/execution.ts
@@ -8,10 +8,6 @@ import {
   Transaction
 } from '../types';
 
-const BROVIDER_URL = 'https://rpc.brovider.xyz';
-const getRpcUrl = (chainId: number) =>
-  `${BROVIDER_URL}/${chainId}?client=sx.js`;
-
 type Abi = (Fragment | JsonFragment | string)[];
 
 type CallInfo = {
@@ -19,6 +15,10 @@ type CallInfo = {
   calldata: `0x${string}` | '';
   value: string;
 };
+
+const BROVIDER_URL = 'https://rpc.brovider.xyz';
+const getRpcUrl = (chainId: number) =>
+  `${BROVIDER_URL}/${chainId}?client=sx.js`;
 
 const ABI_CACHE = new Map<`${number}:0x${string}`, Abi>();
 const CUSTOM_PROXY_RESOLVERS = {


### PR DESCRIPTION
## Summary

- Switch all backend RPC traffic from `rpc.snapshot.org` to `rpc.brovider.xyz` and append `?client=<app>` so brovider can attribute traffic to its source (ui, api, mana, mcp, highlight, sequencer, sx.js, auction, delegates-api).
- Consolidate the base URL into per-workspace constants/helpers (`BROVIDER_URL`, `getRpcUrl()`) so the literal lives in one place per workspace.
- Sequencer: replace the `snapshot.utils.getProvider` call sites with a local helper at [apps/sequencer/src/helpers/provider.ts](apps/sequencer/src/helpers/provider.ts) so `?client=sequencer` can be appended (snapshot.js hardcodes `` `${broviderUrl}/${networkId}` `` and won't accept a query param via `broviderUrl`). Starknet networks are delegated back to `snapshot.utils.getProvider` so they keep the `RpcProvider` and the `sn`/`sn-sep` broviderId mapping (fixes the proposal-creation block check flagged in review).
- Docs: swap example RPC URL to `https://eth.drpc.org` — a free public archive node that works without an API key.

## Known gap

Starknet providers (delegated to `snapshot.utils.getProvider`), `snapshot.utils.getSpaceController` and `snapshot.utils.getSpaceUri` in sequencer still construct their providers/URLs internally inside `@snapshot-labs/snapshot.js`, so those requests go out without `?client=sequencer`. Closing that needs an upstream `clientName` option in snapshot.js (worth doing as a follow-up so all consumers get attribution for free).

## Test plan

- [ ] CI typecheck passes across api, ui, highlight, mana, sequencer, sx.js, mcp, auction, delegates-api
- [ ] Spot-check that brovider sees `?client=<app>` on requests from each service after deploy
- [ ] Confirm starknet proposal creation still resolves the snapshot block (uses the starknet `RpcProvider` path)

