### PR TITLE
feat(sequencer): extend default alias expiry to 90 days

### DIFF
--- a/apps/sequencer/src/helpers/alias.ts
+++ b/apps/sequencer/src/helpers/alias.ts
@@ -1,6 +1,6 @@
 import db from './mysql';
 
-const DEFAULT_ALIAS_EXPIRY_DAYS = 30;
+const DEFAULT_ALIAS_EXPIRY_DAYS = 90;
 
 const TYPES_EXECUTABLE_BY_ALIAS: readonly string[] = [
   'follow',


### PR DESCRIPTION
## Summary

- Bump `DEFAULT_ALIAS_EXPIRY_DAYS` in the sequencer's alias helper from 30 to 90.
- Read-time check inside `verifyAlias` now accepts aliases whose `created` is within the last 90 days.

30 days forced users to re-authorize too frequently in practice; 90 days is a more reasonable default for a delegated signing key while still leaving a meaningful TTL.

## Test plan

- [x] Unit tests for `isExistingAlias` still pass (the "expired" fixture has `created: 1`, far older than either TTL).
- [ ] After deploy, confirm a freshly authorized alias is still valid on day 89.