### PR TITLE
feat(mcp): expose version on root response

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -53,6 +53,14 @@ if (process.argv.includes('--stdio')) {
   const app = createMcpExpressApp({ host: '0.0.0.0' });
   app.set('trust proxy', 1);
 
+  app.get('/', (_req: Request, res: Response): void => {
+    const commit = process.env.COMMIT_HASH ?? '';
+    const version = commit
+      ? `${pkg.version}#${commit.substring(0, 7)}`
+      : pkg.version;
+    res.json({ name: 'snapshot-mcp', version });
+  });
+
   const provider = new SnapshotOAuthProvider();
   app.use(mcpAuthRouter({ provider, issuerUrl: new URL(baseUrl) }));
   app.get('/auth/callback', provider.callback);


### PR DESCRIPTION
## What

Adds a `version` field to the Snapshot MCP server's root response so we can see which build is live on **mcp.snapshot.box**, matching how `apps/sequencer` and `apps/hub` already expose theirs.

```bash
curl https://mcp.snapshot.box/
# {"name":"snapshot-mcp","version":"0.1.0#019b851"}
```

## How

A tiny unauthenticated `GET /` handler (HTTP mode only), registered before the auth middleware so it never touches the OAuth/JSON-RPC tool path:

```ts
app.get('/', (_req, res) => {
  const commit = process.env.COMMIT_HASH ?? '';
  const version = commit ? `${pkg.version}#${commit.substring(0, 7)}` : pkg.version;
  res.json({ name: 'snapshot-mcp', version });
});
```

Version string is `<semver>#<shortsha>` from `package.json` version + `COMMIT_HASH` — the exact mechanism/format used by `apps/sequencer/src/api.ts` and `apps/hub/src/api.ts`. The commit comes from the infra-injected `COMMIT_HASH` env var (same as the other apps); falls back to bare semver when unset.

## Changes vs the previous revision

Dropped the separate `/version` route file, the `X-Commit` header, the `{commit, builtAt}` shape, and the build-time `bun --define` bake / `GIT_SHA`/`SOURCE_COMMIT` resolution — all replaced by the 8-line root handler above to mirror sequencer/hub. No new files, no package.json/README/.env changes.

Single file: `apps/mcp/src/index.ts` (+8). `tsc` and `eslint` pass.