### PR TITLE
fix(api): set OZ governor proposal quorum at voting-start (snapshot) block

### DIFF
--- a/apps/api/src/evm/protocols/openzeppelin/writers.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/writers.ts
@@ -403,9 +403,8 @@ export function createWriters(
     proposal.max_end_block_number = proposal.min_end_block_number;
     proposal.snapshot = event.args.voteStart;
     proposal.treasuries = spaceMetadataItem?.treasuries || [];
-    // Provisional: snapshot block is still in the future, finalized on first VoteCast.
+    // Provisional: snapshot block is still in the future, re-read on each VoteCast.
     proposal.quorum = executionStrategy.quorum;
-    proposal.quorum_finalized = false;
     proposal.strategies = space.strategies;
     proposal.strategies_params = space.strategies_params;
     proposal.strategies_indices = space.strategies_indices;
@@ -590,17 +589,17 @@ export function createWriters(
     if (!space || !proposal || !user) return;
 
     // Re-read quorum at the snapshot block, now in the past (see handleProposalCreated).
-    if (!proposal.quorum_finalized) {
-      try {
-        const quorum = await getQuorumAtSnapshot({
-          address: spaceAddress,
-          timepoint: BigInt(proposal.snapshot)
-        });
-        proposal.quorum = quorum.toString();
-      } catch (err) {
-        logger.error({ err }, 'Failed to finalize quorum at snapshot block');
-      }
-      proposal.quorum_finalized = true;
+    // quorum(voteStart) is immutable once voteStart is in the past, so re-reading on
+    // every vote always yields the same value and a transient RPC failure self-heals
+    // on the next vote; the prior value is kept on failure.
+    try {
+      const quorum = await getQuorumAtSnapshot({
+        address: spaceAddress,
+        timepoint: BigInt(proposal.snapshot)
+      });
+      proposal.quorum = quorum.toString();
+    } catch (err) {
+      logger.error({ err }, 'Failed to read quorum at snapshot block');
     }
 
     space.vote_count += 1;

--- a/apps/api/src/evm/protocols/openzeppelin/writers.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/writers.ts
@@ -403,8 +403,10 @@ export function createWriters(
     proposal.max_end_block_number = proposal.min_end_block_number;
     proposal.snapshot = event.args.voteStart;
     proposal.treasuries = spaceMetadataItem?.treasuries || [];
-    // Provisional: snapshot block is still in the future, re-read on each VoteCast.
+    // Provisional: snapshot block is still in the future. Finalized on the first
+    // successful VoteCast read once the snapshot block is in the past.
     proposal.quorum = executionStrategy.quorum;
+    proposal.quorum_finalized = false;
     proposal.strategies = space.strategies;
     proposal.strategies_params = space.strategies_params;
     proposal.strategies_indices = space.strategies_indices;
@@ -588,18 +590,21 @@ export function createWriters(
     ]);
     if (!space || !proposal || !user) return;
 
-    // Re-read quorum at the snapshot block, now in the past (see handleProposalCreated).
-    // quorum(voteStart) is immutable once voteStart is in the past, so re-reading on
-    // every vote always yields the same value and a transient RPC failure self-heals
-    // on the next vote; the prior value is kept on failure.
-    try {
-      const quorum = await getQuorumAtSnapshot({
-        address: spaceAddress,
-        timepoint: BigInt(proposal.snapshot)
-      });
-      proposal.quorum = quorum.toString();
-    } catch (err) {
-      logger.error({ err }, 'Failed to read quorum at snapshot block');
+    // Read quorum once at the snapshot block, now in the past (see handleProposalCreated).
+    // quorum(voteStart) is immutable once voteStart is in the past, so we read it only on
+    // the first vote and mark it finalized. The flag is set true ONLY after a successful
+    // read, so a transient RPC failure leaves it false and the next vote retries.
+    if (!proposal.quorum_finalized) {
+      try {
+        const quorum = await getQuorumAtSnapshot({
+          address: spaceAddress,
+          timepoint: BigInt(proposal.snapshot)
+        });
+        proposal.quorum = quorum.toString();
+        proposal.quorum_finalized = true;
+      } catch (err) {
+        logger.error({ err }, 'Failed to read quorum at snapshot block');
+      }
     }
 
     space.vote_count += 1;

--- a/apps/api/src/evm/protocols/openzeppelin/writers.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/writers.ts
@@ -117,6 +117,28 @@ export function createWriters(
     });
   }
 
+  // Reads quorum at the proposal's voting-start (snapshot) timepoint. `timepoint`
+  // is the value emitted in ProposalCreated.voteStart, which is already expressed
+  // in the governor's clock (an L1 block number on Arbitrum), so no
+  // getActualBlockNumber translation is needed here - unlike getQuorum which has
+  // to translate the indexer's creation block. For OZ governors with a voting
+  // delay, quorum (past-total-supply based) drifts between the creation block and
+  // the snapshot block, so this is the value that must be displayed.
+  async function getQuorumAtSnapshot({
+    address,
+    timepoint
+  }: {
+    address: `0x${string}`;
+    timepoint: bigint;
+  }) {
+    return client.readContract({
+      address,
+      abi: IGovernorAbi,
+      functionName: 'quorum',
+      args: [timepoint]
+    });
+  }
+
   async function initializeStrategies({
     spaceAddress,
     decimals,
@@ -387,7 +409,12 @@ export function createWriters(
     proposal.max_end_block_number = proposal.min_end_block_number;
     proposal.snapshot = event.args.voteStart;
     proposal.treasuries = spaceMetadataItem?.treasuries || [];
+    // Provisional quorum read at the creation block. The correct value is
+    // quorum(snapshot), but the snapshot block (voteStart) is in the future at
+    // index time, so it cannot be read yet. We finalize it lazily on the first
+    // VoteCast (see handleVoteCast), once the snapshot block is in the past.
     proposal.quorum = executionStrategy.quorum;
+    proposal.quorum_finalized = false;
     proposal.strategies = space.strategies;
     proposal.strategies_params = space.strategies_params;
     proposal.strategies_indices = space.strategies_indices;
@@ -570,6 +597,24 @@ export function createWriters(
       User.loadEntity(voterAddress, config.indexerName)
     ]);
     if (!space || !proposal || !user) return;
+
+    // Finalize quorum at the voting-start (snapshot) block. At creation time the
+    // snapshot block is in the future so quorum(snapshot) cannot be read, and the
+    // creation-block quorum can drift from it (OZ quorum tracks past total
+    // supply). By the first vote the snapshot block is in the past, so re-read it
+    // once and persist. Guarded by quorum_finalized so we only do it once.
+    if (!proposal.quorum_finalized) {
+      try {
+        const quorum = await getQuorumAtSnapshot({
+          address: spaceAddress,
+          timepoint: BigInt(proposal.snapshot)
+        });
+        proposal.quorum = quorum.toString();
+      } catch (err) {
+        logger.error({ err }, 'Failed to finalize quorum at snapshot block');
+      }
+      proposal.quorum_finalized = true;
+    }
 
     space.vote_count += 1;
     proposal.vote_count += 1;

--- a/apps/api/src/evm/protocols/openzeppelin/writers.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/writers.ts
@@ -117,13 +117,7 @@ export function createWriters(
     });
   }
 
-  // Reads quorum at the proposal's voting-start (snapshot) timepoint. `timepoint`
-  // is the value emitted in ProposalCreated.voteStart, which is already expressed
-  // in the governor's clock (an L1 block number on Arbitrum), so no
-  // getActualBlockNumber translation is needed here - unlike getQuorum which has
-  // to translate the indexer's creation block. For OZ governors with a voting
-  // delay, quorum (past-total-supply based) drifts between the creation block and
-  // the snapshot block, so this is the value that must be displayed.
+  // Reads quorum at the snapshot timepoint (voteStart), already in the governor's clock.
   async function getQuorumAtSnapshot({
     address,
     timepoint
@@ -409,10 +403,7 @@ export function createWriters(
     proposal.max_end_block_number = proposal.min_end_block_number;
     proposal.snapshot = event.args.voteStart;
     proposal.treasuries = spaceMetadataItem?.treasuries || [];
-    // Provisional quorum read at the creation block. The correct value is
-    // quorum(snapshot), but the snapshot block (voteStart) is in the future at
-    // index time, so it cannot be read yet. We finalize it lazily on the first
-    // VoteCast (see handleVoteCast), once the snapshot block is in the past.
+    // Provisional: snapshot block is still in the future, finalized on first VoteCast.
     proposal.quorum = executionStrategy.quorum;
     proposal.quorum_finalized = false;
     proposal.strategies = space.strategies;
@@ -598,11 +589,7 @@ export function createWriters(
     ]);
     if (!space || !proposal || !user) return;
 
-    // Finalize quorum at the voting-start (snapshot) block. At creation time the
-    // snapshot block is in the future so quorum(snapshot) cannot be read, and the
-    // creation-block quorum can drift from it (OZ quorum tracks past total
-    // supply). By the first vote the snapshot block is in the past, so re-read it
-    // once and persist. Guarded by quorum_finalized so we only do it once.
+    // Re-read quorum at the snapshot block, now in the past (see handleProposalCreated).
     if (!proposal.quorum_finalized) {
       try {
         const quorum = await getQuorumAtSnapshot({

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -288,8 +288,6 @@ type Proposal {
   scores_total: BigDecimalVP!
   "Minimum voting power required for execution"
   quorum: BigDecimalVP!
-  "Whether quorum has been (re)read at the voting-start snapshot block (OZ governors only)"
-  quorum_finalized: Boolean!
   "Quorum counting mode (e.g. for_only for Bravo-style where only For votes count)"
   quorum_type: String
   "Parsed total voting power as float"

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -288,6 +288,8 @@ type Proposal {
   scores_total: BigDecimalVP!
   "Minimum voting power required for execution"
   quorum: BigDecimalVP!
+  "Whether quorum has been read at the snapshot block (OZ governors read it once on first vote)"
+  quorum_finalized: Boolean!
   "Quorum counting mode (e.g. for_only for Bravo-style where only For votes count)"
   quorum_type: String
   "Parsed total voting power as float"

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -288,6 +288,8 @@ type Proposal {
   scores_total: BigDecimalVP!
   "Minimum voting power required for execution"
   quorum: BigDecimalVP!
+  "Whether quorum has been (re)read at the voting-start snapshot block (OZ governors only)"
+  quorum_finalized: Boolean!
   "Quorum counting mode (e.g. for_only for Bravo-style where only For votes count)"
   quorum_type: String
   "Parsed total voting power as float"


### PR DESCRIPTION
## Problem

Closes: https://github.com/snapshot-labs/workflow/issues/815

OpenZeppelin governors expose `quorum(timepoint)` derived from **past total supply** at that block. The indexer was reading quorum at the **proposal creation block** and storing it as `proposal.quorum`, while the proposal's actual quorum is evaluated at the **voteStart / snapshot block** (`proposal.snapshot = event.args.voteStart`).

For governors with a voting delay (e.g. Arbitrum), quorum drifts between those two blocks, so the displayed number was wrong.

Reported on the Arbitrum non-constitutional governor `0x789fC99093B09aD01C34DC7251D0C89ce743e5a4` (snapshot block `25295692`): UI showed **145.27M**, correct value is **152.76M**.

Verified on-chain (Etherscan v2, Arbitrum chainid 42161):

- `quorum(25295692)` on `0x789fC9...e5a4` (non-constitutional) = `152758872443132931936848805` ≈ **152.76M** ✅
- `quorum(25295692)` on `0xf07DeD...95B9` (constitutional) = `190948590553916164921061006` ≈ **190.95M**

## Why not just read quorum(snapshot) at creation

The snapshot block (`voteStart`) is in the **future** at index time, so `quorum(snapshot)` reverts/can't be read when `ProposalCreated` fires. It only becomes readable once voting opens.

## Fix (lazy recompute on first vote)

OZ has no "voting started" event, so the minimal robust hook is the first `VoteCast` (by then the snapshot block is in the past):

- `handleProposalCreated`: keep the creation-block quorum as a **provisional** value, set `quorum_finalized = false`.
- `handleVoteCast`: if `!quorum_finalized`, re-read `quorum(proposal.snapshot)` and persist, then set `quorum_finalized = true` so it runs exactly once.
- New `getQuorumAtSnapshot` helper reads `quorum(timepoint)` directly with **no `getActualBlockNumber` translation** — `voteStart` is already in the governor's clock (an L1 block on Arbitrum), unlike the creation-block path which must translate the indexer block.
- Added `quorum_finalized: Boolean!` to the `Proposal` schema (defaults to `false` via codegen; other protocols unaffected).

### Provisional-until-first-vote behavior

Between creation and the first vote, `proposal.quorum` holds the creation-block value (best available, same as before). It self-corrects on the first vote. In practice quorum is only consequential once votes exist.

## Backfill (separate)

This fixes proposals going forward. Already-affected existing proposals still need a **one-off backfill** (re-read `quorum(snapshot)` for past OZ proposals) — that's option 2 and is not included here.

## Testing

- `bun run build` (tsc) ✅
- `bun run lint` ✅
- `bun run test` ✅ (23 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)