### PR TITLE
feat: Herodotus Satellite voting strategies (UI templates + mana official-API routing)

### DIFF
--- a/apps/mana/src/stark/herodotus.ts
+++ b/apps/mana/src/stark/herodotus.ts
@@ -46,8 +46,19 @@ type DbProposal = {
   herodotusId: string | null;
 };
 
-function getApi(accumulatesChainId: string) {
-  if (accumulatesChainId === '1') {
+// Host/key selection is by strategy generation, not chain:
+//
+// - Satellite V2 strategies use the official Herodotus API (api.herodotus.cloud)
+//   with HERODOTUS_API_KEY on BOTH Starknet mainnet and sepolia. They resolve the
+//   timestamp -> L1 block mapping and storage root entirely on-chain via the
+//   Satellite contract, so they never touch the indexer's remapper endpoints.
+//
+// - Legacy storage-proof strategies keep the frozen host for mainnet
+//   (snapshot.api.herodotus.cloud + snapshot.rs-indexer, HERODOTUS_LEGACY_API_KEY)
+//   because they still depend on snapshot.rs-indexer's /remappers/binsearch-path.
+//   Legacy sepolia already runs on the official host.
+function getApi(accumulatesChainId: string, isSatellite: boolean) {
+  if (!isSatellite && accumulatesChainId === '1') {
     return {
       apiUrl: 'https://snapshot.api.herodotus.cloud',
       indexerUrl: 'https://snapshot.rs-indexer.api.herodotus.cloud',
@@ -95,8 +106,12 @@ function isSatelliteStrategy(
     .includes(validateAndParseAddress(strategyAddress));
 }
 
-async function getStatus(id: string, accumulatesChainId: string) {
-  const { apiUrl, apiKey } = getApi(accumulatesChainId);
+async function getStatus(
+  id: string,
+  accumulatesChainId: string,
+  isSatellite: boolean
+) {
+  const { apiUrl, apiKey } = getApi(accumulatesChainId, isSatellite);
 
   const res = await fetch(
     `${apiUrl}/batch-query-status?apiKey=${apiKey}&batchQueryId=${id}`,
@@ -119,6 +134,11 @@ async function submitBatch(proposal: ApiProposal) {
 
   const { DESTINATION_CHAIN_ID, ACCUMULATES_CHAIN_ID, FEE } = mapping;
 
+  const isSatellite = isSatelliteStrategy(
+    proposal.chainId,
+    proposal.strategyAddress
+  );
+
   const body: any = {
     destinationChainId: DESTINATION_CHAIN_ID,
     fee: FEE,
@@ -135,7 +155,7 @@ async function submitBatch(proposal: ApiProposal) {
     }
   };
 
-  const { apiUrl, apiKey } = getApi(ACCUMULATES_CHAIN_ID);
+  const { apiUrl, apiKey } = getApi(ACCUMULATES_CHAIN_ID, isSatellite);
   const res = await fetch(`${apiUrl}/submit-batch-query?apiKey=${apiKey}`, {
     method: 'post',
     headers: {
@@ -182,7 +202,10 @@ export async function registerProposal(proposal: ApiProposal) {
   try {
     await submitBatch(proposal);
   } catch (err) {
-    logger.error({ err, proposal }, 'Failed to submit herodotus batch');
+    logger.error(
+      { err, proposalId: getId(proposal), proposal },
+      'Failed to submit herodotus batch'
+    );
   }
 }
 
@@ -201,8 +224,17 @@ export async function processProposal(proposal: DbProposal) {
   if (!mapping) throw new Error('Invalid chainId');
   const { DESTINATION_CHAIN_ID, ACCUMULATES_CHAIN_ID } = mapping;
 
+  const isSatellite = isSatelliteStrategy(
+    proposal.chainId,
+    proposal.strategyAddress
+  );
+
   try {
-    const status = await getStatus(proposal.herodotusId, ACCUMULATES_CHAIN_ID);
+    const status = await getStatus(
+      proposal.herodotusId,
+      ACCUMULATES_CHAIN_ID,
+      isSatellite
+    );
     if (status !== 'DONE') {
       logger.info(
         { herodotusId: proposal.herodotusId, status },
@@ -226,7 +258,7 @@ export async function processProposal(proposal: DbProposal) {
   // timestamp -> L1 block mapping and storage root into the Satellite contract,
   // which voters read on-chain via get_block_by_timestamp. No on-chain
   // cache_timestamp tx is required, so we are done.
-  if (isSatelliteStrategy(proposal.chainId, proposal.strategyAddress)) {
+  if (isSatellite) {
     logger.info({ proposalId: proposal.id }, 'Satellite proposal processed');
     return db.markProposalProcessed(proposal.id);
   }
@@ -236,7 +268,7 @@ export async function processProposal(proposal: DbProposal) {
   const { getAccount, herodotusController } = getClient(proposal.chainId);
   const { account, nonceManager, deployAccount } = getAccount('0x0');
 
-  const { indexerUrl } = getApi(ACCUMULATES_CHAIN_ID);
+  const { indexerUrl } = getApi(ACCUMULATES_CHAIN_ID, isSatellite);
 
   const res = await fetch(
     `${indexerUrl}/remappers/binsearch-path?timestamp=${proposal.timestamp}&deployed_on_chain=${DESTINATION_CHAIN_ID}&accumulates_chain=${ACCUMULATES_CHAIN_ID}`,

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -68,14 +68,28 @@ export function createConstants(
     [config.Strategies.ERC20Votes]: true,
     [config.Strategies.EVMSlotValue]: true,
     [config.Strategies.OZVotesStorageProof]: true,
-    [config.Strategies.OZVotesTrace208StorageProof]: true
+    [config.Strategies.OZVotesTrace208StorageProof]: true,
+    ...(config.Strategies.EVMSlotValueV2 && {
+      [config.Strategies.EVMSlotValueV2]: true
+    }),
+    ...(config.Strategies.OZVotesStorageProofV2 && {
+      [config.Strategies.OZVotesStorageProofV2]: true
+    }),
+    ...(config.Strategies.OZVotesTrace208StorageProofV2 && {
+      [config.Strategies.OZVotesTrace208StorageProofV2]: true
+    })
   };
 
-  const STORAGE_PROOF_STRATEGIES_TYPES = [
-    config.Strategies.EVMSlotValue,
-    config.Strategies.OZVotesStorageProof,
-    config.Strategies.OZVotesTrace208StorageProof
-  ];
+  const STORAGE_PROOF_STRATEGIES_TYPES = (
+    [
+      config.Strategies.EVMSlotValue,
+      config.Strategies.OZVotesStorageProof,
+      config.Strategies.OZVotesTrace208StorageProof,
+      config.Strategies.EVMSlotValueV2,
+      config.Strategies.OZVotesStorageProofV2,
+      config.Strategies.OZVotesTrace208StorageProofV2
+    ] as (string | undefined)[]
+  ).filter((address): address is string => !!address);
 
   const SUPPORTED_EXECUTORS = {
     EthRelayer: true
@@ -95,11 +109,22 @@ export function createConstants(
   const STRATEGIES = {
     [config.Strategies.MerkleWhitelist]: 'Merkle whitelist',
     [config.Strategies.ERC20Votes]: 'ERC-20 Votes (EIP-5805)',
-    [config.Strategies.EVMSlotValue]: 'EVM slot value',
+    [config.Strategies.EVMSlotValue]: 'EVM slot value (deprecated)',
     [config.Strategies.OZVotesStorageProof]:
-      'OZ Votes storage proof (trace 224)',
+      'OZ Votes storage proof (trace 224, deprecated)',
     [config.Strategies.OZVotesTrace208StorageProof]:
-      'OZ Votes storage proof (trace 208)'
+      'OZ Votes storage proof (trace 208, deprecated)',
+    ...(config.Strategies.EVMSlotValueV2 && {
+      [config.Strategies.EVMSlotValueV2]: 'EVM slot value'
+    }),
+    ...(config.Strategies.OZVotesStorageProofV2 && {
+      [config.Strategies.OZVotesStorageProofV2]:
+        'OZ Votes storage proof (trace 224)'
+    }),
+    ...(config.Strategies.OZVotesTrace208StorageProofV2 && {
+      [config.Strategies.OZVotesTrace208StorageProofV2]:
+        'OZ Votes storage proof (trace 208)'
+    })
   };
 
   const EXECUTORS = {
@@ -111,12 +136,14 @@ export function createConstants(
     address: string,
     name: string,
     about: string,
-    link?: string
+    link?: string,
+    deprecated = false
   ): StrategyTemplate => ({
     address,
     name,
     about,
     link,
+    deprecated,
     icon: IHCode,
     generateSummary: (params: Record<string, any>) =>
       `(${shorten(params.contractAddress)}, ${params.slotIndex})`,
@@ -461,13 +488,18 @@ export function createConstants(
         }
       }
     },
+    // Deprecated legacy Herodotus storage-proof strategies (facts registry +
+    // timestamp remappers). Kept so existing spaces still render and remain
+    // editable, but hidden from the add-strategy picker via `deprecated: true`.
+    // Superseded by the Satellite versions below (sx-starknet#641).
     ...(config.Strategies.EVMSlotValue
       ? [
           createSlotValueStrategyConfig(
             config.Strategies.EVMSlotValue,
-            'EVM slot value',
+            'EVM slot value (deprecated)',
             'A strategy that allows to use the value of an slot on EVM chain (for example ERC-20 balance on L1) as voting power.',
-            `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#evm-slot-value`
+            `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#evm-slot-value`,
+            true
           )
         ]
       : []),
@@ -475,9 +507,10 @@ export function createConstants(
       ? [
           createSlotValueStrategyConfig(
             config.Strategies.OZVotesStorageProof,
-            'OZ Votes storage proof (trace 224)',
+            'OZ Votes storage proof (trace 224, deprecated)',
             'A strategy that allows to use the value of an slot on EVM chain (for example ERC-20 balance on L1) as voting power including delegated balances (trace 224 format).',
-            `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#oz-votes-storage-proof`
+            `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#oz-votes-storage-proof`,
+            true
           )
         ]
       : []),
@@ -485,6 +518,38 @@ export function createConstants(
       ? [
           createSlotValueStrategyConfig(
             config.Strategies.OZVotesTrace208StorageProof,
+            'OZ Votes storage proof (trace 208, deprecated)',
+            'A strategy that allows to use the value of an slot on EVM chain (for example ERC-20 balance on L1) as voting power including delegated balances (trace 208 format).',
+            `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#oz-votes-storage-proof`,
+            true
+          )
+        ]
+      : []),
+    // Herodotus Satellite storage-proof strategies (sx-starknet#641).
+    ...(config.Strategies.EVMSlotValueV2
+      ? [
+          createSlotValueStrategyConfig(
+            config.Strategies.EVMSlotValueV2,
+            'EVM slot value',
+            'A strategy that allows to use the value of an slot on EVM chain (for example ERC-20 balance on L1) as voting power.',
+            `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#evm-slot-value`
+          )
+        ]
+      : []),
+    ...(config.Strategies.OZVotesStorageProofV2
+      ? [
+          createSlotValueStrategyConfig(
+            config.Strategies.OZVotesStorageProofV2,
+            'OZ Votes storage proof (trace 224)',
+            'A strategy that allows to use the value of an slot on EVM chain (for example ERC-20 balance on L1) as voting power including delegated balances (trace 224 format).',
+            `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#oz-votes-storage-proof`
+          )
+        ]
+      : []),
+    ...(config.Strategies.OZVotesTrace208StorageProofV2
+      ? [
+          createSlotValueStrategyConfig(
+            config.Strategies.OZVotesTrace208StorageProofV2,
             'OZ Votes storage proof (trace 208)',
             'A strategy that allows to use the value of an slot on EVM chain (for example ERC-20 balance on L1) as voting power including delegated balances (trace 208 format).',
             `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#oz-votes-storage-proof`
@@ -500,7 +565,10 @@ export function createConstants(
           [
             config.Strategies.EVMSlotValue,
             config.Strategies.OZVotesStorageProof,
-            config.Strategies.OZVotesTrace208StorageProof
+            config.Strategies.OZVotesTrace208StorageProof,
+            config.Strategies.EVMSlotValueV2,
+            config.Strategies.OZVotesStorageProofV2,
+            config.Strategies.OZVotesTrace208StorageProofV2
           ] as string[]
         ).includes(strategy.address)
     );

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -69,27 +69,19 @@ export function createConstants(
     [config.Strategies.EVMSlotValue]: true,
     [config.Strategies.OZVotesStorageProof]: true,
     [config.Strategies.OZVotesTrace208StorageProof]: true,
-    ...(config.Strategies.EVMSlotValueV2 && {
-      [config.Strategies.EVMSlotValueV2]: true
-    }),
-    ...(config.Strategies.OZVotesStorageProofV2 && {
-      [config.Strategies.OZVotesStorageProofV2]: true
-    }),
-    ...(config.Strategies.OZVotesTrace208StorageProofV2 && {
-      [config.Strategies.OZVotesTrace208StorageProofV2]: true
-    })
+    [config.Strategies.EVMSlotValueV2]: true,
+    [config.Strategies.OZVotesStorageProofV2]: true,
+    [config.Strategies.OZVotesTrace208StorageProofV2]: true
   };
 
-  const STORAGE_PROOF_STRATEGIES_TYPES = (
-    [
-      config.Strategies.EVMSlotValue,
-      config.Strategies.OZVotesStorageProof,
-      config.Strategies.OZVotesTrace208StorageProof,
-      config.Strategies.EVMSlotValueV2,
-      config.Strategies.OZVotesStorageProofV2,
-      config.Strategies.OZVotesTrace208StorageProofV2
-    ] as (string | undefined)[]
-  ).filter((address): address is string => !!address);
+  const STORAGE_PROOF_STRATEGIES_TYPES: string[] = [
+    config.Strategies.EVMSlotValue,
+    config.Strategies.OZVotesStorageProof,
+    config.Strategies.OZVotesTrace208StorageProof,
+    config.Strategies.EVMSlotValueV2,
+    config.Strategies.OZVotesStorageProofV2,
+    config.Strategies.OZVotesTrace208StorageProofV2
+  ];
 
   const SUPPORTED_EXECUTORS = {
     EthRelayer: true
@@ -114,17 +106,11 @@ export function createConstants(
       'OZ Votes storage proof (trace 224, deprecated)',
     [config.Strategies.OZVotesTrace208StorageProof]:
       'OZ Votes storage proof (trace 208, deprecated)',
-    ...(config.Strategies.EVMSlotValueV2 && {
-      [config.Strategies.EVMSlotValueV2]: 'EVM slot value'
-    }),
-    ...(config.Strategies.OZVotesStorageProofV2 && {
-      [config.Strategies.OZVotesStorageProofV2]:
-        'OZ Votes storage proof (trace 224)'
-    }),
-    ...(config.Strategies.OZVotesTrace208StorageProofV2 && {
-      [config.Strategies.OZVotesTrace208StorageProofV2]:
-        'OZ Votes storage proof (trace 208)'
-    })
+    [config.Strategies.EVMSlotValueV2]: 'EVM slot value',
+    [config.Strategies.OZVotesStorageProofV2]:
+      'OZ Votes storage proof (trace 224)',
+    [config.Strategies.OZVotesTrace208StorageProofV2]:
+      'OZ Votes storage proof (trace 208)'
   };
 
   const EXECUTORS = {
@@ -560,17 +546,7 @@ export function createConstants(
 
   const EDITOR_PROPOSAL_VALIDATION_VOTING_STRATEGIES =
     EDITOR_VOTING_STRATEGIES.filter(
-      strategy =>
-        !(
-          [
-            config.Strategies.EVMSlotValue,
-            config.Strategies.OZVotesStorageProof,
-            config.Strategies.OZVotesTrace208StorageProof,
-            config.Strategies.EVMSlotValueV2,
-            config.Strategies.OZVotesStorageProofV2,
-            config.Strategies.OZVotesTrace208StorageProofV2
-          ] as string[]
-        ).includes(strategy.address)
+      strategy => !STORAGE_PROOF_STRATEGIES_TYPES.includes(strategy.address)
     );
 
   const EDITOR_EXECUTION_STRATEGIES = [

--- a/apps/ui/src/queries/votingPower.ts
+++ b/apps/ui/src/queries/votingPower.ts
@@ -80,7 +80,13 @@ export async function getVotingPower(
     if (
       err instanceof utils.errors.VotingPowerDetailsError &&
       err.details === 'NOT_READY_YET' &&
-      ['evmSlotValue', 'ozVotesStorageProof', 'apeGas'].includes(err.source)
+      [
+        'evmSlotValue',
+        'ozVotesStorageProof',
+        'evmSlotValueV2',
+        'ozVotesStorageProofV2',
+        'apeGas'
+      ].includes(err.source)
     ) {
       throw new Error('NOT_READY_YET');
     }


### PR DESCRIPTION
## What

Combined, atomically-deployable change for the Herodotus Satellite (V2) storage-proof voting strategies on Starknet. It carries **both** the `apps/ui` strategy templates and the `apps/mana` official-API routing so the frontend and the relayer ship together (per Sekhmet's request, folded in from #2206).

### UI (`apps/ui`)

Adds the strategy templates for the new Herodotus Satellite (V2) storage-proof voting strategies and deprecates the legacy facts-registry strategies in the UI:

- `apps/ui/src/networks/starknet/constants.ts` — registers `EVMSlotValueV2`, `OZVotesStorageProofV2`, `OZVotesTrace208StorageProofV2` strategy templates; renames the legacy ones to "(deprecated)" and hides them from the add-strategy picker via `deprecated: true`, while keeping them so existing spaces still render/edit.
- `apps/ui/src/queries/votingPower.ts` — adds the V2 sources to the `NOT_READY_YET` handling.

### mana (`apps/mana`)

Routes Herodotus host/key selection in `apps/mana/src/stark/herodotus.ts` by **strategy generation** instead of by chain:

- **Satellite V2 strategies** (`EVMSlotValueV2`, `OZVotesStorageProofV2`, `OZVotesTrace208StorageProofV2`) now use the official Herodotus API (`api.herodotus.cloud` + `HERODOTUS_API_KEY`) on **both** Starknet mainnet and sepolia. They resolve the timestamp -> L1 block mapping and storage root on-chain via the Satellite contract, so they never touch the indexer's remapper endpoints.
- **Legacy storage-proof strategies** keep the frozen mainnet host (`snapshot.api.herodotus.cloud` + `snapshot.rs-indexer`, `HERODOTUS_LEGACY_API_KEY`) because they still depend on `snapshot.rs-indexer`'s `/remappers/binsearch-path`. Legacy sepolia already ran on the official host.

Also includes the computed proposal id in the `registerProposal` submit-failure log so swallowed failures are traceable.

#### mana rationale / probe findings

The move is informed by the Herodotus interaction demo (`mikjakbiak/sx-starknet` `scripts/herodotus-interaction-demo.ts` @ `f8e90d5`), which drives Satellite queries against the official `api.herodotus.cloud`. Rather than blindly adopt the demo's newer endpoint names, I verified empirically what the live official host actually accepts and kept the existing `submit-batch-query` / `batch-query-status` names, which keeps the diff minimal and avoids a payload/parsing rewrite.

What was verified against live `api.herodotus.cloud`:

| Request | Result | Meaning |
|---|---|---|
| `GET /batch-query-status?batchQueryId=abc` | `401 {"error":"Invalid apiKey"}` (with bogus `api-key`) | route exists, auth enforced |
| `POST /submit-batch-query` (empty body) | `400` requiring `destinationChainId`, `fee`, `data` (camelCase) | route exists, matches our payload |
| `GET /get_queries/abc` | `404 Route ... not found` | demo's newer name NOT on this host |
| `POST /submit-request` | `404` | demo's newer name NOT on this host |

So the official host speaks the same `submit-batch-query` / `batch-query-status` contract mana already uses. Only host + key routing needed to change; header `api-key` auth is honored (the legacy `?apiKey=` query param is retained harmlessly).

## Testing

- `tsc --noEmit` (apps/mana): clean
- `eslint` on the three touched files: clean
- The two pre-existing `vue-tsc` errors in apps/ui are unrelated to this change.
- No unit tests exist in apps/mana.
- No live submit dry-run: mana has no local `.env`, so no real `HERODOTUS_API_KEY` was available. A status query is safe but requires a valid key; a batch submit was intentionally not attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
