### PR TITLE
refactor(api): clean up legacy workarounds

### DIFF
--- a/apps/api/src/api.ts
+++ b/apps/api/src/api.ts
@@ -27,12 +27,6 @@ export async function startApiServer(checkpoint: Checkpoint) {
   await server.start();
 
   app.use(cors());
-  app.get('/deployment', (req, res) => {
-    res.json({
-      index: process.env.DATABASE_URL_INDEX ?? 'default'
-    });
-  });
-
   app.use(
     '/',
     express.json({ limit: '50mb' }),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -29,10 +29,6 @@ function getDatabaseConnection() {
     return process.env.DATABASE_URL;
   }
 
-  if (process.env.DATABASE_URL_INDEX) {
-    return process.env[`DATABASE_URL_${process.env.DATABASE_URL_INDEX}`];
-  }
-
   throw new Error('No valid database connection URL found.');
 }
 

--- a/apps/api/src/indexer.ts
+++ b/apps/api/src/indexer.ts
@@ -9,12 +9,7 @@ import {
 import logger from './logger';
 import { addStarknetIndexers } from './starknet';
 
-const PRODUCTION_INDEXER_DELAY = 60 * 1000;
-
 const GIT_COMMIT = process.env.GIT_COMMIT;
-const IS_PRODUCTION = process.env.NODE_ENV === 'production';
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 async function initializeCheckpoint(checkpoint: Checkpoint) {
   if (!GIT_COMMIT) {
@@ -66,13 +61,6 @@ async function initializeCheckpoint(checkpoint: Checkpoint) {
 export async function startIndexer(checkpoint: Checkpoint) {
   addStarknetIndexers(checkpoint);
   addEvmIndexers(checkpoint);
-
-  if (IS_PRODUCTION) {
-    logger.info(
-      'Delaying indexer to prevent multiple processes indexing at the same time.'
-    );
-    await sleep(PRODUCTION_INDEXER_DELAY);
-  }
 
   await initializeCheckpoint(checkpoint);
 


### PR DESCRIPTION
### Summary

With new deployment we no longer need `DATABASE_URL_INDEX` (we don't have separate deployment for routing to proper instance) and we don't need delay when starting the indexer.