### PR TITLE
fix(sx.js): zero-pad merkle whitelist proof elements (fixes InvalidProof revert)

### DIFF
--- a/.changeset/merkle-proof-zero-pad.md
+++ b/.changeset/merkle-proof-zero-pad.md
@@ -1,0 +1,5 @@
+---
+'@snapshot-labs/sx': patch
+---
+
+Zero-pad merkle whitelist proof elements to 32 bytes before encoding. The whitelist proof server (wls.snapshot.box) can return proof elements with a stripped leading zero byte (31 bytes), which caused an on-chain `InvalidProof()` revert for whitelisted voters whose proof contained a hash starting with a zero byte.

--- a/packages/sx.js/src/strategies/evm/merkleWhitelist.ts
+++ b/packages/sx.js/src/strategies/evm/merkleWhitelist.ts
@@ -1,4 +1,5 @@
 import { AbiCoder } from '@ethersproject/abi';
+import { hexZeroPad } from '@ethersproject/bytes';
 import { StandardMerkleTree } from '@openzeppelin/merkle-tree';
 import {
   ClientConfig,
@@ -86,10 +87,18 @@ export default function createMerkleWhitelist(): Strategy {
 
       if (!proof) throw new Error('Signer is not in whitelist');
 
+      // The whitelist proof server (wls.snapshot.box) can return proof
+      // elements with a stripped leading zero byte (31 bytes instead of a
+      // full bytes32). Left-pad each element to 32 bytes so the encoded proof
+      // is valid on-chain (otherwise voters whose proof contains a hash
+      // starting with a zero byte hit InvalidProof()). No-op for correct
+      // 32-byte values.
+      const normalizedProof = proof.proof.map(node => hexZeroPad(node, 32));
+
       const abiCoder = new AbiCoder();
       return abiCoder.encode(
         ['bytes32[]', 'tuple(address, uint96)'],
-        [proof.proof, whitelist[proof.index]]
+        [normalizedProof, whitelist[proof.index]]
       );
     },
     async getVotingPower(


### PR DESCRIPTION
Fixes #2141.

## Problem
The whitelist proof server `wls.snapshot.box` (`getMerkleProof`) returns proof elements with a stripped leading zero byte — 63 hex chars / 31 bytes instead of a full 32-byte `bytes32` (e.g. `0xb659954…553f` instead of `0x0b659954…553f`).

`sx.js` consumed the value verbatim and ABI-encoded it as `bytes32[]`, producing a malformed proof element. On-chain this causes an `InvalidProof()` revert for any whitelisted voter whose merkle proof contains a hash that starts with a zero byte.

## Fix (client-side guard)
In `packages/sx.js/src/strategies/evm/merkleWhitelist.ts`, normalize each proof element to a full 32-byte hex string with `hexZeroPad(node, 32)` (from `@ethersproject/bytes`, already used elsewhere in sx.js) before ABI-encoding. This is a no-op for already-correct 32-byte values and also covers the local-tree fallback path.

```ts
const normalizedProof = proof.proof.map(node => hexZeroPad(node, 32));
```

## Note
The ideal long-term fix is server-side (padding the output in `wls.snapshot.box`). This PR is the client-side guard so affected whitelisted voters can vote immediately.

A changeset (`patch` to `@snapshot-labs/sx`) is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)