### PR TITLE
fix: update checkpoint.box links to checkpoint.snapshot.box

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the Snapshot monorepository containing a Vue frontend, GraphQL API, a tr
 ## Apps
 
 - [`./apps/ui`](./apps/ui): Snapshot official frontend using Vue 3
-- [`./apps/api`](./apps/api): Multichain indexer for Snapshot X using [Checkpoint](https://checkpoint.box)
+- [`./apps/api`](./apps/api): Multichain indexer for Snapshot X using [Checkpoint](https://checkpoint.snapshot.box)
 - [`./apps/hub`](./apps/hub): GraphQL API for the Snapshot offchain protocol
 - [`./apps/mana`](./apps/mana): Transaction relayer for gasless voting on Snapshot X
 - [`./apps/mcp`](./apps/mcp): MCP server for the Snapshot API

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -4,7 +4,7 @@
 
 This API uses Checkpoint SDK to index Snapshot X and Governor spaces information on multiple EVM chains and Starknet.
 
-For more about how checkpoint works, refer to its documentation here: https://docs.checkpoint.box
+For more about how checkpoint works, refer to its documentation here: https://docs.checkpoint.snapshot.box
 
 ## Getting Started (Local Development)
 

--- a/apps/delegates-api/README.md
+++ b/apps/delegates-api/README.md
@@ -3,7 +3,7 @@
 This API uses the Checkpoint SDK to index ERC20Votes delegate information across
 multiple EVM chains and Starknet.
 
-For more about how Checkpoint works, refer to its documentation here: https://docs.checkpoint.box
+For more about how Checkpoint works, refer to its documentation here: https://docs.checkpoint.snapshot.box
 
 ## Getting Started (Local Development)
 

--- a/docs/snapshot-x/services/api.mdx
+++ b/docs/snapshot-x/services/api.mdx
@@ -2,7 +2,7 @@
 title: "API"
 ---
 
-The API indexes Snapshot X data. Specifically, it monitors events emitted by spaces and space factories so that votes, proposals, and the deployment of new spaces can be tracked. Anyone can run the API. It uses [Checkpoint](https://checkpoint.box) and support multiple chains.
+The API indexes Snapshot X data. Specifically, it monitors events emitted by spaces and space factories so that votes, proposals, and the deployment of new spaces can be tracked. Anyone can run the API. It uses [Checkpoint](https://checkpoint.snapshot.box) and support multiple chains.
 
 #### GitHub
 


### PR DESCRIPTION
Updates all `checkpoint.box` documentation links to `checkpoint.snapshot.box` (the correct Checkpoint docs host).

Changed files (docs/READMEs only, no code):
- README.md
- apps/api/README.md
- apps/delegates-api/README.md
- docs/snapshot-x/services/api.mdx

Both `checkpoint.box` and `docs.checkpoint.box` occurrences were updated; no double-replacement and no remaining bare `checkpoint.box`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)