### PR TITLE
fix(sequencer): normalize proposal author address comparison casing

### DIFF
--- a/apps/sequencer/src/writer/delete-proposal.ts
+++ b/apps/sequencer/src/writer/delete-proposal.ts
@@ -14,7 +14,7 @@ export async function verify(body): Promise<any> {
   if (
     !admins.includes(body.address.toLowerCase()) &&
     !mods.includes(body.address.toLowerCase()) &&
-    proposal.author !== body.address
+    proposal.author.toLowerCase() !== body.address.toLowerCase()
   )
     return Promise.reject('not authorized to archive proposal');
 }

--- a/apps/sequencer/src/writer/update-proposal.ts
+++ b/apps/sequencer/src/writer/update-proposal.ts
@@ -50,7 +50,8 @@ export async function verify(body): Promise<any> {
     );
   }
 
-  if (proposal.author !== body.address) return Promise.reject('Not the author');
+  if (proposal.author.toLowerCase() !== body.address.toLowerCase())
+    return Promise.reject('Not the author');
 
   const spacePrivacy = space.voting?.privacy ?? 'any';
   const proposalPrivacy = msg.payload.privacy;


### PR DESCRIPTION
## Problem

Same bug class as #2161. The proposal author is stored and compared using the client-supplied casing, with no normalization. When a legitimate author edits or deletes their own proposal but the address casing differs (checksummed vs lowercase mismatch), the author authz check fails and they are wrongly denied access to their own proposal.

The admin/moderator branches already lowercase both sides (see `delete-proposal.ts` lines ~15-16), and #2161 fixed the same pattern for the space controller comparison. The proposal-author comparison was left out.

## Fix

Normalize casing on both sides of the proposal-author authz checks, matching the existing admin/mod branches and #2161:

- `apps/sequencer/src/writer/delete-proposal.ts` - `proposal.author !== body.address` -> `proposal.author.toLowerCase() !== body.address.toLowerCase()`
- `apps/sequencer/src/writer/update-proposal.ts` - same change to the `Not the author` check

## Verification

- `yarn lint` (eslint) clean
- `tsc --noEmit` typecheck clean

Refs #2161

🤖 Generated with [Claude Code](https://claude.com/claude-code)