### PR TITLE
docs(mcp): fix inaccurate snapshot-propose docs

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -64,7 +64,7 @@ Requires a wallet to be configured for signing (see [Configuration](#configurati
 
 ### `snapshot-propose`
 
-Creates a Snapshot proposal. Most defaults come from the space itself, so for typical use you only need `space`, `title`, and `body`. The space's enforced voting type, voting period, snapshot block, and privacy mode are read from Snapshot and applied automatically.
+Creates a Snapshot proposal. Most defaults come from the space itself, so for typical use you only need `space`, `title`, and `body`. The space's enforced voting type, voting period, and privacy mode are read from Snapshot and applied automatically.
 
 | Input | Type | Description |
 |-------|------|-------------|
@@ -77,7 +77,7 @@ Creates a Snapshot proposal. Most defaults come from the space itself, so for ty
 | `labels` | `string[]?` | Proposal label IDs |
 | `start` | `number?` | Voting start as a unix timestamp in seconds. Defaults to `now + space.voting.delay`. |
 | `end` | `number?` | Voting end as a unix timestamp in seconds. Defaults to `start + space.voting.period` (3 days if the space sets none). |
-| `shielded` | `boolean?` | Opt into Shutter-encrypted voting. Only honored when the space's `voting.privacy` is `"any"`; spaces with `voting.privacy === "shutter"` always encrypt. |
+| `privacy` | `"shutter" \| "none"?` | Opt into Shutter-encrypted voting with `"shutter"`. Only honored when the space's `voting.privacy` is `"any"`; spaces with `voting.privacy === "shutter"` always encrypt. |
 
 The snapshot block is read from `https://rpc.snapshot.org/<chainId>` based on the space's network. Requires a wallet, same as `snapshot-vote`.
 

--- a/apps/mcp/src/instructions.md
+++ b/apps/mcp/src/instructions.md
@@ -16,6 +16,6 @@ Timestamps (`created`, `start`, `end`, `updated`) are unix seconds UTC, not ms. 
 
 Re-calling snapshot-vote on the same proposal replaces the previous vote (this is how to change a vote).
 
-Use snapshot-propose to create a proposal: only `space`, `title`, `body` are required. Voting type, choices, period, snapshot block, and privacy are derived from the space (override only when needed).
+Use snapshot-propose to create a proposal: only `space`, `title`, `body` are required. Voting type, choices, period, and privacy are derived from the space (override only when needed); the snapshot block is set automatically to the current chain head of the space's network.
 
 Use snapshot-follow to follow or unfollow a space: `action: "follow"` (default) adds it to the user's followed list, `action: "unfollow"` removes it. Both directions are idempotent no-ops when already in the target state. Followed spaces are queryable via `follows(where: { follower: $user })`.

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -272,7 +272,7 @@ export function registerProposeTool(
     'snapshot-propose',
     {
       description:
-        'Create a Snapshot proposal. Only `space`, `title`, `body` are required. The space\'s enforced voting type, voting period, snapshot block, and privacy mode are read from the space and applied automatically. `choices` defaults to ["For", "Against", "Abstain"] for basic voting and is required for other types. Pass `privacy: "shutter"` only on spaces where `voting.privacy === "any"` to opt into Shutter encryption; spaces with `voting.privacy === "shutter"` always encrypt.',
+        'Create a Snapshot proposal. Only `space`, `title`, `body` are required. The space\'s enforced voting type, voting period, and privacy mode are read from the space and applied automatically; the snapshot block is set to the current chain head of the space\'s network. `choices` defaults to ["For", "Against", "Abstain"] for basic voting and is required for other types. Pass `privacy: "shutter"` only on spaces where `voting.privacy === "any"` to opt into Shutter encryption; spaces with `voting.privacy === "shutter"` always encrypt.',
       inputSchema: {
         space: z.string().describe('Space ID slug (e.g. "ens.eth")'),
         title: z.string().min(1).describe('Proposal title'),


### PR DESCRIPTION
Two `snapshot-propose` doc inaccuracies where the docs don't match the code.

**1. Snapshot block source.** The tool description and instructions claimed the snapshot block is "read from the space". It isn't — `getProposalSnapshotBlock` (`apps/mcp/src/hub.ts`) fetches the current chain head via `https://rpc.snapshot.org/<chainId>` (minus a 4-block reorg offset) for the space's network. Corrected the wording (the README already described this correctly at line 82).

**2. Non-existent `shielded` input.** The README documented an input `shielded` (`boolean`), but the actual input is `privacy` (`"shutter" | "none"`, see `tools.ts`). Fixed the parameter row.

## Test plan
- [ ] Docs read correctly; no behavior change.