### PR TITLE
feat: migrate to Satellite based Herodotus strategies

### DIFF
--- a/apps/mana/src/stark/herodotus.ts
+++ b/apps/mana/src/stark/herodotus.ts
@@ -10,6 +10,8 @@ type HerodotusConfig = {
   FEE: string;
 };
 
+const TIMESTAMP_AVAILABILITY_BUFFER = 60;
+
 const HERODOTUS_API_KEY = process.env.HERODOTUS_API_KEY || '';
 const HERODOTUS_LEGACY_API_KEY = process.env.HERODOTUS_LEGACY_API_KEY || '';
 const HERODOTUS_MAPPING = new Map<string, HerodotusConfig>([
@@ -128,7 +130,10 @@ async function getStatus(
   return { queryStatus, info };
 }
 
-async function submitBatch(proposal: ApiProposal) {
+async function submitBatch(proposal: DbProposal) {
+  const [, l1TokenAddress] = proposal.id.split('-');
+  if (!l1TokenAddress) throw new Error('Invalid proposal id');
+
   const mapping = HERODOTUS_MAPPING.get(proposal.chainId);
   if (!mapping) throw new Error('Invalid chainId');
 
@@ -146,7 +151,7 @@ async function submitBatch(proposal: ApiProposal) {
       [ACCUMULATES_CHAIN_ID]: {
         [`timestamp:${proposal.timestamp}`]: {
           accounts: {
-            [proposal.l1TokenAddress]: {
+            [l1TokenAddress]: {
               props: ['STORAGE_ROOT']
             }
           }
@@ -173,13 +178,13 @@ async function submitBatch(proposal: ApiProposal) {
         { proposal },
         'Invalid account address or ENS in herodotus batch proposal'
       );
-      return db.markProposalProcessed(getId(proposal));
+      return db.markProposalProcessed(proposal.id);
     }
 
     throw new Error(result.error);
   }
 
-  await db.updateProposal(getId(proposal), {
+  await db.updateProposal(proposal.id, {
     herodotusId: result.internalId
   });
 }
@@ -198,30 +203,22 @@ export async function registerProposal(proposal: ApiProposal) {
     strategyAddress: proposal.strategyAddress,
     herodotusId: null
   });
-
-  try {
-    await submitBatch(proposal);
-  } catch (err) {
-    logger.error(
-      { err, proposalId: getId(proposal), proposal },
-      'Failed to submit herodotus batch'
-    );
-  }
-}
-
-function resubmitBatch(proposal: DbProposal) {
-  const [, l1TokenAddress] = proposal.id.split('-');
-  if (!l1TokenAddress) throw new Error('Invalid proposal id');
-
-  return submitBatch({
-    ...proposal,
-    l1TokenAddress
-  });
 }
 
 export async function processProposal(proposal: DbProposal) {
+  const isTimestampAvailable =
+    proposal.timestamp <=
+    Math.floor(Date.now() / 1000) - TIMESTAMP_AVAILABILITY_BUFFER;
+  if (!isTimestampAvailable) {
+    logger.info(
+      { proposalId: proposal.id, timestamp: proposal.timestamp },
+      'Proposal timestamp is not available on L1 yet'
+    );
+    return;
+  }
+
   if (!proposal.herodotusId) {
-    return resubmitBatch(proposal);
+    return submitBatch(proposal);
   }
 
   const mapping = HERODOTUS_MAPPING.get(proposal.chainId);
@@ -250,7 +247,7 @@ export async function processProposal(proposal: DbProposal) {
           { proposalId: proposal.id, herodotusId: proposal.herodotusId, info },
           'Query was rejected because timestamp was not available yet, submitting a new batch'
         );
-        return resubmitBatch(proposal);
+        return submitBatch(proposal);
       }
 
       logger.error(

--- a/apps/mana/src/stark/herodotus.ts
+++ b/apps/mana/src/stark/herodotus.ts
@@ -48,18 +48,8 @@ type DbProposal = {
   herodotusId: string | null;
 };
 
-// Host/key selection is by strategy generation, not chain:
-//
-// - Satellite V2 strategies use the official Herodotus API (api.herodotus.cloud)
-//   with HERODOTUS_API_KEY on BOTH Starknet mainnet and sepolia. They resolve the
-//   timestamp -> L1 block mapping and storage root entirely on-chain via the
-//   Satellite contract, so they never touch the indexer's remapper endpoints.
-//
-// - Legacy storage-proof strategies keep the frozen host for mainnet
-//   (snapshot.api.herodotus.cloud + snapshot.rs-indexer, HERODOTUS_LEGACY_API_KEY)
-//   because they still depend on snapshot.rs-indexer's /remappers/binsearch-path.
-//   Legacy sepolia already runs on the official host.
 function getApi(accumulatesChainId: string, isSatellite: boolean) {
+  // NOTE: Deprecated - can be removed once we migrate to V2 strategies.
   if (!isSatellite && accumulatesChainId === '1') {
     return {
       apiUrl: 'https://snapshot.api.herodotus.cloud',
@@ -85,11 +75,6 @@ function getNetworkId(chainId: string): 'sn' | 'sn-sep' | null {
   return null;
 }
 
-// The Herodotus Satellite versions of the storage-proof voting strategies
-// (sx-starknet#641). The same batch query populates the Satellite contract with
-// the timestamp -> L1 block mapping and the storage root, which voters read
-// on-chain via `get_block_by_timestamp`. So, unlike the legacy strategies, these
-// need no on-chain `cache_timestamp` tx after the query completes.
 function isSatelliteStrategy(
   chainId: string,
   strategyAddress: string

--- a/apps/mana/src/stark/herodotus.ts
+++ b/apps/mana/src/stark/herodotus.ts
@@ -122,10 +122,10 @@ async function getStatus(
     }
   );
 
-  const { queryStatus, error } = await res.json();
+  const { queryStatus, info, error } = await res.json();
   if (error) throw new Error(error);
 
-  return queryStatus;
+  return { queryStatus, info };
 }
 
 async function submitBatch(proposal: ApiProposal) {
@@ -209,15 +209,19 @@ export async function registerProposal(proposal: ApiProposal) {
   }
 }
 
+function resubmitBatch(proposal: DbProposal) {
+  const [, l1TokenAddress] = proposal.id.split('-');
+  if (!l1TokenAddress) throw new Error('Invalid proposal id');
+
+  return submitBatch({
+    ...proposal,
+    l1TokenAddress
+  });
+}
+
 export async function processProposal(proposal: DbProposal) {
   if (!proposal.herodotusId) {
-    const [, l1TokenAddress] = proposal.id.split('-');
-    if (!l1TokenAddress) throw new Error('Invalid proposal id');
-
-    return submitBatch({
-      ...proposal,
-      l1TokenAddress
-    });
+    return resubmitBatch(proposal);
   }
 
   const mapping = HERODOTUS_MAPPING.get(proposal.chainId);
@@ -230,14 +234,35 @@ export async function processProposal(proposal: DbProposal) {
   );
 
   try {
-    const status = await getStatus(
+    const { queryStatus, info } = await getStatus(
       proposal.herodotusId,
       ACCUMULATES_CHAIN_ID,
       isSatellite
     );
-    if (status !== 'DONE') {
+
+    if (queryStatus === 'REJECTED') {
+      const isTimestampNotAvailableYet = Boolean(
+        info?.some((message: string) => message.startsWith('Too big:'))
+      );
+
+      if (isTimestampNotAvailableYet) {
+        logger.warn(
+          { proposalId: proposal.id, herodotusId: proposal.herodotusId, info },
+          'Query was rejected because timestamp was not available yet, submitting a new batch'
+        );
+        return resubmitBatch(proposal);
+      }
+
+      logger.error(
+        { proposalId: proposal.id, herodotusId: proposal.herodotusId, info },
+        'Query was rejected'
+      );
+      return;
+    }
+
+    if (queryStatus !== 'DONE') {
       logger.info(
-        { herodotusId: proposal.herodotusId, status },
+        { herodotusId: proposal.herodotusId, status: queryStatus },
         'Proposal is not ready yet'
       );
       return;

--- a/apps/mana/src/stark/herodotus.ts
+++ b/apps/mana/src/stark/herodotus.ts
@@ -46,8 +46,19 @@ type DbProposal = {
   herodotusId: string | null;
 };
 
-function getApi(accumulatesChainId: string) {
-  if (accumulatesChainId === '1') {
+// Host/key selection is by strategy generation, not chain:
+//
+// - Satellite V2 strategies use the official Herodotus API (api.herodotus.cloud)
+//   with HERODOTUS_API_KEY on BOTH Starknet mainnet and sepolia. They resolve the
+//   timestamp -> L1 block mapping and storage root entirely on-chain via the
+//   Satellite contract, so they never touch the indexer's remapper endpoints.
+//
+// - Legacy storage-proof strategies keep the frozen host for mainnet
+//   (snapshot.api.herodotus.cloud + snapshot.rs-indexer, HERODOTUS_LEGACY_API_KEY)
+//   because they still depend on snapshot.rs-indexer's /remappers/binsearch-path.
+//   Legacy sepolia already runs on the official host.
+function getApi(accumulatesChainId: string, isSatellite: boolean) {
+  if (!isSatellite && accumulatesChainId === '1') {
     return {
       apiUrl: 'https://snapshot.api.herodotus.cloud',
       indexerUrl: 'https://snapshot.rs-indexer.api.herodotus.cloud',
@@ -95,8 +106,12 @@ function isSatelliteStrategy(
     .includes(validateAndParseAddress(strategyAddress));
 }
 
-async function getStatus(id: string, accumulatesChainId: string) {
-  const { apiUrl, apiKey } = getApi(accumulatesChainId);
+async function getStatus(
+  id: string,
+  accumulatesChainId: string,
+  isSatellite: boolean
+) {
+  const { apiUrl, apiKey } = getApi(accumulatesChainId, isSatellite);
 
   const res = await fetch(
     `${apiUrl}/batch-query-status?apiKey=${apiKey}&batchQueryId=${id}`,
@@ -119,6 +134,11 @@ async function submitBatch(proposal: ApiProposal) {
 
   const { DESTINATION_CHAIN_ID, ACCUMULATES_CHAIN_ID, FEE } = mapping;
 
+  const isSatellite = isSatelliteStrategy(
+    proposal.chainId,
+    proposal.strategyAddress
+  );
+
   const body: any = {
     destinationChainId: DESTINATION_CHAIN_ID,
     fee: FEE,
@@ -135,7 +155,7 @@ async function submitBatch(proposal: ApiProposal) {
     }
   };
 
-  const { apiUrl, apiKey } = getApi(ACCUMULATES_CHAIN_ID);
+  const { apiUrl, apiKey } = getApi(ACCUMULATES_CHAIN_ID, isSatellite);
   const res = await fetch(`${apiUrl}/submit-batch-query?apiKey=${apiKey}`, {
     method: 'post',
     headers: {
@@ -182,7 +202,10 @@ export async function registerProposal(proposal: ApiProposal) {
   try {
     await submitBatch(proposal);
   } catch (err) {
-    logger.error({ err, proposal }, 'Failed to submit herodotus batch');
+    logger.error(
+      { err, proposalId: getId(proposal), proposal },
+      'Failed to submit herodotus batch'
+    );
   }
 }
 
@@ -201,8 +224,17 @@ export async function processProposal(proposal: DbProposal) {
   if (!mapping) throw new Error('Invalid chainId');
   const { DESTINATION_CHAIN_ID, ACCUMULATES_CHAIN_ID } = mapping;
 
+  const isSatellite = isSatelliteStrategy(
+    proposal.chainId,
+    proposal.strategyAddress
+  );
+
   try {
-    const status = await getStatus(proposal.herodotusId, ACCUMULATES_CHAIN_ID);
+    const status = await getStatus(
+      proposal.herodotusId,
+      ACCUMULATES_CHAIN_ID,
+      isSatellite
+    );
     if (status !== 'DONE') {
       logger.info(
         { herodotusId: proposal.herodotusId, status },
@@ -226,7 +258,7 @@ export async function processProposal(proposal: DbProposal) {
   // timestamp -> L1 block mapping and storage root into the Satellite contract,
   // which voters read on-chain via get_block_by_timestamp. No on-chain
   // cache_timestamp tx is required, so we are done.
-  if (isSatelliteStrategy(proposal.chainId, proposal.strategyAddress)) {
+  if (isSatellite) {
     logger.info({ proposalId: proposal.id }, 'Satellite proposal processed');
     return db.markProposalProcessed(proposal.id);
   }
@@ -236,7 +268,7 @@ export async function processProposal(proposal: DbProposal) {
   const { getAccount, herodotusController } = getClient(proposal.chainId);
   const { account, nonceManager, deployAccount } = getAccount('0x0');
 
-  const { indexerUrl } = getApi(ACCUMULATES_CHAIN_ID);
+  const { indexerUrl } = getApi(ACCUMULATES_CHAIN_ID, isSatellite);
 
   const res = await fetch(
     `${indexerUrl}/remappers/binsearch-path?timestamp=${proposal.timestamp}&deployed_on_chain=${DESTINATION_CHAIN_ID}&accumulates_chain=${ACCUMULATES_CHAIN_ID}`,

--- a/apps/mana/src/stark/herodotus.ts
+++ b/apps/mana/src/stark/herodotus.ts
@@ -49,8 +49,16 @@ type DbProposal = {
 };
 
 function getApi(accumulatesChainId: string, isSatellite: boolean) {
+  if (isSatellite) {
+    return {
+      apiUrl: 'https://mission-control.api.herodotus.cloud',
+      indexerUrl: null,
+      apiKey: HERODOTUS_API_KEY
+    };
+  }
+
   // NOTE: Deprecated - can be removed once we migrate to V2 strategies.
-  if (!isSatellite && accumulatesChainId === '1') {
+  if (accumulatesChainId === '1') {
     return {
       apiUrl: 'https://snapshot.api.herodotus.cloud',
       indexerUrl: 'https://snapshot.rs-indexer.api.herodotus.cloud',
@@ -97,8 +105,32 @@ async function getStatus(
   id: string,
   accumulatesChainId: string,
   isSatellite: boolean
-) {
+): Promise<{ queryStatus: string; info?: string[] }> {
   const { apiUrl, apiKey } = getApi(accumulatesChainId, isSatellite);
+
+  if (isSatellite) {
+    const res = await fetch(`${apiUrl}/get_queries/${id}`, {
+      headers: {
+        accept: 'application/json',
+        'api-key': apiKey
+      }
+    });
+
+    const { queries, error } = await res.json();
+    if (error) throw new Error(error);
+
+    const statuses: string[] = queries.map(
+      (query: { status: string }) => query.status
+    );
+
+    const anyFailed = statuses.some(
+      status => status === 'FAILED' || status === 'REJECTED'
+    );
+    if (anyFailed) return { queryStatus: 'REJECTED', info: statuses };
+
+    const allCompleted = statuses.every(status => status === 'COMPLETED');
+    return { queryStatus: allCompleted ? 'DONE' : statuses.join(', ') };
+  }
 
   const res = await fetch(
     `${apiUrl}/batch-query-status?apiKey=${apiKey}&batchQueryId=${id}`,
@@ -129,16 +161,12 @@ async function submitBatch(proposal: DbProposal) {
     proposal.strategyAddress
   );
 
-  const body: any = {
-    destinationChainId: DESTINATION_CHAIN_ID,
-    fee: FEE,
-    data: {
-      [ACCUMULATES_CHAIN_ID]: {
-        [`timestamp:${proposal.timestamp}`]: {
-          accounts: {
-            [l1TokenAddress]: {
-              props: ['STORAGE_ROOT']
-            }
+  const data = {
+    [ACCUMULATES_CHAIN_ID]: {
+      [`timestamp:${proposal.timestamp}`]: {
+        accounts: {
+          [l1TokenAddress]: {
+            props: ['STORAGE_ROOT']
           }
         }
       }
@@ -146,7 +174,15 @@ async function submitBatch(proposal: DbProposal) {
   };
 
   const { apiUrl, apiKey } = getApi(ACCUMULATES_CHAIN_ID, isSatellite);
-  const res = await fetch(`${apiUrl}/submit-batch-query?apiKey=${apiKey}`, {
+
+  const url = isSatellite
+    ? `${apiUrl}/submit-request`
+    : `${apiUrl}/submit-batch-query?apiKey=${apiKey}`;
+  const body = isSatellite
+    ? { destination_chain_id: DESTINATION_CHAIN_ID, data }
+    : { destinationChainId: DESTINATION_CHAIN_ID, fee: FEE, data };
+
+  const res = await fetch(url, {
     method: 'post',
     headers: {
       'Content-Type': 'application/json',
@@ -170,7 +206,7 @@ async function submitBatch(proposal: DbProposal) {
   }
 
   await db.updateProposal(proposal.id, {
-    herodotusId: result.internalId
+    herodotusId: isSatellite ? result.request_id : result.internalId
   });
 }
 

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -74,7 +74,7 @@ export function createConstants(
     [config.Strategies.OZVotesTrace208StorageProofV2]: true
   };
 
-  const STORAGE_PROOF_STRATEGIES_TYPES = [
+  const STORAGE_PROOF_STRATEGIES_TYPES: string[] = [
     config.Strategies.EVMSlotValue,
     config.Strategies.OZVotesStorageProof,
     config.Strategies.OZVotesTrace208StorageProof,

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -68,14 +68,28 @@ export function createConstants(
     [config.Strategies.ERC20Votes]: true,
     [config.Strategies.EVMSlotValue]: true,
     [config.Strategies.OZVotesStorageProof]: true,
-    [config.Strategies.OZVotesTrace208StorageProof]: true
+    [config.Strategies.OZVotesTrace208StorageProof]: true,
+    ...(config.Strategies.EVMSlotValueV2 && {
+      [config.Strategies.EVMSlotValueV2]: true
+    }),
+    ...(config.Strategies.OZVotesStorageProofV2 && {
+      [config.Strategies.OZVotesStorageProofV2]: true
+    }),
+    ...(config.Strategies.OZVotesTrace208StorageProofV2 && {
+      [config.Strategies.OZVotesTrace208StorageProofV2]: true
+    })
   };
 
-  const STORAGE_PROOF_STRATEGIES_TYPES = [
-    config.Strategies.EVMSlotValue,
-    config.Strategies.OZVotesStorageProof,
-    config.Strategies.OZVotesTrace208StorageProof
-  ];
+  const STORAGE_PROOF_STRATEGIES_TYPES = (
+    [
+      config.Strategies.EVMSlotValue,
+      config.Strategies.OZVotesStorageProof,
+      config.Strategies.OZVotesTrace208StorageProof,
+      config.Strategies.EVMSlotValueV2,
+      config.Strategies.OZVotesStorageProofV2,
+      config.Strategies.OZVotesTrace208StorageProofV2
+    ] as (string | undefined)[]
+  ).filter((address): address is string => !!address);
 
   const SUPPORTED_EXECUTORS = {
     EthRelayer: true
@@ -95,11 +109,22 @@ export function createConstants(
   const STRATEGIES = {
     [config.Strategies.MerkleWhitelist]: 'Merkle whitelist',
     [config.Strategies.ERC20Votes]: 'ERC-20 Votes (EIP-5805)',
-    [config.Strategies.EVMSlotValue]: 'EVM slot value',
+    [config.Strategies.EVMSlotValue]: 'EVM slot value (deprecated)',
     [config.Strategies.OZVotesStorageProof]:
-      'OZ Votes storage proof (trace 224)',
+      'OZ Votes storage proof (trace 224, deprecated)',
     [config.Strategies.OZVotesTrace208StorageProof]:
-      'OZ Votes storage proof (trace 208)'
+      'OZ Votes storage proof (trace 208, deprecated)',
+    ...(config.Strategies.EVMSlotValueV2 && {
+      [config.Strategies.EVMSlotValueV2]: 'EVM slot value'
+    }),
+    ...(config.Strategies.OZVotesStorageProofV2 && {
+      [config.Strategies.OZVotesStorageProofV2]:
+        'OZ Votes storage proof (trace 224)'
+    }),
+    ...(config.Strategies.OZVotesTrace208StorageProofV2 && {
+      [config.Strategies.OZVotesTrace208StorageProofV2]:
+        'OZ Votes storage proof (trace 208)'
+    })
   };
 
   const EXECUTORS = {
@@ -111,12 +136,14 @@ export function createConstants(
     address: string,
     name: string,
     about: string,
-    link?: string
+    link?: string,
+    deprecated = false
   ): StrategyTemplate => ({
     address,
     name,
     about,
     link,
+    deprecated,
     icon: IHCode,
     generateSummary: (params: Record<string, any>) =>
       `(${shorten(params.contractAddress)}, ${params.slotIndex})`,
@@ -461,13 +488,18 @@ export function createConstants(
         }
       }
     },
+    // Deprecated legacy Herodotus storage-proof strategies (facts registry +
+    // timestamp remappers). Kept so existing spaces still render and remain
+    // editable, but hidden from the add-strategy picker via `deprecated: true`.
+    // Superseded by the Satellite versions below (sx-starknet#641).
     ...(config.Strategies.EVMSlotValue
       ? [
           createSlotValueStrategyConfig(
             config.Strategies.EVMSlotValue,
-            'EVM slot value',
+            'EVM slot value (deprecated)',
             'A strategy that allows to use the value of an slot on EVM chain (for example ERC-20 balance on L1) as voting power.',
-            `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#evm-slot-value`
+            `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#evm-slot-value`,
+            true
           )
         ]
       : []),
@@ -475,9 +507,10 @@ export function createConstants(
       ? [
           createSlotValueStrategyConfig(
             config.Strategies.OZVotesStorageProof,
-            'OZ Votes storage proof (trace 224)',
+            'OZ Votes storage proof (trace 224, deprecated)',
             'A strategy that allows to use the value of an slot on EVM chain (for example ERC-20 balance on L1) as voting power including delegated balances (trace 224 format).',
-            `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#oz-votes-storage-proof`
+            `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#oz-votes-storage-proof`,
+            true
           )
         ]
       : []),
@@ -485,6 +518,38 @@ export function createConstants(
       ? [
           createSlotValueStrategyConfig(
             config.Strategies.OZVotesTrace208StorageProof,
+            'OZ Votes storage proof (trace 208, deprecated)',
+            'A strategy that allows to use the value of an slot on EVM chain (for example ERC-20 balance on L1) as voting power including delegated balances (trace 208 format).',
+            `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#oz-votes-storage-proof`,
+            true
+          )
+        ]
+      : []),
+    // Herodotus Satellite storage-proof strategies (sx-starknet#641).
+    ...(config.Strategies.EVMSlotValueV2
+      ? [
+          createSlotValueStrategyConfig(
+            config.Strategies.EVMSlotValueV2,
+            'EVM slot value',
+            'A strategy that allows to use the value of an slot on EVM chain (for example ERC-20 balance on L1) as voting power.',
+            `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#evm-slot-value`
+          )
+        ]
+      : []),
+    ...(config.Strategies.OZVotesStorageProofV2
+      ? [
+          createSlotValueStrategyConfig(
+            config.Strategies.OZVotesStorageProofV2,
+            'OZ Votes storage proof (trace 224)',
+            'A strategy that allows to use the value of an slot on EVM chain (for example ERC-20 balance on L1) as voting power including delegated balances (trace 224 format).',
+            `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#oz-votes-storage-proof`
+          )
+        ]
+      : []),
+    ...(config.Strategies.OZVotesTrace208StorageProofV2
+      ? [
+          createSlotValueStrategyConfig(
+            config.Strategies.OZVotesTrace208StorageProofV2,
             'OZ Votes storage proof (trace 208)',
             'A strategy that allows to use the value of an slot on EVM chain (for example ERC-20 balance on L1) as voting power including delegated balances (trace 208 format).',
             `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#oz-votes-storage-proof`
@@ -500,7 +565,10 @@ export function createConstants(
           [
             config.Strategies.EVMSlotValue,
             config.Strategies.OZVotesStorageProof,
-            config.Strategies.OZVotesTrace208StorageProof
+            config.Strategies.OZVotesTrace208StorageProof,
+            config.Strategies.EVMSlotValueV2,
+            config.Strategies.OZVotesStorageProofV2,
+            config.Strategies.OZVotesTrace208StorageProofV2
           ] as string[]
         ).includes(strategy.address)
     );

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -69,27 +69,19 @@ export function createConstants(
     [config.Strategies.EVMSlotValue]: true,
     [config.Strategies.OZVotesStorageProof]: true,
     [config.Strategies.OZVotesTrace208StorageProof]: true,
-    ...(config.Strategies.EVMSlotValueV2 && {
-      [config.Strategies.EVMSlotValueV2]: true
-    }),
-    ...(config.Strategies.OZVotesStorageProofV2 && {
-      [config.Strategies.OZVotesStorageProofV2]: true
-    }),
-    ...(config.Strategies.OZVotesTrace208StorageProofV2 && {
-      [config.Strategies.OZVotesTrace208StorageProofV2]: true
-    })
+    [config.Strategies.EVMSlotValueV2]: true,
+    [config.Strategies.OZVotesStorageProofV2]: true,
+    [config.Strategies.OZVotesTrace208StorageProofV2]: true
   };
 
-  const STORAGE_PROOF_STRATEGIES_TYPES = (
-    [
-      config.Strategies.EVMSlotValue,
-      config.Strategies.OZVotesStorageProof,
-      config.Strategies.OZVotesTrace208StorageProof,
-      config.Strategies.EVMSlotValueV2,
-      config.Strategies.OZVotesStorageProofV2,
-      config.Strategies.OZVotesTrace208StorageProofV2
-    ] as (string | undefined)[]
-  ).filter((address): address is string => !!address);
+  const STORAGE_PROOF_STRATEGIES_TYPES: string[] = [
+    config.Strategies.EVMSlotValue,
+    config.Strategies.OZVotesStorageProof,
+    config.Strategies.OZVotesTrace208StorageProof,
+    config.Strategies.EVMSlotValueV2,
+    config.Strategies.OZVotesStorageProofV2,
+    config.Strategies.OZVotesTrace208StorageProofV2
+  ];
 
   const SUPPORTED_EXECUTORS = {
     EthRelayer: true
@@ -114,17 +106,11 @@ export function createConstants(
       'OZ Votes storage proof (trace 224, deprecated)',
     [config.Strategies.OZVotesTrace208StorageProof]:
       'OZ Votes storage proof (trace 208, deprecated)',
-    ...(config.Strategies.EVMSlotValueV2 && {
-      [config.Strategies.EVMSlotValueV2]: 'EVM slot value'
-    }),
-    ...(config.Strategies.OZVotesStorageProofV2 && {
-      [config.Strategies.OZVotesStorageProofV2]:
-        'OZ Votes storage proof (trace 224)'
-    }),
-    ...(config.Strategies.OZVotesTrace208StorageProofV2 && {
-      [config.Strategies.OZVotesTrace208StorageProofV2]:
-        'OZ Votes storage proof (trace 208)'
-    })
+    [config.Strategies.EVMSlotValueV2]: 'EVM slot value',
+    [config.Strategies.OZVotesStorageProofV2]:
+      'OZ Votes storage proof (trace 224)',
+    [config.Strategies.OZVotesTrace208StorageProofV2]:
+      'OZ Votes storage proof (trace 208)'
   };
 
   const EXECUTORS = {
@@ -560,17 +546,7 @@ export function createConstants(
 
   const EDITOR_PROPOSAL_VALIDATION_VOTING_STRATEGIES =
     EDITOR_VOTING_STRATEGIES.filter(
-      strategy =>
-        !(
-          [
-            config.Strategies.EVMSlotValue,
-            config.Strategies.OZVotesStorageProof,
-            config.Strategies.OZVotesTrace208StorageProof,
-            config.Strategies.EVMSlotValueV2,
-            config.Strategies.OZVotesStorageProofV2,
-            config.Strategies.OZVotesTrace208StorageProofV2
-          ] as string[]
-        ).includes(strategy.address)
+      strategy => !STORAGE_PROOF_STRATEGIES_TYPES.includes(strategy.address)
     );
 
   const EDITOR_EXECUTION_STRATEGIES = [

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -74,7 +74,7 @@ export function createConstants(
     [config.Strategies.OZVotesTrace208StorageProofV2]: true
   };
 
-  const STORAGE_PROOF_STRATEGIES_TYPES: string[] = [
+  const STORAGE_PROOF_STRATEGIES_TYPES = [
     config.Strategies.EVMSlotValue,
     config.Strategies.OZVotesStorageProof,
     config.Strategies.OZVotesTrace208StorageProof,

--- a/apps/ui/src/queries/votingPower.ts
+++ b/apps/ui/src/queries/votingPower.ts
@@ -80,7 +80,13 @@ export async function getVotingPower(
     if (
       err instanceof utils.errors.VotingPowerDetailsError &&
       err.details === 'NOT_READY_YET' &&
-      ['evmSlotValue', 'ozVotesStorageProof', 'apeGas'].includes(err.source)
+      [
+        'evmSlotValue',
+        'ozVotesStorageProof',
+        'evmSlotValueV2',
+        'ozVotesStorageProofV2',
+        'apeGas'
+      ].includes(err.source)
     ) {
       throw new Error('NOT_READY_YET');
     }

--- a/packages/sx.js/src/strategies/starknet/evmSlotValue.ts
+++ b/packages/sx.js/src/strategies/starknet/evmSlotValue.ts
@@ -193,6 +193,16 @@ export default function createEvmSlotValueStrategy({
           // can be removed after contracts include this
           // https://github.com/snapshot-labs/sx-starknet/pull/624
           if (err.message.includes('Slot is zero')) return 0n;
+
+          // Satellite already has the timestamp -> block mapping, but not the
+          // token account's storage root yet.
+          if (err.message.includes('SP_ACCOUNT_FIELD_NOT_SAVED')) {
+            throw new VotingPowerDetailsError(
+              'Storage root is not saved yet',
+              type,
+              'NOT_READY_YET'
+            );
+          }
         }
 
         throw err;

--- a/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
+++ b/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
@@ -256,6 +256,16 @@ export default function createOzVotesStorageProofStrategy({
           // can be removed after contracts include this
           // https://github.com/snapshot-labs/sx-starknet/pull/624
           if (err.message.includes('Slot is zero')) return 0n;
+
+          // Satellite already has the timestamp -> block mapping, but not the
+          // token account's storage root yet.
+          if (err.message.includes('SP_ACCOUNT_FIELD_NOT_SAVED')) {
+            throw new VotingPowerDetailsError(
+              'Storage root is not saved yet',
+              type,
+              'NOT_READY_YET'
+            );
+          }
         }
 
         throw err;


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/820

This PR deprecates legacy Herodotus strategies in favor of new Satellite based ones. On UI old strategies will be displayed as deprecated in settings.

There were missing things from previous Tony's PRs in Mana to handle migration, those are covered in this PR (can be safely merged as one unit as Mana/UI will deploy roughly in sync):
1. All Satellite based strategies will use official API instead of our frozen ones.
2. With new API submitting batch request for timestamp in the future results in REJECTED batch which won't recover - to handle that we now resubmit batch if that happens and update database entry.
3. To reduce chance of 2. happening we now also wait for votingDelay to pass before submitting a batch.
4. Handle `SP_ACCOUNT_FIELD_NOT_SAVED` error that can cause VP to fail to load on UI - it's similar to `NOT_READY_YET` and needs to be handled as timestamps are made available earlier than account fields so we can end up calling `get_voting_power` too early.

### How to test

1. Create Starknet space that uses new strategy OZ Votes Storage Proof (Trace 224) with following settings (contractAddress: `0x7421b0f131c32876c0ef305f9e4b2591bfbff472`, slotIndex: `8`, decimals: `18`, symbol: `TEST`).
2. Mint this token to your voter address and delegate to self [here](https://etherscan.io/address/0x7421b0f131c32876c0ef305f9e4b2591bfbff472#code).
3. You should see some VP on Proposals page.
5. Create proposal on that space.
6. Run local API + Mana + UI (you need to have `sn` enabled, see diff below).
7. You should have VP on proposal (after processing time).
8. You should be able to vote on that proposal.

#### Diff for using `bun dev run:interactive`
```diff
diff --git a/apps/api/src/starknet/config.ts b/apps/api/src/starknet/config.ts
index 1714444a..c22ef85a 100644
--- a/apps/api/src/starknet/config.ts
+++ b/apps/api/src/starknet/config.ts
@@ -21,7 +21,7 @@ const CONFIG = {
     networkNodeUrl: snNetworkNodeUrl,
     l1NetworkNodeUrl: 'https://rpc.brovider.xyz/1',
     contract: starknetNetworks['sn'].Meta.spaceFactory,
-    start: 445498,
+    start: 11527982,
     verifiedSpaces: [
       '0x009fedaf0d7a480d21a27683b0965c0f8ded35b3f1cac39827a25a06a8a682a4',
       '0x05ea5ef0c54c84dc7382629684c6e536c0b06246b3b0981c426b42372e3ef263',
@@ -34,7 +34,7 @@ const CONFIG = {
     networkNodeUrl: snSepNetworkNodeUrl,
     l1NetworkNodeUrl: 'https://rpc.brovider.xyz/11155111',
     contract: starknetNetworks['sn-sep'].Meta.spaceFactory,
-    start: 17960,
+    start: 11638610,
     verifiedSpaces: [
       '0x0141464688e48ae5b7c83045edb10ecc242ce0e1ad4ff44aca3402f7f47c1ab9'
     ]
diff --git a/scripts/dev-interactive.ts b/scripts/dev-interactive.ts
index 396aa7cc..9abce14a 100644
--- a/scripts/dev-interactive.ts
+++ b/scripts/dev-interactive.ts
@@ -25,8 +25,8 @@ const SERVICES: Record<ServiceType, Service> = {
   api: {
     env: {
       UI_URL: 'http://localhost:8080',
-      ENABLED_NETWORKS: 'sep,sn-sep',
-      VITE_ENABLED_NETWORKS: 's-tn,sep,sn-sep',
+      ENABLED_NETWORKS: 'sn,sn-sep',
+      VITE_ENABLED_NETWORKS: 's-tn,sn,sn-sep',
       VITE_METADATA_NETWORK: 's-tn',
       VITE_API_TESTNET_URL: 'http://localhost:3000'
     }

```