### PR TITLE
feat(api): add proposal choices array

### DIFF
--- a/apps/api/src/common/ipfs.ts
+++ b/apps/api/src/common/ipfs.ts
@@ -1,4 +1,4 @@
-import { dropIpfs, getExecutionHash, getJSON } from './utils';
+import { BASIC_CHOICES, dropIpfs, getExecutionHash, getJSON } from './utils';
 import {
   ProposalMetadataItem,
   StrategiesParsedMetadataDataItem,
@@ -23,13 +23,13 @@ export async function handleProposalMetadata(
     dropIpfs(metadataUri),
     config.indexerName
   );
-  if (exists) return;
+  if (exists) return exists;
 
   const proposalMetadataItem = new ProposalMetadataItem(
     dropIpfs(metadataUri),
     config.indexerName
   );
-  proposalMetadataItem.choices = ['For', 'Against', 'Abstain'];
+  proposalMetadataItem.choices = BASIC_CHOICES;
   proposalMetadataItem.labels = [];
 
   const metadata: any = await getJSON(metadataUri);
@@ -66,6 +66,8 @@ export async function handleProposalMetadata(
   }
 
   await proposalMetadataItem.save();
+
+  return proposalMetadataItem;
 }
 
 async function handleStrategiesParsedMetadata(

--- a/apps/api/src/common/utils.ts
+++ b/apps/api/src/common/utils.ts
@@ -8,6 +8,8 @@ import { UI_URL } from '../config';
 
 type ExecutionType = Parameters<typeof getExecutionData>[0];
 
+export const BASIC_CHOICES = ['For', 'Against', 'Abstain'];
+
 export function getSpaceLink({
   networkId,
   spaceId

--- a/apps/api/src/evm/protocols/governor-bravo/writers.ts
+++ b/apps/api/src/evm/protocols/governor-bravo/writers.ts
@@ -19,6 +19,7 @@ import {
   VotingPowerValidationStrategiesParsedMetadataItem
 } from '../../../../.checkpoint/models';
 import {
+  BASIC_CHOICES,
   getCurrentTimestamp,
   getParsedVP,
   getProposalLink,
@@ -356,6 +357,7 @@ export function createWriters(
     proposal.execution_strategy_details = executionStrategy.id;
     proposal.vp_decimals = spaceDataEntry.decimals;
     proposal.type = 'basic';
+    proposal.choices = BASIC_CHOICES;
     proposal.quorum_type = 'for_only';
     proposal.created = Number(block?.timestamp ?? getCurrentTimestamp());
     proposal.tx = txId;
@@ -395,7 +397,7 @@ export function createWriters(
 
     proposalMetadata.title = getProposalTitle(proposalBody);
     proposalMetadata.body = getProposalBody(proposalBody);
-    proposalMetadata.choices = ['For', 'Against', 'Abstain'];
+    proposalMetadata.choices = BASIC_CHOICES;
     proposalMetadata.execution = JSON.stringify(execution);
 
     let leaderboardItem = await Leaderboard.loadEntity(

--- a/apps/api/src/evm/protocols/openzeppelin/writers.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/writers.ts
@@ -32,6 +32,7 @@ import {
   VotingPowerValidationStrategiesParsedMetadataItem
 } from '../../../../.checkpoint/models';
 import {
+  BASIC_CHOICES,
   getCurrentTimestamp,
   getParsedVP,
   getProposalLink,
@@ -415,6 +416,7 @@ export function createWriters(
     proposal.execution_strategy_details = executionStrategy.id;
     proposal.vp_decimals = strategyParsedMetadataDataItem.decimals;
     proposal.type = 'basic';
+    proposal.choices = BASIC_CHOICES;
     proposal.quorum_type = getGovernanceInfo(spaceAddress).quorumType || null;
     proposal.created = Number(block?.timestamp ?? getCurrentTimestamp());
     proposal.tx = txId;
@@ -443,7 +445,7 @@ export function createWriters(
 
     proposalMetadata.title = getProposalTitle(proposalBody);
     proposalMetadata.body = getProposalBody(proposalBody);
-    proposalMetadata.choices = ['For', 'Against', 'Abstain'];
+    proposalMetadata.choices = BASIC_CHOICES;
     proposalMetadata.execution = JSON.stringify(execution);
 
     const descriptionHash = keccak256(toHex(proposalBody));

--- a/apps/api/src/evm/protocols/snapshot-x/writers.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/writers.ts
@@ -38,6 +38,7 @@ import {
   handleVoteMetadata
 } from '../../../common/ipfs';
 import {
+  BASIC_CHOICES,
   dropIpfs,
   getCurrentTimestamp,
   getParsedVP,
@@ -639,6 +640,7 @@ export function createWriters(
     );
     proposal.snapshot = BigInt(event.args.proposal.startBlockNumber);
     proposal.type = 'basic';
+    proposal.choices = BASIC_CHOICES;
     proposal.scores_1 = '0';
     proposal.scores_1_parsed = 0;
     proposal.scores_2 = '0';
@@ -710,7 +712,7 @@ export function createWriters(
 
     try {
       const metadataUri = event.args.metadataUri;
-      await handleProposalMetadata(
+      const metadataItem = await handleProposalMetadata(
         'evm',
         proposal.execution_strategy_type,
         proposal.execution_destination,
@@ -720,6 +722,7 @@ export function createWriters(
       );
 
       proposal.metadata = dropIpfs(metadataUri);
+      proposal.choices = metadataItem.choices;
     } catch (err) {
       logger.warn({ err }, 'Failed to handle proposal metadata');
     }
@@ -890,7 +893,7 @@ export function createWriters(
     }
 
     try {
-      await handleProposalMetadata(
+      const metadataItem = await handleProposalMetadata(
         'evm',
         proposal.execution_strategy_type,
         proposal.execution_destination,
@@ -900,6 +903,7 @@ export function createWriters(
       );
 
       proposal.metadata = dropIpfs(metadataUri);
+      proposal.choices = metadataItem.choices;
       proposal.edited = Number(block?.timestamp ?? getCurrentTimestamp());
     } catch (err) {
       logger.warn({ err }, 'Failed to handle proposal metadata');

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -266,6 +266,8 @@ type Proposal {
   vp_decimals: Int!
   "Type of proposal (e.g., 'basic', 'single-choice')"
   type: String!
+  "Array of voting choice labels (index 0 = choice 1)"
+  choices: [String!]!
   "Voting power for choice 1"
   scores_1: BigDecimalVP!
   "Parsed voting power for choice 1 as float"

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -27,6 +27,7 @@ import {
   handleVoteMetadata
 } from '../common/ipfs';
 import {
+  BASIC_CHOICES,
   dropIpfs,
   getCurrentTimestamp,
   getParsedVP,
@@ -468,6 +469,7 @@ export function createWriters(config: FullConfig) {
     );
     proposal.execution_strategy_type = 'none';
     proposal.type = 'basic';
+    proposal.choices = BASIC_CHOICES;
     proposal.scores_1 = '0';
     proposal.scores_1_parsed = 0;
     proposal.scores_2 = '0';
@@ -538,7 +540,7 @@ export function createWriters(config: FullConfig) {
 
     try {
       const metadataUri = longStringToText(event.metadata_uri);
-      await handleProposalMetadata(
+      const metadataItem = await handleProposalMetadata(
         'starknet',
         proposal.execution_strategy_type,
         proposal.execution_destination,
@@ -548,6 +550,7 @@ export function createWriters(config: FullConfig) {
       );
 
       proposal.metadata = dropIpfs(metadataUri);
+      proposal.choices = metadataItem.choices;
     } catch (err) {
       logger.warn({ err }, 'Failed to handle proposal metadata');
     }
@@ -715,7 +718,7 @@ export function createWriters(config: FullConfig) {
     }
 
     try {
-      await handleProposalMetadata(
+      const metadataItem = await handleProposalMetadata(
         'starknet',
         proposal.execution_strategy_type,
         proposal.execution_destination,
@@ -725,6 +728,7 @@ export function createWriters(config: FullConfig) {
       );
 
       proposal.metadata = dropIpfs(metadataUri);
+      proposal.choices = metadataItem.choices;
       proposal.edited = block?.timestamp ?? getCurrentTimestamp();
     } catch (err) {
       logger.warn({ err }, 'Failed to handle proposal metadata');


### PR DESCRIPTION
First step toward variable-length choice/score arrays (needed for offchain proposal ingestion and future multi-choice voting): adds `choices` to `Proposal`, copied from the pinned IPFS metadata on proposal creation and edit. Custom labels are only used when they map 1:1 onto the 3 onchain vote options; `handleProposalMetadata` already validates this (exactly 3 strings) and falls back to the new shared `BASIC_CHOICES` constant otherwise, so a proposal can never expose more choices than SX or Governor support. Governor-bravo and OpenZeppelin get the fixed labels, matching their `support` semantics.

Purely additive, safe to merge/deploy in any order relative to the UI. The `scores`/`scores_parsed` arrays follow in #2243. The new column appears through the standard from-scratch reindex on deploy (`syncVersion` changes with `GIT_COMMIT`).

## Test Plan

1. Run the API against Sepolia with a fresh DB and let it reindex
2. Create an SX proposal with custom choice labels; query `proposal { choices }` and confirm the custom labels are returned
3. Create one without custom labels; confirm `choices` is `["For", "Against", "Abstain"]` (same for governor-bravo/OZ proposals)
4. Edit a proposal's choices before voting starts; confirm `choices` reflects the edit

Verified on a from-scratch local Sepolia reindex with real onchain data (steps 1-3, on the pre-split branch containing these same changes).

Note: the `getSpaceController` shib test may fail in CI: stamp.fyi's `get_owner` for Shibarium returns `500 unauthorized`. Unrelated, fails identically on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
