### PR TITLE
fix(sequencer): pin turbo last_indexed_block query to the EVM indexer

### DIFF
--- a/apps/sequencer/src/helpers/turbo.ts
+++ b/apps/sequencer/src/helpers/turbo.ts
@@ -10,6 +10,7 @@ type Space = {
 
 const SCHNAPS_API_URL = process.env.SCHNAPS_API_URL;
 const NETWORK_PREFIX = process.env.NETWORK === 'mainnet' ? 's:' : 's-tn:';
+const EVM_INDEXER = process.env.NETWORK === 'mainnet' ? 'eth' : 'sep';
 const RUN_INTERVAL = 10 * 1e3; // 10 seconds
 
 const provider = snapshot.utils.getProvider(
@@ -71,7 +72,7 @@ async function updateTurboStatuses(
 async function getSpacesExpirationDates(): Promise<Space[]> {
   const query = `
     query GetSpaces {
-      _metadata(id: "last_indexed_block") {
+      _metadata(id: "last_indexed_block", indexer: "${EVM_INDEXER}") {
         id
         value
       }
@@ -96,6 +97,13 @@ async function getSpacesExpirationDates(): Promise<Space[]> {
 
     if (data.errors) {
       capture(data);
+      return [];
+    }
+
+    if (!data.data._metadata) {
+      console.log(
+        `Schnaps last_indexed_block missing for indexer "${EVM_INDEXER}". Skipping update.`
+      );
       return [];
     }
 


### PR DESCRIPTION
## Summary

Now that schnaps api indexes two indexer (stripe and eth) 

The sequencer keeps each space's **Snapshot Pro** status in sync by asking schnaps-api *"how up to date are you?"* and only syncing when the answer is recent. This PR fixes a bug that will make that check fail — and silently stop syncing Pro for **every space** — the moment card payments are switched on.

## The fix

Tell the query which indexer we mean — the EVM one, since that's the chain the freshness check compares against:

```ts
const EVM_INDEXER = process.env.NETWORK === 'mainnet' ? 'eth' : 'sep';
```

```graphql
_metadata(id: "last_indexed_block", indexer: "${EVM_INDEXER}") { value }
```

## How to test

The sandbox is the only place both indexers actually run, so you can watch the bug and the fix directly — no local setup:

```bash
API=https://schnaps-api-sandbox-stripe-lgba3.ondigitalocean.app/

# 1) Both indexers are present:
curl -s -X POST $API -H 'Content-Type: application/json' \
  -d '{"query":"{ _metadatas(where:{id:\"last_indexed_block\"}){ value indexer } }"}'
#   → one row indexer:"stripe" (~495000)  AND one indexer:"eth" (~25,500,000)

# 2) OLD query (before this PR) → grabs Stripe → looks ~25M blocks behind → sync skipped:
curl -s -X POST $API -H 'Content-Type: application/json' \
  -d '{"query":"{ _metadata(id:\"last_indexed_block\"){ value indexer } }"}'
#   → { value: "~495000", indexer: "stripe" }

# 3) FIXED query (this PR) → grabs eth → ~1 block behind → sync runs:
curl -s -X POST $API -H 'Content-Type: application/json' \
  -d '{"query":"{ _metadata(id:\"last_indexed_block\", indexer:\"eth\"){ value indexer } }"}'
#   → { value: "~25,500,000", indexer: "eth" }
```

Compare each `value` to the live Ethereum head — with the old query the gap is ~25 million (→ "outdated", skip); with the fix it's ~0 (→ fresh, sync).

**No-regression check** against prod (single indexer, so filtering changes nothing):
- `https://schnaps.snapshot.box` with `indexer: "eth"`
- `https://testnet-schnaps.snapshot.box` with `indexer: "sep"`

Both return the same row as the unfiltered query does today.

Related: snapshot-labs/schnaps-api#20 · snapshot-labs/sx-monorepo#2140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
