### PR TITLE
fix(mcp): allow proposal typed-data signing in CDP account policy

### DIFF
--- a/apps/mcp/src/cdp.ts
+++ b/apps/mcp/src/cdp.ts
@@ -5,7 +5,7 @@ import {
   type EvmServerAccount
 } from '@coinbase/cdp-sdk';
 
-const POLICY_DESCRIPTION = 'snapshot mcp v8';
+const POLICY_DESCRIPTION = 'snapshot mcp v9';
 
 // Snapshot off-chain EIP-712 envelopes (vote, propose, follow, ...) are all
 // signed via signEvmTypedData under a domain of { name: "snapshot" } with no
@@ -15,23 +15,89 @@ const POLICY_DESCRIPTION = 'snapshot mcp v8';
 // happened to let through (e.g. Vote) succeed while others (Proposal) are
 // rejected with a 401 "Wallet authentication error".
 //
-// An evmTypedDataField criterion is scoped to a single primaryType (it carries
-// the EIP-712 `types`/`primaryType` and matches conditions against the signed
-// message). We add one accept criterion per snapshot envelope the MCP signs,
-// each keyed on its primaryType with a permissive match on the always-present
-// `from` field. This explicitly allows snapshot's typed data without being a
-// blanket allow-everything: raw message signing (signEvmMessage) stays
-// rejected, and value-bearing transaction operations stay rejected.
+// An evmTypedDataField criterion (SignEvmTypedDataFieldCriterionSchema in the
+// CDP SDK) carries the full EIP-712 type definition: `types.primaryType` (the
+// root type name) and `types.types` (the EIP-712 map of type name -> field
+// list). The engine uses that declaration to interpret the incoming signed
+// payload and resolve the `conditions[].path` fields against it. Each criterion
+// is scoped to one primaryType and matches when the request's primaryType
+// equals it and every condition passes.
+//
+// CRITICAL: the declared struct must mirror the struct that is actually signed.
+// The real Proposal envelope (snapshot.js proposalTypes / sx.js offchain
+// proposeTypes) has 15 fields, not 1. A stub declaration that lists only `from`
+// risks not matching the real payload, depending on whether the engine compares
+// the type definition structurally before resolving conditions. We therefore
+// declare the COMPLETE field set for each primaryType, copied verbatim from
+// packages/sx.js/src/clients/offchain/ethereum-sig/types.ts, so the criterion
+// matches exactly what is signed under every interpretation. Conditions stay a
+// permissive match on the always-present `from` field, so this explicitly
+// allows snapshot's typed data without being a blanket allow-everything: raw
+// message signing (signEvmMessage) stays rejected and value-bearing transaction
+// operations stay rejected.
+//
+// Vote's `choice` field type varies by voting system (uint32 / uint32[] /
+// string for encrypted, ranked, weighted). EIP-712 field-name resolution is
+// what the conditions need, and `from` is identical across all variants, so we
+// declare the common Vote shape with the string `choice` superset; the accept
+// is gated on `from` only, never on `choice`.
+const SNAPSHOT_PRIMARY_TYPES: Record<
+  'Vote' | 'Proposal' | 'Follow' | 'Unfollow',
+  Array<{ name: string; type: string }>
+> = {
+  Vote: [
+    { name: 'from', type: 'string' },
+    { name: 'space', type: 'string' },
+    { name: 'timestamp', type: 'uint64' },
+    { name: 'proposal', type: 'string' },
+    { name: 'choice', type: 'string' },
+    { name: 'reason', type: 'string' },
+    { name: 'app', type: 'string' },
+    { name: 'metadata', type: 'string' }
+  ],
+  Proposal: [
+    { name: 'from', type: 'string' },
+    { name: 'space', type: 'string' },
+    { name: 'timestamp', type: 'uint64' },
+    { name: 'type', type: 'string' },
+    { name: 'title', type: 'string' },
+    { name: 'body', type: 'string' },
+    { name: 'discussion', type: 'string' },
+    { name: 'choices', type: 'string[]' },
+    { name: 'labels', type: 'string[]' },
+    { name: 'start', type: 'uint64' },
+    { name: 'end', type: 'uint64' },
+    { name: 'snapshot', type: 'uint64' },
+    { name: 'plugins', type: 'string' },
+    { name: 'privacy', type: 'string' },
+    { name: 'app', type: 'string' }
+  ],
+  Follow: [
+    { name: 'from', type: 'string' },
+    { name: 'network', type: 'string' },
+    { name: 'space', type: 'string' },
+    { name: 'timestamp', type: 'uint64' }
+  ],
+  Unfollow: [
+    { name: 'from', type: 'string' },
+    { name: 'network', type: 'string' },
+    { name: 'space', type: 'string' },
+    { name: 'timestamp', type: 'uint64' }
+  ]
+};
+
 const SNAPSHOT_TYPED_DATA_ACCEPT = {
   action: 'accept',
   operation: 'signEvmTypedData',
   criteria: (
-    ['Vote', 'Proposal', 'Follow', 'Unfollow'] as const
+    Object.keys(SNAPSHOT_PRIMARY_TYPES) as Array<
+      keyof typeof SNAPSHOT_PRIMARY_TYPES
+    >
   ).map(primaryType => ({
     type: 'evmTypedDataField',
     types: {
       primaryType,
-      types: { [primaryType]: [{ name: 'from', type: 'string' }] }
+      types: { [primaryType]: SNAPSHOT_PRIMARY_TYPES[primaryType] }
     },
     conditions: [{ path: 'from', match: '.*' }]
   }))

--- a/apps/mcp/src/cdp.ts
+++ b/apps/mcp/src/cdp.ts
@@ -5,9 +5,40 @@ import {
   type EvmServerAccount
 } from '@coinbase/cdp-sdk';
 
-const POLICY_DESCRIPTION = 'snapshot mcp v7';
+const POLICY_DESCRIPTION = 'snapshot mcp v8';
+
+// Snapshot off-chain EIP-712 envelopes (vote, propose, follow, ...) are all
+// signed via signEvmTypedData under a domain of { name: "snapshot" } with no
+// verifyingContract. The CDP policy engine is fail-secure: if no rule matches a
+// signing request, it is rejected. We therefore need an explicit accept rule
+// for signEvmTypedData; without one, only the typed-data shapes the engine
+// happened to let through (e.g. Vote) succeed while others (Proposal) are
+// rejected with a 401 "Wallet authentication error".
+//
+// An evmTypedDataField criterion is scoped to a single primaryType (it carries
+// the EIP-712 `types`/`primaryType` and matches conditions against the signed
+// message). We add one accept criterion per snapshot envelope the MCP signs,
+// each keyed on its primaryType with a permissive match on the always-present
+// `from` field. This explicitly allows snapshot's typed data without being a
+// blanket allow-everything: raw message signing (signEvmMessage) stays
+// rejected, and value-bearing transaction operations stay rejected.
+const SNAPSHOT_TYPED_DATA_ACCEPT = {
+  action: 'accept',
+  operation: 'signEvmTypedData',
+  criteria: (
+    ['Vote', 'Proposal', 'Follow', 'Unfollow'] as const
+  ).map(primaryType => ({
+    type: 'evmTypedDataField',
+    types: {
+      primaryType,
+      types: { [primaryType]: [{ name: 'from', type: 'string' }] }
+    },
+    conditions: [{ path: 'from', match: '.*' }]
+  }))
+} as const;
 
 const POLICY_RULES = [
+  SNAPSHOT_TYPED_DATA_ACCEPT,
   ...['signEvmTransaction', 'sendEvmTransaction'].map(operation => ({
     action: 'reject',
     operation,


### PR DESCRIPTION
## Root cause

`snapshot-propose` fails with a Coinbase CDP **401 "Wallet authentication error"** thrown from `signTypedData` (`@coinbase/cdp-sdk` `toEvmServerAccount.js:95`), while `snapshot-whoami` (read-only) and `snapshot-vote` succeed. Observed in BetterStack logs at **13:43:57** and **13:44:04 UTC**.

The CDP policy engine is **fail-secure**: a signing request that matches no rule is rejected (per CDP docs: "Rules are processed in order. The first matching rule's action is applied. If no rule matches, the request is rejected").

The account policy in `apps/mcp/src/cdp.ts` (`snapshot mcp v7`) contained **only reject rules** for `signEvmTransaction`, `sendEvmTransaction`, and `signEvmMessage`, and **no accept rule for `signEvmTypedData`**. Snapshot's off-chain envelopes (vote, propose, follow) are all signed via `signEvmTypedData` under domain `{ name: "snapshot" }` (no `verifyingContract`). With no accept rule covering them, the engine denied the `Proposal` typed-data envelope at sign time.

## Fix

Add a single, **scoped** `accept` rule for `signEvmTypedData`, with one `evmTypedDataField` criterion per snapshot off-chain `primaryType` the MCP signs (`Vote`, `Proposal`, `Follow`, `Unfollow`), each keyed on its `primaryType` with a permissive match on the always-present `from` field.

This is **not** a blanket allow-everything:
- Raw message signing (`signEvmMessage`, match `.*`) stays **rejected**.
- Value-bearing transaction ops (`signEvmTransaction`, `sendEvmTransaction`) stay **rejected**.

## Strengthening: full typed-data struct declarations (v8 -> v9)

A deep-dive flagged a load-bearing risk in the first cut of this fix. The `evmTypedDataField` criterion (`SignEvmTypedDataFieldCriterionSchema` in `@coinbase/cdp-sdk` v1.48.3) is not keyed on `primaryType` alone: it carries the **full EIP-712 type definition** in `types` (`types.primaryType` = root type name, `types.types` = the EIP-712 map of type name -> field list). The engine uses that declaration to interpret the incoming signed payload and resolve the `conditions[].path` fields against it.

The v8 rule declared each `primaryType` with **only the `from` field**. The real signed `Proposal` struct (snapshot.js `proposalTypes` / sx.js offchain `proposeTypes`) has **15 fields**. If CDP compares the declared type definition against the signed payload's type definition (structurally or by EIP-712 type hash) before resolving conditions, the 1-field stub would **not match** the real envelope, and `propose` would still be rejected, intermittently or consistently, depending on the engine's matching mode.

v9 declares the **complete struct** for each `primaryType`, copied verbatim from `packages/sx.js/src/clients/offchain/ethereum-sig/types.ts`, so the criterion matches exactly what is signed under either interpretation (structural/hash match or path resolution). This is strictly safer than the stub and changes nothing about the accept surface: conditions still gate only on the always-present `from` field, and the value-bearing rejects are untouched. `Vote`'s `choice` type varies by voting system (uint32 / uint32[] / string), so the common Vote shape uses the string superset and the accept never conditions on `choice`.

Policy description bumped **v8 -> v9** so accounts re-point to the corrected policy on next use.

Rule shapes validated against `@coinbase/cdp-sdk` `SignEvmTypedDataRuleSchema` / `SignEvmTypedDataFieldCriterionSchema` (v1.48.3). typecheck + lint clean (pre-existing `pino` module-resolution error on `src/logger.ts` is unrelated and present on master).

## Deploy note

The CDP account policy is created/updated at runtime by the snapshot-mcp service. This needs the **snapshot-mcp DigitalOcean app redeploy** to create the new `v9` policy and re-point existing signer accounts.

### Intermittency finding + recommended live test

The 401 was reported as intermittent. Two contributors: (1) the v8 stub-vs-real-struct mismatch above, and (2) CDP-side **eventual consistency** between `updateAccount` re-pointing an account to a new policy and the policy engine enforcing it, so the same account can flip between old and new policy behavior for a short window after redeploy. After redeploy, run a **live `snapshot-propose` test** to confirm, including a proposal that exercises the full struct: a **shutter-privacy** proposal (non-empty `privacy`) and one **with `labels`**, since those are exactly the `Proposal` fields absent from the old stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)