### PR TITLE
feat(mcp): add snapshot-unfollow tool

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -14,6 +14,7 @@ import {
   registerProposeTool,
   registerQueryTool,
   registerSchemaTool,
+  registerUnfollowTool,
   registerVoteTool
 } from './tools.js';
 
@@ -39,6 +40,7 @@ function createMcpServer(mode: 'http' | 'stdio'): McpServer {
   registerVoteTool(server, resolveContext);
   registerProposeTool(server, resolveContext);
   registerFollowTool(server, resolveContext);
+  registerUnfollowTool(server, resolveContext);
   return server;
 }
 

--- a/apps/mcp/src/instructions.md
+++ b/apps/mcp/src/instructions.md
@@ -17,3 +17,5 @@ Re-calling snapshot-vote on the same proposal replaces the previous vote (this i
 Use snapshot-propose to create a proposal: only `space`, `title`, `body` are required. Voting type, choices, period, snapshot block, and privacy are derived from the space (override only when needed).
 
 Use snapshot-follow to add a space to the user's followed list. Calling it again on a space already followed is a no-op. Followed spaces are queryable via `follows(where: { follower: $user })`.
+
+Use snapshot-unfollow to remove a space from the user's followed list. No-op if the space is not followed.

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -330,3 +330,30 @@ export function registerFollowTool(
       })
   );
 }
+
+export function registerUnfollowTool(
+  server: McpServer,
+  resolveContext: ResolveContext
+): void {
+  server.registerTool(
+    'snapshot-unfollow',
+    {
+      description:
+        'Remove a Snapshot space from the user\'s followed list. Calling this on a space the user does not follow is a no-op on Snapshot\'s side.',
+      inputSchema: {
+        space: z.string().describe('Space ID slug (e.g. "ens.eth")')
+      }
+    },
+    (data, extra) =>
+      handle('snapshot-unfollow', extra, async () => {
+        const { user: from, signer } = await resolveContext(extra);
+        const space = await requireSpace<{ id: string }>(data.space, 'id');
+        const envelope = await sx.unfollowSpace({
+          signer: signer as Wallet,
+          data: { from, space: space.id, network: 's' }
+        });
+        const result = (await sx.send(envelope)) as unknown;
+        return { result, links: { space: `https://snapshot.box/#/s:${space.id}` } };
+      })
+  );
+}


### PR DESCRIPTION
## Summary

- Add `snapshot-unfollow` MCP tool, mirroring `snapshot-follow` via `sx.unfollowSpace`.
- Wire it into `createMcpServer` and document it in `instructions.md`.

The follow / unfollow types already exist in `sx.js` and the sequencer, so this is purely a tools.ts addition.

## Test plan

- [x] `bun run typecheck`, `bun run lint`, `bun test` in `apps/mcp`.
- [ ] Manual: call `snapshot-unfollow` against a space the user follows and confirm it disappears from `follows(where: { follower: $user })`.