### PR TITLE
feat: show active proposals for Snapshot X and Governor

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -46,7 +46,26 @@ async function run() {
     resetOnConfigChange: true,
     pinoOptions,
     overridesConfig: overrides,
-    dbConnection: getDatabaseConnection()
+    dbConnection: getDatabaseConnection(),
+    resolvers: {
+      Space: {
+        active_proposal_count: async (parent, _args, context) => {
+          const now = Math.floor(Date.now() / 1000);
+          const tableName = `${parent._indexer}_proposals`;
+          const result = await context.knex(tableName)
+            .where('space', parent.id)
+            .where('start', '<=', now)
+            .where('max_end', '>', now)
+            .where('cancelled', false)
+            .where('executed', false)
+            .where('vetoed', false)
+            .whereRaw('upper_inf(block_range)')
+            .count('* as count')
+            .first();
+          return Number(result?.count ?? 0);
+        }
+      }
+    }
   });
 
   await startApiServer(checkpoint);

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -69,6 +69,8 @@ type Space {
   proposer_count: Int!
   "Number of unique voters in this space"
   voter_count: Int!
+  "Number of currently active proposals in this space"
+  active_proposal_count: Int! @computed
   "Timestamp when the space was created"
   created: Int!
   "Transaction hash of space creation"

--- a/apps/ui/src/components/SpacesListItem.vue
+++ b/apps/ui/src/components/SpacesListItem.vue
@@ -54,7 +54,6 @@ const avatarSpace = computed(() =>
     <ButtonFollow :space="space" class="hidden group-hover:block -my-2" />
     <div class="text-[21px] font-bold flex text-center">
       <span
-        v-if="space.protocol === 'snapshot'"
         class="w-[50px] md:w-[100px]"
         :class="{ 'text-skin-success': (space.active_proposals ?? 0) > 0 }"
         v-text="_n(space.active_proposals ?? 0, 'compact')"

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -335,7 +335,7 @@ function formatSpace(
     terms: '',
     privacy: 'none',
     voting_power_symbol: space.metadata.voting_power_symbol,
-    active_proposals: null,
+    active_proposals: space.active_proposal_count,
     voting_types: constants.EDITOR_VOTING_TYPES,
     treasuries: space.metadata.treasuries.map(treasury =>
       formatMetadataTreasury(treasury)
@@ -759,9 +759,15 @@ export function createApi(
         });
       }
 
-      return data.spaces
+      const spaces = data.spaces
         .filter(space => isSpaceWithMetadata(space))
         .map(space => formatSpace(space, constants));
+
+      spaces.sort(
+        (a, b) => (b.active_proposals ?? 0) - (a.active_proposals ?? 0)
+      );
+
+      return spaces;
     },
     loadSpace: async (id: string): Promise<Space | null> => {
       const [{ data }, highlightResult] = await Promise.all([

--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -91,6 +91,7 @@ gql(`
     authenticators
     proposal_count
     vote_count
+    active_proposal_count
     created
   }
 

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -205,11 +205,7 @@ watchEffect(() => setTitle('Explore'));
       <UiSectionHeader label="Spaces" sticky />
       <UiColumnHeader class="hidden md:flex text-center">
         <div class="grow" />
-        <div
-          v-if="protocol === 'snapshot'"
-          class="w-[100px]"
-          v-text="'Active'"
-        />
+        <div class="w-[100px]" v-text="'Active'" />
         <div class="w-[100px]" v-text="'Proposals'" />
         <div
           v-if="protocol === 'snapshot'"


### PR DESCRIPTION
## Summary

- Add `active_proposal_count` as a `@computed` field on `Space` in the API schema, resolved at query time by counting proposals where `start <= now` and `max_end > now`
- Display the active proposals column in the explore page for **all protocols** (Snapshot, Snapshot X, Governor), not just Snapshot offchain
- Sort Snapshot X and Governor spaces by active proposal count (descending)

Depends on https://github.com/snapshot-labs/checkpoint/pull/390 (adds `@computed` directive and custom resolvers to Checkpoint).

## Changes

| File | Change |
|------|--------|
| `apps/api/src/schema.gql` | Add `active_proposal_count: Int! @computed` to Space |
| `apps/api/src/index.ts` | Register computed resolver that counts active proposals |
| `apps/ui/src/.../queries.ts` | Add `active_proposal_count` to spaceFields fragment |
| `apps/ui/src/.../graphqlApi/index.ts` | Map field + sort spaces by active proposals |
| `apps/ui/src/views/My/Explore.vue` | Show Active column for all protocols |
| `apps/ui/src/components/SpacesListItem.vue` | Show active count for all protocols |

## Test plan

- [ ] Verify Snapshot X explore page shows "Active" column with live counts
- [ ] Verify Governor explore page shows "Active" column with live counts
- [ ] Verify spaces with active proposals appear first (sorted desc)
- [ ] Verify Snapshot offchain explore page still works as before
- [ ] Verify active count turns green when > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)