### PR TITLE
refactor(ui): remove Axiom and Isokratia execution strategies

### DIFF
--- a/apps/ui/src/components/ProposalExecutionActions.vue
+++ b/apps/ui/src/components/ProposalExecutionActions.vue
@@ -11,19 +11,16 @@ const props = defineProps<{
 
 const { web3 } = useWeb3();
 const {
-  hasFinalize,
   hasExecuteQueued,
   fetchingDetails,
   message,
   warningMessage,
   executionTx,
   executionTxUrl,
-  finalizeProposalSending,
   executeProposalSending,
   executeQueuedProposalSending,
   vetoProposalSending,
   executionCountdown,
-  finalizeProposal,
   executeProposal,
   executeQueuedProposal,
   vetoProposal
@@ -68,16 +65,7 @@ const network = computed(() => getNetwork(props.proposal.network));
     </div>
     <div v-else class="space-y-2">
       <UiButton
-        v-if="hasFinalize"
-        class="w-full"
-        :loading="finalizeProposalSending"
-        @click="finalizeProposal"
-      >
-        <IH-check-circle />
-        Finalize proposal
-      </UiButton>
-      <UiButton
-        v-else-if="!['queued', 'vetoed', 'executed'].includes(proposal.state)"
+        v-if="!['queued', 'vetoed', 'executed'].includes(proposal.state)"
         class="w-full"
         :loading="executeProposalSending"
         @click="executeProposal"

--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -485,20 +485,6 @@ export function useActions() {
     return true;
   }
 
-  async function finalizeProposal(proposal: Proposal) {
-    if (!auth.value) return await forceLogin();
-
-    if (auth.value.connector.type === 'argentx')
-      throw new Error('ArgentX is not supported');
-
-    const network = getReadWriteNetwork(proposal.network);
-
-    await wrapPromise(
-      proposal.network,
-      network.actions.finalizeProposal(auth.value.provider, proposal)
-    );
-  }
-
   async function executeTransactions(proposal: Proposal) {
     if (!auth.value) return await forceLogin();
 
@@ -815,7 +801,6 @@ export function useActions() {
     updateProposal: wrapWithErrors(updateProposal),
     flagProposal: wrapWithErrors(flagProposal),
     cancelProposal: wrapWithErrors(cancelProposal),
-    finalizeProposal: wrapWithErrors(finalizeProposal),
     executeTransactions: wrapWithErrors(executeTransactions),
     executeQueuedProposal: wrapWithErrors(executeQueuedProposal),
     vetoProposal: wrapWithErrors(vetoProposal),

--- a/apps/ui/src/composables/useExecutionActions.ts
+++ b/apps/ui/src/composables/useExecutionActions.ts
@@ -18,7 +18,6 @@ export const STARKNET_L1_EXECUTION_QUERY = gql`
   }
 `;
 
-const STRATEGIES_WITH_FINALIZE = ['Axiom'];
 const STRATEGIES_WITH_EXTERNAL_DETAILS = ['EthRelayer'];
 
 export function useExecutionActions(
@@ -35,7 +34,6 @@ export function useExecutionActions(
   const message: Ref<string | null> = ref(null);
   const warningMessage: Ref<string | null> = ref(null);
   const executionNetwork = ref<Network>(getNetwork(toValue(proposal).network));
-  const finalizeProposalSending = ref(false);
   const executeProposalSending = ref(false);
   const executeQueuedProposalSending = ref(false);
   const vetoProposalSending = ref(false);
@@ -54,11 +52,6 @@ export function useExecutionActions(
   }, 1000);
 
   const network = computed(() => getNetwork(toValue(proposal).network));
-  const hasFinalize = computed(
-    () =>
-      STRATEGIES_WITH_FINALIZE.includes(toValue(execution).strategyType) &&
-      !toValue(proposal).execution_ready
-  );
   const hasExecuteQueued = computed(() => {
     const executionValue = toValue(execution);
     const proposalValue = toValue(proposal);
@@ -138,16 +131,6 @@ export function useExecutionActions(
     }
   }
 
-  async function finalizeProposal() {
-    finalizeProposalSending.value = true;
-
-    try {
-      await actions.finalizeProposal(toValue(proposal));
-    } finally {
-      finalizeProposalSending.value = false;
-    }
-  }
-
   async function executeProposal() {
     executeProposalSending.value = true;
 
@@ -208,19 +191,16 @@ export function useExecutionActions(
   );
 
   return {
-    hasFinalize,
     hasExecuteQueued,
     fetchingDetails,
     message,
     warningMessage,
     executionTx,
     executionTxUrl,
-    finalizeProposalSending,
     executeProposalSending,
     executeQueuedProposalSending,
     vetoProposalSending,
     executionCountdown,
-    finalizeProposal,
     executeProposal,
     executeQueuedProposal,
     vetoProposal

--- a/apps/ui/src/helpers/mana.ts
+++ b/apps/ui/src/helpers/mana.ts
@@ -47,11 +47,7 @@ export async function registerTransaction(
 export async function executionCall(
   network: 'eth' | 'stark',
   chainId: number | string,
-  method:
-    | 'finalizeProposal'
-    | 'execute'
-    | 'executeQueuedProposal'
-    | 'executeStarknetProposal',
+  method: 'execute' | 'executeQueuedProposal' | 'executeStarknetProposal',
   params: any
 ) {
   return rpcCall(`${network}_rpc/${chainId}`, method, params);

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -427,7 +427,7 @@ function formatProposal(
     discussion: proposal.metadata?.discussion ?? '',
     execution_network: executionNetworkId,
     executions: processExecutions(proposal, executionNetworkId),
-    has_execution_window_opened: ['Axiom', 'EthRelayer'].includes(
+    has_execution_window_opened: ['EthRelayer'].includes(
       proposal.execution_strategy_type
     )
       ? Number(proposal.max_end_block_number ?? proposal.max_end) <= current

--- a/apps/ui/src/networks/common/graphqlApi/queries.ts
+++ b/apps/ui/src/networks/common/graphqlApi/queries.ts
@@ -153,7 +153,6 @@ gql(`
     execution_tx
     veto_tx
     vote_count
-    execution_ready
     executed
     vetoed
     execution_settled

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -23,7 +23,6 @@ import {
 } from '@snapshot-labs/sx';
 import { APE_GAS_CONFIGS } from '@/helpers/constants';
 import { getIsContract as _getIsContract } from '@/helpers/contracts';
-import { vote as highlightVote } from '@/helpers/highlight';
 import { getSwapLink } from '@/helpers/link';
 import { executionCall, getRelayerInfo, MANA_URL } from '@/helpers/mana';
 import Multicaller from '@/helpers/multicaller';
@@ -617,10 +616,6 @@ export function createActions(
         chainId
       };
 
-      if (!isContract && proposal.execution_strategy_type === 'Axiom') {
-        return highlightVote({ signer, data });
-      }
-
       if (relayerType === 'evm') {
         return ethSigClient.vote({
           signer,
@@ -637,14 +632,6 @@ export function createActions(
         },
         { noWait: isContract && connectorType !== 'sequence' }
       );
-    },
-    finalizeProposal: async (web3: Web3Provider, proposal: Proposal) => {
-      await executionCall('eth', chainId, 'finalizeProposal', {
-        space: proposal.space.id,
-        proposalId: proposal.proposal_id
-      });
-
-      return null;
     },
     executeTransactions: async (web3: Web3Provider, proposal: Proposal) => {
       await verifyNetwork(web3, chainId);

--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -107,8 +107,6 @@ export function createConstants(
   const SUPPORTED_EXECUTORS = {
     SimpleQuorumAvatar: true,
     SimpleQuorumTimelock: true,
-    Axiom: true,
-    Isokratia: true,
     // Governor Bravo
     GovernorBravoTimelock: true,
     // OpenZeppelin
@@ -138,8 +136,6 @@ export function createConstants(
   const EXECUTORS = {
     SimpleQuorumAvatar: 'Safe module (Zodiac)',
     SimpleQuorumTimelock: 'Timelock',
-    Axiom: 'Axiom',
-    Isokratia: 'Isokratia',
     GovernorBravoTimelock: 'Timelock',
     OpenZeppelinTimelockController: 'Timelock'
   };
@@ -738,161 +734,7 @@ export function createConstants(
           }
         }
       }
-    },
-    ...(config.ExecutionStrategies.Axiom
-      ? [
-          {
-            address: '',
-            type: 'Axiom',
-            name: EXECUTORS.Axiom,
-            about:
-              'This strategy enables offchain votes on the space. The validity of votes and voting power is verified onchain in bulk using a zkSNARK of storage proofs, which then triggers the execution of transactions.',
-            icon: IHCode,
-            generateSummary: (params: Record<string, any>) =>
-              `(${shorten(params.contractAddress)}, ${params.slotIndex})`,
-            deploy: async (
-              client: clients.EvmEthereumTx,
-              web3: Web3Provider,
-              _controller: string,
-              spaceAddress: string,
-              params: Record<string, any>
-            ): Promise<{ address: string; txId: string }> => {
-              return client.deployAxiomExecution({
-                signer: web3.getSigner(),
-                params: {
-                  controller:
-                    params.controller ||
-                    '0x0000000000000000000000000000000000000000',
-                  quorum: BigInt(params.quorum),
-                  contractAddress:
-                    params.contractAddress ||
-                    '0x0000000000000000000000000000000000000000',
-                  slotIndex: BigInt(params.slotIndex),
-                  space: spaceAddress,
-                  querySchema:
-                    '0xa09cc16ccaa32b96ca5c404c1b4be60d7883a7178f432e8f9f3c22157fc0f873'
-                }
-              });
-            },
-            paramsDefinition: {
-              type: 'object',
-              title: 'Params',
-              additionalProperties: false,
-              required: [
-                'controller',
-                'quorum',
-                'contractAddress',
-                'slotIndex'
-              ],
-              properties: {
-                controller: {
-                  type: 'string',
-                  format: 'address',
-                  chainId: config.Meta.eip712ChainId,
-                  title: 'Controller address',
-                  examples: ['0x0000…']
-                },
-                quorum: {
-                  type: 'integer',
-                  title: 'Quorum',
-                  examples: ['1']
-                },
-                contractAddress: {
-                  type: 'string',
-                  format: 'address',
-                  chainId: config.Meta.eip712ChainId,
-                  title: 'Contract address',
-                  examples: ['0x0000…']
-                },
-                slotIndex: {
-                  type: 'integer',
-                  title: 'Slot index',
-                  examples: ['0']
-                }
-              }
-            }
-          }
-        ]
-      : []),
-    ...(config.ExecutionStrategies.Isokratia
-      ? [
-          {
-            address: '',
-            type: 'Isokratia',
-            name: EXECUTORS.Isokratia,
-            about:
-              'This strategy enables offchain votes on the space. The validity of votes is verified onchain in bulk using a zkSNARK, which then triggers the execution of transactions.',
-            icon: IHCode,
-            generateSummary: (params: Record<string, any>) =>
-              `(${shorten(params.contractAddress)}, ${params.slotIndex})`,
-            deploy: async (
-              client: clients.EvmEthereumTx,
-              web3: Web3Provider,
-              _controller: string,
-              _spaceAddress: string,
-              params: Record<string, any>
-            ): Promise<{ address: string; txId: string }> => {
-              return client.deployIsokratiaExecution({
-                signer: web3.getSigner(),
-                params: {
-                  provingTimeAllowance: params.provingTimeAllowance,
-                  quorum: BigInt(params.quorum),
-                  queryAddress:
-                    params.queryAddress ||
-                    '0x0000000000000000000000000000000000000000',
-                  contractAddress:
-                    params.contractAddress ||
-                    '0x0000000000000000000000000000000000000000',
-                  slotIndex: BigInt(params.slotIndex)
-                }
-              });
-            },
-            paramsDefinition: {
-              type: 'object',
-              title: 'Params',
-              additionalProperties: false,
-              required: [
-                'provingTimeAllowance',
-                'quorum',
-                'queryAddress',
-                'contractAddress',
-                'slotIndex'
-              ],
-              properties: {
-                provingTimeAllowance: {
-                  type: 'integer',
-                  title: 'Proving time allowance',
-                  examples: ['3600']
-                },
-                quorum: {
-                  type: 'integer',
-                  title: 'Quorum',
-                  examples: ['1']
-                },
-                queryAddress: {
-                  type: 'string',
-                  format: 'address',
-                  chainId: config.Meta.eip712ChainId,
-                  title: 'Query address',
-                  examples: ['0x0000…']
-                },
-                contractAddress: {
-                  type: 'string',
-                  format: 'address',
-                  chainId: config.Meta.eip712ChainId,
-                  title: 'Contract address',
-                  examples: ['0x0000…']
-                },
-                slotIndex: {
-                  type: 'integer',
-                  title: 'Slot index',
-                  examples: ['0']
-                }
-              }
-            }
-          }
-        ]
-      : [])
+    }
   ];
 
   const EDITOR_VOTING_TYPES: VoteType[] = ['basic'];

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -449,7 +449,6 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     has_execution_window_opened: state === 'passed',
     // NOTE: ignored
     execution_network: networkId,
-    execution_ready: false,
     execution_hash: '',
     execution_time: 0,
     execution_strategy: '',

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -532,7 +532,6 @@ export function createActions(
         data
       });
     },
-    finalizeProposal: () => null,
     executeTransactions: async (web3: any, proposal: Proposal) => {
       const executionData = getExecutionData(
         proposal.space,

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -265,7 +265,6 @@ export type NetworkActions = ReadOnlyNetworkActions & {
       metadata: SpaceMetadata;
     }
   );
-  finalizeProposal(web3: Web3Provider, proposal: Proposal);
   executeTransactions(web3: Web3Provider, proposal: Proposal);
   executeQueuedProposal(web3: Web3Provider, proposal: Proposal);
   vetoProposal(web3: Web3Provider, proposal: Proposal);

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -333,7 +333,6 @@ export type Proposal = {
   veto_tx: string | null;
   vote_count: number;
   has_execution_window_opened: boolean;
-  execution_ready: boolean;
   vetoed: boolean;
   /**
    * Determines if proposal execution is settled - all transactions have been executed or vetoed.


### PR DESCRIPTION
## Summary

Removes all **UI** references to the Axiom and Isokratia execution strategies. This is **PR 1 of 2** and should be merged **first**, so the UI stops referencing these strategies (and the `axiom_snapshot_*` / `execution_ready` schema fields) before they are removed from the SDK and indexer (PR 2). That way the deployed UI never breaks on the API/schema change.

## Changes (apps/ui)

- Drop Axiom/Isokratia from `SUPPORTED_EXECUTORS` / `EXECUTORS` and remove their deploy strategy definitions in `networks/evm/constants.ts`.
- Remove the Axiom-only highlight (offchain) vote path in `networks/evm/actions.ts`.
- Remove the proposal **finalize** flow, which was gated solely on Axiom (`STRATEGIES_WITH_FINALIZE = ['Axiom']`): the `finalizeProposal` method on the network actions interface and its EVM/Starknet implementations, `useActions`, `useExecutionActions`, the finalize button in `ProposalExecutionActions.vue`, and the `finalizeProposal` mana RPC method.
- Stop tagging `Axiom` in `has_execution_window_opened` (now `EthRelayer` only).
- Remove the now-unused **`execution_ready`** field (the `Proposal` type, the GraphQL query selection, and the offchain adapter setter). Its only consumer was the Axiom finalize gate; nothing reads it anymore.

## Verification

- `turbo run typecheck` (ui) — pass
- `turbo run lint` (ui) — pass

## Follow-up

- PR 2 removes the same strategies (and the `execution_ready` / `axiom_snapshot_*` schema fields + writers) from `packages/sx.js` and `apps/api` (stacked on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)