### PR TITLE
fix(docs): open MCP connector buttons in a new tab

### DIFF
--- a/docs/tools/snapshot-mcp.mdx
+++ b/docs/tools/snapshot-mcp.mdx
@@ -24,7 +24,7 @@ Building an agent? Point it at [llms.txt](https://docs.snapshot.box/llms.txt) fo
 <Tabs>
 <Tab title="Claude.ai">
 
-<Card title="Add to Claude.ai" href="https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Snapshot&connectorUrl=https%3A%2F%2Fmcp.snapshot.box" horizontal />
+<Card title="Add to Claude.ai" href="https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Snapshot&connectorUrl=https%3A%2F%2Fmcp.snapshot.box" horizontal target="_blank" rel="noopener noreferrer" />
 
 One-click setup, then authorize the connector. Or add it manually:
 
@@ -70,7 +70,7 @@ Verify with `claude mcp list`.
 
 <Tab title="ChatGPT">
 
-<Card title="Add to ChatGPT" href="https://chatgpt.com/#settings/ConnectorSettings?create-connector=true" horizontal arrow />
+<Card title="Add to ChatGPT" href="https://chatgpt.com/#settings/ConnectorSettings?create-connector=true" horizontal arrow target="_blank" rel="noopener noreferrer" />
 
 The button opens the new app modal directly. Or open **Settings > Apps** and click **Create** (enable **Developer mode** under Advanced settings if prompted).
 
@@ -88,7 +88,7 @@ Custom apps require Developer mode and are available on Plus, Pro, Business, Ent
 
 <Tab title="Cursor">
 
-<Card title="Add to Cursor" href="cursor://anysphere.cursor-deeplink/mcp/install?name=snapshot&config=eyJ1cmwiOiJodHRwczovL21jcC5zbmFwc2hvdC5ib3gifQ==" horizontal arrow />
+<Card title="Add to Cursor" href="cursor://anysphere.cursor-deeplink/mcp/install?name=snapshot&config=eyJ1cmwiOiJodHRwczovL21jcC5zbmFwc2hvdC5ib3gifQ==" horizontal arrow target="_blank" rel="noopener noreferrer" />
 
 Or open **Settings > MCP > Add new MCP server**, choose **HTTP**, paste `https://mcp.snapshot.box`.
 
@@ -96,7 +96,7 @@ Or open **Settings > MCP > Add new MCP server**, choose **HTTP**, paste `https:/
 
 <Tab title="VS Code">
 
-<Card title="Add to VS Code" href="https://insiders.vscode.dev/redirect/mcp/install?name=snapshot&config=%7B%22url%22%3A%22https%3A%2F%2Fmcp.snapshot.box%22%7D" horizontal />
+<Card title="Add to VS Code" href="https://insiders.vscode.dev/redirect/mcp/install?name=snapshot&config=%7B%22url%22%3A%22https%3A%2F%2Fmcp.snapshot.box%22%7D" horizontal target="_blank" rel="noopener noreferrer" />
 
 Or add it from your terminal:
 


### PR DESCRIPTION
## Problem

On https://docs.snapshot.box/tools/snapshot-mcp the **Add to ChatGPT** button opens in the same tab instead of a new tab. The href is `https://chatgpt.com/#settings/ConnectorSettings?create-connector=true` — Mintlify's link heuristic sees the leading `/#` hash and treats it as an in-page anchor, so it navigates in the current tab (losing the docs page).

## Fix

Added `target="_blank" rel="noopener noreferrer"` to all four MCP connector `<Card>` buttons on the Snapshot MCP page so every external "Add to ..." button consistently opens in a new tab:

- Add to Claude.ai
- Add to ChatGPT (the reported case)
- Add to Cursor
- Add to VS Code

## Sweep

Grepped the entire `docs/` tree for `<Card>` / `<Button>` / `<Link>` components with external (`https://`, custom-protocol) hrefs — these four were the only external-link button components in the docs. Inline markdown links and navbar `externalLinks` already open in a new tab via Mintlify's default external-link handling, so no other cases needed changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)