### PR TITLE
ci(e2e): run E2E against Netlify livenet preview, drop in-CI dev server

### DIFF
--- a/.github/workflows/hub-test.yml
+++ b/.github/workflows/hub-test.yml
@@ -1,11 +1,12 @@
 name: Hub Test
 
 on:
-  push:
+  pull_request:
     paths:
       - 'apps/hub/**'
       - '.github/workflows/hub-test.yml'
-  pull_request:
+  push:
+    branches: [master]
     paths:
       - 'apps/hub/**'
       - '.github/workflows/hub-test.yml'

--- a/.github/workflows/sequencer-test.yml
+++ b/.github/workflows/sequencer-test.yml
@@ -1,11 +1,12 @@
 name: Sequencer Test
 
 on:
-  push:
+  pull_request:
     paths:
       - 'apps/sequencer/**'
       - '.github/workflows/sequencer-test.yml'
-  pull_request:
+  push:
+    branches: [master]
     paths:
       - 'apps/sequencer/**'
       - '.github/workflows/sequencer-test.yml'

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,8 +1,9 @@
 name: E2E Tests
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -2,16 +2,14 @@ name: E2E Tests
 
 on:
   pull_request:
-  push:
-    branches: [master]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.sha || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 jobs:
   test:
-    timeout-minutes: 60
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.56.1-noble
@@ -28,8 +26,28 @@ jobs:
         bun-version: "1.3.9"
     - name: Install dependencies
       run: bun install --frozen-lockfile
+
+    - name: Wait for Netlify livenet preview
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        url="https://deploy-preview-${PR_NUMBER}--snapshot-livenet.netlify.app"
+        echo "Waiting for: $url"
+        for i in $(seq 1 60); do
+          status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$url" || echo "000")
+          echo "[$i/60] HTTP $status"
+          if [ "$status" = "200" ]; then
+            echo "PLAYWRIGHT_BASE_URL=$url" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          sleep 10
+        done
+        echo "::error::Netlify preview did not respond 200 within 10 minutes"
+        exit 1
+
     - name: Run E2E Tests
       run: PLAYWRIGHT_HTML_OPEN=never bun run test:e2e --reporter=html
+
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.sha || github.sha }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,20 +7,25 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   outputDir: '.browser/test-results',
   use: {
-    baseURL: 'http://localhost:8080',
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8080',
     trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure'
   },
   expect: {
     // 5 seconds is not quite enough it seems
     timeout: 10000
   },
-  webServer: {
-    command: 'bun run dev',
-    url: 'http://localhost:8080',
-    reuseExistingServer: !process.env.CI,
-    stdout: 'ignore',
-    stderr: 'pipe'
-  },
+  // Local: tests spin up `bun run dev` if no PLAYWRIGHT_BASE_URL is set.
+  // CI: PLAYWRIGHT_BASE_URL points at the Netlify livenet preview, so no
+  // local dev server is needed.
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: 'bun run dev',
+        url: 'http://localhost:8080',
+        reuseExistingServer: !process.env.CI,
+        stdout: 'ignore',
+        stderr: 'pipe'
+      },
   projects: [
     {
       name: 'chromium',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   outputDir: '.browser/test-results',
   use: {
     baseURL: 'http://localhost:8080',
-    trace: process.env.CI ? 'on' : 'retain-on-failure'
+    trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure'
   },
   expect: {
     // 5 seconds is not quite enough it seems


### PR DESCRIPTION
## Why

The E2E job currently builds the UI inside the workflow (\`bun run dev\` via turbo) before tests can run. That's:

- **Slow.** Cold vite compile + turbo build adds 30-60 s before any test starts.
- **Redundant.** Netlify is already building 5 previews per PR (livenet, testnet, docs, storybook, etc.). The E2E job builds it a **6th** time.

We can just point tests at the existing \`snapshot-livenet\` preview.

## What

| Before | After |
|---|---|
| \`bun run dev\` spins up turbo + vite and serves \`localhost:8080\` | Step polls \`https://deploy-preview-<PR>--snapshot-livenet.netlify.app\` with curl until it 200s, then exports \`PLAYWRIGHT_BASE_URL\` |
| Tests hit \`localhost:8080\` | Tests hit the Netlify preview URL |
| \`webServer:\` block always spins up dev server | \`webServer:\` skipped when \`PLAYWRIGHT_BASE_URL\` is set; still spins up for local dev without env |
| \`push\` + \`pull_request\` triggers, 60 m timeout | \`pull_request\` only, 30 m timeout |

Local \`bun run test:e2e\` is unchanged.

## Stacked on

#2137 (which is on top of #2136). Merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)