### PR TITLE
fix(mcp): error on failed snapshot-block resolution instead of NaN

### DIFF
--- a/apps/mcp/src/hub.ts
+++ b/apps/mcp/src/hub.ts
@@ -12,7 +12,17 @@ export async function getProposalSnapshotBlock(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_blockNumber' })
   });
-  const { result } = (await res.json()) as { result: string };
+  if (!res.ok) {
+    throw new Error(
+      `Failed to resolve snapshot block for chain ${chainId} (HTTP ${res.status})`
+    );
+  }
+  const { result } = (await res.json()) as { result?: string };
+  if (typeof result !== 'string' || !/^0x[0-9a-fA-F]+$/.test(result)) {
+    throw new Error(
+      `Invalid block number for chain ${chainId}: ${JSON.stringify(result)}`
+    );
+  }
   return Math.max(0, parseInt(result, 16) - SNAPSHOT_BLOCK_OFFSET);
 }
 


### PR DESCRIPTION
`getProposalSnapshotBlock` (`apps/mcp/src/hub.ts`) didn't check `res.ok` or validate the RPC result, so a failed block lookup silently became `NaN`.

When `https://rpc.snapshot.org/<chainId>` rejects a chain id with a result-less `404 {"error":"Invalid network"}` (realistic case: a space still on a deprecated chain like Goerli `5`), `parseInt(undefined, 16)` → `NaN` → `Math.max(0, NaN)` → `NaN`. That `NaN` flows into `sx.propose({ snapshot: NaN })` and serializes to `snapshot: null` — a corrupt proposal is signed and sent instead of failing with a clear error.

The `Number.isFinite(chainId)` guard in `tools.ts` doesn't catch this: it only rejects non-numeric networks. `Number.isFinite(0)` / `Number.isFinite(5)` are `true`.

Fix: check `res.ok` and validate `result` is a hex string; throw a clear error otherwise. Valid chains (incl. testnets the gateway serves, e.g. Zora Sepolia `999999999`) are unaffected.

## Test plan
Verified the logic against the live RPC:
- chain `1` → block resolved ✓
- chain `999999999` (Zora Sepolia, valid) → block resolved ✓
- chain `5` (Goerli, gateway 404) → throws `Failed to resolve snapshot block for chain 5 (HTTP 404)` (was `NaN`) ✓
- chain `0` → throws (was `NaN`) ✓