### PR TITLE
fix(ui): escape attacker-controlled values in transaction titles

### DIFF
--- a/apps/ui/src/components/TransactionsListItem.vue
+++ b/apps/ui/src/components/TransactionsListItem.vue
@@ -2,7 +2,12 @@
 import { formatUnits } from '@ethersproject/units';
 import { getGenericExplorerUrl } from '@/helpers/generic';
 import { getNames } from '@/helpers/stamp';
-import { _n, escapeHtml, shorten } from '@/helpers/utils';
+import {
+  _n,
+  escapeHtml,
+  replaceNamePlaceholder,
+  shorten
+} from '@/helpers/utils';
 import { ChainId, Transaction } from '@/types';
 
 const props = defineProps<{ chainId: ChainId; tx: Transaction }>();
@@ -141,15 +146,9 @@ const parsedTitle = computedAsync(
     const names = await getNames([recipient]);
     const name = names[recipient] || shorten(recipient);
 
-    return title.value.replace(
-      '<b>_NAME_</b>',
-      () => `<b>${escapeHtml(name)}</b>`
-    );
+    return replaceNamePlaceholder(title.value, name);
   },
-  title.value.replace(
-    '<b>_NAME_</b>',
-    () => `<b>${escapeHtml(shorten(props.tx._form.recipient))}</b>`
-  )
+  replaceNamePlaceholder(title.value, shorten(props.tx._form.recipient))
 );
 </script>
 

--- a/apps/ui/src/components/TransactionsListItem.vue
+++ b/apps/ui/src/components/TransactionsListItem.vue
@@ -141,11 +141,14 @@ const parsedTitle = computedAsync(
     const names = await getNames([recipient]);
     const name = names[recipient] || shorten(recipient);
 
-    return title.value.replace('<b>_NAME_</b>', `<b>${escapeHtml(name)}</b>`);
+    return title.value.replace(
+      '<b>_NAME_</b>',
+      () => `<b>${escapeHtml(name)}</b>`
+    );
   },
   title.value.replace(
     '<b>_NAME_</b>',
-    `<b>${escapeHtml(shorten(props.tx._form.recipient))}</b>`
+    () => `<b>${escapeHtml(shorten(props.tx._form.recipient))}</b>`
   )
 );
 </script>

--- a/apps/ui/src/components/TransactionsListItem.vue
+++ b/apps/ui/src/components/TransactionsListItem.vue
@@ -2,7 +2,7 @@
 import { formatUnits } from '@ethersproject/units';
 import { getGenericExplorerUrl } from '@/helpers/generic';
 import { getNames } from '@/helpers/stamp';
-import { _n, shorten } from '@/helpers/utils';
+import { _n, escapeHtml, shorten } from '@/helpers/utils';
 import { ChainId, Transaction } from '@/types';
 
 const props = defineProps<{ chainId: ChainId; tx: Transaction }>();
@@ -11,9 +11,9 @@ const expanded = ref(false);
 
 const title = computed(() => {
   if (props.tx._type === 'sendToken') {
-    return `Send <b>${_n(formatUnits(props.tx._form.amount, props.tx._form.token.decimals), 'standard', { formatDust: true })}</b> ${
+    return `Send <b>${_n(formatUnits(props.tx._form.amount, props.tx._form.token.decimals), 'standard', { formatDust: true })}</b> ${escapeHtml(
       props.tx._form.token.symbol
-    } to <b>_NAME_</b>`;
+    )} to <b>_NAME_</b>`;
   }
 
   if (props.tx._type === 'sendNft') {
@@ -25,7 +25,7 @@ const title = computed(() => {
   }
 
   if (props.tx._type === 'contractCall') {
-    return `<b>${props.tx._form.method.split('(')[0]}</b> on <b>_NAME_</b>`;
+    return `<b>${escapeHtml(props.tx._form.method.split('(')[0])}</b> on <b>_NAME_</b>`;
   }
 
   if (props.tx._type === 'raw') {
@@ -141,9 +141,9 @@ const parsedTitle = computedAsync(
     const names = await getNames([recipient]);
     const name = names[recipient] || shorten(recipient);
 
-    return title.value.replace('_NAME_', name);
+    return title.value.replace('_NAME_', escapeHtml(name));
   },
-  title.value.replace('_NAME_', shorten(props.tx._form.recipient))
+  title.value.replace('_NAME_', escapeHtml(shorten(props.tx._form.recipient)))
 );
 </script>
 

--- a/apps/ui/src/components/TransactionsListItem.vue
+++ b/apps/ui/src/components/TransactionsListItem.vue
@@ -141,9 +141,12 @@ const parsedTitle = computedAsync(
     const names = await getNames([recipient]);
     const name = names[recipient] || shorten(recipient);
 
-    return title.value.replace('_NAME_', escapeHtml(name));
+    return title.value.replace('<b>_NAME_</b>', `<b>${escapeHtml(name)}</b>`);
   },
-  title.value.replace('_NAME_', escapeHtml(shorten(props.tx._form.recipient)))
+  title.value.replace(
+    '<b>_NAME_</b>',
+    `<b>${escapeHtml(shorten(props.tx._form.recipient))}</b>`
+  )
 );
 </script>
 

--- a/apps/ui/src/helpers/utils.test.ts
+++ b/apps/ui/src/helpers/utils.test.ts
@@ -11,6 +11,7 @@ import {
   getSpaceController,
   getStampUrl,
   getUserFacingErrorMessage,
+  replaceNamePlaceholder,
   uniqBy
 } from './utils';
 
@@ -33,6 +34,40 @@ describe('utils', () => {
     it('should handle nullish input', () => {
       expect(escapeHtml(undefined)).toBe('');
       expect(escapeHtml(null)).toBe('');
+    });
+  });
+
+  describe('replaceNamePlaceholder', () => {
+    const title = 'Raw transaction to <b>_NAME_</b>';
+
+    it('should insert an escaped plain name', () => {
+      expect(replaceNamePlaceholder(title, 'usdcoin.eth')).toBe(
+        'Raw transaction to <b>usdcoin.eth</b>'
+      );
+    });
+
+    it('should not splice the marker when the name contains $&', () => {
+      expect(replaceNamePlaceholder(title, 'a$&b.eth')).toBe(
+        'Raw transaction to <b>a$&amp;b.eth</b>'
+      );
+    });
+
+    it('should not drop characters when the name contains $$', () => {
+      expect(replaceNamePlaceholder(title, 'usd$$coin.eth')).toBe(
+        'Raw transaction to <b>usd$$coin.eth</b>'
+      );
+    });
+
+    it("should not misinterpret $` and $' replacement patterns", () => {
+      expect(replaceNamePlaceholder(title, "a$`b$'c.eth")).toBe(
+        'Raw transaction to <b>a$`b$&#39;c.eth</b>'
+      );
+    });
+
+    it('should still escape HTML in the name', () => {
+      expect(
+        replaceNamePlaceholder(title, '<img src=x onerror=alert(1)>')
+      ).toBe('Raw transaction to <b>&lt;img src=x onerror=alert(1)&gt;</b>');
     });
   });
 

--- a/apps/ui/src/helpers/utils.test.ts
+++ b/apps/ui/src/helpers/utils.test.ts
@@ -31,8 +31,8 @@ describe('utils', () => {
     });
 
     it('should handle nullish input', () => {
-      expect(escapeHtml(undefined as unknown as string)).toBe('');
-      expect(escapeHtml(null as unknown as string)).toBe('');
+      expect(escapeHtml(undefined)).toBe('');
+      expect(escapeHtml(null)).toBe('');
     });
   });
 

--- a/apps/ui/src/helpers/utils.test.ts
+++ b/apps/ui/src/helpers/utils.test.ts
@@ -6,6 +6,7 @@ import {
   _vp,
   abiToDefinition,
   createErc1155Metadata,
+  escapeHtml,
   formatAddress,
   getSpaceController,
   getStampUrl,
@@ -14,6 +15,27 @@ import {
 } from './utils';
 
 describe('utils', () => {
+  describe('escapeHtml', () => {
+    it('should neutralize an img onerror XSS payload', () => {
+      expect(escapeHtml('<img src=x onerror=alert(1)>')).toBe(
+        '&lt;img src=x onerror=alert(1)&gt;'
+      );
+    });
+
+    it('should escape all HTML-sensitive characters', () => {
+      expect(escapeHtml(`<>&"'`)).toBe('&lt;&gt;&amp;&quot;&#39;');
+    });
+
+    it('should leave plain text untouched', () => {
+      expect(escapeHtml('USDC')).toBe('USDC');
+    });
+
+    it('should handle nullish input', () => {
+      expect(escapeHtml(undefined as unknown as string)).toBe('');
+      expect(escapeHtml(null as unknown as string)).toBe('');
+    });
+  });
+
   describe('uniqBy', () => {
     it('should return unique values by key', () => {
       const arr = [

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -658,6 +658,15 @@ export function getChoiceText(availableChoices: string[], choice: Choice) {
     .join(', ');
 }
 
+export function escapeHtml(text: string) {
+  return String(text ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export function autoLinkText(text: string) {
   if (!text) return text;
 

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -667,6 +667,10 @@ export function escapeHtml(text: string | null | undefined) {
     .replace(/'/g, '&#39;');
 }
 
+export function replaceNamePlaceholder(title: string, name: string) {
+  return title.replace('<b>_NAME_</b>', () => `<b>${escapeHtml(name)}</b>`);
+}
+
 export function autoLinkText(text: string) {
   if (!text) return text;
 

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -658,8 +658,8 @@ export function getChoiceText(availableChoices: string[], choice: Choice) {
     .join(', ');
 }
 
-export function escapeHtml(text: string) {
-  return String(text ?? '')
+export function escapeHtml(text: string | null | undefined) {
+  return (text ?? '')
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')


### PR DESCRIPTION
Follow-up to #2233. Chaitu asked us to sweep the rest of the frontend for the same class of XSS after the Markdown language-label fix. I audited every `innerHTML` / `outerHTML` / `insertAdjacentHTML` / `document.write` / `v-html` / `dangerouslySetInnerHTML` site in apps/ui.

One real issue: `TransactionsListItem.vue` builds a transaction summary string with intentional `<b>` markup and renders it via `v-html`. Three of the interpolated values are attacker-controlled and were going in unescaped:
- `token.symbol` - an ERC20's on-chain `symbol()`; anyone can deploy a token whose symbol is an `<img onerror=...>` payload
- contract-call `method` name - comes from an ABI the proposal author supplies
- the resolved recipient `name` - an ENS reverse record the recipient controls

Any of these renders when a viewer opens a proposal that carries such an execution transaction, so it's stored XSS reachable by a proposal author. Fix escapes just the dynamic pieces with a small `escapeHtml` helper and keeps the static formatting markup.

Everything else came back clean (see audit table below), so no other code changes.

## Audit

| Site | Sink | Provenance | Verdict |
|------|------|-----------|---------|
| components/TransactionsListItem.vue:164 | v-html parsedTitle | token symbol / method / ENS name | FIXED (was exploitable) |
| components/Ui/Markdown.vue:124 | v-html parsed | proposal/space markdown | SAFE - Remarkable `html:false`, htmltag/htmlblock rules disabled |
| components/Ui/Markdown.vue:95,100,103 | innerHTML | static iconify svg | SAFE - constant |
| views/User.vue:179, SpaceUser.vue:249 | v-html autoLinkText(user.about) | user profile | SAFE - Autolinker `sanitizeHtml:true` |
| views/Space/Overview.vue:150, Organization/Overview.vue:176 | v-html autoLinkText(about) | space about | SAFE - Autolinker `sanitizeHtml:true` |
| components/Modal/VoteReason.vue:22 | v-html autoLinkText(reason) | vote reason | SAFE - Autolinker `sanitizeHtml:true` |
| views/Space/Editor.vue:585,611 | v-html of `<b>${name}</b>` | strategy/network names | SAFE - values only ever members of hardcoded allowlists (DISABLED/DEPRECATED/OVERRIDING_STRATEGIES) or curated network config |
| helpers/turndownService.ts:21,32,83,99,107 | reads `.innerHTML` | n/a | SAFE - read (source), not an assignment sink |
| docs/icons.mdx:16,28 | dangerouslySetInnerHTML | static iconify body | SAFE - internal icon docs, constant |

## Test plan
- Added `escapeHtml` unit tests in `utils.test.ts` covering the `<img onerror>` payload, all HTML-sensitive chars, plain text, and nullish input.
- `vitest run src/helpers/utils.test.ts` -> 36 passed.
- eslint + prettier clean on touched files.
- Typecheck: no new errors from touched files (pre-existing codegen `./gql` errors unrelated).