### PR TITLE
fix(e2e): switch CI trace from 'on' to 'on-first-retry'

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   outputDir: '.browser/test-results',
   use: {
     baseURL: 'http://localhost:8080',
-    trace: process.env.CI ? 'on' : 'retain-on-failure'
+    trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure'
   },
   expect: {
     // 5 seconds is not quite enough it seems


### PR DESCRIPTION
## Why

E2E tests have been failing on every PR (and master) with 30-second timeouts on a moving set of specs, despite individual test bodies completing in 3-19 s. The actual bug is **trace serialization during fixture teardown**: with \`trace: 'on'\` in CI, Playwright captures and serializes the full trace (network requests, DOM mutations, console output) at the end of every test. For pages with active background work, the trace serialization itself blows the test budget.

Documented upstream:
- [microsoft/playwright#18016 — \"Test timeout exceeded while tearing down 'context' when trace is enabled\"](https://github.com/microsoft/playwright/issues/18016)
- [microsoft/playwright#24210 — \"Test finished within timeout, but tearing down 'context' ran out of time\"](https://github.com/microsoft/playwright/issues/24210)

## What

One line in [\`playwright.config.ts\`](playwright.config.ts):

\`\`\`diff
- trace: process.env.CI ? 'on' : 'retain-on-failure'
+ trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure'
\`\`\`

\`'on-first-retry'\` keeps the diagnostic value (a failing test that retries gets a trace) without paying the serialization cost on the common-case passing first attempt. Local dev unchanged.

## Followups (separate PRs)

- #2137 — workflow trigger dedup, unrelated hygiene.
- #2138 — switch E2E to run against the Netlify preview instead of an in-CI dev server, unrelated perf win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)