### PR TITLE
docs(mcp): correct snapshot-follow idempotency claim

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -83,7 +83,7 @@ The snapshot block is read from `https://rpc.snapshot.org/<chainId>` based on th
 
 ### `snapshot-follow`
 
-Follows or unfollows a space for the user. Neither direction is idempotent: following an already-followed space, or unfollowing one the user does not follow, returns an error. Check the current state via `follows(where: { follower: $user })` first.
+Follows or unfollows a space for the user. Following a space you already follow returns an error, and so does unfollowing a space you do not follow. Check the current state with `follows(where: { follower: $user })` before calling this.
 
 | Input | Type | Description |
 |-------|------|-------------|

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -83,7 +83,7 @@ The snapshot block is read from `https://rpc.snapshot.org/<chainId>` based on th
 
 ### `snapshot-follow`
 
-Follows or unfollows a space for the user. Both directions are idempotent — following an already-followed space, or unfollowing one the user does not follow, is a harmless no-op.
+Follows or unfollows a space for the user. Neither direction is idempotent: following an already-followed space, or unfollowing one the user does not follow, returns an error. Check the current state via `follows(where: { follower: $user })` first.
 
 | Input | Type | Description |
 |-------|------|-------------|

--- a/apps/mcp/src/instructions.md
+++ b/apps/mcp/src/instructions.md
@@ -18,4 +18,4 @@ Re-calling snapshot-vote on the same proposal replaces the previous vote (this i
 
 Use snapshot-propose to create a proposal: only `space`, `title`, `body` are required. Voting type, choices, period, snapshot block, and privacy are derived from the space (override only when needed).
 
-Use snapshot-follow to follow or unfollow a space: `action: "follow"` (default) adds it to the user's followed list, `action: "unfollow"` removes it. Neither direction is idempotent: re-following an already-followed space, or unfollowing one the user does not follow, returns an error — check `follows(where: { follower: $user })` first. That same query lists followed spaces.
+Use snapshot-follow to follow or unfollow a space: `action: "follow"` (default) adds it to the user's followed list, `action: "unfollow"` removes it. Following a space you already follow returns an error, and so does unfollowing a space you do not follow, so check `follows(where: { follower: $user })` first. That same query lists followed spaces.

--- a/apps/mcp/src/instructions.md
+++ b/apps/mcp/src/instructions.md
@@ -18,4 +18,4 @@ Re-calling snapshot-vote on the same proposal replaces the previous vote (this i
 
 Use snapshot-propose to create a proposal: only `space`, `title`, `body` are required. Voting type, choices, period, snapshot block, and privacy are derived from the space (override only when needed).
 
-Use snapshot-follow to follow or unfollow a space: `action: "follow"` (default) adds it to the user's followed list, `action: "unfollow"` removes it. Both directions are idempotent no-ops when already in the target state. Followed spaces are queryable via `follows(where: { follower: $user })`.
+Use snapshot-follow to follow or unfollow a space: `action: "follow"` (default) adds it to the user's followed list, `action: "unfollow"` removes it. Neither direction is idempotent: re-following an already-followed space, or unfollowing one the user does not follow, returns an error — check `follows(where: { follower: $user })` first. That same query lists followed spaces.

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -352,7 +352,7 @@ export function registerFollowTool(
     'snapshot-follow',
     {
       description:
-        'Follow or unfollow a Snapshot space for the user. Set `action: "follow"` (default) to add the space to the followed list, or `action: "unfollow"` to remove it. Both are idempotent on Snapshot\'s side: following an already-followed space, or unfollowing a space the user does not follow, is a harmless no-op. Use `follows(where: { follower: $user })` via snapshot-query to list followed spaces.',
+        'Follow or unfollow a Snapshot space for the user. Set `action: "follow"` (default) to add the space to the followed list, or `action: "unfollow"` to remove it. Neither action is idempotent: following an already-followed space errors with "you are already following this space", and unfollowing a space the user does not follow errors with "you can only unfollow a space you follow". Check the current state first via `follows(where: { follower: $user })` (which also lists followed spaces).',
       inputSchema: {
         space: z.string().describe('Space ID slug (e.g. "ens.eth")'),
         action: z

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -352,7 +352,7 @@ export function registerFollowTool(
     'snapshot-follow',
     {
       description:
-        'Follow or unfollow a Snapshot space for the user. Set `action: "follow"` (default) to add the space to the followed list, or `action: "unfollow"` to remove it. Neither action is idempotent: following an already-followed space errors with "you are already following this space", and unfollowing a space the user does not follow errors with "you can only unfollow a space you follow". Check the current state first via `follows(where: { follower: $user })` (which also lists followed spaces).',
+        'Follow or unfollow a Snapshot space for the user. Set `action: "follow"` (default) to add the space to the followed list, or `action: "unfollow"` to remove it. Following a space you already follow returns the error "you are already following this space", and unfollowing a space you do not follow returns "you can only unfollow a space you follow". Check the current state first via `follows(where: { follower: $user })`, which also lists followed spaces.',
       inputSchema: {
         space: z.string().describe('Space ID slug (e.g. "ens.eth")'),
         action: z


### PR DESCRIPTION
Fixes #2153.

`snapshot-follow` docs claimed follow/unfollow are idempotent no-ops, but the relayer errors in both directions:
- follow already-followed: `you are already following this space`
- unfollow not-followed: `you can only unfollow a space you follow`

Option A from the issue (fix the docs to match server behavior). Corrected in all three places:
- `apps/mcp/src/tools.ts`: tool description
- `apps/mcp/src/instructions.md`: model-facing instructions
- `apps/mcp/README.md`

## Test plan
- [ ] Docs read correctly; no behavior change.