### PR TITLE
feat(api): add indexer sync-lag health endpoint

### DIFF
--- a/apps/api/src/api.ts
+++ b/apps/api/src/api.ts
@@ -7,7 +7,13 @@ import { expressMiddleware } from '@as-integrations/express4';
 import Checkpoint, { createGetLoader } from '@snapshot-labs/checkpoint';
 import cors from 'cors';
 import express from 'express';
+import {
+  createKnexLastIndexedBlockReader,
+  createStarknetHeadFetchers,
+  getHealthReport
+} from './health';
 import logger from './logger';
+import { starknetConfigs } from './starknet';
 
 const PORT = process.env.PORT ? parseInt(process.env.PORT) : 3000;
 
@@ -31,6 +37,28 @@ export async function startApiServer(checkpoint: Checkpoint) {
     res.json({
       index: process.env.DATABASE_URL_INDEX ?? 'default'
     });
+  });
+
+  // Indexer health / sync-lag endpoint.
+  //
+  // Reports, per indexer, the last indexed block vs the current chain head and
+  // the derived lag. Returns HTTP 503 when any monitored indexer is unhealthy
+  // (lag over threshold or chain head unreachable) so uptime monitors such as
+  // Betterstack can alert even while the API process itself is up.
+  const headFetchers = createStarknetHeadFetchers(starknetConfigs);
+  app.get('/health', async (req, res) => {
+    try {
+      const { knex } = checkpoint.getBaseContext();
+      const report = await getHealthReport(
+        createKnexLastIndexedBlockReader(knex),
+        headFetchers
+      );
+
+      res.status(report.healthy ? 200 : 503).json(report);
+    } catch (err) {
+      logger.error({ err }, 'failed to build health report');
+      res.status(503).json({ healthy: false, error: 'health check failed' });
+    }
   });
 
   app.use(

--- a/apps/api/src/health.test.ts
+++ b/apps/api/src/health.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { getHealthReport } from './health';
+
+describe('getHealthReport', () => {
+  const reader = (rows: { indexer: string; value: string }[]) => async () =>
+    rows;
+
+  it('reports healthy when lag is within threshold', async () => {
+    const report = await getHealthReport(
+      reader([{ indexer: 'sn', value: '1000' }]),
+      { sn: async () => 1050 }
+    );
+
+    expect(report.healthy).toBe(true);
+    expect(report.indexers[0]).toMatchObject({
+      indexer: 'sn',
+      indexedBlock: 1000,
+      chainHead: 1050,
+      lag: 50,
+      healthy: true
+    });
+  });
+
+  it('reports unhealthy when lag exceeds threshold', async () => {
+    const report = await getHealthReport(
+      reader([{ indexer: 'sn', value: '1000' }]),
+      { sn: async () => 20000 }
+    );
+
+    expect(report.healthy).toBe(false);
+    expect(report.indexers[0].lag).toBe(19000);
+    expect(report.indexers[0].healthy).toBe(false);
+  });
+
+  it('reports unhealthy when chain head cannot be fetched', async () => {
+    const report = await getHealthReport(
+      reader([{ indexer: 'sn', value: '1000' }]),
+      {
+        sn: async () => {
+          throw new Error('rpc down');
+        }
+      }
+    );
+
+    expect(report.healthy).toBe(false);
+    expect(report.indexers[0]).toMatchObject({
+      chainHead: null,
+      lag: null,
+      healthy: false,
+      error: 'failed to fetch chain head'
+    });
+  });
+
+  it('handles a monitored indexer with no indexed block yet', async () => {
+    const report = await getHealthReport(reader([]), { sn: async () => 30 });
+
+    expect(report.indexers[0]).toMatchObject({
+      indexer: 'sn',
+      indexedBlock: null,
+      chainHead: 30,
+      lag: 30
+    });
+  });
+});

--- a/apps/api/src/health.test.ts
+++ b/apps/api/src/health.test.ts
@@ -28,8 +28,7 @@ describe('getHealthReport', () => {
     );
 
     expect(report.healthy).toBe(false);
-    expect(report.indexers[0].lag).toBe(19000);
-    expect(report.indexers[0].healthy).toBe(false);
+    expect(report.indexers[0]).toMatchObject({ lag: 19000, healthy: false });
   });
 
   it('reports unhealthy when chain head cannot be fetched', async () => {

--- a/apps/api/src/health.ts
+++ b/apps/api/src/health.ts
@@ -1,0 +1,175 @@
+import { RpcProvider } from 'starknet';
+import logger from './logger';
+
+/**
+ * Maximum acceptable lag (chain head - last indexed block) before an indexer is
+ * considered unhealthy. Can be overridden via the HEALTH_MAX_LAG env variable.
+ */
+const DEFAULT_MAX_LAG = 100;
+
+const MAX_LAG = process.env.HEALTH_MAX_LAG
+  ? parseInt(process.env.HEALTH_MAX_LAG)
+  : DEFAULT_MAX_LAG;
+
+/**
+ * How long a chain-head lookup is allowed to take before it is treated as
+ * failed. Keeps the health endpoint responsive even when an RPC is down.
+ */
+const HEAD_FETCH_TIMEOUT = 10000;
+
+const Table = {
+  Metadata: '_metadatas'
+};
+
+const Fields = {
+  Metadata: {
+    Id: 'id',
+    Indexer: 'indexer',
+    Value: 'value'
+  }
+};
+
+const LAST_INDEXED_BLOCK = 'last_indexed_block';
+
+/**
+ * A function returning the current chain head (latest block number) for a
+ * given indexer's network.
+ */
+type HeadFetcher = () => Promise<number>;
+
+export type IndexerHealth = {
+  indexer: string;
+  indexedBlock: number | null;
+  chainHead: number | null;
+  lag: number | null;
+  healthy: boolean;
+  error?: string;
+};
+
+export type HealthReport = {
+  healthy: boolean;
+  maxLag: number;
+  indexers: IndexerHealth[];
+};
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error('timeout')), ms)
+    )
+  ]);
+}
+
+/**
+ * Builds the map of head fetchers for the Starknet indexers, which are the ones
+ * tracked by the indexer-lag alerting. EVM networks can be added here later.
+ */
+export function createStarknetHeadFetchers(
+  configs: { indexerName: string; network_node_url: string }[]
+): Record<string, HeadFetcher> {
+  const fetchers: Record<string, HeadFetcher> = {};
+
+  for (const config of configs) {
+    const provider = new RpcProvider({ nodeUrl: config.network_node_url });
+    fetchers[config.indexerName] = () => provider.getBlockNumber();
+  }
+
+  return fetchers;
+}
+
+/**
+ * Reads the last indexed block for every indexer from the checkpoint metadata
+ * table, compares it against the current chain head, and reports the lag.
+ *
+ * This is the data Betterstack (or any uptime monitor) can poll: a frozen
+ * indexer head shows up as growing lag even while the API process is up.
+ */
+type MetadataRow = { indexer: string; value: string };
+
+/**
+ * Reads the last-indexed-block rows from the checkpoint metadata table.
+ * Provided by the caller so this module stays decoupled from the knex type.
+ */
+export type LastIndexedBlockReader = () => Promise<MetadataRow[]>;
+
+export function createKnexLastIndexedBlockReader(knex: {
+  (table: string): {
+    select: (...columns: string[]) => {
+      where: (filter: Record<string, unknown>) => Promise<MetadataRow[]>;
+    };
+  };
+}): LastIndexedBlockReader {
+  return () =>
+    knex(Table.Metadata)
+      .select(Fields.Metadata.Indexer, Fields.Metadata.Value)
+      .where({ [Fields.Metadata.Id]: LAST_INDEXED_BLOCK });
+}
+
+export async function getHealthReport(
+  readLastIndexedBlocks: LastIndexedBlockReader,
+  headFetchers: Record<string, HeadFetcher>
+): Promise<HealthReport> {
+  const rows = await readLastIndexedBlocks();
+
+  const indexedByName = new Map<string, number>();
+  for (const row of rows) {
+    indexedByName.set(row.indexer, parseInt(row.value));
+  }
+
+  // Report on every indexer we have a head fetcher for (i.e. is monitored),
+  // even if it has not written a last_indexed_block row yet.
+  const indexerNames = new Set([
+    ...Object.keys(headFetchers),
+    ...indexedByName.keys()
+  ]);
+
+  const indexers: IndexerHealth[] = await Promise.all(
+    [...indexerNames].map(async indexer => {
+      const indexedBlock = indexedByName.get(indexer) ?? null;
+      const fetcher = headFetchers[indexer];
+
+      if (!fetcher) {
+        // Not monitored for lag (no head fetcher); report block only.
+        return {
+          indexer,
+          indexedBlock,
+          chainHead: null,
+          lag: null,
+          healthy: true
+        };
+      }
+
+      try {
+        const chainHead = await withTimeout(fetcher(), HEAD_FETCH_TIMEOUT);
+        const lag =
+          indexedBlock === null ? chainHead : chainHead - indexedBlock;
+
+        return {
+          indexer,
+          indexedBlock,
+          chainHead,
+          lag,
+          healthy: lag <= MAX_LAG
+        };
+      } catch (err) {
+        logger.warn({ err, indexer }, 'failed to fetch chain head for health');
+
+        return {
+          indexer,
+          indexedBlock,
+          chainHead: null,
+          lag: null,
+          healthy: false,
+          error: 'failed to fetch chain head'
+        };
+      }
+    })
+  );
+
+  return {
+    healthy: indexers.every(indexer => indexer.healthy),
+    maxLag: MAX_LAG,
+    indexers
+  };
+}

--- a/apps/api/src/starknet/index.ts
+++ b/apps/api/src/starknet/index.ts
@@ -6,6 +6,8 @@ import { registerIndexer } from '../register';
 const snConfig = createConfig('sn');
 const snSepConfig = createConfig('sn-sep');
 
+export const starknetConfigs = [snConfig, snSepConfig];
+
 const snIndexer = new starknet.StarknetIndexer(createWriters(snConfig));
 const snSepIndexer = new starknet.StarknetIndexer(createWriters(snSepConfig));
 


### PR DESCRIPTION
## Summary

Adds a `/health` endpoint to `apps/api` that exposes indexer sync lag so a stalled indexer can be detected and alerted on. Today the API process can be up while the indexer head is frozen, so plain uptime pinging is not enough (the indexer recently fell ~17k blocks behind before anyone noticed). This gives Betterstack something concrete to alert on.

Closes #2163.

## What it does

`GET /health` returns, per indexer:

```json
{
  "healthy": false,
  "maxLag": 100,
  "indexers": [
    { "indexer": "sn", "indexedBlock": 1700000, "chainHead": 1717000, "lag": 17000, "healthy": false },
    { "indexer": "sn-sep", "indexedBlock": 500000, "chainHead": 500030, "lag": 30, "healthy": true }
  ]
}
```

- `indexedBlock` is read from the checkpoint metadata table (`_metadatas`, `id = last_indexed_block`).
- `chainHead` is the current chain head from the network RPC.
- `lag = chainHead - indexedBlock`.
- Returns **HTTP 200** when all monitored indexers are within the lag threshold, **HTTP 503** otherwise (lag over threshold, or chain head unreachable).
- Threshold configurable via `HEALTH_MAX_LAG` (default `100`).
- Chain-head lookups are bounded by a 10s timeout so the endpoint stays responsive when an RPC is down.

Currently monitors the Starknet indexers (`sn`, `sn-sep`), which are the subject of the linked issues. EVM networks can be added to `createStarknetHeadFetchers`'s caller with no other changes (the report logic is network-agnostic).

## Betterstack monitor config

Two monitors against the deployed indexer API (e.g. `https://api-indexer-2.snapshot.box`):

1. **Sync lag / stall** - HTTP monitor on `GET /health`, expected status `200`. A stalled or lagging indexer returns `503`, triggering the alert. (Optionally also keyword-check the body for `"healthy":true`.)
2. **Process down** - same URL covers liveness; if the process is down the request fails/times out.

Tune the lag threshold per deployment via `HEALTH_MAX_LAG`.

## Testing

- `apps/api` `tsc --noEmit`: clean.
- `eslint` (incl. `no-console: error`) + prettier: clean.
- New `src/health.test.ts` (4 cases: healthy, over-threshold, RPC failure, no-indexed-block-yet): passing.

## Note on #2162 (stalls / restart deadlock)

Root-cause findings for the stall + restart deadlock are posted as a comment on #2162. The substantive fix (transactional checkpointing / single-writer) lives in `@snapshot-labs/checkpoint`, not `apps/api`, so it is intentionally not bundled into this PR to avoid a speculative app-side change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)