### PR TITLE
feat(mcp): add snapshot-whoami tool

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -14,7 +14,8 @@ import {
   registerProposeTool,
   registerQueryTool,
   registerSchemaTool,
-  registerVoteTool
+  registerVoteTool,
+  registerWhoamiTool
 } from './tools.js';
 
 const ICONS = [
@@ -36,6 +37,7 @@ function createMcpServer(mode: 'http' | 'stdio'): McpServer {
   const resolveContext = createResolveContext(mode);
   registerSchemaTool(server);
   registerQueryTool(server, resolveContext);
+  registerWhoamiTool(server, resolveContext);
   registerVoteTool(server, resolveContext);
   registerProposeTool(server, resolveContext);
   registerFollowTool(server, resolveContext);

--- a/apps/mcp/src/instructions.md
+++ b/apps/mcp/src/instructions.md
@@ -2,6 +2,8 @@ Snapshot governance MCP. Reads via snapshot-query, writes via snapshot-vote, sch
 
 The user's address is auto-bound as `$user` on every snapshot-query: declare it (`query Foo($user: String!)`) and reference it; do NOT pass `user` in `variables`.
 
+Call snapshot-whoami once at the start of a session (or before any write) to confirm the connected address, primary ENS, and Snapshot profile.
+
 Common patterns:
 - Find a space by name: `spaces(where: { search: "<name>" })`. Space `id` is a slug ("ens.eth"), never the display name.
 - Search proposals: `proposals(where: { title_contains: "<text>", space_in: [...] })`.

--- a/apps/mcp/src/stamp.ts
+++ b/apps/mcp/src/stamp.ts
@@ -1,0 +1,18 @@
+const STAMP_URL = 'https://stamp.fyi';
+
+async function stamp<T>(method: string, params: unknown): Promise<T> {
+  const res = await fetch(STAMP_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ method, params })
+  });
+  if (!res.ok) throw new Error(`Stamp ${method} failed: ${res.status}`);
+  return ((await res.json()) as { result: T }).result;
+}
+
+export async function lookupAddress(address: string): Promise<string | null> {
+  const result = await stamp<Record<string, string>>('lookup_addresses', [
+    address
+  ]);
+  return result[address] ?? null;
+}

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -13,6 +13,7 @@ import {
   resolveUserFromAlias,
   schemaCache
 } from './hub.js';
+import { lookupAddress } from './stamp.js';
 
 const sx = new clients.OffchainEthereumSig({ networkConfig: offchainMainnet });
 
@@ -107,6 +108,32 @@ async function handle(
       isError: true
     };
   }
+}
+
+export function registerWhoamiTool(
+  server: McpServer,
+  resolveContext: ResolveContext
+): void {
+  server.registerTool(
+    'snapshot-whoami',
+    {
+      description:
+        'Returns the connected user: address, Snapshot profile (name, bio, avatar, social handles), and primary ENS name if any. Use this to confirm who you are acting as before writing on chain.',
+      inputSchema: {}
+    },
+    (_args, extra) =>
+      handle('snapshot-whoami', extra, async () => {
+        const { user } = await resolveContext(extra);
+        const [{ user: profile }, ens] = await Promise.all([
+          gql(
+            'query ($id: String!) { user(id: $id) { name about avatar github twitter lens farcaster } }',
+            { id: user }
+          ) as Promise<{ user: Record<string, string | null> | null }>,
+          lookupAddress(user)
+        ]);
+        return { address: user, ens, profile };
+      })
+  );
 }
 
 export function registerSchemaTool(server: McpServer): void {


### PR DESCRIPTION
## Summary

- Add `snapshot-whoami` MCP tool that returns the connected user's address, primary ENS (via the existing Stamp endpoint), and Snapshot profile in one call.
- Add a tiny `stamp.ts` helper so future tools can share the Stamp client.

Useful before any write — the model can confirm "who am I acting as" without composing a custom GraphQL query.

## Test plan

- [x] `bun run typecheck`, `bun run lint`, `bun test` in `apps/mcp`.
- [ ] Manual: call `snapshot-whoami` while authorized and confirm address + ENS + profile fields look correct.