### PR TITLE
fix: increase alias expiration to 90d

### DIFF
--- a/apps/ui/src/composables/useAlias.ts
+++ b/apps/ui/src/composables/useAlias.ts
@@ -3,7 +3,7 @@ import { getDefaultProvider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
 import pkg from '../../package.json';
 
-const ALIAS_AVAILABILITY_PERIOD = 60 * 60 * 24 * 30; // 30 days
+const ALIAS_AVAILABILITY_PERIOD = 60 * 60 * 24 * 90; // 90 days
 const ALIAS_AVAILABILITY_BUFFER = 60 * 5; // 5 minutes
 
 type GetAliasFn = (


### PR DESCRIPTION
## What

Increase alias availability period from 30 to 90 days in the UI.

- `apps/ui/src/composables/useAlias.ts`: `ALIAS_AVAILABILITY_PERIOD` 30d → 90d.

## Backend / cross-references

- **Sequencer**: the matching backend default (`DEFAULT_ALIAS_EXPIRY_DAYS`) already lives in this monorepo at `apps/sequencer/src/helpers/alias.ts` and is already `90` on `master` — no change needed.
- **snapshot-sequencer** (standalone repo): archived / read-only, non-enforcing — no changes needed.
- **hub**: archived / non-enforcing — no changes needed.
- **snapshot.js**: has no alias TTL — no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)