### PR TITLE
Use ENS Universal Resolver for name and text record resolution

### DIFF
--- a/apps/ui/src/helpers/ens.test.ts
+++ b/apps/ui/src/helpers/ens.test.ts
@@ -12,11 +12,13 @@ describe('ens', () => {
   describe('getNameOwner', () => {
     describe('for names using the onchain resolver', () => {
       it('should return the owner of the name on mainnet', async () => {
+        // Mainnet UR does not expose findOwner yet — falls back to v1 registry
         const owner = await getNameOwner('ens.eth', 1);
         expect(owner).toBe('0xb6E040C9ECAaE172a89bD561c5F73e1C48d28cd9');
       });
 
       it('should return the owner of the name on testnet', async () => {
+        // Sepolia UR has findOwner; unmigrated names return zero and fall back to v1
         const owner = await getNameOwner('ens.eth', 11155111);
         expect(owner).toBe('0x179A862703a4adfb29896552DF9e307980D19285');
       });

--- a/apps/ui/src/helpers/ens.test.ts
+++ b/apps/ui/src/helpers/ens.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { getNameOwner } from './ens';
+import { getNameOwner, resolveName } from './ens';
 
 describe('ens', () => {
+  describe('resolveName', () => {
+    it('should resolve ur.integration-tests.eth to the Universal Resolver integration test address', async () => {
+      const address = await resolveName('ur.integration-tests.eth', 1);
+      expect(address).toBe('0x2222222222222222222222222222222222222222');
+    });
+  });
+
   describe('getNameOwner', () => {
     describe('for names using the onchain resolver', () => {
       it('should return the owner of the name on mainnet', async () => {

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -12,7 +12,9 @@ export type ENSChainId = 1 | 11155111;
 
 const UNIVERSAL_RESOLVER = '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe';
 const UR_ABI = new Interface([
-  'function resolve(bytes name, bytes data) view returns (bytes, address)'
+  'function resolve(bytes name, bytes data) view returns (bytes, address)',
+  // ENSv2-only today (available on Sepolia; mainnet UR does not expose it yet)
+  'function findOwner(bytes name) view returns (address)'
 ]);
 const RESOLVER_ABI = new Interface([
   'function addr(bytes32 node) view returns (address)',
@@ -104,6 +106,62 @@ async function urResolve(
   }
 }
 
+/**
+ * ENSv2 ownership via Universal Resolver.findOwner.
+ * Returns null when unsupported (e.g. mainnet UR), on revert, or for
+ * unmigrated names (zero address) so callers can fall back to the v1 registry.
+ */
+async function urFindOwner(
+  name: string,
+  chainId: ENSChainId
+): Promise<string | null> {
+  const provider = getProvider(chainId);
+  const ur = new Contract(UNIVERSAL_RESOLVER, UR_ABI, provider);
+  try {
+    const owner: string = await ur.findOwner(dnsEncode(name));
+    if (!owner || owner === EVM_EMPTY_ADDRESS) return null;
+    return owner;
+  } catch {
+    return null;
+  }
+}
+
+async function getNameOwnerV1(name: string, chainId: ENSChainId) {
+  const provider = getProvider(chainId);
+  const ensHash = namehash(name);
+
+  let owner = await call(
+    provider,
+    ENS_CONTRACTS.registryAbi,
+    [ENS_CONTRACTS.registry, 'owner', [ensHash]],
+    {
+      blockTag: 'latest'
+    }
+  );
+
+  if (!name.endsWith('.eth') && owner === EVM_EMPTY_ADDRESS) {
+    const resolvedAddress = (await getAddresses([name], chainId))[name];
+    const nameTokens = name.split('.');
+
+    if (nameTokens.length > 2) {
+      owner = resolvedAddress || EVM_EMPTY_ADDRESS;
+    } else if (nameTokens.length === 2 && resolvedAddress) {
+      owner = await getDNSOwner(name);
+    }
+  }
+
+  if (owner !== ENS_CONTRACTS.nameWrappers[chainId]) return owner;
+
+  return call(
+    provider,
+    ENS_CONTRACTS.nameWrapperAbi,
+    [ENS_CONTRACTS.nameWrappers[chainId], 'ownerOf', [ensHash]],
+    {
+      blockTag: 'latest'
+    }
+  );
+}
+
 export async function resolveName(name: string, chainId: ENSChainId) {
   const node = namehash(name);
   const callData = RESOLVER_ABI.encodeFunctionData('addr', [node]);
@@ -162,39 +220,12 @@ export async function setEnsTextRecord(
 }
 
 export async function getNameOwner(name: string, chainId: ENSChainId) {
-  const provider = getProvider(chainId);
-  const ensHash = namehash(name);
+  // Prefer UR.findOwner (ENSv2). Falls back to v1 registry for unmigrated
+  // names and chains where findOwner is not yet available (e.g. mainnet).
+  const urOwner = await urFindOwner(name, chainId);
+  if (urOwner) return urOwner;
 
-  let owner = await call(
-    provider,
-    ENS_CONTRACTS.registryAbi,
-    [ENS_CONTRACTS.registry, 'owner', [ensHash]],
-    {
-      blockTag: 'latest'
-    }
-  );
-
-  if (!name.endsWith('.eth') && owner === EVM_EMPTY_ADDRESS) {
-    const resolvedAddress = (await getAddresses([name], chainId))[name];
-    const nameTokens = name.split('.');
-
-    if (nameTokens.length > 2) {
-      owner = resolvedAddress || EVM_EMPTY_ADDRESS;
-    } else if (nameTokens.length === 2 && resolvedAddress) {
-      owner = await getDNSOwner(name);
-    }
-  }
-
-  if (owner !== ENS_CONTRACTS.nameWrappers[chainId]) return owner;
-
-  return call(
-    provider,
-    ENS_CONTRACTS.nameWrapperAbi,
-    [ENS_CONTRACTS.nameWrappers[chainId], 'ownerOf', [ensHash]],
-    {
-      blockTag: 'latest'
-    }
-  );
+  return getNameOwnerV1(name, chainId);
 }
 
 export async function getSpaceController(name: string, chainId: ENSChainId) {

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -1,13 +1,23 @@
 import { Signer } from '@ethersproject/abstract-signer';
 import { getAddress, isAddress } from '@ethersproject/address';
+import { Interface } from '@ethersproject/abi';
 import { Contract } from '@ethersproject/contracts';
-import { ensNormalize, namehash } from '@ethersproject/hash';
-import { call, multicall } from './call';
+import { dnsEncode, ensNormalize, namehash } from '@ethersproject/hash';
+import { call } from './call';
 import { EVM_EMPTY_ADDRESS } from './constants';
 import { getProvider } from './provider';
 import { getAddresses } from './stamp';
 
 export type ENSChainId = 1 | 11155111;
+
+const UNIVERSAL_RESOLVER = '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe';
+const UR_ABI = new Interface([
+  'function resolve(bytes name, bytes data) view returns (bytes, address)'
+]);
+const RESOLVER_ABI = new Interface([
+  'function addr(bytes32 node) view returns (address)',
+  'function text(bytes32 node, string key) view returns (string)'
+]);
 
 type ENSContracts = {
   registry: string;
@@ -76,43 +86,32 @@ async function getDNSOwner(domain: string): Promise<string> {
   );
 }
 
-async function deepResolve(
+async function urResolve(
+  name: string,
   chainId: ENSChainId,
-  node: string,
-  property: string,
-  params: any[]
-) {
+  callData: string
+): Promise<string | null> {
   const provider = getProvider(chainId);
-  const resolvers = ENS_CONTRACTS.resolvers[chainId];
-  if (!resolvers) throw new Error('Unsupported chainId');
-
-  const calls = [
-    [ENS_CONTRACTS.registry, 'resolver', [node]],
-    ...resolvers.map(resolver => [resolver, property, params])
-  ];
-
-  const [[resolverAddress], ...textRecords]: any[][] = await multicall(
-    chainId.toString(),
-    provider,
-    [...ENS_CONTRACTS.registryAbi, ...ENS_CONTRACTS.resolverAbi],
-    calls
-  );
-
-  const resolverIndex = resolvers.indexOf(resolverAddress);
-  return resolverIndex !== -1 ? textRecords[resolverIndex]?.[0] : null;
+  const ur = new Contract(UNIVERSAL_RESOLVER, UR_ABI, provider);
+  try {
+    const [result] = await ur.resolve(dnsEncode(name), callData, {
+      ccipReadEnabled: true
+    });
+    if (!result || result === '0x') return null;
+    return result;
+  } catch {
+    return null;
+  }
 }
 
 export async function resolveName(name: string, chainId: ENSChainId) {
-  const resolver = ENS_CONTRACTS.resolvers[chainId];
-  if (!resolver) throw new Error('Unsupported chainId');
-
   const node = namehash(name);
-
-  const address: string = await deepResolve(chainId, node, 'addr', [node]);
-
+  const callData = RESOLVER_ABI.encodeFunctionData('addr', [node]);
+  const result = await urResolve(name, chainId, callData);
+  if (!result) return null;
+  const [address] = RESOLVER_ABI.decodeFunctionResult('addr', result);
   if (address === EVM_EMPTY_ADDRESS) return null;
-
-  return address;
+  return address as string;
 }
 
 export async function getEnsTextRecord(
@@ -120,18 +119,16 @@ export async function getEnsTextRecord(
   record: string,
   chainId: ENSChainId
 ) {
-  const resolvers = ENS_CONTRACTS.resolvers[chainId];
-  if (!resolvers) throw new Error('Unsupported chainId');
-
-  let ensHash: string;
-
   try {
-    ensHash = namehash(ensNormalize(ens));
+    const node = namehash(ensNormalize(ens));
+    const callData = RESOLVER_ABI.encodeFunctionData('text', [node, record]);
+    const result = await urResolve(ens, chainId, callData);
+    if (!result) return null;
+    const [text] = RESOLVER_ABI.decodeFunctionResult('text', result);
+    return text as string || null;
   } catch {
     return null;
   }
-
-  return deepResolve(chainId, ensHash, 'text', [ensHash, record]);
 }
 
 export async function setEnsTextRecord(


### PR DESCRIPTION
Updates ENS resolution in the UI to use the Universal Resolver (https://docs.ens.domains/resolvers/universal) (`0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe`) instead of hardcoded resolver addresses.

What changed:
- Forward resolution (name → address) via resolveName now calls the Universal Resolver directly
- Text record reads via `getEnsTextRecord` now call the Universal Resolver directly

What didn't change:
- `setEnsTextRecord` — write operation via a signer, UR doesn't apply.
- `getNameOwner` — ownership checks still query the v1 registry directly

Why: The old approach maintained a hardcoded allowlist of resolver addresses per chain and used multicall to query
all of them in parallel. The Universal Resolver removes that maintenance burden and adds support for wildcard/CCIP-Read resolvers.

Todo:
- [ ] Update `getNameOwner()` to also support v2
- [ ] The Stamp API is used for resolution in some places. Figure out the root of that and fix the API, and/or replace it with a local Ethers lookup