### PR TITLE
ci: run one workflow per PR commit, not two

### DIFF
--- a/.github/workflows/hub-test.yml
+++ b/.github/workflows/hub-test.yml
@@ -1,11 +1,12 @@
 name: Hub Test
 
 on:
-  push:
+  pull_request:
     paths:
       - 'apps/hub/**'
       - '.github/workflows/hub-test.yml'
-  pull_request:
+  push:
+    branches: [master]
     paths:
       - 'apps/hub/**'
       - '.github/workflows/hub-test.yml'

--- a/.github/workflows/sequencer-test.yml
+++ b/.github/workflows/sequencer-test.yml
@@ -1,11 +1,12 @@
 name: Sequencer Test
 
 on:
-  push:
+  pull_request:
     paths:
       - 'apps/sequencer/**'
       - '.github/workflows/sequencer-test.yml'
-  pull_request:
+  push:
+    branches: [master]
     paths:
       - 'apps/sequencer/**'
       - '.github/workflows/sequencer-test.yml'

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,8 +1,9 @@
 name: E2E Tests
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.sha || github.sha }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   outputDir: '.browser/test-results',
   use: {
     baseURL: 'http://localhost:8080',
-    trace: process.env.CI ? 'on' : 'retain-on-failure'
+    trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure'
   },
   expect: {
     // 5 seconds is not quite enough it seems


### PR DESCRIPTION
Before:
<img width="507" height="162" alt="image" src="https://github.com/user-attachments/assets/3224ed16-5895-4819-801d-a295ddad96ca" />

Now:
<img width="584" height="79" alt="image" src="https://github.com/user-attachments/assets/535821ad-c196-4fa9-b63a-85274c034e4a" />


## Why

PR #2102 added \`pull_request\` triggers alongside \`push\` so fork PRs run CI on the upstream repo. PR #2130 then event-scoped the concurrency group so \`push\` and \`pull_request\` runs on the same SHA stop cancelling each other.

Combined effect for same-repo PRs: every commit fires CI **twice** — once for \`push\`, once for \`pull_request\` — both run to completion, doubling runner cost and producing duplicate check entries.

## What

Scope the \`push\` trigger to \`master\` only. Each event then fires **exactly once**:

| Scenario | Now fires |
|---|---|
| Push to \`master\` | \`push\` event (no PR exists for master) |
| Push to a branch with an open PR | \`pull_request\` only |
| Fork PR | \`pull_request\` (the case #2102 enabled — still works) |
| Push to a branch without an open PR | nothing — open a draft PR to get CI |

Applied symmetrically to the four workflows that had the dual-trigger pattern: \`test.yml\`, \`test-e2e.yml\`, \`hub-test.yml\`, \`sequencer-test.yml\` (the latter two keep their existing \`paths:\` filters).

Untouched: \`deploy.yml\`, \`release.yml\`, \`claude.yml\`, \`promote-api.yml\`.

## Stacked on

#2136. Merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)