### PR TITLE
refactor(delegates-api): unify Delegates API

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,7 @@
     "@as-integrations/express4": "^1.1.2",
     "@faker-js/faker": "^7.4.0",
     "@logtail/pino": "^0.5.5",
-    "@snapshot-labs/checkpoint": "^0.1.0-beta.73",
+    "@snapshot-labs/checkpoint": "^0.1.0-beta.74",
     "@snapshot-labs/sx": "^0.1.0",
     "@types/node": "^22.6.0",
     "cors": "^2.8.5",

--- a/apps/api/src/indexer.ts
+++ b/apps/api/src/indexer.ts
@@ -6,63 +6,19 @@ import {
   ENABLE_OPENZEPPELIN,
   ENABLE_SNAPSHOT_X
 } from './evm';
-import logger from './logger';
 import { addStarknetIndexers } from './starknet';
 
 const GIT_COMMIT = process.env.GIT_COMMIT;
-
-async function initializeCheckpoint(checkpoint: Checkpoint) {
-  if (!GIT_COMMIT) {
-    logger.info('No git commit found, resetting database.');
-
-    await checkpoint.resetMetadata();
-    await checkpoint.reset();
-
-    return;
-  }
-
-  const currentVersionTag = `commit:${GIT_COMMIT}|snapshotX:${ENABLE_SNAPSHOT_X}|governorBravo:${ENABLE_GOVERNOR_BRAVO}|openZeppelin:${ENABLE_OPENZEPPELIN}`;
-  const { knex } = checkpoint.getBaseContext();
-
-  const isInitialized = await knex.schema.hasTable('_metadatas');
-
-  if (isInitialized) {
-    const versionTagRow = await knex
-      .select('*')
-      .from('_metadatas')
-      .where({ id: 'version_tag', indexer: '_global' })
-      .first();
-
-    const storedVersionTag = versionTagRow?.value ?? null;
-
-    if (storedVersionTag === currentVersionTag) {
-      return logger.info(
-        { currentVersionTag, storedVersionTag },
-        'No change detected. Continuing.'
-      );
-    }
-
-    logger.info(
-      { currentVersionTag, storedVersionTag },
-      'Stored version tag differs from current. Resetting database.'
-    );
-  }
-
-  await checkpoint.resetMetadata();
-  await checkpoint.reset();
-
-  await knex('_metadatas').insert({
-    id: 'version_tag',
-    indexer: '_global',
-    value: currentVersionTag
-  });
-}
 
 export async function startIndexer(checkpoint: Checkpoint) {
   addStarknetIndexers(checkpoint);
   addEvmIndexers(checkpoint);
 
-  await initializeCheckpoint(checkpoint);
+  const versionTag = GIT_COMMIT
+    ? `commit:${GIT_COMMIT}|snapshotX:${ENABLE_SNAPSHOT_X}|governorBravo:${ENABLE_GOVERNOR_BRAVO}|openZeppelin:${ENABLE_OPENZEPPELIN}`
+    : undefined;
+
+  await checkpoint.syncVersion(versionTag);
 
   checkpoint.start();
 }

--- a/apps/delegates-api/.env.example
+++ b/apps/delegates-api/.env.example
@@ -1,2 +1,3 @@
 DATABASE_URL=postgres://postgres:password@localhost:5432/delegates
+IS_INDEXER=true
 HYPERSYNC_API_TOKEN=

--- a/apps/delegates-api/package.json
+++ b/apps/delegates-api/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "codegen": "checkpoint generate",
-    "lint": "eslint .",
+    "lint": "eslint . --rule 'no-console: error'",
     "lint:fix": "bun run lint --fix",
     "build": "tsc",
     "dev": "nodemon src/index.ts",
@@ -13,9 +13,12 @@
   },
   "dependencies": {
     "@apollo/server": "^5.1.0",
+    "@logtail/pino": "^0.5.5",
     "@snapshot-labs/checkpoint": "^0.1.0-beta.74",
     "@types/node": "^22.6.0",
     "dotenv": "^16.0.1",
+    "pino": "^9.9.0",
+    "pino-pretty": "^13.1.1",
     "starknet": "7.6.4",
     "viem": "^2.38.0"
   },

--- a/apps/delegates-api/package.json
+++ b/apps/delegates-api/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@apollo/server": "^5.1.0",
-    "@snapshot-labs/checkpoint": "^0.1.0-beta.73",
+    "@snapshot-labs/checkpoint": "^0.1.0-beta.74",
     "@types/node": "^22.6.0",
     "dotenv": "^16.0.1",
     "starknet": "7.6.4",

--- a/apps/delegates-api/src/evm/writers.ts
+++ b/apps/delegates-api/src/evm/writers.ts
@@ -1,5 +1,6 @@
 import { evm } from '@snapshot-labs/checkpoint';
 import { formatUnits } from 'viem';
+import logger from '../logger';
 import { BIGINT_ZERO, DECIMALS, getDelegate, getGovernance } from '../utils';
 import GeneralPurposeFactoryAbi from './abis/GeneralPurposeFactory';
 import TokenAbi from './abis/Token';
@@ -85,7 +86,10 @@ export default function createWriters(indexerName: NetworkID) {
         start: blockNumber
       });
     } else {
-      console.log(`Unknown implementation: ${event.args.implementation}`);
+      logger.warn(
+        { implementation: event.args.implementation },
+        'Unknown implementation'
+      );
     }
   };
 

--- a/apps/delegates-api/src/index.ts
+++ b/apps/delegates-api/src/index.ts
@@ -16,14 +16,29 @@ const dir = __dirname.endsWith('dist/src') ? '../' : '';
 const schemaFile = path.join(__dirname, `${dir}../src/schema.gql`);
 const schema = fs.readFileSync(schemaFile, 'utf8');
 
-const PRODUCTION_INDEXER_DELAY = 60 * 1000;
 const PORT = process.env.PORT ? parseInt(process.env.PORT) : 3000;
+const GIT_COMMIT = process.env.GIT_COMMIT;
+
+/**
+ * IS_INDEXER is a boolean that determines if the current process is an indexer.
+ *
+ * If not set only GraphQL API will be started.
+ */
+const IS_INDEXER = process.env.IS_INDEXER === 'true';
 
 if (process.env.CA_CERT) {
   process.env.CA_CERT = process.env.CA_CERT.replace(/\\n/g, '\n');
 }
 
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+async function startIndexer(checkpoint: Checkpoint) {
+  addEvmIndexers(checkpoint);
+  addStarknetIndexers(checkpoint);
+
+  const versionTag = GIT_COMMIT ? `commit:${GIT_COMMIT}` : undefined;
+
+  await checkpoint.syncVersion(versionTag);
+  checkpoint.start();
+}
 
 async function run() {
   const checkpoint = new Checkpoint(schema, {
@@ -33,9 +48,6 @@ async function run() {
     prettifyLogs: process.env.NODE_ENV !== 'production',
     overridesConfig
   });
-
-  addEvmIndexers(checkpoint);
-  addStarknetIndexers(checkpoint);
 
   const server = new ApolloServer({
     schema: checkpoint.getSchema(),
@@ -56,18 +68,9 @@ async function run() {
 
   console.log(`Listening at ${url}`);
 
-  if (process.env.NODE_ENV === 'production') {
-    console.log(
-      'Delaying indexer to prevent multiple processes indexing at the same time.'
-    );
-    await sleep(PRODUCTION_INDEXER_DELAY);
+  if (IS_INDEXER) {
+    await startIndexer(checkpoint);
   }
-
-  await checkpoint.resetMetadata();
-  await checkpoint.reset();
-  console.log('Checkpoint ready');
-
-  await checkpoint.start();
 }
 
 run();

--- a/apps/delegates-api/src/index.ts
+++ b/apps/delegates-api/src/index.ts
@@ -9,6 +9,7 @@ import Checkpoint, {
   LogLevel
 } from '@snapshot-labs/checkpoint';
 import { addEvmIndexers } from './evm';
+import logger, { pinoOptions } from './logger';
 import overridesConfig from './overrides.json';
 import { addStarknetIndexers } from './starknet';
 
@@ -45,7 +46,7 @@ async function run() {
     logLevel: LogLevel.Info,
     resetOnConfigChange: true,
     skipBlockFetching: true,
-    prettifyLogs: process.env.NODE_ENV !== 'production',
+    pinoOptions,
     overridesConfig
   });
 
@@ -66,7 +67,7 @@ async function run() {
     }
   });
 
-  console.log(`Listening at ${url}`);
+  logger.info(`Listening at ${url}`);
 
   if (IS_INDEXER) {
     await startIndexer(checkpoint);

--- a/apps/delegates-api/src/logger.ts
+++ b/apps/delegates-api/src/logger.ts
@@ -1,0 +1,36 @@
+import pino from 'pino';
+
+const prettifyLogs = process.env.NODE_ENV !== 'production';
+
+const LOGTAIL_HOST = process.env.LOGTAIL_HOST;
+const LOGTAIL_TOKEN = process.env.LOGTAIL_TOKEN;
+
+function getPinoOptions() {
+  if (LOGTAIL_HOST && LOGTAIL_TOKEN) {
+    return {
+      transport: {
+        target: '@logtail/pino',
+        options: {
+          sourceToken: LOGTAIL_TOKEN,
+          options: {
+            endpoint: `https://${LOGTAIL_HOST}`
+          }
+        }
+      }
+    };
+  }
+
+  if (prettifyLogs) {
+    return {
+      transport: {
+        target: 'pino-pretty'
+      }
+    };
+  }
+
+  return {};
+}
+
+export const pinoOptions = getPinoOptions();
+
+export default pino(pinoOptions);

--- a/apps/highlight/package.json
+++ b/apps/highlight/package.json
@@ -20,7 +20,7 @@
     "@ethersproject/hash": "^5.8.0",
     "@ethersproject/providers": "^5.8.0",
     "@ethersproject/wallet": "^5.8.0",
-    "@snapshot-labs/checkpoint": "^0.1.0-beta.72",
+    "@snapshot-labs/checkpoint": "^0.1.0-beta.74",
     "@snapshot-labs/sx": "^0.1.7",
     "async-lock": "^1.4.0",
     "change-case": "^4.1.2",

--- a/bun.lock
+++ b/bun.lock
@@ -118,9 +118,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@apollo/server": "^5.1.0",
+        "@logtail/pino": "^0.5.5",
         "@snapshot-labs/checkpoint": "^0.1.0-beta.74",
         "@types/node": "^22.6.0",
         "dotenv": "^16.0.1",
+        "pino": "^9.9.0",
+        "pino-pretty": "^13.1.1",
         "starknet": "7.6.4",
         "viem": "^2.38.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
         "@as-integrations/express4": "^1.1.2",
         "@faker-js/faker": "^7.4.0",
         "@logtail/pino": "^0.5.5",
-        "@snapshot-labs/checkpoint": "^0.1.0-beta.73",
+        "@snapshot-labs/checkpoint": "^0.1.0-beta.74",
         "@snapshot-labs/sx": "^0.1.0",
         "@types/node": "^22.6.0",
         "cors": "^2.8.5",
@@ -118,7 +118,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@apollo/server": "^5.1.0",
-        "@snapshot-labs/checkpoint": "^0.1.0-beta.73",
+        "@snapshot-labs/checkpoint": "^0.1.0-beta.74",
         "@types/node": "^22.6.0",
         "dotenv": "^16.0.1",
         "starknet": "7.6.4",
@@ -140,7 +140,7 @@
         "@ethersproject/hash": "^5.8.0",
         "@ethersproject/providers": "^5.8.0",
         "@ethersproject/wallet": "^5.8.0",
-        "@snapshot-labs/checkpoint": "^0.1.0-beta.72",
+        "@snapshot-labs/checkpoint": "^0.1.0-beta.74",
         "@snapshot-labs/sx": "^0.1.7",
         "async-lock": "^1.4.0",
         "change-case": "^4.1.2",
@@ -1689,7 +1689,7 @@
 
     "@sinonjs/fake-timers": ["@sinonjs/fake-timers@10.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.0" } }, "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA=="],
 
-    "@snapshot-labs/checkpoint": ["@snapshot-labs/checkpoint@0.1.0-beta.73", "", { "dependencies": { "@graphql-tools/schema": "^8.5.1", "@starknet-io/types-js": "^0.9.2", "connection-string": "^4.3.5", "dataloader": "^2.1.0", "express-graphql": "^0.12.0", "graphql": "^16.5.0", "graphql-fields": "^2.0.3", "graphql-parse-resolve-info": "^4.14.1", "json-to-graphql-query": "^2.2.4", "knex": "^3.1.0", "object-hash": "^3.0.0", "pg": "^8.10.0", "pino": "^9.9.0", "pino-pretty": "^13.1.1", "pluralize": "^8.0.0", "starknet": "~5.19.3", "viem": "^2.36.0", "yargs": "^17.7.2", "zod": "^3.21.4" }, "bin": { "checkpoint": "dist/src/bin/index.js" } }, "sha512-1qpoioDuzF52aRMDPVTHeptsun+FKBcclLfhHhy3SZWzE4gc5wp3ar44GRtsAGJXY5GNnY6gtZjyqyiHlY2niA=="],
+    "@snapshot-labs/checkpoint": ["@snapshot-labs/checkpoint@0.1.0-beta.74", "", { "dependencies": { "@graphql-tools/schema": "^8.5.1", "@starknet-io/types-js": "^0.9.2", "connection-string": "^4.3.5", "dataloader": "^2.1.0", "express-graphql": "^0.12.0", "graphql": "^16.5.0", "graphql-fields": "^2.0.3", "graphql-parse-resolve-info": "^4.14.1", "json-to-graphql-query": "^2.2.4", "knex": "^3.1.0", "object-hash": "^3.0.0", "pg": "^8.10.0", "pino": "^9.9.0", "pino-pretty": "^13.1.1", "pluralize": "^8.0.0", "starknet": "~5.19.3", "viem": "^2.36.0", "yargs": "^17.7.2", "zod": "^3.21.4" }, "bin": { "checkpoint": "dist/src/bin/index.js" } }, "sha512-M9lAfNb2HLBhg7XJ6ylfvxS03sNPCclFsR6gi60PdSeNmq6J3DN9M9tyGk2YjZyBjDjznE+bjBE4ousGRraXtA=="],
 
     "@snapshot-labs/eslint-config": ["@snapshot-labs/eslint-config@workspace:packages/eslint-config"],
 
@@ -5293,8 +5293,6 @@
 
     "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
-    "highlight/@snapshot-labs/checkpoint": ["@snapshot-labs/checkpoint@0.1.0-beta.72", "", { "dependencies": { "@graphql-tools/schema": "^8.5.1", "@starknet-io/types-js": "^0.9.2", "connection-string": "^4.3.5", "dataloader": "^2.1.0", "express-graphql": "^0.12.0", "graphql": "^16.5.0", "graphql-fields": "^2.0.3", "graphql-parse-resolve-info": "^4.14.1", "json-to-graphql-query": "^2.2.4", "knex": "^3.1.0", "object-hash": "^3.0.0", "pg": "^8.10.0", "pino": "^9.9.0", "pino-pretty": "^13.1.1", "pluralize": "^8.0.0", "starknet": "~5.19.3", "viem": "^2.36.0", "yargs": "^17.7.2", "zod": "^3.21.4" }, "bin": { "checkpoint": "dist/src/bin/index.js" } }, "sha512-BoRyfaXK0IfUKKmqaRiGOFKGp2JAA7p131Q4wdVs4R1uuFZa0WaaHrkd0j5cbRGKJzgz1t/J0NzuMbjEInlXOQ=="],
-
     "highlight/@types/express": ["@types/express@4.17.25", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^4.17.33", "@types/qs": "*", "@types/serve-static": "^1" } }, "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw=="],
 
     "highlight/nodemon": ["nodemon@2.0.22", "", { "dependencies": { "chokidar": "^3.5.2", "debug": "^3.2.7", "ignore-by-default": "^1.0.1", "minimatch": "^3.1.2", "pstree.remy": "^1.1.8", "semver": "^5.7.1", "simple-update-notifier": "^1.0.7", "supports-color": "^5.5.0", "touch": "^3.1.0", "undefsafe": "^2.0.5" }, "bin": { "nodemon": "bin/nodemon.js" } }, "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ=="],
@@ -6045,12 +6043,6 @@
 
     "graphql-config/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
-    "highlight/@snapshot-labs/checkpoint/@graphql-tools/schema": ["@graphql-tools/schema@8.5.1", "", { "dependencies": { "@graphql-tools/merge": "8.3.1", "@graphql-tools/utils": "8.9.0", "tslib": "^2.4.0", "value-or-promise": "1.0.11" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg=="],
-
-    "highlight/@snapshot-labs/checkpoint/connection-string": ["connection-string@4.4.0", "", {}, "sha512-D4xsUjSoE8m/B5yMOvCIHY+2ME6FIZhCq0NzBBT57Q8BuL7ArFhBK04osOfReoW4KFr5ztzFwWRdmnv9rCvu2w=="],
-
-    "highlight/@snapshot-labs/checkpoint/starknet": ["starknet@5.19.6", "", { "dependencies": { "@noble/curves": "~1.2.0", "@scure/starknet": "~0.3.0", "abi-wan-kanabi": "^1.0.3", "isomorphic-fetch": "^3.0.0", "lossless-json": "^2.0.8", "pako": "^2.0.4", "url-join": "^4.0.1" } }, "sha512-MyO48QKu+d8CBH/7ruI/RPrDwoFRNV/uxql2nBeA4ccqBXs698FkeGkMhZv++VIwf1MRajHcTM91KuyZQMyMLw=="],
-
     "highlight/@types/express/@types/express-serve-static-core": ["@types/express-serve-static-core@4.19.8", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA=="],
 
     "highlight/@types/express/@types/serve-static": ["@types/serve-static@1.15.10", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw=="],
@@ -6571,18 +6563,6 @@
 
     "graphql-config/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "highlight/@snapshot-labs/checkpoint/@graphql-tools/schema/@graphql-tools/merge": ["@graphql-tools/merge@8.3.1", "", { "dependencies": { "@graphql-tools/utils": "8.9.0", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg=="],
-
-    "highlight/@snapshot-labs/checkpoint/@graphql-tools/schema/@graphql-tools/utils": ["@graphql-tools/utils@8.9.0", "", { "dependencies": { "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg=="],
-
-    "highlight/@snapshot-labs/checkpoint/starknet/@noble/curves": ["@noble/curves@1.2.0", "", { "dependencies": { "@noble/hashes": "1.3.2" } }, "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw=="],
-
-    "highlight/@snapshot-labs/checkpoint/starknet/@scure/starknet": ["@scure/starknet@0.3.0", "", { "dependencies": { "@noble/curves": "~1.2.0", "@noble/hashes": "~1.3.2" } }, "sha512-Ma66yZlwa5z00qI5alSxdWtIpky5LBhy22acVFdoC5kwwbd9uDyMWEYzWHdNyKmQg9t5Y2UOXzINMeb3yez+Gw=="],
-
-    "highlight/@snapshot-labs/checkpoint/starknet/abi-wan-kanabi": ["abi-wan-kanabi@1.0.3", "", { "dependencies": { "abi-wan-kanabi": "^1.0.1", "fs-extra": "^10.0.0", "rome": "^12.1.3", "typescript": "^4.9.5", "yargs": "^17.7.2" }, "bin": { "generate": "dist/generate.js" } }, "sha512-Xwva0AnhXx/IVlzo3/kwkI7Oa7ZX7codtcSn+Gmoa2PmjGPF/0jeVud9puasIPtB7V50+uBdUj4Mh3iATqtBvg=="],
-
-    "highlight/@snapshot-labs/checkpoint/starknet/lossless-json": ["lossless-json@2.0.11", "", {}, "sha512-BP0vn+NGYvzDielvBZaFain/wgeJ1hTvURCqtKvhr1SCPePdaaTanmmcplrHfEJSJOUql7hk4FHwToNJjWRY3g=="],
-
     "highlight/@types/express/@types/serve-static/@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
 
     "highlight/nodemon/simple-update-notifier/semver": ["semver@7.0.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="],
@@ -6909,14 +6889,6 @@
 
     "graphql-config/@graphql-tools/url-loader/@graphql-tools/wrap/@graphql-tools/delegate/@graphql-tools/batch-execute": ["@graphql-tools/batch-execute@10.0.7", "", { "dependencies": { "@graphql-tools/utils": "^11.0.0", "@whatwg-node/promise-helpers": "^1.3.2", "dataloader": "^2.2.3", "tslib": "^2.8.1" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-vKo9XUiy2sc5tzMupXoxZbu5afVY/9yJ0+yLrM5Dhh38yHYULf3z9VC1eAwW0kj8pWpOo8d8CV3jpleGwv83PA=="],
 
-    "highlight/@snapshot-labs/checkpoint/starknet/@noble/curves/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
-
-    "highlight/@snapshot-labs/checkpoint/starknet/@scure/starknet/@noble/hashes": ["@noble/hashes@1.3.3", "", {}, "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA=="],
-
-    "highlight/@snapshot-labs/checkpoint/starknet/abi-wan-kanabi/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
-
-    "highlight/@snapshot-labs/checkpoint/starknet/abi-wan-kanabi/typescript": ["typescript@4.9.5", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="],
-
     "qrcode/yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "thirdweb/@walletconnect/sign-client/@walletconnect/core/@walletconnect/relay-auth/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
@@ -6952,10 +6924,6 @@
     "@walletconnect/modal-ui/qrcode/yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "get-package-info/read-pkg-up/find-up/locate-path/p-locate/p-limit": ["p-limit@1.3.0", "", { "dependencies": { "p-try": "^1.0.0" } }, "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q=="],
-
-    "highlight/@snapshot-labs/checkpoint/starknet/abi-wan-kanabi/fs-extra/jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
-
-    "highlight/@snapshot-labs/checkpoint/starknet/abi-wan-kanabi/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "get-package-info/read-pkg-up/find-up/locate-path/p-locate/p-limit/p-try": ["p-try@1.0.0", "", {}, "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww=="],
   }

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -30,7 +30,7 @@ const config: KnipConfig = {
     },
     'apps/delegates-api': {
       entry: ['src/index.ts'],
-      ignoreDependencies: ['ts-node']
+      ignoreDependencies: ['@logtail/pino', 'pino-pretty', 'ts-node']
     },
     'apps/highlight': {
       entry: ['src/index.ts']


### PR DESCRIPTION
### Summary

To match existing setup of API we make few changes:
1. Use `syncVersion` to detect new schema versions (we also replace `initializeCheckpoint` in API with this helper).
2. Add IS_INDEXER flag so we can separate API and indexer parts.
3. Migrate to logger from console.logs with Logtail support.