### PR TITLE
feat(mcp): structured logging with pino and catch-all error handling

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -19,11 +19,14 @@
   "dependencies": {
     "@coinbase/cdp-sdk": "^1.45.0",
     "@ethersproject/wallet": "^5.8.0",
+    "@logtail/pino": "^0.5.5",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@shutter-network/shutter-crypto": "1.0.1",
     "@snapshot-labs/sx": "^0.1.10",
     "express": "^5.2.1",
     "jose": "^6.2.2",
+    "pino": "^9.9.0",
+    "pino-pretty": "^13.1.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -4,10 +4,11 @@ import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { type Request, type Response } from 'express';
+import { type NextFunction, type Request, type Response } from 'express';
 import pkg from '../package.json' with { type: 'json' };
 import { SnapshotOAuthProvider } from './auth.js';
 import instructions from './instructions.md' with { type: 'text' };
+import logger from './logger.js';
 import {
   createResolveContext,
   registerFollowTool,
@@ -17,6 +18,17 @@ import {
   registerVoteTool,
   registerWhoamiTool
 } from './tools.js';
+
+// Log strays instead of dying silently. An uncaught exception leaves the
+// process in an undefined state, so exit and let the orchestrator restart.
+process.on('uncaughtException', (err: unknown) => {
+  logger.fatal({ err }, 'uncaught exception');
+  process.exit(1);
+});
+
+process.on('unhandledRejection', (err: unknown) => {
+  logger.error({ err }, 'unhandled rejection');
+});
 
 const ICONS = [
   { src: 'https://snapshot.box/favicon-dark.svg', mimeType: 'image/svg+xml', sizes: ['any'], theme: 'light' as const },
@@ -45,7 +57,14 @@ function createMcpServer(mode: 'http' | 'stdio'): McpServer {
 }
 
 if (process.argv.includes('--stdio')) {
-  await createMcpServer('stdio').connect(new StdioServerTransport());
+  try {
+    await createMcpServer('stdio').connect(new StdioServerTransport());
+    logger.info('MCP server connected over stdio');
+  } catch (e) {
+    logger.fatal({ err: e }, 'failed to start stdio server');
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(1);
+  }
 } else {
   const port = Number(process.env.PORT ?? 8080);
   const baseUrl = process.env.BASE_URL ?? `http://localhost:${port}`;
@@ -69,13 +88,17 @@ if (process.argv.includes('--stdio')) {
 
   // Stateless mode: a fresh transport per request so deploys never strand an active session.
   app.post('/', authMiddleware, async (req: Request, res: Response): Promise<void> => {
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined
-    });
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
     res.on('close', () => { transport.close().catch(() => {}); });
     await createMcpServer('http').connect(transport);
     await transport.handleRequest(req, res, req.body);
   });
 
-  app.listen(port);
+  // Express forwards rejections from the handlers above (and auth/OAuth router) here.
+  app.use((err: unknown, _req: Request, res: Response, _next: NextFunction): void => {
+    logger.error({ err }, 'request error');
+    if (!res.headersSent) res.status(500).json({ error: 'internal_server_error' });
+  });
+
+  app.listen(port, () => logger.info({ port, baseUrl }, 'MCP server listening'));
 }

--- a/apps/mcp/src/logger.ts
+++ b/apps/mcp/src/logger.ts
@@ -1,0 +1,47 @@
+import pino from 'pino';
+
+const prettifyLogs = process.env.NODE_ENV !== 'production';
+
+const LOGTAIL_HOST = process.env.LOGTAIL_HOST;
+const LOGTAIL_TOKEN = process.env.LOGTAIL_TOKEN;
+
+// The `err` serializer flattens an error's own enumerable properties into the
+// log record, so a Coinbase CDP `APIError` surfaces its `errorType`,
+// `statusCode` and `correlationId` as queryable fields in Better Stack.
+const base = {
+  level: process.env.LOG_LEVEL ?? 'info',
+  serializers: { err: pino.stdSerializers.err }
+};
+
+function createLogger(): pino.Logger {
+  if (LOGTAIL_HOST && LOGTAIL_TOKEN) {
+    return pino({
+      ...base,
+      transport: {
+        target: '@logtail/pino',
+        options: {
+          sourceToken: LOGTAIL_TOKEN,
+          options: {
+            endpoint: `https://${LOGTAIL_HOST}`
+          }
+        }
+      }
+    });
+  }
+
+  // Write to stderr (fd 2) rather than stdout: under the stdio transport,
+  // stdout carries the JSON-RPC stream and must not be polluted with logs.
+  if (prettifyLogs) {
+    return pino({
+      ...base,
+      transport: {
+        target: 'pino-pretty',
+        options: { destination: 2 }
+      }
+    });
+  }
+
+  return pino(base, pino.destination(2));
+}
+
+export default createLogger();

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -7,6 +7,7 @@ import { init as shutterInit } from '@shutter-network/shutter-crypto';
 import { clients, offchainMainnet } from '@snapshot-labs/sx';
 import { z } from 'zod';
 import { type CdpSigner, getWalletForUser } from './cdp.js';
+import logger from './logger.js';
 import {
   getProposalSnapshotBlock,
   gql,
@@ -93,15 +94,15 @@ async function handle(
   const sid = String(ex?.sessionId ?? '-').slice(0, 8);
   const u = ex?.authInfo?.extra?.user;
   const user = u !== undefined && u.length >= 10 ? `${u.slice(0, 6)}...${u.slice(-4)}` : u ?? 'anonymous';
-  const prefix = `[req=${reqId}] [session=${sid}] [tool=${tool}] [user=${user}]`;
-  console.log(`${prefix} start`);
+  const log = logger.child({ reqId, sessionId: sid, tool, user });
+  log.info('tool start');
   try {
     const result = await fn();
-    console.log(`${prefix} ok`);
+    log.info('tool ok');
     return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    console.error(`${prefix} error: ${message}`, e);
+    log.error({ err: e }, 'tool error');
     return {
       content: [{ type: 'text' as const, text: `Error [req=${reqId}]: ${message}` }],
       isError: true

--- a/bun.lock
+++ b/bun.lock
@@ -225,11 +225,14 @@
       "dependencies": {
         "@coinbase/cdp-sdk": "^1.45.0",
         "@ethersproject/wallet": "^5.8.0",
+        "@logtail/pino": "^0.5.5",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@shutter-network/shutter-crypto": "1.0.1",
         "@snapshot-labs/sx": "^0.1.10",
         "express": "^5.2.1",
         "jose": "^6.2.2",
+        "pino": "^9.9.0",
+        "pino-pretty": "^13.1.1",
         "zod": "4.4.3",
       },
       "devDependencies": {


### PR DESCRIPTION
## Summary

Adds structured logging and last-resort error handling to the Snapshot MCP server, so failures (notably CDP signing errors behind `snapshot-propose`) are captured with queryable detail in Better Stack instead of opaque text.

- **pino logger** ([logger.ts](apps/mcp/src/logger.ts)) mirroring `apps/api` / `apps/mana`: ships to Better Stack via `@logtail/pino` when `LOGTAIL_HOST` + `LOGTAIL_TOKEN` are set, else `pino-pretty` (dev) / JSON (prod).
- An **`err` serializer** flattens an error's own enumerable fields, so a Coinbase CDP `APIError` surfaces `errorType`, `statusCode`, `correlationId` as indexed fields.
- Logs are written to **stderr**, keeping stdout clean for the stdio JSON-RPC transport (the one deviation from api/mana, which default to stdout).
- `handle()` now uses a per-request child logger (`{ reqId, sessionId, tool, user }`), replacing the `console.*` prefix strings.
- **Catch-all error handling** in [index.ts](apps/mcp/src/index.ts): `uncaughtException` (log + exit) / `unhandledRejection` (log), wrapped stdio startup, and an Express error middleware that catches rejections forwarded from the request handlers and the auth/OAuth router. Plus a startup log line.

## Context

While debugging why `snapshot-propose` fails with "Wallet authentication error" (while voting works), the underlying CDP error was invisible in the logs. This makes the CDP `errorType`/`correlationId` queryable so the root cause can be pinned from Better Stack.

## Deployment note

For logs to reach Better Stack, the deployed MCP needs `LOGTAIL_HOST` and `LOGTAIL_TOKEN` set (same pair already used by `apps/api` / `apps/mana`).

## Test plan

- [x] `tsc --noEmit` and `eslint src` pass
- [x] Boots over HTTP: `MCP server listening` logged to stderr, stdout empty, unauthenticated `POST /` returns 401
- [x] Injected CDP-shaped error serializes with `err.errorType` / `err.statusCode` / `err.correlationId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)