### PR TITLE
fix(hub): exclude deleted spaces from GraphQL queries

### DIFF
--- a/apps/hub/src/graphql/operations/follows.ts
+++ b/apps/hub/src/graphql/operations/follows.ts
@@ -39,9 +39,9 @@ export default async function (parent, args) {
       spaces.turbo_expiration as spaceTurboExpiration,
       spaces.hibernated as spaceHibernated
     FROM follows f
-    LEFT JOIN spaces ON spaces.id = f.space
+    INNER JOIN spaces ON spaces.id = f.space
     LEFT JOIN skins ON spaces.id = skins.id
-    WHERE 1=1 ${queryStr}
+    WHERE spaces.deleted = 0 ${queryStr}
     ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?
   `;
 

--- a/apps/hub/src/graphql/operations/proposal.ts
+++ b/apps/hub/src/graphql/operations/proposal.ts
@@ -18,7 +18,7 @@ export default async function (parent, { id }) {
     FROM proposals p
     INNER JOIN spaces ON spaces.id = p.space
     LEFT JOIN skins ON spaces.id = skins.id
-    WHERE p.id = ? AND spaces.settings IS NOT NULL
+    WHERE p.id = ? AND spaces.deleted = 0 AND spaces.settings IS NOT NULL
     LIMIT 1
   `;
   try {

--- a/apps/hub/src/graphql/operations/proposals.ts
+++ b/apps/hub/src/graphql/operations/proposals.ts
@@ -104,7 +104,7 @@ export default async function (parent, args) {
     FROM proposals p
     INNER JOIN spaces ON spaces.id = p.space
     LEFT JOIN skins ON spaces.id = skins.id
-    WHERE 1=1 ${queryStr} ${searchSql}
+    WHERE spaces.deleted = 0 ${queryStr} ${searchSql}
     ORDER BY ${orderBy} ${orderDirection}, p.id ASC LIMIT ?, ?
   `;
   params.push(skip, first);

--- a/apps/hub/src/graphql/operations/roles.ts
+++ b/apps/hub/src/graphql/operations/roles.ts
@@ -8,9 +8,11 @@ export default async function (parent, args) {
 
   const query = `
     SELECT * FROM spaces
-    WHERE JSON_CONTAINS(LOWER(settings->'$.admins'), LOWER(JSON_QUOTE(?)))
+    WHERE deleted = 0 AND (
+      JSON_CONTAINS(LOWER(settings->'$.admins'), LOWER(JSON_QUOTE(?)))
       OR JSON_CONTAINS(LOWER(settings->'$.members'), LOWER(JSON_QUOTE(?)))
-      OR JSON_CONTAINS(LOWER(settings->'$.moderators'), LOWER(JSON_QUOTE(?)));
+      OR JSON_CONTAINS(LOWER(settings->'$.moderators'), LOWER(JSON_QUOTE(?)))
+    );
   `;
 
   try {

--- a/apps/hub/src/graphql/operations/statement.ts
+++ b/apps/hub/src/graphql/operations/statement.ts
@@ -4,7 +4,12 @@ import db from '../../helpers/mysql';
 
 export default async function (parent, args) {
   const id = args.id;
-  const query = `SELECT s.* FROM statements s WHERE id = ? LIMIT 1`;
+  const query = `
+    SELECT s.* FROM statements s
+    INNER JOIN spaces sp ON sp.id = s.space
+    WHERE s.id = ? AND sp.deleted = 0
+    LIMIT 1
+  `;
   try {
     const statements = await db.queryAsync(query, id);
     if (statements.length === 1) return statements[0];

--- a/apps/hub/src/graphql/operations/statements.ts
+++ b/apps/hub/src/graphql/operations/statements.ts
@@ -32,7 +32,8 @@ export default async function (parent, args) {
 
   const query = `
     SELECT s.* FROM statements s
-    WHERE 1=1 ${queryStr}
+    INNER JOIN spaces sp ON sp.id = s.space
+    WHERE sp.deleted = 0 ${queryStr}
     ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?
   `;
   params.push(skip, first);

--- a/apps/hub/src/graphql/operations/subscriptions.ts
+++ b/apps/hub/src/graphql/operations/subscriptions.ts
@@ -42,7 +42,7 @@ export default async function (parent, args) {
     FROM subscriptions s
     INNER JOIN spaces ON spaces.id = s.space
     LEFT JOIN skins ON spaces.id = skins.id
-    WHERE spaces.settings IS NOT NULL ${queryStr}
+    WHERE spaces.deleted = 0 AND spaces.settings IS NOT NULL ${queryStr}
     ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?
   `;
   params.push(skip, first);

--- a/apps/hub/src/graphql/operations/votes.ts
+++ b/apps/hub/src/graphql/operations/votes.ts
@@ -42,9 +42,11 @@ async function query(parent, args, context?, info?) {
 
   let votes: any[] = [];
 
+  // cb = -3 marks votes of deleted proposals, pending deletion by the sequencer
   const query = `
     SELECT v.* FROM votes v
-    WHERE 1 = 1 ${queryStr}
+    INNER JOIN spaces ON spaces.id = v.space
+    WHERE spaces.deleted = 0 AND v.cb != -3 ${queryStr}
     ORDER BY ${orderBy} ${orderDirection}, v.id ASC LIMIT ?, ?
   `;
   params.push(skip, first);

--- a/apps/hub/src/graphql/operations/vp.ts
+++ b/apps/hub/src/graphql/operations/vp.ts
@@ -9,7 +9,12 @@ export default async function (_parent, { voter, space, proposal }) {
   }
 
   if (proposal) {
-    const query = `SELECT * FROM proposals WHERE id = ? LIMIT 1`;
+    const query = `
+      SELECT p.* FROM proposals p
+      INNER JOIN spaces s ON s.id = p.space
+      WHERE p.id = ? AND s.deleted = 0
+      LIMIT 1
+    `;
     const [p] = await db.queryAsync(query, [proposal]);
 
     if (!p) {


### PR DESCRIPTION
Together with #2219, this will allow a simpler PR on #2099, by removing most of nullable fields

Deleted spaces (soft-deleted via `deleted = 1`) were still leaking through most GraphQL queries. This filters them out everywhere.

| Query | Before | Added by this PR |
|---|---|---|
| `spaces` / `space` / related spaces | ✅ `s.deleted = 0` in `fetchSpaces` | — |
| `ranking` | ✅ indirect — built from `spacesMetadata`, loaded with `deleted = 0` | — |
| `vp` (space branch) | ✅ `deleted = 0` | — |
| `vp` (proposal branch) | ❌ | join on spaces + `deleted = 0` |
| `proposals` / `proposal` | ❌ | `spaces.deleted = 0` on existing join |
| `votes` / `vote` | ⚠️ space subquery filtered, but vote rows still returned | `INNER JOIN spaces` + `deleted = 0`; also hides votes of deleted proposals (`cb != -3`, pending-deletion) |
| `follows` | ❌ | LEFT JOIN → INNER JOIN + `deleted = 0` (also drops orphan follows whose space row is missing) |
| `subscriptions` | ❌ | `deleted = 0` |
| `statements` / `statement` | ❌ | new join on spaces + `deleted = 0` |
| `roles` | ❌ | `deleted = 0` |

REST endpoints (`/api/spaces/:key`, eip4824) intentionally untouched.

## Test plan

Against a space with `deleted = 1`: `proposals`, `votes`, `follows`, `subscriptions`, `statements`, `roles`, `vp` queries for that space should all return empty/null.