### PR TITLE
fix(ui): extend alias availability window to 90 days

### DIFF
--- a/apps/ui/src/composables/useAlias.ts
+++ b/apps/ui/src/composables/useAlias.ts
@@ -3,7 +3,8 @@ import { getDefaultProvider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
 import pkg from '../../package.json';
 
-const ALIAS_AVAILABILITY_PERIOD = 60 * 60 * 24 * 30; // 30 days
+// Must match the sequencer's DEFAULT_ALIAS_EXPIRY_DAYS (apps/sequencer/src/helpers/alias.ts).
+const ALIAS_AVAILABILITY_PERIOD = 60 * 60 * 24 * 90; // 90 days
 const ALIAS_AVAILABILITY_BUFFER = 60 * 5; // 5 minutes
 
 type GetAliasFn = (


### PR DESCRIPTION
## Problem

The UI reused a stored alias only if it was created within the last **30 days** ([`useAlias.ts`](apps/ui/src/composables/useAlias.ts) `ALIAS_AVAILABILITY_PERIOD`). Past 30 days it created a brand-new alias — making the user re-authorize.

But the sequencer accepts aliases for **90 days** (`DEFAULT_ALIAS_EXPIRY_DAYS`, [apps/sequencer/src/helpers/alias.ts](apps/sequencer/src/helpers/alias.ts), set in #2115). So aliases were silently rotated at 30 days while still valid server-side for another 60 — an unnecessary re-authorization every month.

## Fix

Bump `ALIAS_AVAILABILITY_PERIOD` from 30 → 90 days so the UI reuses an alias for its full server-side lifetime. Added a comment pointing at the sequencer constant it must track.

The 5-minute `ALIAS_AVAILABILITY_BUFFER` is unchanged — it still re-creates slightly before the true 90-day expiry to avoid submitting with an alias about to lapse.

## Scope

- **Sequencer** already 90 (#2115) — no change.
- **Hub** has no hardcoded alias expiry (the `aliases` query filters by the client-supplied `created_gt`) — no change.
- **UI** was the only place still at 30 days — this one-line change.

Covers both consumers of `useAlias` (the main offchain alias flow and townhall).

`vue-tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)