### PR TITLE
fix(ci): unblock failing CI on PRs

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,8 @@ jobs:
         run: cargo install starknet-devnet@${{ env.STARKNET_DEVNET_VERSION }}
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.7.1
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: bun run typecheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Snapshot monorepository
 
-This is the Snapshot monorepository containing a Vue frontend, GraphQL API, transaction relayer, and TypeScript SDK.
+This is the Snapshot monorepository containing a Vue frontend, GraphQL API, a transaction relayer, and a TypeScript SDK.
 
 ## Apps and packages
 


### PR DESCRIPTION
Two unrelated bugs were combining to make CI look broken on most PRs.

## 1. `Install Foundry` step intermittently 403s

`foundry-rs/foundry-toolchain@v1` resolves `version: stable` via an anonymous GitHub API call. Runners share a 60-req/hr NAT quota, so the lookup intermittently returns 403 and fails the job.

**Fix:** pin `version: v1.7.1` (no API call). Matches the repo's convention of pinning every other tool version.

## 2. Every PR push leaves a "cancelled" CI check

`test.yml` and `test-e2e.yml` trigger on both `push` and `pull_request`. Both fire on a PR push with the same SHA, land in the same concurrency group, and `cancel-in-progress: true` kills one.

**Fix:** add `github.event_name` to the concurrency group so each event has its own scope. Stale-commit cancellation still works within each event.

## Files

- `.github/workflows/test.yml`: pin foundry + event-scoped concurrency group
- `.github/workflows/test-e2e.yml`: event-scoped concurrency group
- `README.md`: tiny wording tweak used to probe CI before the cause was known (kept for diff history)
