### PR TITLE
docs: fix truncated delegation description

### DIFF
--- a/apps/ui/src/composables/useAlias.ts
+++ b/apps/ui/src/composables/useAlias.ts
@@ -3,7 +3,8 @@ import { getDefaultProvider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
 import pkg from '../../package.json';
 
-const ALIAS_AVAILABILITY_PERIOD = 60 * 60 * 24 * 30; // 30 days
+// Must match the sequencer's DEFAULT_ALIAS_EXPIRY_DAYS (apps/sequencer/src/helpers/alias.ts).
+const ALIAS_AVAILABILITY_PERIOD = 60 * 60 * 24 * 90; // 90 days
 const ALIAS_AVAILABILITY_BUFFER = 60 * 5; // 5 minutes
 
 type GetAliasFn = (

--- a/docs/user-guides/delegation.mdx
+++ b/docs/user-guides/delegation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Delegation"
-description: "Discover the delegates of specific spaces and delegate your Voting Power directly through Snapshot,"
+description: "Discover the delegates of specific spaces and delegate your Voting Power directly through Snapshot."
 ---
 
 ## How to delegate?


### PR DESCRIPTION
The `delegation` page's frontmatter description ended mid-sentence with a trailing comma, which propagates into the auto-generated [`llms.txt`](https://docs.snapshot.box/llms.txt):

> …delegate your Voting Power directly through Snapshot**,**

Changed the trailing `,` to `.`.