### PR TITLE
test: validate Node 24 actions bump (do not merge)

### DIFF
--- a/.github/workflows/hub-test.yml
+++ b/.github/workflows/hub-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         target: ['22.6']
-    uses: snapshot-labs/actions/.github/workflows/test.yml@main
+    uses: snapshot-labs/actions/.github/workflows/test.yml@chore/bump-node20-actions
     secrets: inherit
     with:
       working_directory: apps/hub

--- a/.github/workflows/sequencer-test.yml
+++ b/.github/workflows/sequencer-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         target: ['22.6']
-    uses: snapshot-labs/actions/.github/workflows/test.yml@main
+    uses: snapshot-labs/actions/.github/workflows/test.yml@chore/bump-node20-actions
     secrets: inherit
     with:
       working_directory: apps/sequencer


### PR DESCRIPTION
**Draft / do-not-merge.** CI validation for snapshot-labs/actions#24.

Temporarily repoints the reusable test workflow ref in `hub-test.yml` and `sequencer-test.yml` from `@main` to `@chore/bump-node20-actions` so this repo's Hub + Sequencer test jobs run against the bumped actions (checkout v7, setup-node v6, codecov v7).

Goal: confirm green + no Node 20 deprecation warning before merging the actions PR. Once actions#24 merges to `main`, close this — `@main` picks up the fix automatically.