### PR TITLE
fix(ui): show delegate-registry delegations across all strategy networks

### DIFF
--- a/apps/ui/src/components/Modal/Delegate.vue
+++ b/apps/ui/src/components/Modal/Delegate.vue
@@ -3,6 +3,7 @@ import { getAddress } from '@ethersproject/address';
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { h, VNode } from 'vue';
 import {
+  candidateChainIds,
   isValidDelegation,
   ValidSpaceMetadataDelegation
 } from '@/helpers/delegation';
@@ -127,7 +128,7 @@ const chainIds = computed(() => {
   // a user write on a chain the read path never queries, hiding the delegation.
   const delegation = selectedDelegation.value;
   if (delegation?.apiType === 'delegate-registry') {
-    const chainIds = (delegation.chainIds ?? [delegation.chainId])
+    const chainIds = candidateChainIds(delegation)
       .map(Number)
       .filter(chainId =>
         DELEGATE_REGISTRY_SUPPORTED_CHAIN_IDS.includes(chainId)
@@ -136,6 +137,9 @@ const chainIds = computed(() => {
     if (chainIds.length) return Array.from(new Set(chainIds));
   }
 
+  // apechain-delegate-registry is always single-chain (sourced from a
+  // delegationPortal, which carries one delegationNetwork), so form.chainId
+  // already equals its sole chain here.
   return [form.chainId];
 });
 

--- a/apps/ui/src/components/Modal/Delegate.vue
+++ b/apps/ui/src/components/Modal/Delegate.vue
@@ -2,7 +2,6 @@
 import { getAddress } from '@ethersproject/address';
 import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { h, VNode } from 'vue';
-import { DELEGATE_REGISTRY_STRATEGIES } from '@/helpers/constants';
 import {
   isValidDelegation,
   ValidSpaceMetadataDelegation
@@ -122,30 +121,22 @@ const chainIds = computed(() => {
     return SPLIT_DELEGATION_SUPPORTED_CHAIN_IDS;
   }
 
-  const delegateRegistryStrategies = props.space.strategies_params.filter(
-    (_, index) =>
-      DELEGATE_REGISTRY_STRATEGIES.includes(props.space.strategies[index])
-  );
+  // Mirror the read path (formatDelegateRegistryDelegations / getDelegation):
+  // the registry lives on the delegation's own chain(s), which already honor
+  // params.delegationNetwork. Offering strategy voting networks here would let
+  // a user write on a chain the read path never queries, hiding the delegation.
+  const delegation = selectedDelegation.value;
+  if (delegation?.apiType === 'delegate-registry') {
+    const chainIds = (delegation.chainIds ?? [delegation.chainId])
+      .map(Number)
+      .filter(chainId =>
+        DELEGATE_REGISTRY_SUPPORTED_CHAIN_IDS.includes(chainId)
+      );
 
-  if (!delegateRegistryStrategies.length) {
-    return [form.chainId];
+    if (chainIds.length) return Array.from(new Set(chainIds));
   }
 
-  const chainIds = delegateRegistryStrategies
-    .flatMap(params => {
-      return [
-        params.network,
-        ...(params.params?.strategies?.flatMap(p => [
-          p.network,
-          p.params?.network
-        ]) || [])
-      ];
-    })
-    .filter(Boolean)
-    .map(Number)
-    .filter(chainId => DELEGATE_REGISTRY_SUPPORTED_CHAIN_IDS.includes(chainId));
-
-  return Array.from(new Set(chainIds));
+  return [form.chainId];
 });
 
 function delegationConnectors(

--- a/apps/ui/src/components/Modal/Delegate.vue
+++ b/apps/ui/src/components/Modal/Delegate.vue
@@ -122,10 +122,6 @@ const chainIds = computed(() => {
     return SPLIT_DELEGATION_SUPPORTED_CHAIN_IDS;
   }
 
-  // Mirror the read path (formatDelegateRegistryDelegations / getDelegation):
-  // the registry lives on the delegation's own chain(s), which already honor
-  // params.delegationNetwork. Offering strategy voting networks here would let
-  // a user write on a chain the read path never queries, hiding the delegation.
   const delegation = selectedDelegation.value;
   if (delegation?.apiType === 'delegate-registry') {
     const chainIds = candidateChainIds(delegation)
@@ -137,9 +133,6 @@ const chainIds = computed(() => {
     if (chainIds.length) return Array.from(new Set(chainIds));
   }
 
-  // apechain-delegate-registry is always single-chain (sourced from a
-  // delegationPortal, which carries one delegationNetwork), so form.chainId
-  // already equals its sole chain here.
   return [form.chainId];
 });
 

--- a/apps/ui/src/composables/useDelegates.test.ts
+++ b/apps/ui/src/composables/useDelegates.test.ts
@@ -3,6 +3,7 @@ import { useDelegates } from './useDelegates';
 
 const queriedChains: string[] = [];
 const responses = new Map<string, string>();
+const rejectChains = new Set<string>();
 
 vi.mock('@apollo/client/core', () => {
   class ApolloClient {
@@ -15,6 +16,9 @@ vi.mock('@apollo/client/core', () => {
     async query() {
       const chainId = this.uri?.split('/').pop() ?? '';
       queriedChains.push(chainId);
+      if (rejectChains.has(chainId)) {
+        throw new Error(`subgraph ${chainId} down`);
+      }
       const delegate = responses.get(chainId);
       return {
         data: {
@@ -49,6 +53,7 @@ describe('useDelegates', () => {
   beforeEach(() => {
     queriedChains.length = 0;
     responses.clear();
+    rejectChains.clear();
   });
 
   afterEach(() => {
@@ -76,6 +81,18 @@ describe('useDelegates', () => {
       const { getDelegation } = setup(['1', '100']);
       const result = await getDelegation('0xdelegator');
 
+      expect(result).toEqual({ id: '100:d', delegate: '0xBBB' });
+    });
+
+    it('ignores a failing chain and returns a delegation on a healthy one', async () => {
+      rejectChains.add('1');
+      responses.set('100', '0xBBB');
+
+      const { getDelegation } = setup(['1', '100']);
+      const result = await getDelegation('0xdelegator');
+
+      // A single rejecting subgraph (Promise.all would throw) must not hide the
+      // delegation that lives on the healthy chain.
       expect(result).toEqual({ id: '100:d', delegate: '0xBBB' });
     });
 

--- a/apps/ui/src/composables/useDelegates.test.ts
+++ b/apps/ui/src/composables/useDelegates.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDelegates } from './useDelegates';
+
+const queriedChains: string[] = [];
+const responses = new Map<string, string>();
+
+vi.mock('@apollo/client/core', () => {
+  class ApolloClient {
+    uri?: string;
+
+    constructor(opts: any) {
+      this.uri = opts?.uri;
+    }
+
+    async query() {
+      const chainId = this.uri?.split('/').pop() ?? '';
+      queriedChains.push(chainId);
+      const delegate = responses.get(chainId);
+      return {
+        data: {
+          delegations: delegate ? [{ id: `${chainId}:d`, delegate }] : []
+        }
+      };
+    }
+  }
+
+  return {
+    ApolloClient,
+    InMemoryCache: class {},
+    createHttpLink: () => ({})
+  };
+});
+
+function setup(chainIds: string[]) {
+  return useDelegates(
+    {
+      name: 'Delegate registry',
+      apiType: 'delegate-registry',
+      apiUrl: 'https://delegate-registry-api.snapshot.box',
+      contractAddress: 'space.eth',
+      chainId: chainIds[0],
+      chainIds
+    } as any,
+    {} as any
+  );
+}
+
+describe('useDelegates', () => {
+  beforeEach(() => {
+    queriedChains.length = 0;
+    responses.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getDelegation', () => {
+    it('probes every candidate chain in parallel and keeps chainIds order', async () => {
+      responses.set('1', '0xAAA');
+      responses.set('100', '0xBBB');
+
+      const { getDelegation } = setup(['1', '100']);
+      const result = await getDelegation('0xdelegator');
+
+      // Promise.all probes all chains (a serial short-circuit would stop after
+      // the first hit); results.find keeps chainIds order, so chain 1 wins.
+      expect(queriedChains).toContain('1');
+      expect(queriedChains).toContain('100');
+      expect(result).toEqual({ id: '1:d', delegate: '0xAAA' });
+    });
+
+    it('returns the first non-empty result following chainIds order', async () => {
+      responses.set('100', '0xBBB');
+
+      const { getDelegation } = setup(['1', '100']);
+      const result = await getDelegation('0xdelegator');
+
+      expect(result).toEqual({ id: '100:d', delegate: '0xBBB' });
+    });
+
+    it('warns and skips chains without a delegation subgraph', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { getDelegation } = setup(['999']);
+      const result = await getDelegation('0xdelegator');
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('999'));
+      expect(queriedChains).toEqual([]);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/ui/src/composables/useDelegates.test.ts
+++ b/apps/ui/src/composables/useDelegates.test.ts
@@ -68,8 +68,6 @@ describe('useDelegates', () => {
       const { getDelegation } = setup(['1', '100']);
       const result = await getDelegation('0xdelegator');
 
-      // Promise.all probes all chains (a serial short-circuit would stop after
-      // the first hit); results.find keeps chainIds order, so chain 1 wins.
       expect(queriedChains).toContain('1');
       expect(queriedChains).toContain('100');
       expect(result).toEqual({ id: '1:d', delegate: '0xAAA' });
@@ -91,8 +89,6 @@ describe('useDelegates', () => {
       const { getDelegation } = setup(['1', '100']);
       const result = await getDelegation('0xdelegator');
 
-      // A single rejecting subgraph (Promise.all would throw) must not hide the
-      // delegation that lives on the healthy chain.
       expect(result).toEqual({ id: '100:d', delegate: '0xBBB' });
     });
 

--- a/apps/ui/src/composables/useDelegates.ts
+++ b/apps/ui/src/composables/useDelegates.ts
@@ -347,7 +347,9 @@ export function useDelegates(
 
     const chainIds = candidateChainIds(delegation);
 
-    const results = await Promise.all(
+    // allSettled (not all): one unhealthy subgraph must not hide a delegation
+    // that lives on a healthy chain, which a single rejection would do here.
+    const results = await Promise.allSettled(
       chainIds.map(async chainId => {
         const delegationSubgraph = DELEGATION_SUBGRAPHS[chainId];
         if (!delegationSubgraph) {
@@ -381,7 +383,11 @@ export function useDelegates(
 
     // Preserve chainIds order so the primary chain wins when a delegation
     // exists on more than one.
-    return results.find(Boolean) ?? null;
+    for (const result of results) {
+      if (result.status === 'fulfilled' && result.value) return result.value;
+    }
+
+    return null;
   }
 
   return {

--- a/apps/ui/src/composables/useDelegates.ts
+++ b/apps/ui/src/composables/useDelegates.ts
@@ -4,6 +4,7 @@ import {
   InMemoryCache
 } from '@apollo/client/core';
 import gql from 'graphql-tag';
+import { candidateChainIds } from '@/helpers/delegation';
 import { getNames } from '@/helpers/stamp';
 import { compareAddresses, formatAddress } from '@/helpers/utils';
 import { getNetwork, metadataNetwork as metadataNetworkId } from '@/networks';
@@ -344,10 +345,7 @@ export function useDelegates(
       ? DELEGATIONS_RAW_QUERY
       : DELEGATIONS_QUERY;
 
-    const chainIds =
-      delegation.chainIds && delegation.chainIds.length
-        ? delegation.chainIds
-        : [delegation.chainId];
+    const chainIds = candidateChainIds(delegation);
 
     const results = await Promise.all(
       chainIds.map(async chainId => {

--- a/apps/ui/src/composables/useDelegates.ts
+++ b/apps/ui/src/composables/useDelegates.ts
@@ -337,21 +337,6 @@ export function useDelegates(
       throw new Error('getDelegation is only supported for delegate-registry');
     }
 
-    const delegationSubgraph = DELEGATION_SUBGRAPHS[delegation.chainId];
-    if (!delegationSubgraph) {
-      throw new Error('Delegation subgraph not found');
-    }
-
-    const client = new ApolloClient({
-      uri: delegationSubgraph,
-      cache: new InMemoryCache(),
-      defaultOptions: {
-        query: {
-          fetchPolicy: 'no-cache'
-        }
-      }
-    });
-
     const isApeChainDelegateRegistry =
       delegation.apiType === 'apechain-delegate-registry';
 
@@ -359,15 +344,37 @@ export function useDelegates(
       ? DELEGATIONS_RAW_QUERY
       : DELEGATIONS_QUERY;
 
-    const { data } = await client.query({
-      query,
-      variables: {
-        space: delegation.contractAddress,
-        delegator
-      }
-    });
+    const chainIds =
+      delegation.chainIds && delegation.chainIds.length
+        ? delegation.chainIds
+        : [delegation.chainId];
 
-    return data.delegations[0] ?? null;
+    for (const chainId of chainIds) {
+      const delegationSubgraph = DELEGATION_SUBGRAPHS[chainId];
+      if (!delegationSubgraph) continue;
+
+      const client = new ApolloClient({
+        uri: delegationSubgraph,
+        cache: new InMemoryCache(),
+        defaultOptions: {
+          query: {
+            fetchPolicy: 'no-cache'
+          }
+        }
+      });
+
+      const { data } = await client.query({
+        query,
+        variables: {
+          space: delegation.contractAddress,
+          delegator
+        }
+      });
+
+      if (data.delegations[0]) return data.delegations[0];
+    }
+
+    return null;
   }
 
   return {

--- a/apps/ui/src/composables/useDelegates.ts
+++ b/apps/ui/src/composables/useDelegates.ts
@@ -349,32 +349,41 @@ export function useDelegates(
         ? delegation.chainIds
         : [delegation.chainId];
 
-    for (const chainId of chainIds) {
-      const delegationSubgraph = DELEGATION_SUBGRAPHS[chainId];
-      if (!delegationSubgraph) continue;
+    const results = await Promise.all(
+      chainIds.map(async chainId => {
+        const delegationSubgraph = DELEGATION_SUBGRAPHS[chainId];
+        if (!delegationSubgraph) {
+          console.warn(
+            `No delegation subgraph for chain ${chainId} (registry ${delegation.contractAddress}); skipping.`
+          );
+          return null;
+        }
 
-      const client = new ApolloClient({
-        uri: delegationSubgraph,
-        cache: new InMemoryCache(),
-        defaultOptions: {
-          query: {
-            fetchPolicy: 'no-cache'
+        const client = new ApolloClient({
+          uri: delegationSubgraph,
+          cache: new InMemoryCache(),
+          defaultOptions: {
+            query: {
+              fetchPolicy: 'no-cache'
+            }
           }
-        }
-      });
+        });
 
-      const { data } = await client.query({
-        query,
-        variables: {
-          space: delegation.contractAddress,
-          delegator
-        }
-      });
+        const { data } = await client.query({
+          query,
+          variables: {
+            space: delegation.contractAddress,
+            delegator
+          }
+        });
 
-      if (data.delegations[0]) return data.delegations[0];
-    }
+        return data.delegations[0] ?? null;
+      })
+    );
 
-    return null;
+    // Preserve chainIds order so the primary chain wins when a delegation
+    // exists on more than one.
+    return results.find(Boolean) ?? null;
   }
 
   return {

--- a/apps/ui/src/composables/useDelegates.ts
+++ b/apps/ui/src/composables/useDelegates.ts
@@ -362,9 +362,7 @@ export function useDelegates(
     const { data } = await client.query({
       query,
       variables: {
-        space: isApeChainDelegateRegistry
-          ? delegation.contractAddress
-          : space.id,
+        space: delegation.contractAddress,
         delegator
       }
     });

--- a/apps/ui/src/composables/useDelegates.ts
+++ b/apps/ui/src/composables/useDelegates.ts
@@ -347,8 +347,6 @@ export function useDelegates(
 
     const chainIds = candidateChainIds(delegation);
 
-    // allSettled (not all): one unhealthy subgraph must not hide a delegation
-    // that lives on a healthy chain, which a single rejection would do here.
     const results = await Promise.allSettled(
       chainIds.map(async chainId => {
         const delegationSubgraph = DELEGATION_SUBGRAPHS[chainId];
@@ -381,8 +379,6 @@ export function useDelegates(
       })
     );
 
-    // Preserve chainIds order so the primary chain wins when a delegation
-    // exists on more than one.
     for (const result of results) {
       if (result.status === 'fulfilled' && result.value) return result.value;
     }

--- a/apps/ui/src/helpers/delegation.ts
+++ b/apps/ui/src/helpers/delegation.ts
@@ -36,3 +36,14 @@ export function isValidDelegation(
     delegation.contractAddress
   );
 }
+
+// Single source of truth for the chains a delegation must be probed/written on.
+// `chainIds` carries every candidate chain for a multichain registry; `chainId`
+// is the primary one and the only value present for single-chain delegations.
+export function candidateChainIds(
+  delegation: Pick<SpaceMetadataDelegation, 'chainId' | 'chainIds'>
+): string[] {
+  if (delegation.chainIds?.length) return delegation.chainIds;
+
+  return delegation.chainId ? [delegation.chainId] : [];
+}

--- a/apps/ui/src/helpers/delegation.ts
+++ b/apps/ui/src/helpers/delegation.ts
@@ -37,9 +37,6 @@ export function isValidDelegation(
   );
 }
 
-// Single source of truth for the chains a delegation must be probed/written on.
-// `chainIds` carries every candidate chain for a multichain registry; `chainId`
-// is the primary one and the only value present for single-chain delegations.
 export function candidateChainIds(
   delegation: Pick<SpaceMetadataDelegation, 'chainId' | 'chainIds'>
 ): string[] {

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -809,6 +809,10 @@ export function createActions(
         // delegationContract carries the registry namespace the read path keys
         // on (delegationSpace || space.id); writing under space.id would delegate
         // to a different id than getDelegation reads, hiding the delegation.
+        // NOTE: formatBytes32String throws for namespaces over 31 bytes (e.g. a
+        // 0x…40 address used as delegationSpace), so those fail before sending
+        // any transaction. Encoding them as raw bytes needs to match the
+        // delegation subgraph's id decoding — left to a follow-up.
         const delegationId =
           delegationType === 'delegate-registry'
             ? formatBytes32String(delegationContract)

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -806,9 +806,12 @@ export function createActions(
             ? '0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446'
             : APE_GAS_CONFIGS[currentChainId].registryContract;
 
+        // delegationContract carries the registry namespace the read path keys
+        // on (delegationSpace || space.id); writing under space.id would delegate
+        // to a different id than getDelegation reads, hiding the delegation.
         const delegationId =
           delegationType === 'delegate-registry'
-            ? formatBytes32String(space.id)
+            ? formatBytes32String(delegationContract)
             : delegationContract;
 
         if (delegatees[0]) {

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -886,6 +886,10 @@ export function createActions(
         // delegationContract carries the registry namespace the read path keys
         // on (delegationSpace || space.id); writing under space.id would delegate
         // to a different id than getDelegation reads, hiding the delegation.
+        // NOTE: formatBytes32String throws for namespaces over 31 bytes (e.g. a
+        // 0x…40 address used as delegationSpace), so those fail before sending
+        // any transaction. Encoding them as raw bytes needs to match the
+        // delegation subgraph's id decoding — left to a follow-up.
         const delegationId =
           delegationType === 'delegate-registry'
             ? formatBytes32String(delegationContract)

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -883,9 +883,12 @@ export function createActions(
             ? '0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446'
             : APE_GAS_CONFIGS[currentChainId].registryContract;
 
+        // delegationContract carries the registry namespace the read path keys
+        // on (delegationSpace || space.id); writing under space.id would delegate
+        // to a different id than getDelegation reads, hiding the delegation.
         const delegationId =
           delegationType === 'delegate-registry'
-            ? formatBytes32String(space.id)
+            ? formatBytes32String(delegationContract)
             : delegationContract;
 
         if (delegatees[0]) {

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -883,13 +883,9 @@ export function createActions(
             ? '0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446'
             : APE_GAS_CONFIGS[currentChainId].registryContract;
 
-        // delegationContract carries the registry namespace the read path keys
-        // on (delegationSpace || space.id); writing under space.id would delegate
-        // to a different id than getDelegation reads, hiding the delegation.
-        // NOTE: formatBytes32String throws for namespaces over 31 bytes (e.g. a
-        // 0x…40 address used as delegationSpace), so those fail before sending
-        // any transaction. Encoding them as raw bytes needs to match the
-        // delegation subgraph's id decoding — left to a follow-up.
+        // delegationContract is the namespace getDelegation reads
+        // (delegationSpace || space.id); space.id here would write under an
+        // id nothing ever queries.
         const delegationId =
           delegationType === 'delegate-registry'
             ? formatBytes32String(delegationContract)

--- a/apps/ui/src/networks/offchain/api/index.test.ts
+++ b/apps/ui/src/networks/offchain/api/index.test.ts
@@ -140,6 +140,31 @@ describe('formatDelegateRegistryDelegations', () => {
     ]);
   });
 
+  it('disambiguates two registries that render on the same chain', () => {
+    const result = formatDelegateRegistryDelegations(
+      {
+        id: 'pleasurecoin.eth',
+        network: '137',
+        strategies: [
+          strategy('delegation', '137', {
+            delegationSpace: '0x1111111111111111111111111111111111111111'
+          }),
+          strategy('delegation', '137', {
+            delegationSpace: '0x2222222222222222222222222222222222222222'
+          })
+        ]
+      },
+      API_URL
+    );
+
+    expect(result).toHaveLength(2);
+    // Same chain would otherwise produce identical labels; the registry
+    // namespace must make them distinguishable.
+    const names = result.map(d => d.name);
+    expect(new Set(names).size).toBe(2);
+    names.forEach(name => expect(name).toContain(' · 0x'));
+  });
+
   it('ignores non delegate-registry strategies', () => {
     const result = formatDelegateRegistryDelegations(
       {

--- a/apps/ui/src/networks/offchain/api/index.test.ts
+++ b/apps/ui/src/networks/offchain/api/index.test.ts
@@ -165,6 +165,27 @@ describe('formatDelegateRegistryDelegations', () => {
     names.forEach(name => expect(name).toContain(' · 0x'));
   });
 
+  it('labels two registries on different chains by chain, without a namespace suffix', () => {
+    const result = formatDelegateRegistryDelegations(
+      {
+        id: 'multiregistry.eth',
+        network: '1',
+        strategies: [
+          strategy('delegation', '1', { delegationSpace: 'one.eth' }),
+          strategy('delegation', '137', { delegationSpace: 'two.eth' })
+        ]
+      },
+      API_URL
+    );
+
+    expect(result).toHaveLength(2);
+    // Distinct chains already disambiguate the tabs, so the registry namespace
+    // suffix (` · `) must not be appended.
+    const names = result.map(d => d.name);
+    names.forEach(name => expect(name).not.toContain(' · '));
+    expect(new Set(names).size).toBe(2);
+  });
+
   it('ignores non delegate-registry strategies', () => {
     const result = formatDelegateRegistryDelegations(
       {

--- a/apps/ui/src/networks/offchain/api/index.test.ts
+++ b/apps/ui/src/networks/offchain/api/index.test.ts
@@ -159,14 +159,15 @@ describe('formatDelegateRegistryDelegations', () => {
     );
 
     expect(result).toHaveLength(2);
-    // Same chain would otherwise produce identical labels; the registry
-    // namespace must make them distinguishable.
-    const names = result.map(d => d.name);
-    expect(new Set(names).size).toBe(2);
-    names.forEach(name => expect(name).toContain(' · 0x'));
+    // Registries are labelled by namespace (the dedupe key), so even two
+    // registries on the same chain get distinct labels.
+    expect(result.map(d => d.name)).toEqual([
+      'Delegate registry (0x111111111111111111...)',
+      'Delegate registry (0x222222222222222222...)'
+    ]);
   });
 
-  it('labels two registries on different chains by chain, without a namespace suffix', () => {
+  it('labels multiple registries by their namespace', () => {
     const result = formatDelegateRegistryDelegations(
       {
         id: 'multiregistry.eth',
@@ -180,11 +181,13 @@ describe('formatDelegateRegistryDelegations', () => {
     );
 
     expect(result).toHaveLength(2);
-    // Distinct chains already disambiguate the tabs, so the registry namespace
-    // suffix (` · `) must not be appended.
-    const names = result.map(d => d.name);
-    names.forEach(name => expect(name).not.toContain(' · '));
-    expect(new Set(names).size).toBe(2);
+    // Short namespaces (e.g. ENS names) are kept whole — shorten() with a
+    // numeric limit must not run them through address formatting, which
+    // throws on non-address strings.
+    expect(result.map(d => d.name)).toEqual([
+      'Delegate registry (one.eth)',
+      'Delegate registry (two.eth)'
+    ]);
   });
 
   it('ignores non delegate-registry strategies', () => {

--- a/apps/ui/src/networks/offchain/api/index.test.ts
+++ b/apps/ui/src/networks/offchain/api/index.test.ts
@@ -25,10 +25,11 @@ describe('formatDelegateRegistryDelegations', () => {
     // The delegate-registry API returns the same delegate list for a given
     // registry regardless of chain, so a registry that reads several chains
     // must collapse into ONE tab (chainIds carries the chains to probe for the
-    // connected account's own delegation), not one duplicate tab per chain.
+    // connected account's own delegation), not one duplicate tab per chain. A
+    // lone registry keeps the plain label; the chain it lives on is not a tab.
     expect(result).toEqual([
       {
-        name: 'Delegate registry (Gnosis Chain)',
+        name: 'Delegate registry',
         apiType: 'delegate-registry',
         apiUrl: API_URL,
         contractAddress: 'gnosis.eth',

--- a/apps/ui/src/networks/offchain/api/index.test.ts
+++ b/apps/ui/src/networks/offchain/api/index.test.ts
@@ -12,7 +12,7 @@ function strategy(
 }
 
 describe('formatDelegateRegistryDelegations', () => {
-  it('emits one delegation per distinct network for direct multichain delegation', () => {
+  it('emits a single delegation spanning every network for a multichain registry', () => {
     const result = formatDelegateRegistryDelegations(
       {
         id: 'gnosis.eth',
@@ -22,22 +22,39 @@ describe('formatDelegateRegistryDelegations', () => {
       API_URL
     );
 
+    // The delegate-registry API returns the same delegate list for a given
+    // registry regardless of chain, so a registry that reads several chains
+    // must collapse into ONE tab (chainIds carries the chains to probe for the
+    // connected account's own delegation), not one duplicate tab per chain.
     expect(result).toEqual([
       {
         name: 'Delegate registry (Gnosis Chain)',
         apiType: 'delegate-registry',
         apiUrl: API_URL,
         contractAddress: 'gnosis.eth',
-        chainId: '100'
-      },
-      {
-        name: 'Delegate registry (Ethereum)',
-        apiType: 'delegate-registry',
-        apiUrl: API_URL,
-        contractAddress: 'gnosis.eth',
-        chainId: '1'
+        chainId: '100',
+        chainIds: ['100', '1']
       }
     ]);
+  });
+
+  it('does not duplicate a registry that appears on multiple networks', () => {
+    const result = formatDelegateRegistryDelegations(
+      {
+        id: 'multichain.eth',
+        network: '1',
+        strategies: [
+          strategy('delegation', '1', { delegationSpace: 'shared.eth' }),
+          strategy('delegation', '100', { delegationSpace: 'shared.eth' }),
+          strategy('delegation', '137', { delegationSpace: 'shared.eth' })
+        ]
+      },
+      API_URL
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].contractAddress).toBe('shared.eth');
+    expect(result[0].chainIds).toEqual(['1', '100', '137']);
   });
 
   it('uses delegationNetwork over the voting network', () => {
@@ -58,7 +75,8 @@ describe('formatDelegateRegistryDelegations', () => {
         apiType: 'delegate-registry',
         apiUrl: API_URL,
         contractAddress: 'giantkin.eth',
-        chainId: '42161'
+        chainId: '42161',
+        chainIds: ['42161']
       }
     ]);
   });
@@ -92,7 +110,8 @@ describe('formatDelegateRegistryDelegations', () => {
         apiType: 'delegate-registry',
         apiUrl: API_URL,
         contractAddress: 'stgdao.eth',
-        chainId: '1'
+        chainId: '1',
+        chainIds: ['1']
       }
     ]);
   });
@@ -115,7 +134,8 @@ describe('formatDelegateRegistryDelegations', () => {
         apiType: 'delegate-registry',
         apiUrl: API_URL,
         contractAddress: 'apecoin.eth',
-        chainId: '137'
+        chainId: '137',
+        chainIds: ['137']
       }
     ]);
   });

--- a/apps/ui/src/networks/offchain/api/index.test.ts
+++ b/apps/ui/src/networks/offchain/api/index.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { formatDelegateRegistryDelegations } from './index';
+
+const API_URL = 'https://delegate-registry-api.snapshot.box';
+
+function strategy(
+  name: string,
+  network: string,
+  params: Record<string, any> = {}
+) {
+  return { name, network, params };
+}
+
+describe('formatDelegateRegistryDelegations', () => {
+  it('emits one delegation per distinct network for direct multichain delegation', () => {
+    const result = formatDelegateRegistryDelegations(
+      {
+        id: 'gnosis.eth',
+        network: '1',
+        strategies: [strategy('delegation', '100'), strategy('delegation', '1')]
+      },
+      API_URL
+    );
+
+    expect(result).toEqual([
+      {
+        name: 'Delegate registry (Gnosis Chain)',
+        apiType: 'delegate-registry',
+        apiUrl: API_URL,
+        contractAddress: 'gnosis.eth',
+        chainId: '100'
+      },
+      {
+        name: 'Delegate registry (Ethereum)',
+        apiType: 'delegate-registry',
+        apiUrl: API_URL,
+        contractAddress: 'gnosis.eth',
+        chainId: '1'
+      }
+    ]);
+  });
+
+  it('uses delegationNetwork over the voting network', () => {
+    const result = formatDelegateRegistryDelegations(
+      {
+        id: 'giantkin.eth',
+        network: '1',
+        strategies: [
+          strategy('with-delegation', '1', { delegationNetwork: '42161' })
+        ]
+      },
+      API_URL
+    );
+
+    expect(result).toEqual([
+      {
+        name: 'Delegate registry',
+        apiType: 'delegate-registry',
+        apiUrl: API_URL,
+        contractAddress: 'giantkin.eth',
+        chainId: '42161'
+      }
+    ]);
+  });
+
+  it('dedupes repeated strategies sharing one registry', () => {
+    const result = formatDelegateRegistryDelegations(
+      {
+        id: 'stgdao.eth',
+        network: '1',
+        strategies: [
+          strategy('erc20-balance-of-with-delegation', '1', {
+            delegationNetwork: '1',
+            delegationSpace: 'stgdao.eth'
+          }),
+          strategy('erc20-balance-of-with-delegation', '56', {
+            delegationNetwork: '1',
+            delegationSpace: 'stgdao.eth'
+          }),
+          strategy('erc20-balance-of-with-delegation', '43114', {
+            delegationNetwork: '1',
+            delegationSpace: 'stgdao.eth'
+          })
+        ]
+      },
+      API_URL
+    );
+
+    expect(result).toEqual([
+      {
+        name: 'Delegate registry',
+        apiType: 'delegate-registry',
+        apiUrl: API_URL,
+        contractAddress: 'stgdao.eth',
+        chainId: '1'
+      }
+    ]);
+  });
+
+  it('uses delegationSpace over the space id', () => {
+    const result = formatDelegateRegistryDelegations(
+      {
+        id: 'digitech.eth',
+        network: '137',
+        strategies: [
+          strategy('delegation', '137', { delegationSpace: 'apecoin.eth' })
+        ]
+      },
+      API_URL
+    );
+
+    expect(result).toEqual([
+      {
+        name: 'Delegate registry',
+        apiType: 'delegate-registry',
+        apiUrl: API_URL,
+        contractAddress: 'apecoin.eth',
+        chainId: '137'
+      }
+    ]);
+  });
+
+  it('ignores non delegate-registry strategies', () => {
+    const result = formatDelegateRegistryDelegations(
+      {
+        id: 'test.eth',
+        network: '1',
+        strategies: [strategy('erc20-votes', '1', { address: '0x0' })]
+      },
+      API_URL
+    );
+
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/ui/src/networks/offchain/api/index.test.ts
+++ b/apps/ui/src/networks/offchain/api/index.test.ts
@@ -22,11 +22,6 @@ describe('formatDelegateRegistryDelegations', () => {
       API_URL
     );
 
-    // The delegate-registry API returns the same delegate list for a given
-    // registry regardless of chain, so a registry that reads several chains
-    // must collapse into ONE tab (chainIds carries the chains to probe for the
-    // connected account's own delegation), not one duplicate tab per chain. A
-    // lone registry keeps the plain label; the chain it lives on is not a tab.
     expect(result).toEqual([
       {
         name: 'Delegate registry',
@@ -159,8 +154,6 @@ describe('formatDelegateRegistryDelegations', () => {
     );
 
     expect(result).toHaveLength(2);
-    // Registries are labelled by namespace (the dedupe key), so even two
-    // registries on the same chain get distinct labels.
     expect(result.map(d => d.name)).toEqual([
       'Delegate registry (0x111111111111111111...)',
       'Delegate registry (0x222222222222222222...)'
@@ -181,9 +174,6 @@ describe('formatDelegateRegistryDelegations', () => {
     );
 
     expect(result).toHaveLength(2);
-    // Short namespaces (e.g. ENS names) are kept whole — shorten() with a
-    // numeric limit must not run them through address formatting, which
-    // throws on non-address strings.
     expect(result.map(d => d.name)).toEqual([
       'Delegate registry (one.eth)',
       'Delegate registry (two.eth)'

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -497,7 +497,10 @@ export function formatDelegateRegistryDelegations(
   space: Pick<ApiSpace, 'id' | 'network' | 'strategies'>,
   apiUrl: string
 ): SpaceMetadataDelegation[] {
-  const registries = new Map<string, SpaceMetadataDelegation>();
+  const registries = new Map<
+    string,
+    SpaceMetadataDelegation & { chainIds: string[] }
+  >();
 
   for (const strategy of space.strategies) {
     if (!DELEGATE_REGISTRY_STRATEGIES.includes(strategy.name)) continue;
@@ -509,8 +512,8 @@ export function formatDelegateRegistryDelegations(
 
     const existing = registries.get(contractAddress);
     if (existing) {
-      if (!existing.chainIds!.includes(chainId)) {
-        existing.chainIds!.push(chainId);
+      if (!existing.chainIds.includes(chainId)) {
+        existing.chainIds.push(chainId);
       }
       continue;
     }
@@ -529,7 +532,7 @@ export function formatDelegateRegistryDelegations(
   const multipleRegistries = delegations.length > 1;
 
   return delegations.map(delegation => {
-    const spansMultipleChains = (delegation.chainIds?.length ?? 1) > 1;
+    const spansMultipleChains = delegation.chainIds.length > 1;
     if (!multipleRegistries && !spansMultipleChains) return delegation;
 
     const networkName = (

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -502,23 +502,36 @@ export function formatDelegateRegistryDelegations(
   for (const strategy of space.strategies) {
     if (!DELEGATE_REGISTRY_STRATEGIES.includes(strategy.name)) continue;
 
-    const chainId =
-      strategy.params?.delegationNetwork || strategy.network || space.network;
+    const chainId = String(
+      strategy.params?.delegationNetwork || strategy.network || space.network
+    );
     const contractAddress = strategy.params?.delegationSpace || space.id;
 
-    registries.set(`${chainId}:${contractAddress}`, {
+    const existing = registries.get(contractAddress);
+    if (existing) {
+      if (!existing.chainIds!.includes(chainId)) {
+        existing.chainIds!.push(chainId);
+      }
+      continue;
+    }
+
+    registries.set(contractAddress, {
       name: DELEGATION_TYPES_NAMES['delegate-registry'],
       apiType: 'delegate-registry',
       apiUrl,
       contractAddress,
-      chainId
+      chainId,
+      chainIds: [chainId]
     });
   }
 
   const delegations = [...registries.values()];
-  if (delegations.length < 2) return delegations;
+  const multipleRegistries = delegations.length > 1;
 
   return delegations.map(delegation => {
+    const spansMultipleChains = (delegation.chainIds?.length ?? 1) > 1;
+    if (!multipleRegistries && !spansMultipleChains) return delegation;
+
     const networkName = (
       networks as Record<string, { name: string } | undefined>
     )[delegation.chainId as string]?.name;

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -493,15 +493,48 @@ function formatVote(vote: ApiVote): Vote {
   };
 }
 
+export function formatDelegateRegistryDelegations(
+  space: Pick<ApiSpace, 'id' | 'network' | 'strategies'>,
+  apiUrl: string
+): SpaceMetadataDelegation[] {
+  const registries = new Map<string, SpaceMetadataDelegation>();
+
+  for (const strategy of space.strategies) {
+    if (!DELEGATE_REGISTRY_STRATEGIES.includes(strategy.name)) continue;
+
+    const chainId =
+      strategy.params?.delegationNetwork || strategy.network || space.network;
+    const contractAddress = strategy.params?.delegationSpace || space.id;
+
+    registries.set(`${chainId}:${contractAddress}`, {
+      name: DELEGATION_TYPES_NAMES['delegate-registry'],
+      apiType: 'delegate-registry',
+      apiUrl,
+      contractAddress,
+      chainId
+    });
+  }
+
+  const delegations = [...registries.values()];
+  if (delegations.length < 2) return delegations;
+
+  return delegations.map(delegation => {
+    const networkName = (
+      networks as Record<string, { name: string } | undefined>
+    )[delegation.chainId as string]?.name;
+
+    return {
+      ...delegation,
+      name: `${DELEGATION_TYPES_NAMES['delegate-registry']} (${networkName ?? `Chain ${delegation.chainId}`})`
+    };
+  });
+}
+
 function formatDelegations(
   space: ApiSpace,
   networkId: NetworkID
 ): SpaceMetadataDelegation[] {
   const delegations: SpaceMetadataDelegation[] = [];
-
-  const delegateRegistryStrategies = space.strategies.filter(strategy =>
-    DELEGATE_REGISTRY_STRATEGIES.includes(strategy.name)
-  );
 
   if (space.delegationPortal) {
     const apiType =
@@ -522,34 +555,11 @@ function formatDelegations(
     });
   }
 
-  if (delegateRegistryStrategies.length) {
-    const apiUrl = DELEGATE_REGISTRY_URLS[networkId];
-    if (apiUrl) {
-      const chainIds = [
-        ...new Set(
-          delegateRegistryStrategies.map(
-            strategy => strategy.network || space.network
-          )
-        )
-      ];
-
-      for (const chainId of chainIds) {
-        const networkName = (
-          networks as Record<string, { name: string } | undefined>
-        )[String(chainId)]?.name;
-
-        delegations.push({
-          name:
-            chainIds.length > 1
-              ? `${DELEGATION_TYPES_NAMES['delegate-registry']} (${networkName ?? `Chain ${chainId}`})`
-              : DELEGATION_TYPES_NAMES['delegate-registry'],
-          apiType: 'delegate-registry',
-          apiUrl,
-          contractAddress: space.id,
-          chainId
-        });
-      }
-    }
+  const delegateRegistryApiUrl = DELEGATE_REGISTRY_URLS[networkId];
+  if (delegateRegistryApiUrl) {
+    delegations.push(
+      ...formatDelegateRegistryDelegations(space, delegateRegistryApiUrl)
+    );
   }
 
   const splitDelegationStrategy = space.strategies.find(strategy =>

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -13,7 +13,7 @@ import { parseOSnapTransaction } from '@/helpers/osnap/transactions';
 import { getProposalCurrentQuorum } from '@/helpers/quorum';
 import { parseSafeSnapTransaction } from '@/helpers/safesnap/transactions';
 import { getNames } from '@/helpers/stamp';
-import { clone, compareAddresses } from '@/helpers/utils';
+import { clone, compareAddresses, shorten } from '@/helpers/utils';
 import {
   NetworkApi,
   NetworkConstants,
@@ -535,10 +535,24 @@ export function formatDelegateRegistryDelegations(
     const networkName = (
       networks as Record<string, { name: string } | undefined>
     )[delegation.chainId as string]?.name;
+    const chainLabel = networkName ?? `Chain ${delegation.chainId}`;
+
+    // Two registries can render on the same chain (distinct delegationSpace),
+    // which would produce identical tab labels; append the registry namespace
+    // to keep them distinguishable.
+    const sharesChainWithAnother = delegations.some(
+      other =>
+        other !== delegation &&
+        other.chainId === delegation.chainId &&
+        other.contractAddress !== delegation.contractAddress
+    );
+    const label = sharesChainWithAnother
+      ? `${chainLabel} · ${shorten(delegation.contractAddress!)}`
+      : chainLabel;
 
     return {
       ...delegation,
-      name: `${DELEGATION_TYPES_NAMES['delegate-registry']} (${networkName ?? `Chain ${delegation.chainId}`})`
+      name: `${DELEGATION_TYPES_NAMES['delegate-registry']} (${label})`
     };
   });
 }

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -529,12 +529,14 @@ export function formatDelegateRegistryDelegations(
   }
 
   const delegations = [...registries.values()];
-  const multipleRegistries = delegations.length > 1;
+
+  // A single registry is unambiguous on its own, so it keeps the plain
+  // "Delegate registry" label even when it reads several chains (the chain is
+  // an implementation detail of where the delegation lives, not a separate
+  // tab). Only multiple registries need a disambiguating suffix.
+  if (delegations.length <= 1) return delegations;
 
   return delegations.map(delegation => {
-    const spansMultipleChains = delegation.chainIds.length > 1;
-    if (!multipleRegistries && !spansMultipleChains) return delegation;
-
     const networkName = (
       networks as Record<string, { name: string } | undefined>
     )[delegation.chainId as string]?.name;

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -3,7 +3,6 @@ import {
   createHttpLink,
   InMemoryCache
 } from '@apollo/client/core';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import {
   CHAIN_IDS,
   DELEGATE_REGISTRY_STRATEGIES,
@@ -533,33 +532,14 @@ export function formatDelegateRegistryDelegations(
   // A single registry is unambiguous on its own, so it keeps the plain
   // "Delegate registry" label even when it reads several chains (the chain is
   // an implementation detail of where the delegation lives, not a separate
-  // tab). Only multiple registries need a disambiguating suffix.
+  // tab). Multiple registries are labelled by their namespace — the map key,
+  // which is guaranteed unique (chains are not: two registries can share one).
   if (delegations.length <= 1) return delegations;
 
-  return delegations.map(delegation => {
-    const networkName = (
-      networks as Record<string, { name: string } | undefined>
-    )[delegation.chainId as string]?.name;
-    const chainLabel = networkName ?? `Chain ${delegation.chainId}`;
-
-    // Two registries can render on the same chain (distinct delegationSpace),
-    // which would produce identical tab labels; append the registry namespace
-    // to keep them distinguishable.
-    const sharesChainWithAnother = delegations.some(
-      other =>
-        other !== delegation &&
-        other.chainId === delegation.chainId &&
-        other.contractAddress !== delegation.contractAddress
-    );
-    const label = sharesChainWithAnother
-      ? `${chainLabel} · ${shorten(delegation.contractAddress!)}`
-      : chainLabel;
-
-    return {
-      ...delegation,
-      name: `${DELEGATION_TYPES_NAMES['delegate-registry']} (${label})`
-    };
-  });
+  return delegations.map(delegation => ({
+    ...delegation,
+    name: `${DELEGATION_TYPES_NAMES['delegate-registry']} (${shorten(delegation.contractAddress!, 20)})`
+  }));
 }
 
 function formatDelegations(

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -3,6 +3,7 @@ import {
   createHttpLink,
   InMemoryCache
 } from '@apollo/client/core';
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import {
   CHAIN_IDS,
   DELEGATE_REGISTRY_STRATEGIES,
@@ -498,7 +499,7 @@ function formatDelegations(
 ): SpaceMetadataDelegation[] {
   const delegations: SpaceMetadataDelegation[] = [];
 
-  const basicDelegationStrategy = space.strategies.find(strategy =>
+  const delegateRegistryStrategies = space.strategies.filter(strategy =>
     DELEGATE_REGISTRY_STRATEGIES.includes(strategy.name)
   );
 
@@ -521,18 +522,33 @@ function formatDelegations(
     });
   }
 
-  if (basicDelegationStrategy) {
-    const chainId = space.network;
-
+  if (delegateRegistryStrategies.length) {
     const apiUrl = DELEGATE_REGISTRY_URLS[networkId];
     if (apiUrl) {
-      delegations.push({
-        name: DELEGATION_TYPES_NAMES['delegate-registry'],
-        apiType: 'delegate-registry',
-        apiUrl,
-        contractAddress: space.id,
-        chainId
-      });
+      const chainIds = [
+        ...new Set(
+          delegateRegistryStrategies.map(
+            strategy => strategy.network || space.network
+          )
+        )
+      ];
+
+      for (const chainId of chainIds) {
+        const networkName = (
+          networks as Record<string, { name: string } | undefined>
+        )[String(chainId)]?.name;
+
+        delegations.push({
+          name:
+            chainIds.length > 1
+              ? `${DELEGATION_TYPES_NAMES['delegate-registry']} (${networkName ?? `Chain ${chainId}`})`
+              : DELEGATION_TYPES_NAMES['delegate-registry'],
+          apiType: 'delegate-registry',
+          apiUrl,
+          contractAddress: space.id,
+          chainId
+        });
+      }
     }
   }
 

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -3,7 +3,6 @@ import {
   createHttpLink,
   InMemoryCache
 } from '@apollo/client/core';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import {
   CHAIN_IDS,
   DELEGATE_REGISTRY_STRATEGIES,
@@ -545,33 +544,14 @@ export function formatDelegateRegistryDelegations(
   // A single registry is unambiguous on its own, so it keeps the plain
   // "Delegate registry" label even when it reads several chains (the chain is
   // an implementation detail of where the delegation lives, not a separate
-  // tab). Only multiple registries need a disambiguating suffix.
+  // tab). Multiple registries are labelled by their namespace — the map key,
+  // which is guaranteed unique (chains are not: two registries can share one).
   if (delegations.length <= 1) return delegations;
 
-  return delegations.map(delegation => {
-    const networkName = (
-      networks as Record<string, { name: string } | undefined>
-    )[delegation.chainId as string]?.name;
-    const chainLabel = networkName ?? `Chain ${delegation.chainId}`;
-
-    // Two registries can render on the same chain (distinct delegationSpace),
-    // which would produce identical tab labels; append the registry namespace
-    // to keep them distinguishable.
-    const sharesChainWithAnother = delegations.some(
-      other =>
-        other !== delegation &&
-        other.chainId === delegation.chainId &&
-        other.contractAddress !== delegation.contractAddress
-    );
-    const label = sharesChainWithAnother
-      ? `${chainLabel} · ${shorten(delegation.contractAddress!)}`
-      : chainLabel;
-
-    return {
-      ...delegation,
-      name: `${DELEGATION_TYPES_NAMES['delegate-registry']} (${label})`
-    };
-  });
+  return delegations.map(delegation => ({
+    ...delegation,
+    name: `${DELEGATION_TYPES_NAMES['delegate-registry']} (${shorten(delegation.contractAddress!, 20)})`
+  }));
 }
 
 function formatDelegations(

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -3,6 +3,7 @@ import {
   createHttpLink,
   InMemoryCache
 } from '@apollo/client/core';
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import {
   CHAIN_IDS,
   DELEGATE_REGISTRY_STRATEGIES,
@@ -510,7 +511,7 @@ function formatDelegations(
 ): SpaceMetadataDelegation[] {
   const delegations: SpaceMetadataDelegation[] = [];
 
-  const basicDelegationStrategy = space.strategies.find(strategy =>
+  const delegateRegistryStrategies = space.strategies.filter(strategy =>
     DELEGATE_REGISTRY_STRATEGIES.includes(strategy.name)
   );
 
@@ -533,18 +534,33 @@ function formatDelegations(
     });
   }
 
-  if (basicDelegationStrategy) {
-    const chainId = space.network;
-
+  if (delegateRegistryStrategies.length) {
     const apiUrl = DELEGATE_REGISTRY_URLS[networkId];
     if (apiUrl) {
-      delegations.push({
-        name: DELEGATION_TYPES_NAMES['delegate-registry'],
-        apiType: 'delegate-registry',
-        apiUrl,
-        contractAddress: space.id,
-        chainId
-      });
+      const chainIds = [
+        ...new Set(
+          delegateRegistryStrategies.map(
+            strategy => strategy.network || space.network
+          )
+        )
+      ];
+
+      for (const chainId of chainIds) {
+        const networkName = (
+          networks as Record<string, { name: string } | undefined>
+        )[String(chainId)]?.name;
+
+        delegations.push({
+          name:
+            chainIds.length > 1
+              ? `${DELEGATION_TYPES_NAMES['delegate-registry']} (${networkName ?? `Chain ${chainId}`})`
+              : DELEGATION_TYPES_NAMES['delegate-registry'],
+          apiType: 'delegate-registry',
+          apiUrl,
+          contractAddress: space.id,
+          chainId
+        });
+      }
     }
   }
 

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -505,15 +505,48 @@ function formatVote(vote: ApiVote): Vote {
   };
 }
 
+export function formatDelegateRegistryDelegations(
+  space: Pick<ApiSpace, 'id' | 'network' | 'strategies'>,
+  apiUrl: string
+): SpaceMetadataDelegation[] {
+  const registries = new Map<string, SpaceMetadataDelegation>();
+
+  for (const strategy of space.strategies) {
+    if (!DELEGATE_REGISTRY_STRATEGIES.includes(strategy.name)) continue;
+
+    const chainId =
+      strategy.params?.delegationNetwork || strategy.network || space.network;
+    const contractAddress = strategy.params?.delegationSpace || space.id;
+
+    registries.set(`${chainId}:${contractAddress}`, {
+      name: DELEGATION_TYPES_NAMES['delegate-registry'],
+      apiType: 'delegate-registry',
+      apiUrl,
+      contractAddress,
+      chainId
+    });
+  }
+
+  const delegations = [...registries.values()];
+  if (delegations.length < 2) return delegations;
+
+  return delegations.map(delegation => {
+    const networkName = (
+      networks as Record<string, { name: string } | undefined>
+    )[delegation.chainId as string]?.name;
+
+    return {
+      ...delegation,
+      name: `${DELEGATION_TYPES_NAMES['delegate-registry']} (${networkName ?? `Chain ${delegation.chainId}`})`
+    };
+  });
+}
+
 function formatDelegations(
   space: ApiSpace,
   networkId: NetworkID
 ): SpaceMetadataDelegation[] {
   const delegations: SpaceMetadataDelegation[] = [];
-
-  const delegateRegistryStrategies = space.strategies.filter(strategy =>
-    DELEGATE_REGISTRY_STRATEGIES.includes(strategy.name)
-  );
 
   if (space.delegationPortal) {
     const apiType =
@@ -534,34 +567,11 @@ function formatDelegations(
     });
   }
 
-  if (delegateRegistryStrategies.length) {
-    const apiUrl = DELEGATE_REGISTRY_URLS[networkId];
-    if (apiUrl) {
-      const chainIds = [
-        ...new Set(
-          delegateRegistryStrategies.map(
-            strategy => strategy.network || space.network
-          )
-        )
-      ];
-
-      for (const chainId of chainIds) {
-        const networkName = (
-          networks as Record<string, { name: string } | undefined>
-        )[String(chainId)]?.name;
-
-        delegations.push({
-          name:
-            chainIds.length > 1
-              ? `${DELEGATION_TYPES_NAMES['delegate-registry']} (${networkName ?? `Chain ${chainId}`})`
-              : DELEGATION_TYPES_NAMES['delegate-registry'],
-          apiType: 'delegate-registry',
-          apiUrl,
-          contractAddress: space.id,
-          chainId
-        });
-      }
-    }
+  const delegateRegistryApiUrl = DELEGATE_REGISTRY_URLS[networkId];
+  if (delegateRegistryApiUrl) {
+    delegations.push(
+      ...formatDelegateRegistryDelegations(space, delegateRegistryApiUrl)
+    );
   }
 
   const splitDelegationStrategy = space.strategies.find(strategy =>

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -541,11 +541,6 @@ export function formatDelegateRegistryDelegations(
 
   const delegations = [...registries.values()];
 
-  // A single registry is unambiguous on its own, so it keeps the plain
-  // "Delegate registry" label even when it reads several chains (the chain is
-  // an implementation detail of where the delegation lives, not a separate
-  // tab). Multiple registries are labelled by their namespace — the map key,
-  // which is guaranteed unique (chains are not: two registries can share one).
   if (delegations.length <= 1) return delegations;
 
   return delegations.map(delegation => ({

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -514,23 +514,36 @@ export function formatDelegateRegistryDelegations(
   for (const strategy of space.strategies) {
     if (!DELEGATE_REGISTRY_STRATEGIES.includes(strategy.name)) continue;
 
-    const chainId =
-      strategy.params?.delegationNetwork || strategy.network || space.network;
+    const chainId = String(
+      strategy.params?.delegationNetwork || strategy.network || space.network
+    );
     const contractAddress = strategy.params?.delegationSpace || space.id;
 
-    registries.set(`${chainId}:${contractAddress}`, {
+    const existing = registries.get(contractAddress);
+    if (existing) {
+      if (!existing.chainIds!.includes(chainId)) {
+        existing.chainIds!.push(chainId);
+      }
+      continue;
+    }
+
+    registries.set(contractAddress, {
       name: DELEGATION_TYPES_NAMES['delegate-registry'],
       apiType: 'delegate-registry',
       apiUrl,
       contractAddress,
-      chainId
+      chainId,
+      chainIds: [chainId]
     });
   }
 
   const delegations = [...registries.values()];
-  if (delegations.length < 2) return delegations;
+  const multipleRegistries = delegations.length > 1;
 
   return delegations.map(delegation => {
+    const spansMultipleChains = (delegation.chainIds?.length ?? 1) > 1;
+    if (!multipleRegistries && !spansMultipleChains) return delegation;
+
     const networkName = (
       networks as Record<string, { name: string } | undefined>
     )[delegation.chainId as string]?.name;

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -541,12 +541,14 @@ export function formatDelegateRegistryDelegations(
   }
 
   const delegations = [...registries.values()];
-  const multipleRegistries = delegations.length > 1;
+
+  // A single registry is unambiguous on its own, so it keeps the plain
+  // "Delegate registry" label even when it reads several chains (the chain is
+  // an implementation detail of where the delegation lives, not a separate
+  // tab). Only multiple registries need a disambiguating suffix.
+  if (delegations.length <= 1) return delegations;
 
   return delegations.map(delegation => {
-    const spansMultipleChains = delegation.chainIds.length > 1;
-    if (!multipleRegistries && !spansMultipleChains) return delegation;
-
     const networkName = (
       networks as Record<string, { name: string } | undefined>
     )[delegation.chainId as string]?.name;

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -13,7 +13,7 @@ import { parseOSnapTransaction } from '@/helpers/osnap/transactions';
 import { getProposalCurrentQuorum } from '@/helpers/quorum';
 import { parseSafeSnapTransaction } from '@/helpers/safesnap/transactions';
 import { getNames } from '@/helpers/stamp';
-import { clone, compareAddresses } from '@/helpers/utils';
+import { clone, compareAddresses, shorten } from '@/helpers/utils';
 import {
   NetworkApi,
   NetworkConstants,
@@ -547,10 +547,24 @@ export function formatDelegateRegistryDelegations(
     const networkName = (
       networks as Record<string, { name: string } | undefined>
     )[delegation.chainId as string]?.name;
+    const chainLabel = networkName ?? `Chain ${delegation.chainId}`;
+
+    // Two registries can render on the same chain (distinct delegationSpace),
+    // which would produce identical tab labels; append the registry namespace
+    // to keep them distinguishable.
+    const sharesChainWithAnother = delegations.some(
+      other =>
+        other !== delegation &&
+        other.chainId === delegation.chainId &&
+        other.contractAddress !== delegation.contractAddress
+    );
+    const label = sharesChainWithAnother
+      ? `${chainLabel} · ${shorten(delegation.contractAddress!)}`
+      : chainLabel;
 
     return {
       ...delegation,
-      name: `${DELEGATION_TYPES_NAMES['delegate-registry']} (${networkName ?? `Chain ${delegation.chainId}`})`
+      name: `${DELEGATION_TYPES_NAMES['delegate-registry']} (${label})`
     };
   });
 }

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -509,7 +509,10 @@ export function formatDelegateRegistryDelegations(
   space: Pick<ApiSpace, 'id' | 'network' | 'strategies'>,
   apiUrl: string
 ): SpaceMetadataDelegation[] {
-  const registries = new Map<string, SpaceMetadataDelegation>();
+  const registries = new Map<
+    string,
+    SpaceMetadataDelegation & { chainIds: string[] }
+  >();
 
   for (const strategy of space.strategies) {
     if (!DELEGATE_REGISTRY_STRATEGIES.includes(strategy.name)) continue;
@@ -521,8 +524,8 @@ export function formatDelegateRegistryDelegations(
 
     const existing = registries.get(contractAddress);
     if (existing) {
-      if (!existing.chainIds!.includes(chainId)) {
-        existing.chainIds!.push(chainId);
+      if (!existing.chainIds.includes(chainId)) {
+        existing.chainIds.push(chainId);
       }
       continue;
     }
@@ -541,7 +544,7 @@ export function formatDelegateRegistryDelegations(
   const multipleRegistries = delegations.length > 1;
 
   return delegations.map(delegation => {
-    const spansMultipleChains = (delegation.chainIds?.length ?? 1) > 1;
+    const spansMultipleChains = delegation.chainIds.length > 1;
     if (!multipleRegistries && !spansMultipleChains) return delegation;
 
     const networkName = (

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -105,6 +105,7 @@ export type SpaceMetadataDelegation = {
   apiUrl: string | null;
   contractAddress: string | null;
   chainId: string | null;
+  chainIds?: string[];
 };
 
 export type SpaceMetadata = {


### PR DESCRIPTION
When a space doesn't set a `delegationPortal`, the Delegates page builds its delegate-registry config from the space's voting strategies. The old code only ever created a single registry entry pinned to `space.network` and `space.id`, so:

- a space with delegation strategies on more than one chain only ever read the delegation subgraph for its main network — anyone who delegated on another chain saw "You are not delegating your voting power yet" even though their delegation was live on-chain (`gnosis.eth`, the reported ticket);
- `params.delegationNetwork` was ignored, so registries living on a different chain than the voting strategies were queried on the wrong chain (`giantkin.eth`);
- `params.delegationSpace` was ignored on both read and write, so delegations were queried — and written — under the wrong registry namespace (`digitech.eth`).

This derives the registry identity from the delegation config instead: `chainId` from `params.delegationNetwork` (falling back to `strategy.network`, then `space.network`) and the registry namespace from `params.delegationSpace` (falling back to `space.id`). Strategies sharing a namespace are deduped into **one registry entry** carrying every candidate chain on `chainIds`; `getDelegation` probes all of them in parallel (`Promise.allSettled`, first hit in order wins) so the connected account's delegation is found on whichever chain it actually lives, and one flaky subgraph can't hide it. The write path (`setDelegate`/`clearDelegate`) now uses the same namespace the read path queries. A single registry keeps the plain `Delegate registry` tab label; multiple registries are labelled by their (unique) namespace.

## How to test

Run locally: check out this branch, `yarn && yarn dev` in `apps/ui`, and open the space's Delegates page. To view as a specific address append `?as=0x…` to the URL.

**1. `gnosis.eth` — the reported ticket (registry read on several chains)**
Open `/#/s:gnosis.eth/delegates?as=0xfDEA8140093878BfcA93aAA35d3D3087F4Ab136d` (this Safe delegated to `0x3752…5f93` on the Gnosis Chain registry).
Before: "You are not delegating your voting power yet" — only the chain-1 registry was read. After: the "Delegating to" panel shows the delegation, under a single plain **Delegate registry** tab.

**2. `stgdao.eth` — dedup (8 strategies, 7 voting networks, all `delegationNetwork: 1`)**
Before: one registry entry per voting network — 7 subgraph requests, including a broken Avalanche one. After: a single chain-1 registry entry, one request (check the network tab).

**3. `giantkin.eth` — `delegationNetwork` override**
Voting network is 1 but `delegationNetwork` is 42161. Before: registry queried on chain 1 (wrong). After: queried on Arbitrum — and the Delegate modal's network picker now offers Arbitrum (the chain the registry lives on) instead of chain 1.

**4. `digitech.eth` — `delegationSpace` override (read *and* write)**
`delegationSpace` is `apecoin.eth`. Before: the page queried under `digitech.eth`, and a delegate transaction wrote `setDelegate(bytes32('digitech.eth'), …)` — the tx succeeded, cost gas, and stayed invisible; undelegating a real `apecoin.eth` delegation reverted with "No delegate set". After: read and write both use the `apecoin.eth` namespace, so a delegation made from the modal shows up, and undelegate clears the right id.

**5. `pleasurecoin.eth` — two registries on the same chain**
Two `delegation` strategies with different hex `delegationSpace` values, both on chain 137. Before: identical duplicate tabs. After: two tabs labelled by their shortened namespace, each querying its own registry.

**6. `equilibriafi.eth` — one registry across 6 chains + resilience**
Single namespace registered on 6 networks. After: one tab; `getDelegation` probes all six chains in parallel, so the delegation is found wherever it lives and a single unhealthy subgraph no longer hides it (previously any one rejection failed the whole lookup).

**7. `ens.eth` / `gitcoindao.eth` — `delegationPortal` + registry coexist**
Both delegation methods render as separate tabs (ERC-20 Votes + Delegate registry), unchanged by this PR — regression check.

**8. `victorbibiano.eth` — unsupported `delegationNetwork` (1663)**
No delegation subgraph exists for that chain: the read logs a `console.warn` and shows the empty state instead of crashing.

**9. Regression — single-network, single-registry spaces (the vast majority)**
Output is identical to before: same single plain `Delegate registry` tab, same query.

Unit tests: `apps/ui/src/networks/offchain/api/index.test.ts` (registry derivation, dedup, overrides, labels) and `apps/ui/src/composables/useDelegates.test.ts` (parallel probing, order preservation, unsupported-chain skip) — 12 tests.

## Known follow-up (out of scope here)

- Undelegate targets the registry's primary chain (`chainIds[0]`); a delegation living on a secondary candidate chain of a multi-chain registry (e.g. `equilibriafi.eth`, `gnosis.eth`) is displayed but the clear button no-ops on the wrong chain. Needs the found chain threaded through the `Delegatee` type.
- `formatBytes32String` throws for registry namespaces over 31 bytes (a `0x…40` address used as `delegationSpace`): the write fails before sending a transaction; encoding those as raw bytes must match the delegation subgraph's id decoding.
