### PR TITLE
ci(delegates-api): deploy Delegates API to k8s cluster

### DIFF
--- a/.github/workflows/_deploy-app.yml
+++ b/.github/workflows/_deploy-app.yml
@@ -1,0 +1,159 @@
+name: Deploy app (reusable)
+
+# Reusable blue-green deploy: builds the app image once, then deploys it to the
+# INACTIVE color (staging) of each environment. Called by deploy-api.yml and
+# deploy-delegates-api.yml.
+#
+# Required configuration:
+#   vars.DOKS_CLUSTER                  - DigitalOcean Kubernetes cluster name or id
+#   secrets.DIGITALOCEAN_ACCESS_TOKEN  - DOKS cluster access
+#   secrets.GHCR_PULL_TOKEN            - read:packages PAT for the ghcr pull secret
+#   GitHub environments: <app_key>_<environment> (hold POSTGRES_PASSWORD,
+#     HYPERSYNC_API_TOKEN, and the optional LOGTAIL_* secrets)
+#
+# Image is pushed to GHCR (ghcr.io/<owner>/<image_name>) via the built-in GITHUB_TOKEN.
+
+on:
+  workflow_call:
+    inputs:
+      app_key:
+        description: Key used for GitHub environments (<app_key>_<env>) and values files (values-<app_key>-<env>.yaml)
+        type: string
+        required: true
+      app_name:
+        description: Kubernetes app name (appName in the chart values; prefixes Deployments, Services and secrets)
+        type: string
+        required: true
+      image_name:
+        description: GHCR image name
+        type: string
+        required: true
+      dockerfile:
+        description: Path to the Dockerfile
+        type: string
+        required: true
+      environments:
+        description: JSON array of environments to deploy to
+        type: string
+        required: true
+      release_infix:
+        description: Inserted into Helm release names (<env>-<release_infix><color>), to keep releases of different apps in a shared namespace apart
+        type: string
+        default: ''
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and push image
+        run: |
+          TAG="${GITHUB_SHA::12}"
+          docker build -f "${{ inputs.dockerfile }}" -t "$IMAGE:$TAG" .
+          docker push "$IMAGE:$TAG"
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: ${{ fromJSON(inputs.environments) }}
+    environment: ${{ inputs.app_key }}_${{ matrix.environment }}
+    concurrency:
+      group: deploy-${{ inputs.app_key }}-${{ matrix.environment }}
+    env:
+      ENVIRONMENT: ${{ matrix.environment }}
+      CHART: helm/checkpoint
+      APP_NAME: ${{ inputs.app_name }}
+      APP_KEY: ${{ inputs.app_key }}
+      RELEASE_INFIX: ${{ inputs.release_infix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Configure cluster access
+        run: doctl kubernetes cluster kubeconfig save "$DOKS_CLUSTER"
+        env:
+          DOKS_CLUSTER: ${{ vars.DOKS_CLUSTER }}
+
+      - name: Resolve image tag
+        id: tag
+        run: echo "tag=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
+      - name: Sync secrets into the namespace
+        run: |
+          NS="$ENVIRONMENT"
+          kubectl get namespace "$NS" >/dev/null 2>&1 || kubectl create namespace "$NS"
+          kubectl -n "$NS" create secret generic "$APP_NAME-secrets" \
+            --from-literal=POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+            --from-literal=HYPERSYNC_API_TOKEN="$HYPERSYNC_API_TOKEN" \
+            --dry-run=client -o yaml | kubectl apply -f -
+          kubectl -n "$NS" create secret docker-registry ghcr \
+            --docker-server=ghcr.io \
+            --docker-username="$GITHUB_ACTOR" \
+            --docker-password="$GHCR_PULL_TOKEN" \
+            --dry-run=client -o yaml | kubectl apply -f -
+        env:
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          HYPERSYNC_API_TOKEN: ${{ secrets.HYPERSYNC_API_TOKEN }}
+          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
+
+      - name: Determine inactive (staging) color
+        id: color
+        run: |
+          NS="$ENVIRONMENT"
+          ACTIVE=$(kubectl -n "$NS" get svc "$APP_NAME" -o jsonpath='{.spec.selector.color}' 2>/dev/null || echo "")
+          if [ "$ACTIVE" = "blue" ]; then INACTIVE=green; else INACTIVE=blue; fi
+          echo "Active color for $APP_NAME in $NS is '${ACTIVE:-none}' -> deploying to '$INACTIVE'"
+          echo "inactive=$INACTIVE" >> "$GITHUB_OUTPUT"
+
+      - name: Sync logtail secret (per color)
+        env:
+          LOGTAIL_HOST_BLUE: ${{ secrets.LOGTAIL_HOST_BLUE }}
+          LOGTAIL_TOKEN_BLUE: ${{ secrets.LOGTAIL_TOKEN_BLUE }}
+          LOGTAIL_HOST_GREEN: ${{ secrets.LOGTAIL_HOST_GREEN }}
+          LOGTAIL_TOKEN_GREEN: ${{ secrets.LOGTAIL_TOKEN_GREEN }}
+        run: |
+          C="${{ steps.color.outputs.inactive }}"
+          HOST_VAR="LOGTAIL_HOST_${C^^}"
+          TOKEN_VAR="LOGTAIL_TOKEN_${C^^}"
+          kubectl -n "$ENVIRONMENT" create secret generic "$APP_NAME-logtail-$C" \
+            --from-literal=LOGTAIL_HOST="${!HOST_VAR}" \
+            --from-literal=LOGTAIL_TOKEN="${!TOKEN_VAR}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Deploy inactive color with Helm
+        run: |
+          helm upgrade --install "$ENVIRONMENT-$RELEASE_INFIX${{ steps.color.outputs.inactive }}" "$CHART" \
+            --namespace "$ENVIRONMENT" --create-namespace \
+            --values "$CHART/values-$APP_KEY-$ENVIRONMENT.yaml" \
+            --set color="${{ steps.color.outputs.inactive }}" \
+            --set image.repository="$IMAGE" \
+            --set image.tag="${{ steps.tag.outputs.tag }}" \
+            --wait --timeout 10m
+
+      - name: Summary
+        run: |
+          echo "Deployed $IMAGE:${{ steps.tag.outputs.tag }} to $ENVIRONMENT / ${{ steps.color.outputs.inactive }} (staging)." >> "$GITHUB_STEP_SUMMARY"
+          echo "Run the promote workflow for $ENVIRONMENT to cut over once it has caught up." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/_promote-app.yml
+++ b/.github/workflows/_promote-app.yml
@@ -1,0 +1,87 @@
+name: Promote app (reusable)
+
+# Reusable cutover: upgrades the public Helm release to point at the
+# currently-inactive color. Called by promote-api.yml and
+# promote-delegates-api.yml.
+#
+# Required configuration:
+#   vars.DOKS_CLUSTER
+#   secrets.DIGITALOCEAN_ACCESS_TOKEN
+#   GitHub environments: <app_key>_<environment>_promote
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: Environment to promote
+        type: string
+        required: true
+      app_key:
+        description: Key used for GitHub environments (<app_key>_<env>_promote) and values files (values-<app_key>-<env>.yaml)
+        type: string
+        required: true
+      app_name:
+        description: Kubernetes app name (appName in the chart values; prefixes Deployments, Services and secrets)
+        type: string
+        required: true
+      release_infix:
+        description: Inserted into Helm release names (<env>-<release_infix>public), to keep releases of different apps in a shared namespace apart
+        type: string
+        default: ''
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.app_key }}_${{ inputs.environment }}_promote
+    concurrency:
+      group: promote-${{ inputs.app_key }}-${{ inputs.environment }}
+    env:
+      ENVIRONMENT: ${{ inputs.environment }}
+      PUBLIC_CHART: helm/public
+      APP_NAME: ${{ inputs.app_name }}
+      APP_KEY: ${{ inputs.app_key }}
+      RELEASE_INFIX: ${{ inputs.release_infix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Configure cluster access
+        run: doctl kubernetes cluster kubeconfig save "$DOKS_CLUSTER"
+        env:
+          DOKS_CLUSTER: ${{ vars.DOKS_CLUSTER }}
+
+      - name: Determine active/inactive colors
+        id: color
+        run: |
+          NS="$ENVIRONMENT"
+          ACTIVE=$(kubectl -n "$NS" get svc "$APP_NAME" -o jsonpath='{.spec.selector.color}' 2>/dev/null || echo "")
+          if [ "$ACTIVE" = "blue" ]; then INACTIVE=green; else INACTIVE=blue; fi
+          echo "Promoting $NS: ${ACTIVE:-none} -> $INACTIVE"
+          echo "namespace=$NS" >> "$GITHUB_OUTPUT"
+          echo "inactive=$INACTIVE" >> "$GITHUB_OUTPUT"
+
+      - name: Verify target color is healthy
+        run: |
+          NS="${{ steps.color.outputs.namespace }}"
+          C="${{ steps.color.outputs.inactive }}"
+          kubectl -n "$NS" rollout status "deploy/$APP_NAME-api-$C" --timeout=120s
+          kubectl -n "$NS" rollout status "deploy/$APP_NAME-indexer-$C" --timeout=120s
+
+      - name: Flip public Service via Helm
+        run: |
+          C="${{ steps.color.outputs.inactive }}"
+          helm upgrade --install "$ENVIRONMENT-${RELEASE_INFIX}public" "$PUBLIC_CHART" \
+            --namespace "$ENVIRONMENT" --create-namespace \
+            --values "$PUBLIC_CHART/values-$APP_KEY-$ENVIRONMENT.yaml" \
+            --set activeColor="$C"
+          echo "Promoted $ENVIRONMENT: public traffic now served by $C." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,16 +1,5 @@
 name: Deploy API
 
-# Builds the sx-api image once, then deploys it to the INACTIVE color (blue-green
-# staging) of BOTH environments (testnet + mainnet).
-#
-# Required configuration:
-#   vars.DOKS_CLUSTER                  - DigitalOcean Kubernetes cluster name or id
-#   secrets.DIGITALOCEAN_ACCESS_TOKEN  - DOKS cluster access
-#   GitHub environments: api_testnet, api_mainnet (hold POSTGRES_PASSWORD,
-#     HYPERSYNC_API_TOKEN, GHCR_PULL_TOKEN, and the LOGTAIL_* secrets)
-#
-# Image is pushed to GHCR (ghcr.io/<owner>/sx-api) via the built-in GITHUB_TOKEN.
-
 on:
   push:
     branches: [master]
@@ -18,119 +7,19 @@ on:
       - 'apps/api/**'
       - 'helm/**'
       - '.github/workflows/deploy-api.yml'
+      - '.github/workflows/_deploy-app.yml'
   workflow_dispatch:
 
-env:
-  IMAGE: ghcr.io/${{ github.repository_owner }}/sx-api
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  deploy:
+    uses: ./.github/workflows/_deploy-app.yml
     permissions:
       contents: read
       packages: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-
-      - name: Build and push image
-        run: |
-          TAG="${GITHUB_SHA::12}"
-          docker build -f apps/api/Dockerfile -t "$IMAGE:$TAG" .
-          docker push "$IMAGE:$TAG"
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        environment: [testnet, mainnet]
-    environment: api_${{ matrix.environment }}
-    concurrency:
-      group: deploy-api-${{ matrix.environment }}
-    env:
-      ENVIRONMENT: ${{ matrix.environment }}
-      CHART: helm/checkpoint
-      APP_NAME: sx-api
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v4
-
-      - name: Configure cluster access
-        run: doctl kubernetes cluster kubeconfig save "$DOKS_CLUSTER"
-        env:
-          DOKS_CLUSTER: ${{ vars.DOKS_CLUSTER }}
-
-      - name: Resolve image tag
-        id: tag
-        run: echo "tag=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
-
-      - name: Sync secrets into the namespace
-        run: |
-          NS="$ENVIRONMENT"
-          kubectl get namespace "$NS" >/dev/null 2>&1 || kubectl create namespace "$NS"
-          kubectl -n "$NS" create secret generic "$APP_NAME-secrets" \
-            --from-literal=POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
-            --from-literal=HYPERSYNC_API_TOKEN="$HYPERSYNC_API_TOKEN" \
-            --dry-run=client -o yaml | kubectl apply -f -
-          kubectl -n "$NS" create secret docker-registry ghcr \
-            --docker-server=ghcr.io \
-            --docker-username="$GITHUB_ACTOR" \
-            --docker-password="$GHCR_PULL_TOKEN" \
-            --dry-run=client -o yaml | kubectl apply -f -
-        env:
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-          HYPERSYNC_API_TOKEN: ${{ secrets.HYPERSYNC_API_TOKEN }}
-          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
-
-      - name: Determine inactive (staging) color
-        id: color
-        run: |
-          NS="$ENVIRONMENT"
-          ACTIVE=$(kubectl -n "$NS" get svc "$APP_NAME" -o jsonpath='{.spec.selector.color}' 2>/dev/null || echo "")
-          if [ "$ACTIVE" = "blue" ]; then INACTIVE=green; else INACTIVE=blue; fi
-          echo "Active color for $APP_NAME in $NS is '${ACTIVE:-none}' -> deploying to '$INACTIVE'"
-          echo "inactive=$INACTIVE" >> "$GITHUB_OUTPUT"
-
-      - name: Sync logtail secret (per color)
-        env:
-          LOGTAIL_HOST_BLUE: ${{ secrets.LOGTAIL_HOST_BLUE }}
-          LOGTAIL_TOKEN_BLUE: ${{ secrets.LOGTAIL_TOKEN_BLUE }}
-          LOGTAIL_HOST_GREEN: ${{ secrets.LOGTAIL_HOST_GREEN }}
-          LOGTAIL_TOKEN_GREEN: ${{ secrets.LOGTAIL_TOKEN_GREEN }}
-        run: |
-          C="${{ steps.color.outputs.inactive }}"
-          HOST_VAR="LOGTAIL_HOST_${C^^}"
-          TOKEN_VAR="LOGTAIL_TOKEN_${C^^}"
-          kubectl -n "$ENVIRONMENT" create secret generic "$APP_NAME-logtail-$C" \
-            --from-literal=LOGTAIL_HOST="${!HOST_VAR}" \
-            --from-literal=LOGTAIL_TOKEN="${!TOKEN_VAR}" \
-            --dry-run=client -o yaml | kubectl apply -f -
-
-      - name: Deploy inactive color with Helm
-        run: |
-          helm upgrade --install "$ENVIRONMENT-${{ steps.color.outputs.inactive }}" "$CHART" \
-            --namespace "$ENVIRONMENT" --create-namespace \
-            --values "$CHART/values-api-$ENVIRONMENT.yaml" \
-            --set color="${{ steps.color.outputs.inactive }}" \
-            --set image.repository="$IMAGE" \
-            --set image.tag="${{ steps.tag.outputs.tag }}" \
-            --wait --timeout 10m
-
-      - name: Summary
-        run: |
-          echo "Deployed $IMAGE:${{ steps.tag.outputs.tag }} to $ENVIRONMENT / ${{ steps.color.outputs.inactive }} (staging)." >> "$GITHUB_STEP_SUMMARY"
-          echo "Run 'Promote API' for $ENVIRONMENT to cut over once it has caught up." >> "$GITHUB_STEP_SUMMARY"
+    secrets: inherit
+    with:
+      app_key: api
+      app_name: sx-api
+      image_name: sx-api
+      dockerfile: apps/api/Dockerfile
+      environments: '["testnet", "mainnet"]'

--- a/.github/workflows/deploy-delegates-api.yml
+++ b/.github/workflows/deploy-delegates-api.yml
@@ -1,0 +1,26 @@
+name: Deploy Delegates API
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'apps/delegates-api/**'
+      - 'helm/**'
+      - '.github/workflows/deploy-delegates-api.yml'
+      - '.github/workflows/_deploy-app.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/_deploy-app.yml
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit
+    with:
+      app_key: delegates
+      app_name: delegates
+      image_name: delegates-api
+      dockerfile: apps/delegates-api/Dockerfile
+      environments: '["mainnet"]'
+      release_infix: delegates-

--- a/.github/workflows/promote-delegates-api.yml
+++ b/.github/workflows/promote-delegates-api.yml
@@ -1,4 +1,4 @@
-name: Promote API
+name: Promote Delegates API
 
 on:
   workflow_dispatch:
@@ -6,7 +6,7 @@ on:
       environment:
         description: Environment to promote
         type: choice
-        options: [testnet, mainnet]
+        options: [mainnet]
         required: true
 
 jobs:
@@ -15,5 +15,6 @@ jobs:
     secrets: inherit
     with:
       environment: ${{ inputs.environment }}
-      app_key: api
-      app_name: sx-api
+      app_key: delegates
+      app_name: delegates
+      release_infix: delegates-

--- a/apps/delegates-api/src/evm/config.ts
+++ b/apps/delegates-api/src/evm/config.ts
@@ -1,7 +1,7 @@
 import GeneralPurposeFactory from './abis/GeneralPurposeFactory';
 import Token from './abis/Token';
 
-export type NetworkID = 'eth' | 'arb1';
+export type NetworkID = 'eth';
 
 type Source = {
   name: string;
@@ -10,8 +10,8 @@ type Source = {
 };
 
 const NETWORK_NODE_URLS: Record<NetworkID, string> = {
-  eth: 'https://rpc.snapshot.org/1',
-  arb1: 'https://rpc.snapshot.org/42161'
+  eth: 'https://rpc.snapshot.org/1'
+  // arb1: 'https://rpc.snapshot.org/42161'
 };
 
 const TOKEN_SOURCES: Record<NetworkID, Source[]> = {
@@ -51,14 +51,14 @@ const TOKEN_SOURCES: Record<NetworkID, Source[]> = {
       contract: '0xfe4bce4b3949c35fb17691d8b03c3cadbe2e5e23',
       start: 22565398
     }
-  ],
-  arb1: [
-    {
-      name: 'ARB',
-      contract: '0x912ce59144191c1204e64559fe8253a0e49e6548',
-      start: 70398215
-    }
   ]
+  // arb1: [
+  //   {
+  //     name: 'ARB',
+  //     contract: '0x912ce59144191c1204e64559fe8253a0e49e6548',
+  //     start: 70398215
+  //   }
+  // ]
 };
 
 export default function createConfig(network: NetworkID) {

--- a/apps/delegates-api/src/evm/index.ts
+++ b/apps/delegates-api/src/evm/index.ts
@@ -7,13 +7,13 @@ const ethIndexer = process.env.HYPERSYNC_API_TOKEN
       apiToken: process.env.HYPERSYNC_API_TOKEN
     })
   : new evm.EvmIndexer(createWriters('eth'));
-const arb1Indexer = process.env.HYPERSYNC_API_TOKEN
-  ? new evm.HyperSyncEvmIndexer(createWriters('arb1'), {
-      apiToken: process.env.HYPERSYNC_API_TOKEN
-    })
-  : new evm.EvmIndexer(createWriters('arb1'));
+// const arb1Indexer = process.env.HYPERSYNC_API_TOKEN
+//   ? new evm.HyperSyncEvmIndexer(createWriters('arb1'), {
+//       apiToken: process.env.HYPERSYNC_API_TOKEN
+//     })
+//   : new evm.EvmIndexer(createWriters('arb1'));
 
 export function addEvmIndexers(checkpoint: Checkpoint) {
   checkpoint.addIndexer('eth', createConfig('eth'), ethIndexer);
-  checkpoint.addIndexer('arb1', createConfig('arb1'), arb1Indexer);
+  // checkpoint.addIndexer('arb1', createConfig('arb1'), arb1Indexer);
 }

--- a/helm/README.md
+++ b/helm/README.md
@@ -8,14 +8,23 @@ Blue-green deploy of Checkpoint apps (API + indexer + PostgreSQL) on DOKS.
 
 One chart (`checkpoint/`) serves every Checkpoint app; each app is a set of values files:
 
-| App             | image           | `appName`   | values prefix | layout                       |
-| --------------- | --------------- | ----------- | ------------- | ---------------------------- |
-| `api`           | `sx-api`        | `sx-api`    | `api`         | separate API + indexer pods  |
-| `delegates-api` | `delegates-api` | `delegates` | `delegates`   | single pod that also indexes |
+| App             | image           | `appName`   | values prefix |
+| --------------- | --------------- | ----------- | ------------- |
+| `api`           | `sx-api`        | `sx-api`    | `api`         |
+| `delegates-api` | `delegates-api` | `delegates` | `delegates`   |
+
+Each app runs separate API + indexer pods per color.
 
 Each env (testnet/mainnet) has two colors (blue/green) with their own DB. Deploy
 to the inactive color, then flip the public Service to it. Apps share a namespace
 and the gateway; resources are namespaced by `appName`.
+
+Deploys and promotions run via GitHub Actions: `Deploy API` / `Deploy Delegates API`
+build and deploy the inactive color on pushes to master, `Promote API` /
+`Promote Delegates API` cut traffic over on manual dispatch. The shared logic lives
+in `.github/workflows/_deploy-app.yml` and `_promote-app.yml` (which also sync the
+secrets below from GitHub environment secrets). The commands in this document are
+the manual equivalent.
 
 > Run commands from the repo root (chart paths are `helm/...`). Examples below use
 > `api` in `testnet` — swap the values prefix (`api` → `delegates`) and release
@@ -50,7 +59,7 @@ per app (`<appName>-secrets`); `delegates` bootstraps the same way with
 ## Deploy
 
 ```bash
-# logtail is optional and api-only
+# logtail is optional
 kubectl -n testnet create secret generic sx-api-logtail-blue \
   --from-literal=LOGTAIL_HOST=<host> --from-literal=LOGTAIL_TOKEN=<token>
 


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/workflow/issues/822

This PR disabled Arbitrum One on delegates API and deploys those to k8s automatically.

To avoid duplication workflows are extracted and only simplified per-app workflows are used now.