### PR TITLE
refactor(ui): extract dedicated org proposals view

### DIFF
--- a/apps/ui/src/components/ButtonNewProposal.vue
+++ b/apps/ui/src/components/ButtonNewProposal.vue
@@ -2,11 +2,21 @@
 import { Space } from '@/types';
 
 defineProps<{ spaces: Space[]; gap?: string; placement?: 'start' | 'end' }>();
+
+function getEditorRoute(s: Space) {
+  return {
+    name: 'space-editor',
+    params: { space: `${s.network}:${s.id}` }
+  };
+}
 </script>
 
 <template>
   <UiTooltip title="New proposal">
-    <UiDropdown :gap="gap" :placement="placement">
+    <UiButton v-if="spaces.length === 1" :to="getEditorRoute(spaces[0])" uniform>
+      <IH-pencil-alt />
+    </UiButton>
+    <UiDropdown v-else :gap="gap" :placement="placement">
       <template #button>
         <UiButton uniform>
           <IH-pencil-alt />
@@ -16,10 +26,7 @@ defineProps<{ spaces: Space[]; gap?: string; placement?: 'start' | 'end' }>();
         <UiDropdownItem
           v-for="s in spaces"
           :key="`${s.network}:${s.id}`"
-          :to="{
-            name: 'space-editor',
-            params: { space: `${s.network}:${s.id}` }
-          }"
+          :to="getEditorRoute(s)"
         >
           <slot name="label" :space="s">{{ s.name }}</slot>
         </UiDropdownItem>

--- a/apps/ui/src/components/ButtonNewProposal.vue
+++ b/apps/ui/src/components/ButtonNewProposal.vue
@@ -13,7 +13,11 @@ function getEditorRoute(s: Space) {
 
 <template>
   <UiTooltip title="New proposal">
-    <UiButton v-if="spaces.length === 1" :to="getEditorRoute(spaces[0])" uniform>
+    <UiButton
+      v-if="spaces.length === 1"
+      :to="getEditorRoute(spaces[0])"
+      uniform
+    >
       <IH-pencil-alt />
     </UiButton>
     <UiDropdown v-else :gap="gap" :placement="placement">

--- a/apps/ui/src/components/DropdownNewProposal.vue
+++ b/apps/ui/src/components/DropdownNewProposal.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { Space } from '@/types';
+
+defineProps<{ spaces: Space[]; gap?: string; placement?: 'start' | 'end' }>();
+</script>
+
+<template>
+  <UiTooltip title="New proposal">
+    <UiDropdown :gap="gap" :placement="placement">
+      <template #button>
+        <UiButton uniform>
+          <IH-pencil-alt />
+        </UiButton>
+      </template>
+      <template #items>
+        <UiDropdownItem
+          v-for="s in spaces"
+          :key="`${s.network}:${s.id}`"
+          :to="{
+            name: 'space-editor',
+            params: { space: `${s.network}:${s.id}` }
+          }"
+        >
+          <slot name="label" :space="s">{{ s.name }}</slot>
+        </UiDropdownItem>
+      </template>
+    </UiDropdown>
+  </UiTooltip>
+</template>

--- a/apps/ui/src/components/ProposalsFilters.vue
+++ b/apps/ui/src/components/ProposalsFilters.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import ProposalIconStatus from '@/components/ProposalIconStatus.vue';
+import { ANY_SPACE } from '@/composables/useProposalsFilters';
+import { ProposalsFilter } from '@/networks/types';
+import { SpaceMetadataLabel } from '@/types';
+
+const state = defineModel<NonNullable<ProposalsFilter['state']>>('state', {
+  required: true
+});
+const labels = defineModel<string[]>('labels', { required: true });
+const selectedSpaceId = defineModel<string>('selectedSpaceId', {
+  default: ANY_SPACE
+});
+
+defineProps<{
+  /** Spaces filter options; the filter is rendered only when provided */
+  spacesItems?: { key: string; label: string }[];
+  spaceLabels: Record<string, SpaceMetadataLabel>;
+  labelsList?: SpaceMetadataLabel[];
+}>();
+
+const selectIconBaseProps = {
+  size: 16
+};
+
+function handleClearLabelsFilter(close: () => void) {
+  labels.value = [];
+  close();
+}
+</script>
+
+<template>
+  <div class="flex gap-2">
+    <UiSelectDropdown
+      v-if="spacesItems"
+      v-model="selectedSpaceId"
+      title="Spaces"
+      gap="12"
+      placement="start"
+      :items="spacesItems"
+    />
+    <UiSelectDropdown
+      v-model="state"
+      title="Status"
+      gap="12"
+      placement="start"
+      :items="[
+        {
+          key: 'any',
+          label: 'Any'
+        },
+        {
+          key: 'pending',
+          label: 'Pending',
+          component: ProposalIconStatus,
+          componentProps: { ...selectIconBaseProps, state: 'pending' }
+        },
+        {
+          key: 'active',
+          label: 'Active',
+          component: ProposalIconStatus,
+          componentProps: { ...selectIconBaseProps, state: 'active' }
+        },
+        {
+          key: 'closed',
+          label: 'Closed',
+          component: ProposalIconStatus,
+          componentProps: { ...selectIconBaseProps, state: 'closed' }
+        }
+      ]"
+    />
+    <div v-if="labelsList?.length" class="sm:relative">
+      <PickerLabel
+        v-model="labels"
+        :labels="labelsList"
+        :button-props="{
+          class: [
+            'flex items-center gap-2 relative rounded-full leading-[100%] min-w-[75px] max-w-[230px] border button h-[42px] top-1 text-skin-link bg-skin-bg'
+          ]
+        }"
+        :panel-props="{ class: 'sm:min-w-[290px] sm:ml-0 !mt-3' }"
+      >
+        <template #button="{ close }">
+          <div
+            class="absolute top-[-10px] bg-skin-bg px-1 left-2.5 text-sm text-skin-text"
+          >
+            Labels
+          </div>
+          <div
+            v-if="labels.length"
+            class="flex gap-1 mx-2.5 overflow-hidden items-center"
+          >
+            <ul v-if="labels.length" class="flex gap-1 mr-4">
+              <li v-for="id in labels" :key="id">
+                <UiProposalLabel
+                  :label="spaceLabels[id].name"
+                  :color="spaceLabels[id].color"
+                />
+              </li>
+            </ul>
+            <div
+              class="flex items-center absolute rounded-r-full right-[1px] pr-2 h-[23px] bg-skin-bg"
+            >
+              <div
+                class="block w-2 -ml-2 h-full bg-gradient-to-l from-skin-bg"
+              />
+              <button
+                v-if="labels.length"
+                class="text-skin-text rounded-full hover:text-skin-link"
+                title="Clear all labels"
+                @click.stop="handleClearLabelsFilter(close)"
+                @keydown.enter.stop="handleClearLabelsFilter(close)"
+              >
+                <IH-x-circle size="16" />
+              </button>
+            </div>
+          </div>
+          <span v-else class="px-3 text-skin-link">Any</span>
+        </template>
+      </PickerLabel>
+    </div>
+  </div>
+</template>

--- a/apps/ui/src/composables/useProposalsFilters.ts
+++ b/apps/ui/src/composables/useProposalsFilters.ts
@@ -1,0 +1,115 @@
+import { LocationQueryRaw } from 'vue-router';
+import { ProposalsFilter } from '@/networks/types';
+import { Space } from '@/types';
+
+export const ANY_SPACE = 'any';
+
+/**
+ * State, labels, and space filters for a proposals list, synced with the
+ * URL query. Pass `groupSpaces` (>1) to enable the space filter, where
+ * `ANY_SPACE` selects all of them (merged list).
+ */
+export function useProposalsFilters(
+  space: MaybeRefOrGetter<Space>,
+  groupSpaces: MaybeRefOrGetter<Space[]> = []
+) {
+  const router = useRouter();
+  const route = useRoute();
+
+  const state = ref<NonNullable<ProposalsFilter['state']>>('any');
+  const labels = ref<string[]>([]);
+  const selectedSpaceId = ref<string>(ANY_SPACE);
+
+  const hasSpaceFilter = computed(() => toValue(groupSpaces).length > 1);
+
+  /** The space all space-specific context (voting power, labels, heading) is
+   *  bound to. `null` when showing the merged list. */
+  const selectedSpace = computed<Space | null>(() => {
+    if (!hasSpaceFilter.value) return toValue(space);
+
+    return (
+      toValue(groupSpaces).find(s => s.id === selectedSpaceId.value) ?? null
+    );
+  });
+
+  const spaceLabels = computed(() => {
+    const labelsList = selectedSpace.value?.labels;
+    if (!labelsList) return {};
+
+    return Object.fromEntries(labelsList.map(label => [label.id, label]));
+  });
+
+  watchThrottled(
+    [
+      () => route.query.state as string,
+      () => route.query.labels as string[] | string,
+      () => route.query.space as string | undefined,
+      () => toValue(groupSpaces)
+    ],
+    ([toState, toLabels, toSpace]) => {
+      state.value = ['any', 'active', 'pending', 'closed'].includes(toState)
+        ? (toState as NonNullable<ProposalsFilter['state']>)
+        : 'any';
+      let normalizedLabels = toLabels || [];
+      normalizedLabels = Array.isArray(normalizedLabels)
+        ? normalizedLabels
+        : [normalizedLabels];
+      labels.value = normalizedLabels.filter(id => spaceLabels.value[id]);
+
+      const isValidSpace =
+        toSpace && toValue(groupSpaces).some(s => s.id === toSpace);
+      selectedSpaceId.value = isValidSpace ? toSpace : ANY_SPACE;
+    },
+    { throttle: 1000, immediate: true }
+  );
+
+  watch(
+    [() => toValue(space).id, state, labels, selectedSpaceId],
+    (
+      [toSpaceId, toState, toLabels, toSpace],
+      [fromSpaceId, fromState, fromLabels, fromSpace]
+    ) => {
+      if (
+        toSpaceId !== fromSpaceId ||
+        toState !== fromState ||
+        toLabels !== fromLabels ||
+        toSpace !== fromSpace
+      ) {
+        const query: LocationQueryRaw = { ...route.query };
+
+        if (toState === 'any') {
+          delete query.state;
+        } else {
+          query.state = toState;
+        }
+
+        if (toLabels.length) {
+          query.labels = toLabels;
+        } else {
+          delete query.labels;
+        }
+
+        if (toSpace !== ANY_SPACE) {
+          query.space = toSpace;
+        } else {
+          delete query.space;
+        }
+
+        if (JSON.stringify(query) !== JSON.stringify(route.query)) {
+          // NOTE: If we push the same query it will cause scroll position to be reset
+          router.push({ query });
+        }
+      }
+    },
+    { immediate: true }
+  );
+
+  return {
+    state,
+    labels,
+    selectedSpaceId,
+    selectedSpace,
+    hasSpaceFilter,
+    spaceLabels
+  };
+}

--- a/apps/ui/src/routes/organization.ts
+++ b/apps/ui/src/routes/organization.ts
@@ -1,5 +1,6 @@
 import { RouteRecordRaw } from 'vue-router';
 import OrganizationOverview from '@/views/Organization/Overview.vue';
+import OrganizationProposals from '@/views/Organization/Proposals.vue';
 import Organization from '@/views/Organization.vue';
 import ProposalExecution from '@/views/Proposal/Execution.vue';
 import ProposalOverview from '@/views/Proposal/Overview.vue';
@@ -10,7 +11,6 @@ import Settings from '@/views/Settings.vue';
 import SpaceDelegates from '@/views/Space/Delegates.vue';
 import SpaceDiscussions from '@/views/Space/Discussions.vue';
 import SpaceEditor from '@/views/Space/Editor.vue';
-import SpaceProposals from '@/views/Space/Proposals.vue';
 import SpaceTreasury from '@/views/Space/Treasury.vue';
 import SpaceUserProposals from '@/views/SpaceUser/Proposals.vue';
 import SpaceUserStatement from '@/views/SpaceUser/Statement.vue';
@@ -29,7 +29,7 @@ function createOrgChildren(prefix: 'org' | 'space'): RouteRecordRaw[] {
     {
       path: ':space/proposals',
       name: `${prefix}-proposals`,
-      component: SpaceProposals
+      component: OrganizationProposals
     },
     {
       path: ':space/proposal/:proposal?',

--- a/apps/ui/src/views/Organization/Overview.vue
+++ b/apps/ui/src/views/Organization/Overview.vue
@@ -110,9 +110,9 @@ function getSpaceLabel(s: Space) {
         class="relative bg-skin-bg h-[16px] -top-3 rounded-t-[16px] md:hidden"
       />
       <div class="absolute right-4 top-4 flex gap-2">
-        <DropdownNewProposal :spaces="spaces">
+        <ButtonNewProposal :spaces="spaces">
           <template #label="{ space: s }">{{ getSpaceLabel(s) }}</template>
-        </DropdownNewProposal>
+        </ButtonNewProposal>
       </div>
     </div>
     <div class="px-4">

--- a/apps/ui/src/views/Organization/Overview.vue
+++ b/apps/ui/src/views/Organization/Overview.vue
@@ -110,27 +110,9 @@ function getSpaceLabel(s: Space) {
         class="relative bg-skin-bg h-[16px] -top-3 rounded-t-[16px] md:hidden"
       />
       <div class="absolute right-4 top-4 flex gap-2">
-        <UiTooltip title="New proposal">
-          <UiDropdown>
-            <template #button>
-              <UiButton uniform>
-                <IH-pencil-alt />
-              </UiButton>
-            </template>
-            <template #items>
-              <UiDropdownItem
-                v-for="s in spaces"
-                :key="`${s.network}:${s.id}`"
-                :to="{
-                  name: 'space-editor',
-                  params: { space: `${s.network}:${s.id}` }
-                }"
-              >
-                {{ getSpaceLabel(s) }}
-              </UiDropdownItem>
-            </template>
-          </UiDropdown>
-        </UiTooltip>
+        <DropdownNewProposal :spaces="spaces">
+          <template #label="{ space: s }">{{ getSpaceLabel(s) }}</template>
+        </DropdownNewProposal>
       </div>
     </div>
     <div class="px-4">

--- a/apps/ui/src/views/Organization/Proposals.vue
+++ b/apps/ui/src/views/Organization/Proposals.vue
@@ -1,31 +1,137 @@
 <script setup lang="ts">
+import { ANY_SPACE } from '@/composables/useProposalsFilters';
 import {
   getOrgProposalLabel,
   getOrgProposalSpaces
 } from '@/helpers/organizations';
+import { useProposalsQuery } from '@/queries/proposals';
+import { useSpaceVotingPowerQuery } from '@/queries/votingPower';
 import { Space } from '@/types';
-import SpaceProposals from '@/views/Space/Proposals.vue';
 
 const props = defineProps<{ space: Space }>();
 
+const { setTitle } = useTitle();
+const route = useRoute();
 const { organization } = useOrganization();
+const { web3 } = useWeb3();
 
 const groupSpaces = computed(() =>
   getOrgProposalSpaces(organization.value, props.space.network)
 );
 
-function getTitle(selectedSpace: Space | null) {
-  return getOrgProposalLabel(
-    organization.value,
-    selectedSpace ? `${props.space.network}:${selectedSpace.id}` : undefined
-  );
+const {
+  state,
+  labels,
+  selectedSpaceId,
+  selectedSpace,
+  hasSpaceFilter,
+  spaceLabels
+} = useProposalsFilters(toRef(props, 'space'), groupSpaces);
+
+const isMergedList = computed(() => !selectedSpace.value);
+
+const spacesItems = computed(() => [
+  { key: ANY_SPACE, label: 'Any' },
+  ...groupSpaces.value.map(s => ({
+    key: s.id,
+    label: s.name
+  }))
+]);
+
+const queriedSpaceIds = computed(() => {
+  if (!hasSpaceFilter.value) return [props.space.id];
+
+  return selectedSpace.value
+    ? [selectedSpace.value.id]
+    : groupSpaces.value.map(s => s.id);
+});
+
+const proposalsLabel = computed(() => {
+  const spaceId = selectedSpace.value
+    ? `${props.space.network}:${selectedSpace.value.id}`
+    : undefined;
+
+  return getOrgProposalLabel(organization.value, spaceId) ?? 'Proposals';
+});
+
+const {
+  data: votingPower,
+  isPending: isVotingPowerPending,
+  isError: isVotingPowerError,
+  refetch: fetchVotingPower
+} = useSpaceVotingPowerQuery(
+  toRef(() => web3.value.account),
+  toRef(() => selectedSpace.value ?? props.space)
+);
+
+const {
+  data,
+  fetchNextPage,
+  hasNextPage,
+  isPending,
+  isError,
+  isFetchingNextPage
+} = useProposalsQuery(
+  toRef(() => props.space.network),
+  queriedSpaceIds,
+  {
+    state,
+    labels
+  },
+  toRef(() => (route.query.q as string) || '')
+);
+
+async function handleEndReached() {
+  if (!hasNextPage.value) return;
+
+  fetchNextPage();
 }
+
+watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
 </script>
 
 <template>
-  <SpaceProposals
-    :space="space"
-    :group-spaces="groupSpaces"
-    :get-title="getTitle"
-  />
+  <div>
+    <div
+      class="flex justify-between p-4 gap-2 gap-y-3 flex-row"
+      :class="{ 'flex-col-reverse sm:flex-row': selectedSpace?.labels?.length }"
+    >
+      <ProposalsFilters
+        v-model:state="state"
+        v-model:labels="labels"
+        v-model:selected-space-id="selectedSpaceId"
+        :spaces-items="hasSpaceFilter ? spacesItems : undefined"
+        :space-labels="spaceLabels"
+        :labels-list="selectedSpace?.labels"
+      />
+      <div class="flex gap-2 truncate">
+        <IndicatorVotingPower
+          v-if="selectedSpace"
+          :network-id="space.network"
+          :voting-power="votingPower"
+          :is-loading="isVotingPowerPending"
+          :is-error="isVotingPowerError"
+          @fetch="fetchVotingPower"
+        />
+        <ButtonNewProposal
+          :spaces="hasSpaceFilter ? groupSpaces : [space]"
+          gap="12"
+          placement="end"
+        />
+      </div>
+    </div>
+    <ProposalsList
+      :title="proposalsLabel"
+      limit="off"
+      :is-error="isError"
+      :loading="isPending"
+      :loading-more="isFetchingNextPage"
+      :proposals="data?.pages.flat() ?? []"
+      @end-reached="handleEndReached"
+    >
+      <template v-if="isMergedList" #item-meta="{ proposal }">
+        {{ proposal.space.name }}
+      </template>
+    </ProposalsList>
+  </div>
 </template>

--- a/apps/ui/src/views/Organization/Proposals.vue
+++ b/apps/ui/src/views/Organization/Proposals.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import {
+  getOrgProposalLabel,
+  getOrgProposalSpaces
+} from '@/helpers/organizations';
+import { Space } from '@/types';
+import SpaceProposals from '@/views/Space/Proposals.vue';
+
+const props = defineProps<{ space: Space }>();
+
+const { organization } = useOrganization();
+
+const groupSpaces = computed(() =>
+  getOrgProposalSpaces(organization.value, props.space.network)
+);
+
+function getTitle(selectedSpace: Space | null) {
+  return getOrgProposalLabel(
+    organization.value,
+    selectedSpace ? `${props.space.network}:${selectedSpace.id}` : undefined
+  );
+}
+</script>
+
+<template>
+  <SpaceProposals
+    :space="space"
+    :group-spaces="groupSpaces"
+    :get-title="getTitle"
+  />
+</template>

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
 import { LocationQueryRaw } from 'vue-router';
 import ProposalIconStatus from '@/components/ProposalIconStatus.vue';
-import {
-  getOrgProposalLabel,
-  getOrgProposalSpaces
-} from '@/helpers/organizations';
 import { ProposalsFilter } from '@/networks/types';
 import { useProposalsQuery } from '@/queries/proposals';
 import { useSpaceVotingPowerQuery } from '@/queries/votingPower';
@@ -12,10 +8,19 @@ import { Space } from '@/types';
 
 const ANY_SPACE = 'any';
 
-const props = defineProps<{ space: Space }>();
+const props = withDefaults(
+  defineProps<{
+    space: Space;
+    /** Selectable spaces (same network); >1 enables the Spaces filter with a
+     *  merged list as the "Any" default */
+    groupSpaces?: Space[];
+    /** Resolves the list heading; receives the selected space (null = merged) */
+    getTitle?: (space: Space | null) => string | undefined;
+  }>(),
+  { groupSpaces: () => [], getTitle: undefined }
+);
 
 const { setTitle } = useTitle();
-const { organization } = useOrganization();
 const router = useRouter();
 const route = useRoute();
 const { web3 } = useWeb3();
@@ -24,27 +29,21 @@ const state = ref<NonNullable<ProposalsFilter['state']>>('any');
 const labels = ref<string[]>([]);
 const selectedSpaceId = ref<string>(ANY_SPACE);
 
-const orgProposalSpaces = computed(() =>
-  getOrgProposalSpaces(organization.value, props.space.network)
-);
-
-const hasMultiSpaceFilter = computed(() => orgProposalSpaces.value.length > 1);
+const hasMultiSpaceFilter = computed(() => props.groupSpaces.length > 1);
 
 /** The space all space-specific context (voting power, labels, heading) is
  *  bound to. `null` when showing the merged list. */
 const selectedSpace = computed(() => {
   if (!hasMultiSpaceFilter.value) return props.space;
 
-  return (
-    orgProposalSpaces.value.find(s => s.id === selectedSpaceId.value) ?? null
-  );
+  return props.groupSpaces.find(s => s.id === selectedSpaceId.value) ?? null;
 });
 
 const isMergedList = computed(() => !selectedSpace.value);
 
 const spacesItems = computed(() => [
   { key: ANY_SPACE, label: 'Any' },
-  ...orgProposalSpaces.value.map(s => ({
+  ...props.groupSpaces.map(s => ({
     key: s.id,
     label: s.name
   }))
@@ -54,7 +53,7 @@ const queriedSpaceIds = computed(() => {
   if (!hasMultiSpaceFilter.value) return [props.space.id];
 
   return selectedSpaceId.value === ANY_SPACE
-    ? orgProposalSpaces.value.map(s => s.id)
+    ? props.groupSpaces.map(s => s.id)
     : [selectedSpaceId.value];
 });
 
@@ -62,13 +61,9 @@ const selectIconBaseProps = {
   size: 16
 };
 
-const proposalsLabel = computed(() => {
-  const spaceId = selectedSpace.value
-    ? `${props.space.network}:${selectedSpace.value.id}`
-    : undefined;
-
-  return getOrgProposalLabel(organization.value, spaceId) ?? 'Proposals';
-});
+const proposalsLabel = computed(
+  () => props.getTitle?.(selectedSpace.value) ?? 'Proposals'
+);
 
 const spaceLabels = computed(() => {
   if (!selectedSpace.value?.labels) return {};
@@ -121,7 +116,7 @@ watchThrottled(
     () => route.query.state as string,
     () => route.query.labels as string[] | string,
     () => route.query.space as string | undefined,
-    orgProposalSpaces
+    () => props.groupSpaces
   ],
   ([toState, toLabels, toSpace]) => {
     state.value = ['any', 'active', 'pending', 'closed'].includes(toState)
@@ -134,7 +129,7 @@ watchThrottled(
     labels.value = normalizedLabels.filter(id => spaceLabels.value[id]);
 
     const isValidSpace =
-      toSpace && orgProposalSpaces.value.some(s => s.id === toSpace);
+      toSpace && props.groupSpaces.some(s => s.id === toSpace);
     selectedSpaceId.value = isValidSpace ? toSpace : ANY_SPACE;
   },
   { throttle: 1000, immediate: true }
@@ -290,7 +285,7 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
           @fetch="fetchVotingPower"
         />
         <ButtonNewProposal
-          :spaces="hasMultiSpaceFilter ? orgProposalSpaces : [space]"
+          :spaces="hasMultiSpaceFilter ? groupSpaces : [space]"
           gap="12"
           placement="end"
         />

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -289,23 +289,11 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
           :is-error="isVotingPowerError"
           @fetch="fetchVotingPower"
         />
-        <DropdownNewProposal
-          v-if="hasMultiSpaceFilter"
-          :spaces="orgProposalSpaces"
+        <ButtonNewProposal
+          :spaces="hasMultiSpaceFilter ? orgProposalSpaces : [space]"
           gap="12"
           placement="end"
         />
-        <UiTooltip v-else title="New proposal">
-          <UiButton
-            :to="{
-              name: 'space-editor',
-              params: { space: `${space.network}:${space.id}` }
-            }"
-            uniform
-          >
-            <IH-pencil-alt />
-          </UiButton>
-        </UiTooltip>
       </div>
     </div>
     <ProposalsList

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -289,27 +289,12 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
           :is-error="isVotingPowerError"
           @fetch="fetchVotingPower"
         />
-        <UiDropdown v-if="hasMultiSpaceFilter" gap="12" placement="end">
-          <template #button>
-            <UiTooltip title="New proposal">
-              <UiButton type="button" uniform>
-                <IH-pencil-alt />
-              </UiButton>
-            </UiTooltip>
-          </template>
-          <template #items>
-            <UiDropdownItem
-              v-for="s in orgProposalSpaces"
-              :key="s.id"
-              :to="{
-                name: 'space-editor',
-                params: { space: `${space.network}:${s.id}` }
-              }"
-            >
-              {{ s.name }}
-            </UiDropdownItem>
-          </template>
-        </UiDropdown>
+        <DropdownNewProposal
+          v-if="hasMultiSpaceFilter"
+          :spaces="orgProposalSpaces"
+          gap="12"
+          placement="end"
+        />
         <UiTooltip v-else title="New proposal">
           <UiButton
             :to="{

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -1,77 +1,17 @@
 <script setup lang="ts">
-import { LocationQueryRaw } from 'vue-router';
-import ProposalIconStatus from '@/components/ProposalIconStatus.vue';
-import { ProposalsFilter } from '@/networks/types';
 import { useProposalsQuery } from '@/queries/proposals';
 import { useSpaceVotingPowerQuery } from '@/queries/votingPower';
 import { Space } from '@/types';
 
-const ANY_SPACE = 'any';
-
-const props = withDefaults(
-  defineProps<{
-    space: Space;
-    /** Selectable spaces (same network); >1 enables the Spaces filter with a
-     *  merged list as the "Any" default */
-    groupSpaces?: Space[];
-    /** Resolves the list heading; receives the selected space (null = merged) */
-    getTitle?: (space: Space | null) => string | undefined;
-  }>(),
-  { groupSpaces: () => [], getTitle: undefined }
-);
+const props = defineProps<{ space: Space }>();
 
 const { setTitle } = useTitle();
-const router = useRouter();
 const route = useRoute();
 const { web3 } = useWeb3();
 
-const state = ref<NonNullable<ProposalsFilter['state']>>('any');
-const labels = ref<string[]>([]);
-const selectedSpaceId = ref<string>(ANY_SPACE);
-
-const hasMultiSpaceFilter = computed(() => props.groupSpaces.length > 1);
-
-/** The space all space-specific context (voting power, labels, heading) is
- *  bound to. `null` when showing the merged list. */
-const selectedSpace = computed(() => {
-  if (!hasMultiSpaceFilter.value) return props.space;
-
-  return props.groupSpaces.find(s => s.id === selectedSpaceId.value) ?? null;
-});
-
-const isMergedList = computed(() => !selectedSpace.value);
-
-const spacesItems = computed(() => [
-  { key: ANY_SPACE, label: 'Any' },
-  ...props.groupSpaces.map(s => ({
-    key: s.id,
-    label: s.name
-  }))
-]);
-
-const queriedSpaceIds = computed(() => {
-  if (!hasMultiSpaceFilter.value) return [props.space.id];
-
-  return selectedSpaceId.value === ANY_SPACE
-    ? props.groupSpaces.map(s => s.id)
-    : [selectedSpaceId.value];
-});
-
-const selectIconBaseProps = {
-  size: 16
-};
-
-const proposalsLabel = computed(
-  () => props.getTitle?.(selectedSpace.value) ?? 'Proposals'
+const { state, labels, spaceLabels } = useProposalsFilters(
+  toRef(props, 'space')
 );
-
-const spaceLabels = computed(() => {
-  if (!selectedSpace.value?.labels) return {};
-
-  return Object.fromEntries(
-    selectedSpace.value.labels.map(label => [label.id, label])
-  );
-});
 
 const {
   data: votingPower,
@@ -80,7 +20,7 @@ const {
   refetch: fetchVotingPower
 } = useSpaceVotingPowerQuery(
   toRef(() => web3.value.account),
-  toRef(() => selectedSpace.value ?? props.space)
+  toRef(props, 'space')
 );
 
 const {
@@ -92,7 +32,7 @@ const {
   isFetchingNextPage
 } = useProposalsQuery(
   toRef(() => props.space.network),
-  queriedSpaceIds,
+  toRef(() => [props.space.id]),
   {
     state,
     labels
@@ -100,209 +40,46 @@ const {
   toRef(() => (route.query.q as string) || '')
 );
 
-function handleClearLabelsFilter(close: () => void) {
-  labels.value = [];
-  close();
-}
-
 async function handleEndReached() {
   if (!hasNextPage.value) return;
 
   fetchNextPage();
 }
 
-watchThrottled(
-  [
-    () => route.query.state as string,
-    () => route.query.labels as string[] | string,
-    () => route.query.space as string | undefined,
-    () => props.groupSpaces
-  ],
-  ([toState, toLabels, toSpace]) => {
-    state.value = ['any', 'active', 'pending', 'closed'].includes(toState)
-      ? (toState as NonNullable<ProposalsFilter['state']>)
-      : 'any';
-    let normalizedLabels = toLabels || [];
-    normalizedLabels = Array.isArray(normalizedLabels)
-      ? normalizedLabels
-      : [normalizedLabels];
-    labels.value = normalizedLabels.filter(id => spaceLabels.value[id]);
-
-    const isValidSpace =
-      toSpace && props.groupSpaces.some(s => s.id === toSpace);
-    selectedSpaceId.value = isValidSpace ? toSpace : ANY_SPACE;
-  },
-  { throttle: 1000, immediate: true }
-);
-
-watch(
-  [() => props.space.id, state, labels, selectedSpaceId],
-  (
-    [toSpaceId, toState, toLabels, toSpace],
-    [fromSpaceId, fromState, fromLabels, fromSpace]
-  ) => {
-    if (
-      toSpaceId !== fromSpaceId ||
-      toState !== fromState ||
-      toLabels !== fromLabels ||
-      toSpace !== fromSpace
-    ) {
-      const query: LocationQueryRaw = { ...route.query };
-
-      if (toState === 'any') {
-        delete query.state;
-      } else {
-        query.state = toState;
-      }
-
-      if (toLabels.length) {
-        query.labels = toLabels;
-      } else {
-        delete query.labels;
-      }
-
-      if (toSpace !== ANY_SPACE) {
-        query.space = toSpace;
-      } else {
-        delete query.space;
-      }
-
-      if (JSON.stringify(query) !== JSON.stringify(route.query)) {
-        // NOTE: If we push the same query it will cause scroll position to be reset
-        router.push({ query });
-      }
-    }
-  },
-  { immediate: true }
-);
-
-watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
+watchEffect(() => setTitle(`Proposals - ${props.space.name}`));
 </script>
 
 <template>
   <div>
     <div
       class="flex justify-between p-4 gap-2 gap-y-3 flex-row"
-      :class="{ 'flex-col-reverse sm:flex-row': selectedSpace?.labels?.length }"
+      :class="{ 'flex-col-reverse sm:flex-row': space.labels?.length }"
     >
-      <div class="flex gap-2">
-        <UiSelectDropdown
-          v-if="hasMultiSpaceFilter"
-          v-model="selectedSpaceId"
-          title="Spaces"
-          gap="12"
-          placement="start"
-          :items="spacesItems"
-        />
-        <UiSelectDropdown
-          v-model="state"
-          title="Status"
-          gap="12"
-          placement="start"
-          :items="[
-            {
-              key: 'any',
-              label: 'Any'
-            },
-            {
-              key: 'pending',
-              label: 'Pending',
-              component: ProposalIconStatus,
-              componentProps: { ...selectIconBaseProps, state: 'pending' }
-            },
-            {
-              key: 'active',
-              label: 'Active',
-              component: ProposalIconStatus,
-              componentProps: { ...selectIconBaseProps, state: 'active' }
-            },
-            {
-              key: 'closed',
-              label: 'Closed',
-              component: ProposalIconStatus,
-              componentProps: { ...selectIconBaseProps, state: 'closed' }
-            }
-          ]"
-        />
-        <div v-if="selectedSpace?.labels?.length" class="sm:relative">
-          <PickerLabel
-            v-model="labels"
-            :labels="selectedSpace.labels"
-            :button-props="{
-              class: [
-                'flex items-center gap-2 relative rounded-full leading-[100%] min-w-[75px] max-w-[230px] border button h-[42px] top-1 text-skin-link bg-skin-bg'
-              ]
-            }"
-            :panel-props="{ class: 'sm:min-w-[290px] sm:ml-0 !mt-3' }"
-          >
-            <template #button="{ close }">
-              <div
-                class="absolute top-[-10px] bg-skin-bg px-1 left-2.5 text-sm text-skin-text"
-              >
-                Labels
-              </div>
-              <div
-                v-if="labels.length"
-                class="flex gap-1 mx-2.5 overflow-hidden items-center"
-              >
-                <ul v-if="labels.length" class="flex gap-1 mr-4">
-                  <li v-for="id in labels" :key="id">
-                    <UiProposalLabel
-                      :label="spaceLabels[id].name"
-                      :color="spaceLabels[id].color"
-                    />
-                  </li>
-                </ul>
-                <div
-                  class="flex items-center absolute rounded-r-full right-[1px] pr-2 h-[23px] bg-skin-bg"
-                >
-                  <div
-                    class="block w-2 -ml-2 h-full bg-gradient-to-l from-skin-bg"
-                  />
-                  <button
-                    v-if="labels.length"
-                    class="text-skin-text rounded-full hover:text-skin-link"
-                    title="Clear all labels"
-                    @click.stop="handleClearLabelsFilter(close)"
-                    @keydown.enter.stop="handleClearLabelsFilter(close)"
-                  >
-                    <IH-x-circle size="16" />
-                  </button>
-                </div>
-              </div>
-              <span v-else class="px-3 text-skin-link">Any</span>
-            </template>
-          </PickerLabel>
-        </div>
-      </div>
+      <ProposalsFilters
+        v-model:state="state"
+        v-model:labels="labels"
+        :space-labels="spaceLabels"
+        :labels-list="space.labels"
+      />
       <div class="flex gap-2 truncate">
         <IndicatorVotingPower
-          v-if="selectedSpace"
           :network-id="space.network"
           :voting-power="votingPower"
           :is-loading="isVotingPowerPending"
           :is-error="isVotingPowerError"
           @fetch="fetchVotingPower"
         />
-        <ButtonNewProposal
-          :spaces="hasMultiSpaceFilter ? groupSpaces : [space]"
-          gap="12"
-          placement="end"
-        />
+        <ButtonNewProposal :spaces="[space]" gap="12" placement="end" />
       </div>
     </div>
     <ProposalsList
-      :title="proposalsLabel"
+      title="Proposals"
       limit="off"
       :is-error="isError"
       :loading="isPending"
       :loading-more="isFetchingNextPage"
       :proposals="data?.pages.flat() ?? []"
       @end-reached="handleEndReached"
-    >
-      <template v-if="isMergedList" #item-meta="{ proposal }">
-        {{ proposal.space.name }}
-      </template>
-    </ProposalsList>
+    />
   </div>
 </template>


### PR DESCRIPTION
Splits the multi-space proposals logic out of `Space/Proposals.vue` into a dedicated org view. No user-visible changes.

Stacked on #2103 — contains only the deferred refactor commits.

- `Organization/Proposals.vue`: full org view owning the Spaces filter, merged query, per-row space names, and selected-space context; org + whitelabel proposals routes now render it.
- `Space/Proposals.vue`: single-space again, no org imports.
- `useProposalsFilters`: shared state/labels/space URL sync (single writer).
- `ProposalsFilters`: shared filter chips component.
- `ButtonNewProposal`: shared new-proposal button (1 space → link, 2+ → dropdown), also replaces the org overview's inline copy.

## Test plan

- [ ] http://localhost:8080/#/org/arbitrum → Onchain voting: Spaces filter, merged list, per-row space names unchanged.
- [ ] Same page: voting power indicator hidden on "Any", bound to the selected governor otherwise.
- [ ] Plain space (e.g. http://localhost:8080/#/s:safe.eth/proposals): no Spaces chip, unchanged behavior.
- [ ] Org overview: new-proposal dropdown labels unchanged.