### PR TITLE
fix(ui): Sepolia ENS v2 space creation 'not allowed' (resolver-agnostic controller check)

### DIFF
--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -92,11 +92,19 @@ async function deepResolve(
 
   if (!resolverAddress || resolverAddress === EVM_EMPTY_ADDRESS) return null;
 
-  return call(provider, ENS_CONTRACTS.resolverAbi, [
-    resolverAddress,
-    property,
-    params
-  ]);
+  try {
+    return await call(provider, ENS_CONTRACTS.resolverAbi, [
+      resolverAddress,
+      property,
+      params
+    ]);
+  } catch {
+    // The resolver doesn't implement / reverts on this method (CCIP-read,
+    // ENS v2, or a broken resolver). Treat as "no record", matching the old
+    // multicall path, so callers degrade gracefully (e.g. getSpaceController
+    // falls back to the name owner) instead of throwing.
+    return null;
+  }
 }
 
 export async function resolveName(name: string, chainId: ENSChainId) {

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -84,10 +84,6 @@ async function deepResolve(
   const provider = getProvider(chainId);
   if (!ENS_CONTRACTS.resolvers[chainId]) throw new Error('Unsupported chainId');
 
-  // Resolve the name's resolver dynamically from the ENS registry instead of
-  // matching against a hardcoded allowlist. This keeps the lookup
-  // resolver-agnostic so names using newer resolvers (e.g. ENS v2 on Sepolia)
-  // are not silently treated as unresolved.
   const resolverAddress: string = await call(
     provider,
     ENS_CONTRACTS.registryAbi,

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -92,11 +92,11 @@ async function deepResolve(
 
   if (!resolverAddress || resolverAddress === EVM_EMPTY_ADDRESS) return null;
 
-  return call(
-    provider,
-    ENS_CONTRACTS.resolverAbi,
-    [resolverAddress, property, params]
-  );
+  return call(provider, ENS_CONTRACTS.resolverAbi, [
+    resolverAddress,
+    property,
+    params
+  ]);
 }
 
 export async function resolveName(name: string, chainId: ENSChainId) {

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -2,7 +2,7 @@ import { Signer } from '@ethersproject/abstract-signer';
 import { getAddress, isAddress } from '@ethersproject/address';
 import { Contract } from '@ethersproject/contracts';
 import { ensNormalize, namehash } from '@ethersproject/hash';
-import { call, multicall } from './call';
+import { call } from './call';
 import { EVM_EMPTY_ADDRESS } from './constants';
 import { getProvider } from './provider';
 import { getAddresses } from './stamp';
@@ -82,23 +82,25 @@ async function deepResolve(
   params: any[]
 ) {
   const provider = getProvider(chainId);
-  const resolvers = ENS_CONTRACTS.resolvers[chainId];
-  if (!resolvers) throw new Error('Unsupported chainId');
+  if (!ENS_CONTRACTS.resolvers[chainId]) throw new Error('Unsupported chainId');
 
-  const calls = [
-    [ENS_CONTRACTS.registry, 'resolver', [node]],
-    ...resolvers.map(resolver => [resolver, property, params])
-  ];
-
-  const [[resolverAddress], ...textRecords]: any[][] = await multicall(
-    chainId.toString(),
+  // Resolve the name's resolver dynamically from the ENS registry instead of
+  // matching against a hardcoded allowlist. This keeps the lookup
+  // resolver-agnostic so names using newer resolvers (e.g. ENS v2 on Sepolia)
+  // are not silently treated as unresolved.
+  const resolverAddress: string = await call(
     provider,
-    [...ENS_CONTRACTS.registryAbi, ...ENS_CONTRACTS.resolverAbi],
-    calls
+    ENS_CONTRACTS.registryAbi,
+    [ENS_CONTRACTS.registry, 'resolver', [node]]
   );
 
-  const resolverIndex = resolvers.indexOf(resolverAddress);
-  return resolverIndex !== -1 ? textRecords[resolverIndex]?.[0] : null;
+  if (!resolverAddress || resolverAddress === EVM_EMPTY_ADDRESS) return null;
+
+  return call(
+    provider,
+    ENS_CONTRACTS.resolverAbi,
+    [resolverAddress, property, params]
+  );
 }
 
 export async function resolveName(name: string, chainId: ENSChainId) {
@@ -140,8 +142,7 @@ export async function setEnsTextRecord(
   value: string,
   chainId: ENSChainId
 ) {
-  const resolvers = ENS_CONTRACTS.resolvers[chainId];
-  if (!resolvers) throw new Error('Unsupported chainId');
+  if (!ENS_CONTRACTS.resolvers[chainId]) throw new Error('Unsupported chainId');
 
   const ensHash = namehash(ensNormalize(ens));
 
@@ -151,8 +152,8 @@ export async function setEnsTextRecord(
     [ENS_CONTRACTS.registry, 'resolver', [ensHash]]
   );
 
-  if (!resolvers.includes(resolverAddress))
-    throw new Error('Unsupported resolver');
+  if (!resolverAddress || resolverAddress === EVM_EMPTY_ADDRESS)
+    throw new Error('No resolver set for name');
 
   const contract = new Contract(
     resolverAddress,

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -98,12 +98,14 @@ async function deepResolve(
       property,
       params
     ]);
-  } catch {
-    // The resolver doesn't implement / reverts on this method (CCIP-read,
-    // ENS v2, or a broken resolver). Treat as "no record", matching the old
-    // multicall path, so callers degrade gracefully (e.g. getSpaceController
-    // falls back to the name owner) instead of throwing.
-    return null;
+  } catch (err: any) {
+    // The resolver reverts on this method (CCIP-read, ENS v2, or a broken
+    // resolver). Treat as "no record", matching the old multicall path, so
+    // callers degrade gracefully (e.g. getSpaceController falls back to the
+    // name owner) instead of throwing. Network/timeout errors are re-thrown
+    // so a transient RPC failure is not silently read as "no record".
+    if (err?.code === 'CALL_EXCEPTION') return null;
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary

Sepolia ENS **v2** names fail space creation with a "not allowed" error. This makes ENS controller/record resolution **resolver-agnostic** so any resolver works.

## How to reproduce (before)

1. Go to [testnet.snapshot.box](https://testnet.snapshot.box) (Sepolia).
2. Use an ENS **v2** name on Sepolia that you own/control — one whose resolver is **not** in the hardcoded `ENS_CONTRACTS.resolvers[11155111]` allowlist.
3. Try to create a space with that name and sign.
4. Right after signing you get a **"not allowed"** error — even though you genuinely control the name.

## Cause

`deepResolve` / `setEnsTextRecord` in `apps/ui/src/helpers/ens.ts` only resolved ENS records against a **hardcoded list of resolver addresses**. Names on newer / ENS-v2 resolvers aren't in that list, so they resolve to empty → the ownership check fails → **"not allowed"**.

## Fix (after)

Resolve the name's **actual resolver dynamically** from the ENS registry (`registry.resolver(namehash)`) instead of matching a hardcoded allowlist, so any resolver (including ENS v2 and future ones) works. `setEnsTextRecord` now only rejects when **no resolver is set** for the name.

After the fix, the same Sepolia ENS-v2 name creates the space successfully.

## Notes

- Reported via Intercom.
- Resolver-agnostic: it won't need a new hardcoded address each time ENS ships a new resolver, unlike the prior add-resolver pattern.
