### PR TITLE
fix(networks): restore governorOnly guard for BNB (SX core not deployed)

### DIFF
--- a/apps/ui/src/networks/index.ts
+++ b/apps/ui/src/networks/index.ts
@@ -63,6 +63,9 @@ export const governorNetworks: NetworkID[] = [
   'bnbt',
   'sep'
 ];
+// SX core contracts (proxyFactory/masterSpace) are not deployed on these
+// networks, so they support Governor spaces only (no SX space creation/explore).
+export const governorOnlyNetworks: NetworkID[] = ['bnb', 'bnbt'];
 // This network is used for aliases/follows/profiles/explore page.
 export const metadataNetwork: NetworkID =
   import.meta.env.VITE_METADATA_NETWORK || 's';
@@ -101,7 +104,8 @@ export const enabledReadWriteNetworks: NetworkID[] = enabledNetworks.filter(
   id => !getNetwork(id).readOnly
 );
 
-export const spaceCreationNetworks: NetworkID[] = enabledReadWriteNetworks;
+export const spaceCreationNetworks: NetworkID[] =
+  enabledReadWriteNetworks.filter(id => !governorOnlyNetworks.includes(id));
 
 const onchainApiNetwork =
   enabledNetworks.find(network => !offchainNetworks.includes(network)) || 'eth';
@@ -120,7 +124,9 @@ export const explorePageProtocols: Record<ExplorePageProtocol, ProtocolConfig> =
       label: 'Snapshot X',
       apiNetwork: onchainApiNetwork,
       networks: enabledNetworks.filter(
-        network => !offchainNetworks.includes(network)
+        network =>
+          !offchainNetworks.includes(network) &&
+          !governorOnlyNetworks.includes(network)
       ),
       limit: 18
     },


### PR DESCRIPTION
Reverts #2166.

## What chaituvr caught
\`governorOnlyNetworks = ['bnb', 'bnbt']\` was not dead code - it exists because the SX core contracts are not deployed on BNB. #2166 cleared the list, which was wrong.

## Verification (on-chain)
\`eth_getCode\` for the shared SX addresses, two independent RPC providers each:
- proxyFactory \`0x4B4F7f64Be813Ccc66AEFC3bFCe2baA01188631c\` -> BNB mainnet (56): \`0x\`, BNB testnet (97): \`0x\`, Ethereum mainnet (1): real bytecode
- masterSpace \`0xC3031A7d3326E47D49BfF9D374d74f364B29CE4D\` -> BNB mainnet (56): \`0x\`

So \`createStandardConfig\` in \`packages/sx.js/src/evmNetworks.ts\` hands BNB the same hardcoded addresses as every other chain, but nothing is deployed there. Allowing SX space creation / explore on BNB would point users at nonexistent contracts.

## Change
Restores the guard exactly (with an explanatory comment): \`governorOnlyNetworks\`, the \`spaceCreationNetworks\` filter, and the Snapshot X explore filter. BNB stays in \`governorNetworks\`, so Governor spaces still work there.

## Note
The space-creation BNB option Less mentioned to a community member still works via the Governor flow; only the SX space-creation path is (correctly) gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)