### PR TITLE
fix(sequencer): normalize body.address at ingestion

### DIFF
--- a/apps/sequencer/src/ingestor.ts
+++ b/apps/sequencer/src/ingestor.ts
@@ -134,6 +134,11 @@ export default async function ingestor(req) {
     }
 
     const id = snapshot.utils.getHash(body.data, body.address);
+
+    // Author stored by the writers, lowercased for EVM so it's canonical.
+    const signer =
+      networkDataType === 'evm' ? body.address.toLowerCase() : body.address;
+
     let payload = {};
 
     if (await doesMessageExist(id)) {
@@ -214,7 +219,7 @@ export default async function ingestor(req) {
     }
 
     let legacyBody: any = {
-      address: message.from,
+      address: signer,
       msg: JSON.stringify({
         version: domain.version,
         timestamp: message.timestamp,
@@ -231,7 +236,7 @@ export default async function ingestor(req) {
         type
       )
     ) {
-      legacyBody = message;
+      legacyBody = { ...message, from: signer };
     }
 
     let context;
@@ -272,7 +277,7 @@ export default async function ingestor(req) {
       await storeMsg(
         id,
         ipfs,
-        body.address,
+        signer,
         msg.version,
         msg.timestamp,
         msg.space || '',

--- a/apps/sequencer/test/integration/ingestor.test.ts
+++ b/apps/sequencer/test/integration/ingestor.test.ts
@@ -332,6 +332,27 @@ describe('ingestor', () => {
       expect(dbResult.length).toBe(1);
     });
 
+    it('stores the author normalized to lowercase for a mixed-case EVM submission', async () => {
+      // The ingestor must normalize the EVM signer address once, so that
+      // writers store a canonical lowercase address regardless of how the
+      // client cased it (signature verification is case-insensitive).
+      const mixedCaseAddress = '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3';
+      expect(mixedCaseAddress).not.toBe(mixedCaseAddress.toLowerCase());
+
+      const request = cloneDeep(proposalRequest);
+      request.body.address = mixedCaseAddress;
+      request.body.data.message.from = mixedCaseAddress;
+
+      const typeResult = await ingestor(request);
+      const dbResult = await db.queryAsync(
+        `SELECT author from proposals WHERE id = ? LIMIT 1`,
+        typeResult.id
+      );
+
+      expect(dbResult.length).toBe(1);
+      expect(dbResult[0].author).toBe(mixedCaseAddress.toLowerCase());
+    });
+
     ['vote', 'follow', 'unfollow', 'subscribe', 'unsubscribe'].forEach(type => {
       it.todo(`updates/saves the ${type} in the DB`);
     });


### PR DESCRIPTION
Lowercase the EVM signer address once at ingestion, right after the id hash and signature verification (both case-insensitive and already computed). `body.address` and `message.from` feed every writer and `storeMsg`, so they all store a canonical lowercase author. Starknet addresses are left untouched. No read-side changes; legacy mixed-case rows are unaffected.