### PR TITLE
feat(mcp): add snapshot-resolve tool

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -13,6 +13,7 @@ import {
   registerFollowTool,
   registerProposeTool,
   registerQueryTool,
+  registerResolveTool,
   registerSchemaTool,
   registerVoteTool
 } from './tools.js';
@@ -35,6 +36,7 @@ function createMcpServer(mode: 'http' | 'stdio'): McpServer {
   );
   const resolveContext = createResolveContext(mode);
   registerSchemaTool(server);
+  registerResolveTool(server);
   registerQueryTool(server, resolveContext);
   registerVoteTool(server, resolveContext);
   registerProposeTool(server, resolveContext);

--- a/apps/mcp/src/instructions.md
+++ b/apps/mcp/src/instructions.md
@@ -12,6 +12,8 @@ Common patterns:
 
 Timestamps (`created`, `start`, `end`, `updated`) are unix seconds UTC, not ms. Format with `new Date(t * 1000)` and verify the year before showing dates.
 
+Use snapshot-resolve to translate between a domain name and an address (e.g. `fabien.eth` → `0x…` or `0x…` → primary ENS). It accepts either direction.
+
 Re-calling snapshot-vote on the same proposal replaces the previous vote (this is how to change a vote).
 
 Use snapshot-propose to create a proposal: only `space`, `title`, `body` are required. Voting type, choices, period, snapshot block, and privacy are derived from the space (override only when needed).

--- a/apps/mcp/src/stamp.ts
+++ b/apps/mcp/src/stamp.ts
@@ -1,0 +1,38 @@
+const STAMP_URL = 'https://stamp.fyi';
+
+async function stamp<T>(
+  method: string,
+  params: unknown,
+  network?: number
+): Promise<T> {
+  const res = await fetch(STAMP_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      method,
+      params,
+      ...(network !== undefined && { network })
+    })
+  });
+  if (!res.ok) throw new Error(`Stamp ${method} failed: ${res.status}`);
+  return ((await res.json()) as { result: T }).result;
+}
+
+export async function resolveName(
+  name: string,
+  network = 1
+): Promise<string | null> {
+  const result = await stamp<Record<string, string>>(
+    'resolve_names',
+    [name],
+    network
+  );
+  return result[name] ?? null;
+}
+
+export async function lookupAddress(address: string): Promise<string | null> {
+  const result = await stamp<Record<string, string>>('lookup_addresses', [
+    address
+  ]);
+  return result[address] ?? null;
+}

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -13,6 +13,7 @@ import {
   resolveUserFromAlias,
   schemaCache
 } from './hub.js';
+import { lookupAddress, resolveName } from './stamp.js';
 
 const sx = new clients.OffchainEthereumSig({ networkConfig: offchainMainnet });
 
@@ -107,6 +108,32 @@ async function handle(
       isError: true
     };
   }
+}
+
+const HEX_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+
+export function registerResolveTool(server: McpServer): void {
+  server.registerTool(
+    'snapshot-resolve',
+    {
+      description:
+        'Resolve a name (ENS, Lens, etc.) to a 0x address, or an address to its primary name. Returns both fields whenever resolution succeeds; the missing direction is set to null.',
+      inputSchema: {
+        input: z
+          .string()
+          .describe('A name (e.g. "fabien.eth") or a 0x-prefixed address')
+      }
+    },
+    ({ input }, extra) =>
+      handle('snapshot-resolve', extra, async () => {
+        const trimmed = input.trim();
+        if (HEX_ADDRESS.test(trimmed)) {
+          return { address: trimmed.toLowerCase(), name: await lookupAddress(trimmed) };
+        }
+        const address = await resolveName(trimmed);
+        return { name: trimmed, address: address?.toLowerCase() ?? null };
+      })
+  );
 }
 
 export function registerSchemaTool(server: McpServer): void {


### PR DESCRIPTION
## Summary

- Add `snapshot-resolve` MCP tool that translates between a name (ENS, Lens, …) and a 0x address.
- Routes through the same Stamp API the UI already uses (`resolve_names` / `lookup_addresses`).
- Direction is auto-detected: a 40-char hex string → primary name; anything else → address.

## Test plan

- [x] `bun run typecheck`, `bun run lint`, `bun test` in `apps/mcp`.
- [ ] Manual: `fabien.eth` resolves to `0xef83…43e7`, that address resolves back to `fabien.eth`.