### PR TITLE
feat(sequencer): add proposal re-score script

### DIFF
--- a/apps/sequencer/scripts/rescore-proposal.ts
+++ b/apps/sequencer/scripts/rescore-proposal.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import snapshot from '@snapshot-labs/snapshot.js';
+import { CB } from '../src/constants';
 import db from '../src/helpers/mysql';
 import { getProposal, getVotes, updateProposalScores } from '../src/scores';
 
@@ -36,8 +37,21 @@ async function main() {
     );
   }
 
+  if (proposal.scores_state !== 'final') {
+    throw new Error(
+      `Proposal scores_state is '${proposal.scores_state}'; this script only re-scores proposals already finalized by the normal scoring path`
+    );
+  }
+
   const votes = await getVotes(proposalId);
-  if (!votes) throw new Error(`No votes loaded for ${proposalId}`);
+  if (!votes.length) throw new Error(`No votes loaded for ${proposalId}`);
+
+  const encrypted = votes.filter(vote => typeof vote.choice === 'string');
+  if (encrypted.length > 0) {
+    throw new Error(
+      `${encrypted.length}/${votes.length} votes still have encrypted string choices; refusing to tally`
+    );
+  }
 
   const allFinal = votes.every(vote => vote.vp_state === 'final');
   if (!allFinal) {
@@ -46,11 +60,12 @@ async function main() {
     );
   }
 
-  const voting = new snapshot.utils.voting[proposal.type](
-    proposal,
-    votes,
-    proposal.strategies
-  );
+  const VotingClass = snapshot.utils.voting[proposal.type];
+  if (!VotingClass) {
+    throw new Error(`Unsupported proposal type: ${proposal.type}`);
+  }
+
+  const voting = new VotingClass(proposal, votes, proposal.strategies);
   const results = {
     scores_state: 'final',
     scores: voting.getScores(),
@@ -78,6 +93,11 @@ async function main() {
     return;
   }
 
+  // Re-enter the scores-value pipeline: proposalsScoresValue only picks up
+  // cb = PENDING_COMPUTE, so an already-FINAL proposal would otherwise keep a
+  // scores_total_value derived from the old scores_by_strategy.
+  if (proposal.cb === CB.FINAL) proposal.cb = CB.PENDING_COMPUTE;
+
   await updateProposalScores(proposal, results, votes.length);
   console.log(`\nApplied. Wrote final scores for ${proposal.id}.`);
 }
@@ -87,4 +107,9 @@ main()
     console.error(e);
     process.exitCode = 1;
   })
-  .finally(() => db.endAsync().then(() => process.exit()));
+  .finally(() =>
+    db
+      .endAsync()
+      .catch(() => {})
+      .then(() => process.exit())
+  );

--- a/apps/sequencer/scripts/rescore-proposal.ts
+++ b/apps/sequencer/scripts/rescore-proposal.ts
@@ -1,0 +1,90 @@
+import 'dotenv/config';
+import snapshot from '@snapshot-labs/snapshot.js';
+import db from '../src/helpers/mysql';
+import { getProposal, getVotes, updateProposalScores } from '../src/scores';
+
+// Usage:
+//   bunx ts-node scripts/rescore-proposal.ts --proposal <id>            # dry run
+//   bunx ts-node scripts/rescore-proposal.ts --proposal <id> --apply    # write
+//
+// Recomputes a proposal's results with the currently bundled snapshot.js and,
+// with --apply, writes scores/scores_by_strategy/scores_total/scores_state +
+// scores_updated back to the proposals table.
+//
+// This reads the votes as already stored (for shutter proposals the choices
+// must already be decrypted) and re-tallies using each vote's existing voting
+// power. It does not re-fetch voting power and does not read or modify the
+// proposal's privacy field, so it is safe to run on closed shutter proposals
+// that the normal scoring path refuses to recompute.
+
+async function main() {
+  const proposalArg = process.argv.indexOf('--proposal');
+  const proposalId =
+    proposalArg !== -1 ? process.argv[proposalArg + 1] : process.argv[2];
+  const apply = process.argv.includes('--apply');
+
+  if (!proposalId || !proposalId.startsWith('0x')) {
+    throw new Error('Missing or invalid --proposal <id>');
+  }
+
+  const proposal = await getProposal(proposalId);
+  if (!proposal) throw new Error(`Proposal not found: ${proposalId}`);
+
+  if (proposal.state !== 'closed') {
+    throw new Error(
+      `Proposal is not closed (state: ${proposal.state}); refusing to finalize`
+    );
+  }
+
+  const votes = await getVotes(proposalId);
+  if (!votes) throw new Error(`No votes loaded for ${proposalId}`);
+
+  const allFinal = votes.every(vote => vote.vp_state === 'final');
+  if (!allFinal) {
+    console.warn(
+      'Warning: not all votes have vp_state = final; re-tallying with stored voting power without refreshing it'
+    );
+  }
+
+  const voting = new snapshot.utils.voting[proposal.type](
+    proposal,
+    votes,
+    proposal.strategies
+  );
+  const results = {
+    scores_state: 'final',
+    scores: voting.getScores(),
+    scores_by_strategy: voting.getScoresByStrategy(),
+    scores_total: voting.getScoresTotal()
+  };
+
+  console.log(`Proposal:   ${proposal.id}`);
+  console.log(`Space:      ${proposal.space}`);
+  console.log(`Type:       ${proposal.type}`);
+  console.log(`Votes:      ${votes.length}`);
+  console.log(`snapshot.js voting: ${proposal.type}`);
+  console.log('');
+  console.log('Choice                                   stored -> recomputed');
+  proposal.choices.forEach((choice: string, i: number) => {
+    console.log(`  ${choice}: ${proposal.scores[i]} -> ${results.scores[i]}`);
+  });
+  console.log('');
+  console.log(
+    `scores_total: ${proposal.scores_total} -> ${results.scores_total}`
+  );
+
+  if (!apply) {
+    console.log('\nDry run. Re-run with --apply to write these scores.');
+    return;
+  }
+
+  await updateProposalScores(proposal, results, votes.length);
+  console.log(`\nApplied. Wrote final scores for ${proposal.id}.`);
+}
+
+main()
+  .catch(e => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => db.endAsync().then(() => process.exit()));

--- a/apps/sequencer/scripts/rescore-proposal.ts
+++ b/apps/sequencer/scripts/rescore-proposal.ts
@@ -9,14 +9,16 @@ import { getProposal, getVotes, updateProposalScores } from '../src/scores';
 //   bunx ts-node scripts/rescore-proposal.ts --proposal <id> --apply    # write
 //
 // Recomputes a proposal's results with the currently bundled snapshot.js and,
-// with --apply, writes scores/scores_by_strategy/scores_total/scores_state +
-// scores_updated back to the proposals table.
+// with --apply, writes scores/scores_by_strategy/scores_total/scores_state,
+// scores_updated, votes and cb back to the proposals table.
 //
 // This reads the votes as already stored (for shutter proposals the choices
 // must already be decrypted) and re-tallies using each vote's existing voting
 // power. It does not re-fetch voting power and does not read or modify the
-// proposal's privacy field, so it is safe to run on closed shutter proposals
-// that the normal scoring path refuses to recompute.
+// proposal's privacy field, so it is also safe on closed shutter proposals.
+// updateProposalAndVotes returns early on any proposal whose scores_state is
+// already final, before it reaches the force flag, so this script is the only
+// way to re-tally one.
 
 async function main() {
   const proposalArg = process.argv.indexOf('--proposal');
@@ -77,7 +79,6 @@ async function main() {
   console.log(`Space:      ${proposal.space}`);
   console.log(`Type:       ${proposal.type}`);
   console.log(`Votes:      ${votes.length}`);
-  console.log(`snapshot.js voting: ${proposal.type}`);
   console.log('');
   console.log('Choice                                   stored -> recomputed');
   proposal.choices.forEach((choice: string, i: number) => {

--- a/apps/sequencer/scripts/rescore-proposal.ts
+++ b/apps/sequencer/scripts/rescore-proposal.ts
@@ -7,18 +7,6 @@ import { getProposal, getVotes, updateProposalScores } from '../src/scores';
 // Usage:
 //   bunx ts-node scripts/rescore-proposal.ts --proposal <id>            # dry run
 //   bunx ts-node scripts/rescore-proposal.ts --proposal <id> --apply    # write
-//
-// Recomputes a proposal's results with the currently bundled snapshot.js and,
-// with --apply, writes scores/scores_by_strategy/scores_total/scores_state,
-// scores_updated, votes and cb back to the proposals table.
-//
-// This reads the votes as already stored (for shutter proposals the choices
-// must already be decrypted) and re-tallies using each vote's existing voting
-// power. It does not re-fetch voting power and does not read or modify the
-// proposal's privacy field, so it is also safe on closed shutter proposals.
-// updateProposalAndVotes returns early on any proposal whose scores_state is
-// already final, before it reaches the force flag, so this script is the only
-// way to re-tally one.
 
 async function main() {
   const proposalArg = process.argv.indexOf('--proposal');
@@ -94,9 +82,7 @@ async function main() {
     return;
   }
 
-  // Re-enter the scores-value pipeline: proposalsScoresValue only picks up
-  // cb = PENDING_COMPUTE, so an already-FINAL proposal would otherwise keep a
-  // scores_total_value derived from the old scores_by_strategy.
+  // proposalsScoresValue only selects cb = PENDING_COMPUTE.
   if (proposal.cb === CB.FINAL) proposal.cb = CB.PENDING_COMPUTE;
 
   await updateProposalScores(proposal, results, votes.length);

--- a/apps/sequencer/src/scores.ts
+++ b/apps/sequencer/src/scores.ts
@@ -8,7 +8,7 @@ import { hasStrategyOverride, sha256 } from './helpers/utils';
 const scoreAPIUrl = process.env.SCORE_API_URL || 'https://score.snapshot.org';
 const FINALIZE_SCORE_SECONDS_DELAY = 60;
 
-async function getProposal(id: string): Promise<any | undefined> {
+export async function getProposal(id: string): Promise<any | undefined> {
   const query = 'SELECT * FROM proposals WHERE id = ? LIMIT 1';
   const [proposal] = await db.queryAsync(query, [id]);
   if (!proposal) return;
@@ -26,7 +26,7 @@ async function getProposal(id: string): Promise<any | undefined> {
   return proposal;
 }
 
-async function getVotes(proposalId: string): Promise<any[] | undefined> {
+export async function getVotes(proposalId: string): Promise<any[] | undefined> {
   const query =
     'SELECT id, choice, voter, vp, vp_by_strategy, vp_state, vp_value FROM votes WHERE proposal = ?';
   const votes = await db.queryAsync(query, [proposalId]);
@@ -87,7 +87,11 @@ async function updateVotesVp(
   );
 }
 
-async function updateProposalScores(proposal: any, scores: any, votes: number) {
+export async function updateProposalScores(
+  proposal: any,
+  scores: any,
+  votes: number
+) {
   const ts = (Date.now() / 1e3).toFixed();
   const query = `
     UPDATE proposals

--- a/apps/sequencer/src/scores.ts
+++ b/apps/sequencer/src/scores.ts
@@ -26,7 +26,7 @@ export async function getProposal(id: string): Promise<any | undefined> {
   return proposal;
 }
 
-export async function getVotes(proposalId: string): Promise<any[] | undefined> {
+export async function getVotes(proposalId: string): Promise<any[]> {
   const query =
     'SELECT id, choice, voter, vp, vp_by_strategy, vp_state, vp_value FROM votes WHERE proposal = ?';
   const votes = await db.queryAsync(query, [proposalId]);


### PR DESCRIPTION
## What

Adds a one-off maintenance script that recomputes a single closed proposal's results with the currently bundled `@snapshot-labs/snapshot.js` and, with `--apply`, writes them back to the `proposals` table. Dry run by default.

## Why

Once a proposal's scores are final there is no operator-facing way to re-tally it. `updateProposalAndVotes` returns early on any proposal whose `scores_state` is already final, before it reaches the `force` flag, so the scores endpoint, the vote writer and the Shutter keyper callback all return without recomputing. That leaves no route to repair a proposal scored under a since-changed tiebreak short of editing the row by hand.

The script re-tallies directly from the stored votes, reusing each vote's existing voting power, and writes through the existing `updateProposalScores` helper. It does not refresh voting power and never reads or modifies `privacy`, so it is also safe on closed shutter proposals whose choices are already decrypted.

It refuses to run unless the proposal is closed, its scores are final, and every vote's choice has been decrypted.
