### PR TITLE
chore(api): comment out checkpoint.reset() to prevent prod DB wipes

### DIFF
--- a/apps/api/src/indexer.ts
+++ b/apps/api/src/indexer.ts
@@ -18,10 +18,12 @@ const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 async function initializeCheckpoint(checkpoint: Checkpoint) {
   if (!GIT_COMMIT) {
-    logger.info('No git commit found, resetting database.');
+    logger.warn(
+      'No git commit found — reset skipped (commented out to prevent accidental production DB wipes; see incident 2026-05-28).'
+    );
 
-    await checkpoint.resetMetadata();
-    await checkpoint.reset();
+    // await checkpoint.resetMetadata();
+    // await checkpoint.reset();
 
     return;
   }
@@ -47,14 +49,14 @@ async function initializeCheckpoint(checkpoint: Checkpoint) {
       );
     }
 
-    logger.info(
+    logger.warn(
       { currentVersionTag, storedVersionTag },
-      'Stored version tag differs from current. Resetting database.'
+      'Stored version tag differs from current — reset skipped (commented out; see incident 2026-05-28).'
     );
   }
 
-  await checkpoint.resetMetadata();
-  await checkpoint.reset();
+  // await checkpoint.resetMetadata();
+  // await checkpoint.reset();
 
   await knex('_metadatas').insert({
     id: 'version_tag',


### PR DESCRIPTION
After the 2026-05-28 incident (Arbitrum + Starknet spaces went down because the indexer auto-reset wiped production data), both \`checkpoint.resetMetadata()\` + \`checkpoint.reset()\` calls in \`initializeCheckpoint\` are commented out:

- **\`if (!GIT_COMMIT)\` branch** (was line 23/24) — no-op return instead of wiping.
- **Version-tag mismatch branch** (was line 56/57) — still inserts the \`version_tag\` row so tracking stays correct, just doesn't wipe the DB.

Logger messages bumped from \`info\` → \`warn\` so the skipped-reset paths are visible in logs without grepping.

The reset behaviour should land back behind a deliberate env flag (or a maintenance script) once we've decided how to handle real schema migrations. For now the safe default is **never wipe automatically**.

cc @bonustrack — per your ask in the SX-API incident thread.