### PR TITLE
feat(mcp): support unfollow in snapshot-follow tool

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -69,11 +69,12 @@ The snapshot block is read from `https://rpc.snapshot.org/<chainId>` based on th
 
 ### `snapshot-follow`
 
-Adds a space to the user's followed list. Calling it again on a space the user already follows is safe — Snapshot does not duplicate the follow.
+Follows or unfollows a space for the user. Both directions are idempotent — following an already-followed space, or unfollowing one the user does not follow, is a harmless no-op.
 
 | Input | Type | Description |
 |-------|------|-------------|
 | `space` | `string` | Space ID slug (e.g. `"ens.eth"`) |
+| `action` | `"follow" \| "unfollow"?` | Whether to follow or unfollow. Defaults to `"follow"`. |
 
 Requires a wallet, same as `snapshot-vote` and `snapshot-propose`.
 

--- a/apps/mcp/src/instructions.md
+++ b/apps/mcp/src/instructions.md
@@ -16,4 +16,4 @@ Re-calling snapshot-vote on the same proposal replaces the previous vote (this i
 
 Use snapshot-propose to create a proposal: only `space`, `title`, `body` are required. Voting type, choices, period, snapshot block, and privacy are derived from the space (override only when needed).
 
-Use snapshot-follow to add a space to the user's followed list. Calling it again on a space already followed is a no-op. Followed spaces are queryable via `follows(where: { follower: $user })`.
+Use snapshot-follow to follow or unfollow a space: `action: "follow"` (default) adds it to the user's followed list, `action: "unfollow"` removes it. Both directions are idempotent no-ops when already in the target state. Followed spaces are queryable via `follows(where: { follower: $user })`.

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -312,21 +312,33 @@ export function registerFollowTool(
     'snapshot-follow',
     {
       description:
-        'Add a Snapshot space to the user\'s followed list. Calling this again on a space the user already follows is a no-op on Snapshot\'s side. Use `follows(where: { follower: $user })` via snapshot-query to list followed spaces.',
+        'Follow or unfollow a Snapshot space for the user. Set `action: "follow"` (default) to add the space to the followed list, or `action: "unfollow"` to remove it. Both are idempotent on Snapshot\'s side: following an already-followed space, or unfollowing a space the user does not follow, is a harmless no-op. Use `follows(where: { follower: $user })` via snapshot-query to list followed spaces.',
       inputSchema: {
-        space: z.string().describe('Space ID slug (e.g. "ens.eth")')
+        space: z.string().describe('Space ID slug (e.g. "ens.eth")'),
+        action: z
+          .enum(['follow', 'unfollow'])
+          .default('follow')
+          .describe('Whether to follow or unfollow the space. Defaults to "follow".')
       }
     },
     (data, extra) =>
       handle('snapshot-follow', extra, async () => {
         const { user: from, signer } = await resolveContext(extra);
         const space = await requireSpace<{ id: string }>(data.space, 'id');
-        const envelope = await sx.followSpace({
+        const payload = {
           signer: signer as Wallet,
           data: { from, space: space.id, network: 's' }
-        });
+        };
+        const envelope =
+          data.action === 'unfollow'
+            ? await sx.unfollowSpace(payload)
+            : await sx.followSpace(payload);
         const result = (await sx.send(envelope)) as unknown;
-        return { result, links: { space: `https://snapshot.box/#/s:${space.id}` } };
+        return {
+          action: data.action,
+          result,
+          links: { space: `https://snapshot.box/#/s:${space.id}` }
+        };
       })
   );
 }

--- a/docs/tools/snapshot-mcp.mdx
+++ b/docs/tools/snapshot-mcp.mdx
@@ -169,7 +169,7 @@ The server exposes 5 tools. The AI selects them automatically based on your prom
 | `snapshot-schema` | Return the GraphQL schema. Used when a query fails on an unknown field. | No |
 | `snapshot-vote` | Cast a vote. Voting type and privacy are auto-detected. Re-calling replaces the previous vote. | Yes |
 | `snapshot-propose` | Create a proposal. Only `space`, `title`, and `body` are required. | Yes |
-| `snapshot-follow` | Follow a space. | Yes |
+| `snapshot-follow` | Follow or unfollow a space. Set `action` to `"follow"` (default) or `"unfollow"`. | Yes |
 
 ## How it works
 


### PR DESCRIPTION
## Summary

Makes the `snapshot-follow` MCP tool handle both follow and unfollow, instead of follow only.

Rather than adding a separate `snapshot-unfollow` tool, this adds an `action` enum parameter to the existing tool:

- `action: "follow"` (default) adds the space to the user's followed list
- `action: "unfollow"` removes it

Keeping it as one tool maps to a single concept, keeps the agent's tool list small, and stays backward compatible (the default preserves the old behavior). The handler branches to the existing `sx.unfollowSpace()` client, which already mirrors `followSpace()` in sx.js. Both directions are idempotent no-ops when already in the target state, so the agent never needs a pre-check query. The response now echoes back `action` for unambiguous confirmation.

## Changes

- `apps/mcp/src/tools.ts` — add `action` enum to `snapshot-follow`, branch to `followSpace` / `unfollowSpace`
- `apps/mcp/src/instructions.md` — update the connect-time server instructions
- `apps/mcp/README.md` — document the `action` input
- `docs/tools/snapshot-mcp.mdx` — update the tools table

## Test plan

- `tsc --noEmit` passes
- `eslint src` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)