### PR TITLE
feat(api): always run all protocol indexers

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,4 +1,2 @@
 DATABASE_URL=postgres://postgres:password@localhost:5432/api
 IS_INDEXER=true
-ENABLE_SNAPSHOT_X=true
-ENABLE_GOVERNOR_BRAVO=true

--- a/apps/api/src/evm/config.ts
+++ b/apps/api/src/evm/config.ts
@@ -2,20 +2,15 @@ import { evmNetworks } from '@snapshot-labs/sx';
 import { createConfig as createGovernorBravoConfig } from './protocols/governor-bravo/config';
 import { createConfig as createOpenZeppelinConfig } from './protocols/openzeppelin/config';
 import { createConfig as createSnapshotXConfig } from './protocols/snapshot-x/config';
-import { EVMConfig, NetworkID, PartialConfig, Protocols } from './types';
+import { EVMConfig, NetworkID, PartialConfig } from './types';
 import { applyConfig } from './utils';
 
-export function createConfig(
-  indexerName: NetworkID,
-  protocols: Protocols
-): EVMConfig {
+export function createConfig(indexerName: NetworkID): EVMConfig {
   const network = evmNetworks[indexerName];
 
-  let snapshotXConfig: ReturnType<typeof createSnapshotXConfig> | null = null;
-  let governorBravoConfig: ReturnType<typeof createGovernorBravoConfig> | null =
-    null;
-  let openZeppelinConfig: ReturnType<typeof createOpenZeppelinConfig> | null =
-    null;
+  const snapshotXConfig = createSnapshotXConfig(indexerName);
+  const governorBravoConfig = createGovernorBravoConfig(indexerName);
+  const openZeppelinConfig = createOpenZeppelinConfig(indexerName);
 
   let partialConfig: PartialConfig = {
     sources: [],
@@ -23,33 +18,22 @@ export function createConfig(
     abis: {}
   };
 
-  if (protocols.snapshotX) {
-    snapshotXConfig = createSnapshotXConfig(indexerName);
-    partialConfig = applyConfig(partialConfig, 'snapshotX', snapshotXConfig);
+  partialConfig = applyConfig(partialConfig, 'snapshotX', snapshotXConfig);
+
+  if (governorBravoConfig) {
+    partialConfig = applyConfig(
+      partialConfig,
+      'governorBravo',
+      governorBravoConfig
+    );
   }
 
-  if (protocols.governorBravo) {
-    governorBravoConfig = createGovernorBravoConfig(indexerName);
-
-    if (governorBravoConfig) {
-      partialConfig = applyConfig(
-        partialConfig,
-        'governorBravo',
-        governorBravoConfig
-      );
-    }
-  }
-
-  if (protocols.openZeppelin) {
-    openZeppelinConfig = createOpenZeppelinConfig(indexerName);
-
-    if (openZeppelinConfig) {
-      partialConfig = applyConfig(
-        partialConfig,
-        'openZeppelin',
-        openZeppelinConfig
-      );
-    }
+  if (openZeppelinConfig) {
+    partialConfig = applyConfig(
+      partialConfig,
+      'openZeppelin',
+      openZeppelinConfig
+    );
   }
 
   return {
@@ -57,7 +41,7 @@ export function createConfig(
     network_node_url: `https://rpc.snapshot.org/${network.Meta.eip712ChainId}`,
     ...partialConfig,
     state_retention_blocks: 5000,
-    snapshotXConfig: snapshotXConfig?.protocolConfig,
+    snapshotXConfig: snapshotXConfig.protocolConfig,
     governorBravoConfig: governorBravoConfig?.protocolConfig,
     openZeppelinConfig: openZeppelinConfig?.protocolConfig
   };

--- a/apps/api/src/evm/index.ts
+++ b/apps/api/src/evm/index.ts
@@ -4,42 +4,26 @@ import { registerIndexer } from '../register';
 import { createWriters as createGovernorBravoWriters } from './protocols/governor-bravo/writers';
 import { createWriters as createOpenZeppelinWriters } from './protocols/openzeppelin/writers';
 import { createWriters as createSnapshotXWriters } from './protocols/snapshot-x/writers';
-import { EVMConfig, Protocols } from './types';
+import { EVMConfig } from './types';
 import { applyProtocolPrefixToWriters } from './utils';
 
-// SnapshotX runs by default unless explicitly disabled
-export const ENABLE_SNAPSHOT_X = process.env.ENABLE_SNAPSHOT_X !== 'false';
-export const ENABLE_GOVERNOR_BRAVO =
-  process.env.ENABLE_GOVERNOR_BRAVO === 'true';
-export const ENABLE_OPENZEPPELIN = process.env.ENABLE_OPENZEPPELIN === 'true';
-
-const protocols: Protocols = {
-  snapshotX: ENABLE_SNAPSHOT_X,
-  governorBravo: ENABLE_GOVERNOR_BRAVO,
-  openZeppelin: ENABLE_OPENZEPPELIN
-};
-
-const ethConfig = createConfig('eth', protocols);
-const sepConfig = createConfig('sep', protocols);
-const oethConfig = createConfig('oeth', protocols);
-const maticConfig = createConfig('matic', protocols);
-const arb1Config = createConfig('arb1', protocols);
-const baseConfig = createConfig('base', protocols);
-const mntConfig = createConfig('mnt', protocols);
-const bnbConfig = createConfig('bnb', protocols);
-const bnbtConfig = createConfig('bnbt', protocols);
-const apeConfig = createConfig('ape', protocols);
-const curtisConfig = createConfig('curtis', protocols);
+const ethConfig = createConfig('eth');
+const sepConfig = createConfig('sep');
+const oethConfig = createConfig('oeth');
+const maticConfig = createConfig('matic');
+const arb1Config = createConfig('arb1');
+const baseConfig = createConfig('base');
+const mntConfig = createConfig('mnt');
+const bnbConfig = createConfig('bnb');
+const bnbtConfig = createConfig('bnbt');
+const apeConfig = createConfig('ape');
+const curtisConfig = createConfig('curtis');
 
 function createWriters(config: EVMConfig) {
-  let writers: Record<string, evm.Writer> = {};
-
-  if (config.snapshotXConfig) {
-    writers = applyProtocolPrefixToWriters(
-      'snapshotX',
-      createSnapshotXWriters(config, config.snapshotXConfig)
-    );
-  }
+  let writers = applyProtocolPrefixToWriters(
+    'snapshotX',
+    createSnapshotXWriters(config, config.snapshotXConfig)
+  );
 
   if (config.governorBravoConfig) {
     writers = {

--- a/apps/api/src/evm/types.ts
+++ b/apps/api/src/evm/types.ts
@@ -13,12 +13,6 @@ export type NetworkID =
   | 'ape'
   | 'curtis';
 
-export type Protocols = {
-  snapshotX: boolean;
-  governorBravo: boolean;
-  openZeppelin: boolean;
-};
-
 export type SnapshotXConfig = {
   chainId: number;
   manaRpcUrl: string;
@@ -40,7 +34,7 @@ export type OpenZeppelinConfig = {
 
 export type EVMConfig = {
   indexerName: NetworkID;
-  snapshotXConfig?: SnapshotXConfig;
+  snapshotXConfig: SnapshotXConfig;
   governorBravoConfig?: GovernorBravoConfig;
   openZeppelinConfig?: OpenZeppelinConfig;
 } & CheckpointConfig;

--- a/apps/api/src/indexer.ts
+++ b/apps/api/src/indexer.ts
@@ -1,11 +1,6 @@
 import 'dotenv/config';
 import Checkpoint from '@snapshot-labs/checkpoint';
-import {
-  addEvmIndexers,
-  ENABLE_GOVERNOR_BRAVO,
-  ENABLE_OPENZEPPELIN,
-  ENABLE_SNAPSHOT_X
-} from './evm';
+import { addEvmIndexers } from './evm';
 import { addStarknetIndexers } from './starknet';
 
 const GIT_COMMIT = process.env.GIT_COMMIT;
@@ -14,9 +9,7 @@ export async function startIndexer(checkpoint: Checkpoint) {
   addStarknetIndexers(checkpoint);
   addEvmIndexers(checkpoint);
 
-  const versionTag = GIT_COMMIT
-    ? `commit:${GIT_COMMIT}|snapshotX:${ENABLE_SNAPSHOT_X}|governorBravo:${ENABLE_GOVERNOR_BRAVO}|openZeppelin:${ENABLE_OPENZEPPELIN}`
-    : undefined;
+  const versionTag = GIT_COMMIT ? `commit:${GIT_COMMIT}` : undefined;
 
   await checkpoint.syncVersion(versionTag);
 

--- a/helm/checkpoint/values-api-mainnet.yaml
+++ b/helm/checkpoint/values-api-mainnet.yaml
@@ -17,7 +17,4 @@ db:
 
 config:
   PORT: '3000'
-  ENABLE_SNAPSHOT_X: 'true'
-  ENABLE_GOVERNOR_BRAVO: 'true'
-  ENABLE_OPENZEPPELIN: 'true'
   ENABLED_NETWORKS: 'eth,oeth,base,mnt,arb1,ape,bnb,sn'

--- a/helm/checkpoint/values-api-testnet.yaml
+++ b/helm/checkpoint/values-api-testnet.yaml
@@ -9,7 +9,4 @@ image:
 
 config:
   PORT: '3000'
-  ENABLE_SNAPSHOT_X: 'true'
-  ENABLE_GOVERNOR_BRAVO: 'true'
-  ENABLE_OPENZEPPELIN: 'true'
   ENABLED_NETWORKS: 'sep,curtis,bnbt,sn-sep'

--- a/turbo.json
+++ b/turbo.json
@@ -36,9 +36,6 @@
       "passThroughEnv": [
         "UI_URL",
         "ENABLED_NETWORKS",
-        "ENABLE_SNAPSHOT_X",
-        "ENABLE_GOVERNOR_BRAVO",
-        "ENABLE_OPENZEPPELIN",
         "HYPERSYNC_API_TOKEN",
         "VITE_MANA_URL"
       ]


### PR DESCRIPTION
### Summary

Removing `ENABLE_SNAPSHOT_X`, `ENABLE_GOVERNOR_BRAVO` and `ENABLE_OPENZEPPELIN` so all protocols are ran unconditionally.

Those protocols are now officially supported so it makes sense to run them all at once and avoid extra configuration (whose naming was confusing).