### PR TITLE
fix(hub): use composite index for proposal-scoped votes query

### DIFF
--- a/apps/hub/src/graphql/operations/votes.ts
+++ b/apps/hub/src/graphql/operations/votes.ts
@@ -43,7 +43,11 @@ async function query(parent, args, context?, info?) {
         'SELECT space FROM proposals WHERE id = ? LIMIT 1',
         [where.proposal]
       );
-      if (proposalRows.length > 0) where.space = proposalRows[0].space;
+      // Proposal doesn't exist: no space to scope by and thus no votes to
+      // return. Skip the votes query entirely instead of falling through to the
+      // un-indexed slow path.
+      if (proposalRows.length === 0) return [];
+      where.space = proposalRows[0].space;
     } catch (err: any) {
       capture(err, { args, context, info });
     }

--- a/apps/hub/src/graphql/operations/votes.ts
+++ b/apps/hub/src/graphql/operations/votes.ts
@@ -31,6 +31,18 @@ async function query(parent, args, context?, info?) {
     vp_state: 'string'
   };
 
+  // A single-element proposal_in is the same filter as proposal; collapse it so
+  // it takes the indexed path below. An empty array still means match-nothing.
+  if (
+    where.proposal === undefined &&
+    Array.isArray(where.proposal_in) &&
+    where.proposal_in.length === 1 &&
+    typeof where.proposal_in[0] === 'string'
+  ) {
+    where.proposal = where.proposal_in[0];
+    delete where.proposal_in;
+  }
+
   // Constrain space so a single-proposal filter can seek the composite index
   // (space, proposal, created, id) rather than scan votes ordered by created.
   if (
@@ -49,7 +61,11 @@ async function query(parent, args, context?, info?) {
       if (proposalRows.length === 0) return [];
       where.space = proposalRows[0].space;
     } catch (err: any) {
+      // Fail fast: a swallowed lookup error would leave space unset and fall
+      // through to the un-scoped, un-hinted scan this path exists to avoid.
       capture(err, { args, context, info });
+      log.error(`[graphql] votes, ${JSON.stringify(err)}`);
+      return Promise.reject(new Error('request failed'));
     }
   }
 
@@ -68,7 +84,18 @@ async function query(parent, args, context?, info?) {
 
   // Force the composite index; for large spaces the optimizer otherwise picks a
   // (space, created) index and scans millions of rows until the LIMIT is filled.
+  // Skip the hint when a more selective predicate is present (id is unique,
+  // voter is the primary-key prefix): forcing the index would turn those point
+  // lookups into a scan of the proposal's entire vote range.
+  const hasSelectiveFilter =
+    where.id !== undefined ||
+    where.id_in !== undefined ||
+    where.ipfs !== undefined ||
+    where.ipfs_in !== undefined ||
+    where.voter !== undefined ||
+    where.voter_in !== undefined;
   const forceProposalIndex =
+    !hasSelectiveFilter &&
     typeof where.proposal === 'string' &&
     typeof where.space === 'string' &&
     orderBy === 'v.created';

--- a/apps/hub/src/graphql/operations/votes.ts
+++ b/apps/hub/src/graphql/operations/votes.ts
@@ -43,9 +43,45 @@ async function query(parent, args, context?, info?) {
     delete where.proposal_in;
   }
 
-  // Constrain space so a single-proposal filter can seek the composite index
-  // (space, proposal, created, id) rather than scan votes ordered by created.
+  // Likewise collapse a single-element space_in: it is the same filter as space,
+  // and leaving it as an IN() keeps proposal queries off the indexed path below.
   if (
+    where.space === undefined &&
+    Array.isArray(where.space_in) &&
+    where.space_in.length === 1 &&
+    typeof where.space_in[0] === 'string'
+  ) {
+    where.space = where.space_in[0];
+    delete where.space_in;
+  }
+
+  let orderBy = args.orderBy || 'created';
+  let orderDirection = args.orderDirection || 'desc';
+  if (!['created', 'vp'].includes(orderBy)) orderBy = 'created';
+  orderBy = `v.${orderBy}`;
+  orderDirection = orderDirection.toUpperCase();
+  if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';
+
+  // A more selective predicate is present (id is unique, voter is the
+  // primary-key prefix): the composite-index hint and the space lookup below
+  // both only help the non-selective, created-ordered path.
+  const hasSelectiveFilter =
+    where.id !== undefined ||
+    where.id_in !== undefined ||
+    where.ipfs !== undefined ||
+    where.ipfs_in !== undefined ||
+    where.voter !== undefined ||
+    where.voter_in !== undefined;
+
+  // Constrain space so a single-proposal created query can seek the composite
+  // index (space, proposal, created, id). Gate the lookup on the same
+  // preconditions as the hint below: vp queries resolve via
+  // idx_votes_on_proposal_vp_id and id/ipfs/voter via their own indexes, where
+  // an injected space = ? is a wasted round-trip and, on the vp path, a
+  // competing index that reintroduces the optimizer drift this PR removes.
+  if (
+    !hasSelectiveFilter &&
+    orderBy === 'v.created' &&
     typeof where.proposal === 'string' &&
     where.space === undefined &&
     where.space_in === undefined
@@ -73,27 +109,10 @@ async function query(parent, args, context?, info?) {
   const queryStr = whereQuery.query;
   const params: any[] = whereQuery.params;
 
-  let orderBy = args.orderBy || 'created';
-  let orderDirection = args.orderDirection || 'desc';
-  if (!['created', 'vp'].includes(orderBy)) orderBy = 'created';
-  orderBy = `v.${orderBy}`;
-  orderDirection = orderDirection.toUpperCase();
-  if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';
-
   let votes: any[] = [];
 
   // Force the composite index; for large spaces the optimizer otherwise picks a
   // (space, created) index and scans millions of rows until the LIMIT is filled.
-  // Skip the hint when a more selective predicate is present (id is unique,
-  // voter is the primary-key prefix): forcing the index would turn those point
-  // lookups into a scan of the proposal's entire vote range.
-  const hasSelectiveFilter =
-    where.id !== undefined ||
-    where.id_in !== undefined ||
-    where.ipfs !== undefined ||
-    where.ipfs_in !== undefined ||
-    where.voter !== undefined ||
-    where.voter_in !== undefined;
   const forceProposalIndex =
     !hasSelectiveFilter &&
     typeof where.proposal === 'string' &&

--- a/apps/hub/src/graphql/operations/votes.ts
+++ b/apps/hub/src/graphql/operations/votes.ts
@@ -11,17 +11,6 @@ import {
   formatVote
 } from '../helpers';
 
-// `where` keys that idx_votes_on_space_proposal_created_id (space, proposal,
-// created, id) can evaluate from the index itself. Forcing that index is only
-// safe when the whole filter is in this set: any other key becomes a residual
-// predicate the index cannot answer, so the forced scan walks the proposal in
-// created order fetching every row to test it, which on a 500k-vote proposal
-// takes minutes instead of the ~100ms the optimizer's own plan takes.
-//
-// This is an allow-list on purpose. The inverse (listing the keys that must
-// block the hint) fails open: every filter added to VoteWhere is silently
-// opted in to the forced path, which is exactly how vp*, app and vp_state
-// ended up there.
 const INDEX_COVERED_WHERE_KEYS = new Set([
   'space',
   'space_in',
@@ -55,8 +44,6 @@ async function query(parent, args, context?, info?) {
     vp_state: 'string'
   };
 
-  // A single-element proposal_in is the same filter as proposal; collapse it so
-  // it takes the indexed path below. An empty array still means match-nothing.
   if (
     where.proposal === undefined &&
     Array.isArray(where.proposal_in) &&
@@ -67,8 +54,6 @@ async function query(parent, args, context?, info?) {
     delete where.proposal_in;
   }
 
-  // Likewise collapse a single-element space_in: it is the same filter as space,
-  // and leaving it as an IN() keeps proposal queries off the indexed path below.
   if (
     where.space === undefined &&
     Array.isArray(where.space_in) &&
@@ -86,9 +71,6 @@ async function query(parent, args, context?, info?) {
   orderDirection = orderDirection.toUpperCase();
   if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';
 
-  // A more selective predicate is present (id is unique, voter is the
-  // primary-key prefix): those resolve via their own indexes, where the space
-  // lookup below is a wasted round-trip.
   const hasSelectiveFilter =
     where.id !== undefined ||
     where.id_in !== undefined ||
@@ -97,13 +79,6 @@ async function query(parent, args, context?, info?) {
     where.voter !== undefined ||
     where.voter_in !== undefined;
 
-  // Constrain space so a single-proposal created query can seek the composite
-  // index (space, proposal, created, id). This half is result-neutral (a
-  // proposal belongs to exactly one space) and is where the win comes from, so
-  // it is not gated on the filter shape: vp_gt, app and the rest still get it.
-  // vp-ordered queries are excluded because they resolve via
-  // idx_votes_on_proposal_vp_id, where an injected space = ? is a competing
-  // index that reintroduces the optimizer drift this PR removes.
   if (
     !hasSelectiveFilter &&
     orderBy === 'v.created' &&
@@ -116,14 +91,9 @@ async function query(parent, args, context?, info?) {
         'SELECT space FROM proposals WHERE id = ? LIMIT 1',
         [where.proposal]
       );
-      // Proposal doesn't exist: no space to scope by and thus no votes to
-      // return. Skip the votes query entirely instead of falling through to the
-      // un-indexed slow path.
       if (proposalRows.length === 0) return [];
       where.space = proposalRows[0].space;
     } catch (err: any) {
-      // Fail fast: a swallowed lookup error would leave space unset and fall
-      // through to the un-scoped, un-hinted scan this path exists to avoid.
       capture(err, { args, context, info });
       log.error(`[graphql] votes, ${JSON.stringify(err)}`);
       return Promise.reject(new Error('request failed'));
@@ -136,12 +106,6 @@ async function query(parent, args, context?, info?) {
 
   let votes: any[] = [];
 
-  // Force the composite index; for large spaces the optimizer otherwise picks a
-  // (space, created) index and scans millions of rows until the LIMIT is filled.
-  // Taking the choice away from the optimizer is only safe while it has no
-  // residual filter to evaluate, so the hint needs the whole `where` to be
-  // index-covered; anything else keeps the injected space above but leaves the
-  // plan to the optimizer.
   const isIndexCoveredWhere = Object.keys(where).every(
     key => where[key] === undefined || INDEX_COVERED_WHERE_KEYS.has(key)
   );
@@ -154,11 +118,6 @@ async function query(parent, args, context?, info?) {
     ? 'FORCE INDEX (idx_votes_on_space_proposal_created_id)'
     : '';
 
-  // Match the id tie-break to the primary sort direction. The second sort field
-  // only breaks ties between equal-value rows, so its direction has no effect on
-  // correctness. On the proposal-scoped path it also turns the composite
-  // (space, proposal, created, id) index into a pure (backward) scan instead of a
-  // filesort.
   // cb = -3 marks votes of deleted proposals, pending deletion by the sequencer
   const query = `
     SELECT v.* FROM votes v ${indexHint}

--- a/apps/hub/src/graphql/operations/votes.ts
+++ b/apps/hub/src/graphql/operations/votes.ts
@@ -11,6 +11,30 @@ import {
   formatVote
 } from '../helpers';
 
+// `where` keys that idx_votes_on_space_proposal_created_id (space, proposal,
+// created, id) can evaluate from the index itself. Forcing that index is only
+// safe when the whole filter is in this set: any other key becomes a residual
+// predicate the index cannot answer, so the forced scan walks the proposal in
+// created order fetching every row to test it, which on a 500k-vote proposal
+// takes minutes instead of the ~100ms the optimizer's own plan takes.
+//
+// This is an allow-list on purpose. The inverse (listing the keys that must
+// block the hint) fails open: every filter added to VoteWhere is silently
+// opted in to the forced path, which is exactly how vp*, app and vp_state
+// ended up there.
+const INDEX_COVERED_WHERE_KEYS = new Set([
+  'space',
+  'space_in',
+  'proposal',
+  'proposal_in',
+  'created',
+  'created_in',
+  'created_gt',
+  'created_gte',
+  'created_lt',
+  'created_lte'
+]);
+
 async function query(parent, args, context?, info?) {
   const requestedFields = info ? graphqlFields(info) : {};
   const { first, skip } = args;
@@ -63,8 +87,8 @@ async function query(parent, args, context?, info?) {
   if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';
 
   // A more selective predicate is present (id is unique, voter is the
-  // primary-key prefix): the composite-index hint and the space lookup below
-  // both only help the non-selective, created-ordered path.
+  // primary-key prefix): those resolve via their own indexes, where the space
+  // lookup below is a wasted round-trip.
   const hasSelectiveFilter =
     where.id !== undefined ||
     where.id_in !== undefined ||
@@ -74,11 +98,12 @@ async function query(parent, args, context?, info?) {
     where.voter_in !== undefined;
 
   // Constrain space so a single-proposal created query can seek the composite
-  // index (space, proposal, created, id). Gate the lookup on the same
-  // preconditions as the hint below: vp queries resolve via
-  // idx_votes_on_proposal_vp_id and id/ipfs/voter via their own indexes, where
-  // an injected space = ? is a wasted round-trip and, on the vp path, a
-  // competing index that reintroduces the optimizer drift this PR removes.
+  // index (space, proposal, created, id). This half is result-neutral (a
+  // proposal belongs to exactly one space) and is where the win comes from, so
+  // it is not gated on the filter shape: vp_gt, app and the rest still get it.
+  // vp-ordered queries are excluded because they resolve via
+  // idx_votes_on_proposal_vp_id, where an injected space = ? is a competing
+  // index that reintroduces the optimizer drift this PR removes.
   if (
     !hasSelectiveFilter &&
     orderBy === 'v.created' &&
@@ -113,8 +138,15 @@ async function query(parent, args, context?, info?) {
 
   // Force the composite index; for large spaces the optimizer otherwise picks a
   // (space, created) index and scans millions of rows until the LIMIT is filled.
+  // Taking the choice away from the optimizer is only safe while it has no
+  // residual filter to evaluate, so the hint needs the whole `where` to be
+  // index-covered; anything else keeps the injected space above but leaves the
+  // plan to the optimizer.
+  const isIndexCoveredWhere = Object.keys(where).every(
+    key => where[key] === undefined || INDEX_COVERED_WHERE_KEYS.has(key)
+  );
   const forceProposalIndex =
-    !hasSelectiveFilter &&
+    isIndexCoveredWhere &&
     typeof where.proposal === 'string' &&
     typeof where.space === 'string' &&
     orderBy === 'v.created';

--- a/apps/hub/src/graphql/operations/votes.ts
+++ b/apps/hub/src/graphql/operations/votes.ts
@@ -72,6 +72,9 @@ async function query(parent, args, context?, info?) {
     ? 'FORCE INDEX (idx_votes_on_space_proposal_created_id)'
     : '';
 
+  // Keep the id tie-break in the same direction as the primary sort so the
+  // proposal-scoped created path is a pure (backward) scan of the composite
+  // (space, proposal, created, id) index instead of a filesort.
   // cb = -3 marks votes of deleted proposals, pending deletion by the sequencer
   const query = `
     SELECT v.* FROM votes v ${indexHint}

--- a/apps/hub/src/graphql/operations/votes.ts
+++ b/apps/hub/src/graphql/operations/votes.ts
@@ -72,9 +72,11 @@ async function query(parent, args, context?, info?) {
     ? 'FORCE INDEX (idx_votes_on_space_proposal_created_id)'
     : '';
 
-  // Keep the id tie-break in the same direction as the primary sort so the
-  // proposal-scoped created path is a pure (backward) scan of the composite
-  // (space, proposal, created, id) index instead of a filesort.
+  // Match the id tie-break to the primary sort direction. The second sort field
+  // only breaks ties between equal-value rows, so its direction has no effect on
+  // correctness. On the proposal-scoped path it also turns the composite
+  // (space, proposal, created, id) index into a pure (backward) scan instead of a
+  // filesort.
   // cb = -3 marks votes of deleted proposals, pending deletion by the sequencer
   const query = `
     SELECT v.* FROM votes v ${indexHint}

--- a/apps/hub/src/graphql/operations/votes.ts
+++ b/apps/hub/src/graphql/operations/votes.ts
@@ -11,6 +11,9 @@ import {
   formatVote
 } from '../helpers';
 
+// `where` keys the forced index (space, proposal, created, id) can evaluate
+// itself. Any other key is a residual predicate the forced scan must walk the
+// whole proposal to test, so keep this an allow-list: a deny-list fails open.
 const INDEX_COVERED_WHERE_KEYS = new Set([
   'space',
   'space_in',

--- a/apps/hub/src/graphql/operations/votes.ts
+++ b/apps/hub/src/graphql/operations/votes.ts
@@ -13,7 +13,8 @@ import {
 
 async function query(parent, args, context?, info?) {
   const requestedFields = info ? graphqlFields(info) : {};
-  const { first, skip, where = {} } = args;
+  const { first, skip } = args;
+  const where = { ...(args.where || {}) };
 
   checkLimits(args, 'votes');
 
@@ -29,6 +30,25 @@ async function query(parent, args, context?, info?) {
     vp: 'number',
     vp_state: 'string'
   };
+
+  // Constrain space so a single-proposal filter can seek the composite index
+  // (space, proposal, created, id) rather than scan votes ordered by created.
+  if (
+    typeof where.proposal === 'string' &&
+    where.space === undefined &&
+    where.space_in === undefined
+  ) {
+    try {
+      const proposalRows = await db.queryAsync(
+        'SELECT space FROM proposals WHERE id = ? LIMIT 1',
+        [where.proposal]
+      );
+      if (proposalRows.length > 0) where.space = proposalRows[0].space;
+    } catch (err: any) {
+      capture(err, { args, context, info });
+    }
+  }
+
   const whereQuery = buildWhereQuery(fields, 'v', where);
   const queryStr = whereQuery.query;
   const params: any[] = whereQuery.params;
@@ -42,9 +62,19 @@ async function query(parent, args, context?, info?) {
 
   let votes: any[] = [];
 
+  // Force the composite index; for large spaces the optimizer otherwise picks a
+  // (space, created) index and scans millions of rows until the LIMIT is filled.
+  const forceProposalIndex =
+    typeof where.proposal === 'string' &&
+    typeof where.space === 'string' &&
+    orderBy === 'v.created';
+  const indexHint = forceProposalIndex
+    ? 'FORCE INDEX (idx_votes_on_space_proposal_created_id)'
+    : '';
+
   // cb = -3 marks votes of deleted proposals, pending deletion by the sequencer
   const query = `
-    SELECT v.* FROM votes v
+    SELECT v.* FROM votes v ${indexHint}
     WHERE v.space NOT IN (SELECT id FROM spaces WHERE deleted = 1)
       AND v.cb != -3 ${queryStr}
     ORDER BY ${orderBy} ${orderDirection}, v.id ${orderDirection} LIMIT ?, ?

--- a/apps/hub/test/unit/votes.test.ts
+++ b/apps/hub/test/unit/votes.test.ts
@@ -41,6 +41,11 @@ describe('votes resolver index usage', () => {
     );
     expect(votesSql).toContain('v.space = ?');
     expect(votesSql).toContain('v.proposal = ?');
+    // id tie-break must match the created direction so the composite index is
+    // scanned (backward) instead of triggering a filesort.
+    expect(votesSql.replace(/\s+/g, ' ')).toContain(
+      'ORDER BY v.created DESC, v.id DESC'
+    );
     expect(votesParams.slice(0, 2)).toEqual(['magicappstore.eth', PROPOSAL]);
   });
 

--- a/apps/hub/test/unit/votes.test.ts
+++ b/apps/hub/test/unit/votes.test.ts
@@ -1,0 +1,77 @@
+import fetchVotes from '../../src/graphql/operations/votes';
+import db from '../../src/helpers/mysql';
+
+jest.mock('../../src/helpers/mysql', () => ({
+  __esModule: true,
+  default: { queryAsync: jest.fn() }
+}));
+
+jest.mock('../../src/helpers/requestDeduplicator', () => ({
+  __esModule: true,
+  default: (_key: string, fn: any, args: any[]) => fn(...args)
+}));
+
+const queryAsync = db.queryAsync as jest.Mock;
+
+const PROPOSAL =
+  '0x67d414042da88026e2c718284e90a5d79e1c0a32d322a288b373e0d7a21f4cef';
+
+describe('votes resolver index usage', () => {
+  beforeEach(() => queryAsync.mockReset());
+
+  it('resolves the proposal space and forces the composite index', async () => {
+    queryAsync
+      .mockResolvedValueOnce([{ space: 'magicappstore.eth' }])
+      .mockResolvedValueOnce([]);
+
+    await fetchVotes(null, {
+      first: 1000,
+      skip: 0,
+      where: { proposal: PROPOSAL }
+    });
+
+    const [lookupSql, lookupParams] = queryAsync.mock.calls[0];
+    expect(lookupSql).toContain('FROM proposals');
+    expect(lookupSql).toContain('WHERE id = ?');
+    expect(lookupParams).toEqual([PROPOSAL]);
+
+    const [votesSql, votesParams] = queryAsync.mock.calls[1];
+    expect(votesSql).toContain(
+      'FORCE INDEX (idx_votes_on_space_proposal_created_id)'
+    );
+    expect(votesSql).toContain('v.space = ?');
+    expect(votesSql).toContain('v.proposal = ?');
+    expect(votesParams.slice(0, 2)).toEqual(['magicappstore.eth', PROPOSAL]);
+  });
+
+  it('does not look up space when it is already provided', async () => {
+    queryAsync.mockResolvedValueOnce([]);
+
+    await fetchVotes(null, {
+      first: 1000,
+      skip: 0,
+      where: { proposal: PROPOSAL, space: 'magicappstore.eth' }
+    });
+
+    expect(queryAsync).toHaveBeenCalledTimes(1);
+    const [votesSql] = queryAsync.mock.calls[0];
+    expect(votesSql).toContain(
+      'FORCE INDEX (idx_votes_on_space_proposal_created_id)'
+    );
+    expect(votesSql).toContain('v.space = ?');
+  });
+
+  it('does not force the index or look up space without a proposal filter', async () => {
+    queryAsync.mockResolvedValueOnce([]);
+
+    await fetchVotes(null, {
+      first: 1000,
+      skip: 0,
+      where: { voter: '0x0000000000000000000000000000000000000001' }
+    });
+
+    expect(queryAsync).toHaveBeenCalledTimes(1);
+    const [votesSql] = queryAsync.mock.calls[0];
+    expect(votesSql).not.toContain('FORCE INDEX');
+  });
+});

--- a/apps/hub/test/unit/votes.test.ts
+++ b/apps/hub/test/unit/votes.test.ts
@@ -80,7 +80,7 @@ describe('votes resolver index usage', () => {
     expect(votesSql).not.toContain('FORCE INDEX');
   });
 
-  it('keeps the v.id ASC tie-break on a descending non-proposal query', async () => {
+  it('matches the id tie-break to the sort direction on a non-proposal query', async () => {
     queryAsync.mockResolvedValueOnce([]);
 
     await fetchVotes(null, {
@@ -93,11 +93,11 @@ describe('votes resolver index usage', () => {
     const [votesSql] = queryAsync.mock.calls[0];
     expect(votesSql).not.toContain('FORCE INDEX');
     expect(votesSql.replace(/\s+/g, ' ')).toContain(
-      'ORDER BY v.created DESC, v.id ASC'
+      'ORDER BY v.created DESC, v.id DESC'
     );
   });
 
-  it('keeps the v.id ASC tie-break for a proposal query ordered by vp', async () => {
+  it('matches the id tie-break to the sort direction for a proposal query ordered by vp', async () => {
     queryAsync
       .mockResolvedValueOnce([{ space: 'magicappstore.eth' }])
       .mockResolvedValueOnce([]);
@@ -113,7 +113,23 @@ describe('votes resolver index usage', () => {
     const [votesSql] = queryAsync.mock.calls[1];
     expect(votesSql).not.toContain('FORCE INDEX');
     expect(votesSql.replace(/\s+/g, ' ')).toContain(
-      'ORDER BY v.vp DESC, v.id ASC'
+      'ORDER BY v.vp DESC, v.id DESC'
+    );
+  });
+
+  it('matches the id tie-break to an ascending sort direction', async () => {
+    queryAsync.mockResolvedValueOnce([]);
+
+    await fetchVotes(null, {
+      first: 1000,
+      skip: 0,
+      orderDirection: 'asc',
+      where: { voter: '0x0000000000000000000000000000000000000001' }
+    });
+
+    const [votesSql] = queryAsync.mock.calls[0];
+    expect(votesSql.replace(/\s+/g, ' ')).toContain(
+      'ORDER BY v.created ASC, v.id ASC'
     );
   });
 });

--- a/apps/hub/test/unit/votes.test.ts
+++ b/apps/hub/test/unit/votes.test.ts
@@ -49,6 +49,25 @@ describe('votes resolver index usage', () => {
     expect(votesParams.slice(0, 2)).toEqual(['magicappstore.eth', PROPOSAL]);
   });
 
+  it('returns empty without querying votes when the proposal does not exist', async () => {
+    queryAsync.mockResolvedValueOnce([]);
+
+    const result = await fetchVotes(null, {
+      first: 1000,
+      skip: 0,
+      where: { proposal: PROPOSAL }
+    });
+
+    expect(result).toEqual([]);
+    // Only the proposal->space lookup runs; the votes SELECT is skipped.
+    expect(queryAsync).toHaveBeenCalledTimes(1);
+    const [lookupSql] = queryAsync.mock.calls[0];
+    expect(lookupSql).toContain('FROM proposals');
+    expect(
+      queryAsync.mock.calls.some(([sql]) => sql.includes('FROM votes'))
+    ).toBe(false);
+  });
+
   it('does not look up space when it is already provided', async () => {
     queryAsync.mockResolvedValueOnce([]);
 

--- a/apps/hub/test/unit/votes.test.ts
+++ b/apps/hub/test/unit/votes.test.ts
@@ -116,7 +116,7 @@ describe('votes resolver index usage', () => {
     );
   });
 
-  it('matches the id tie-break to the sort direction for a proposal query ordered by vp', async () => {
+  it('does not force the index for a proposal query ordered by vp', async () => {
     queryAsync
       .mockResolvedValueOnce([{ space: 'magicappstore.eth' }])
       .mockResolvedValueOnce([]);
@@ -131,9 +131,64 @@ describe('votes resolver index usage', () => {
 
     const [votesSql] = queryAsync.mock.calls[1];
     expect(votesSql).not.toContain('FORCE INDEX');
-    expect(votesSql.replace(/\s+/g, ' ')).toContain(
-      'ORDER BY v.vp DESC, v.id DESC'
+  });
+
+  it('does not force the index when a selective filter accompanies the proposal', async () => {
+    queryAsync
+      .mockResolvedValueOnce([{ space: 'magicappstore.eth' }])
+      .mockResolvedValueOnce([]);
+
+    await fetchVotes(null, {
+      first: 1000,
+      skip: 0,
+      where: {
+        proposal: PROPOSAL,
+        voter: '0x0000000000000000000000000000000000000001'
+      }
+    });
+
+    const [votesSql] = queryAsync.mock.calls[1];
+    expect(votesSql).not.toContain('FORCE INDEX');
+  });
+
+  it('collapses a single-element proposal_in onto the indexed path', async () => {
+    queryAsync
+      .mockResolvedValueOnce([{ space: 'magicappstore.eth' }])
+      .mockResolvedValueOnce([]);
+
+    await fetchVotes(null, {
+      first: 1000,
+      skip: 0,
+      where: { proposal_in: [PROPOSAL] }
+    });
+
+    const [lookupSql, lookupParams] = queryAsync.mock.calls[0];
+    expect(lookupSql).toContain('FROM proposals');
+    expect(lookupParams).toEqual([PROPOSAL]);
+
+    const [votesSql, votesParams] = queryAsync.mock.calls[1];
+    expect(votesSql).toContain(
+      'FORCE INDEX (idx_votes_on_space_proposal_created_id)'
     );
+    expect(votesSql).toContain('v.proposal = ?');
+    expect(votesParams.slice(0, 2)).toEqual(['magicappstore.eth', PROPOSAL]);
+  });
+
+  it('rejects when the proposal space lookup fails instead of running the unscoped votes query', async () => {
+    queryAsync.mockRejectedValueOnce(new Error('lookup failed'));
+
+    await expect(
+      fetchVotes(null, {
+        first: 1000,
+        skip: 0,
+        where: { proposal: PROPOSAL }
+      })
+    ).rejects.toThrow('request failed');
+
+    expect(queryAsync).toHaveBeenCalledTimes(1);
+    expect(
+      queryAsync.mock.calls.some(([sql]) => sql.includes('FROM votes'))
+    ).toBe(false);
   });
 
   it('matches the id tie-break to an ascending sort direction', async () => {

--- a/apps/hub/test/unit/votes.test.ts
+++ b/apps/hub/test/unit/votes.test.ts
@@ -79,4 +79,41 @@ describe('votes resolver index usage', () => {
     const [votesSql] = queryAsync.mock.calls[0];
     expect(votesSql).not.toContain('FORCE INDEX');
   });
+
+  it('keeps the v.id ASC tie-break on a descending non-proposal query', async () => {
+    queryAsync.mockResolvedValueOnce([]);
+
+    await fetchVotes(null, {
+      first: 1000,
+      skip: 0,
+      orderDirection: 'desc',
+      where: { voter: '0x0000000000000000000000000000000000000001' }
+    });
+
+    const [votesSql] = queryAsync.mock.calls[0];
+    expect(votesSql).not.toContain('FORCE INDEX');
+    expect(votesSql.replace(/\s+/g, ' ')).toContain(
+      'ORDER BY v.created DESC, v.id ASC'
+    );
+  });
+
+  it('keeps the v.id ASC tie-break for a proposal query ordered by vp', async () => {
+    queryAsync
+      .mockResolvedValueOnce([{ space: 'magicappstore.eth' }])
+      .mockResolvedValueOnce([]);
+
+    await fetchVotes(null, {
+      first: 1000,
+      skip: 0,
+      orderBy: 'vp',
+      orderDirection: 'desc',
+      where: { proposal: PROPOSAL }
+    });
+
+    const [votesSql] = queryAsync.mock.calls[1];
+    expect(votesSql).not.toContain('FORCE INDEX');
+    expect(votesSql.replace(/\s+/g, ' ')).toContain(
+      'ORDER BY v.vp DESC, v.id ASC'
+    );
+  });
 });

--- a/apps/hub/test/unit/votes.test.ts
+++ b/apps/hub/test/unit/votes.test.ts
@@ -116,10 +116,8 @@ describe('votes resolver index usage', () => {
     );
   });
 
-  it('does not force the index for a proposal query ordered by vp', async () => {
-    queryAsync
-      .mockResolvedValueOnce([{ space: 'magicappstore.eth' }])
-      .mockResolvedValueOnce([]);
+  it('does not force the index or look up space for a proposal query ordered by vp', async () => {
+    queryAsync.mockResolvedValueOnce([]);
 
     await fetchVotes(null, {
       first: 1000,
@@ -129,14 +127,19 @@ describe('votes resolver index usage', () => {
       where: { proposal: PROPOSAL }
     });
 
-    const [votesSql] = queryAsync.mock.calls[1];
+    // The space lookup only serves the created path; a vp-ordered query resolves
+    // via idx_votes_on_proposal_vp_id, so it skips the lookup and the hint.
+    expect(queryAsync).toHaveBeenCalledTimes(1);
+    expect(
+      queryAsync.mock.calls.some(([sql]) => sql.includes('FROM proposals'))
+    ).toBe(false);
+    const [votesSql] = queryAsync.mock.calls[0];
     expect(votesSql).not.toContain('FORCE INDEX');
+    expect(votesSql).not.toContain('v.space = ?');
   });
 
-  it('does not force the index when a selective filter accompanies the proposal', async () => {
-    queryAsync
-      .mockResolvedValueOnce([{ space: 'magicappstore.eth' }])
-      .mockResolvedValueOnce([]);
+  it('does not force the index or look up space when a selective filter accompanies the proposal', async () => {
+    queryAsync.mockResolvedValueOnce([]);
 
     await fetchVotes(null, {
       first: 1000,
@@ -147,7 +150,13 @@ describe('votes resolver index usage', () => {
       }
     });
 
-    const [votesSql] = queryAsync.mock.calls[1];
+    // voter resolves via the primary key; the injected space is a wasted
+    // round-trip, so the lookup is skipped along with the hint.
+    expect(queryAsync).toHaveBeenCalledTimes(1);
+    expect(
+      queryAsync.mock.calls.some(([sql]) => sql.includes('FROM proposals'))
+    ).toBe(false);
+    const [votesSql] = queryAsync.mock.calls[0];
     expect(votesSql).not.toContain('FORCE INDEX');
   });
 
@@ -171,6 +180,27 @@ describe('votes resolver index usage', () => {
       'FORCE INDEX (idx_votes_on_space_proposal_created_id)'
     );
     expect(votesSql).toContain('v.proposal = ?');
+    expect(votesParams.slice(0, 2)).toEqual(['magicappstore.eth', PROPOSAL]);
+  });
+
+  it('collapses a single-element space_in onto the indexed path', async () => {
+    queryAsync.mockResolvedValueOnce([]);
+
+    await fetchVotes(null, {
+      first: 1000,
+      skip: 0,
+      where: { proposal: PROPOSAL, space_in: ['magicappstore.eth'] }
+    });
+
+    // space_in already pins the space, so no lookup runs, but the hint still
+    // engages because the filter collapses to v.space = ?.
+    expect(queryAsync).toHaveBeenCalledTimes(1);
+    const [votesSql, votesParams] = queryAsync.mock.calls[0];
+    expect(votesSql).toContain(
+      'FORCE INDEX (idx_votes_on_space_proposal_created_id)'
+    );
+    expect(votesSql).toContain('v.space = ?');
+    expect(votesSql).not.toContain('v.space IN');
     expect(votesParams.slice(0, 2)).toEqual(['magicappstore.eth', PROPOSAL]);
   });
 

--- a/apps/hub/test/unit/votes.test.ts
+++ b/apps/hub/test/unit/votes.test.ts
@@ -221,6 +221,72 @@ describe('votes resolver index usage', () => {
     ).toBe(false);
   });
 
+  it.each([
+    ['app', { app: 'boardroom' }],
+    ['vp_gt', { vp_gt: 1000 }],
+    ['vp_state', { vp_state: 'pending' }],
+    ['reason_not', { reason_not: 'spam' }]
+  ])(
+    'scopes by space but does not force the index when %s filters the proposal',
+    async (_label, filter) => {
+      queryAsync
+        .mockResolvedValueOnce([{ space: 'magicappstore.eth' }])
+        .mockResolvedValueOnce([]);
+
+      await fetchVotes(null, {
+        first: 1000,
+        skip: 0,
+        where: { proposal: PROPOSAL, ...filter }
+      });
+
+      // The forced index cannot evaluate a filter it does not cover, so it
+      // would walk the whole proposal fetching rows; the space scope is still
+      // result-neutral and still the win, so it stays.
+      const [votesSql] = queryAsync.mock.calls[1];
+      expect(votesSql).not.toContain('FORCE INDEX');
+      expect(votesSql).toContain('v.space = ?');
+      expect(votesSql).toContain('v.proposal = ?');
+    }
+  );
+
+  it('still forces the index for a created range on the proposal', async () => {
+    queryAsync
+      .mockResolvedValueOnce([{ space: 'magicappstore.eth' }])
+      .mockResolvedValueOnce([]);
+
+    await fetchVotes(null, {
+      first: 1000,
+      skip: 0,
+      where: { proposal: PROPOSAL, created_gt: 1700000000 }
+    });
+
+    // created is inside the composite index, so it is a range the forced scan
+    // resolves from the index itself.
+    const [votesSql] = queryAsync.mock.calls[1];
+    expect(votesSql).toContain(
+      'FORCE INDEX (idx_votes_on_space_proposal_created_id)'
+    );
+    expect(votesSql).toContain('v.created > ?');
+  });
+
+  it('does not let a collapsed proposal_in carry a non-covered filter onto the forced index', async () => {
+    queryAsync
+      .mockResolvedValueOnce([{ space: 'magicappstore.eth' }])
+      .mockResolvedValueOnce([]);
+
+    await fetchVotes(null, {
+      first: 1000,
+      skip: 0,
+      where: { proposal_in: [PROPOSAL], vp_gte: 1 }
+    });
+
+    const [votesSql, votesParams] = queryAsync.mock.calls[1];
+    expect(votesSql).not.toContain('FORCE INDEX');
+    expect(votesSql).toContain('v.space = ?');
+    expect(votesSql).toContain('v.proposal = ?');
+    expect(votesParams.slice(0, 2)).toEqual(['magicappstore.eth', PROPOSAL]);
+  });
+
   it('matches the id tie-break to an ascending sort direction', async () => {
     queryAsync.mockResolvedValueOnce([]);
 


### PR DESCRIPTION
## Problem

The hub `votes` resolver builds its SQL WHERE from the GraphQL `where` args. When a query filters on a single `proposal` and orders by `created`, `proposal` is the only args-derived predicate:

```sql
SELECT v.* FROM votes v
WHERE v.space NOT IN (SELECT id FROM spaces WHERE deleted = 1)
  AND v.cb != -3 AND v.proposal = ?
ORDER BY v.created ASC, v.id ASC LIMIT 0, 1000
```

`votes` has a composite index `idx_votes_on_space_proposal_created_id (space, proposal, created, id)`, but it leads with `space`. With only `proposal` constrained the planner cannot seek it. Under `ORDER BY created LIMIT` it walks the created-ordered `idx_votes_on_created_id` instead and post-filters by `proposal`. On a large proposal the matching rows are smeared across the whole ~65M-row table, so filling a single page scans a large fraction of it, blows past `max_statement_time` and is killed (errno 3024).

That one shape is essentially all of the real damage. Over 14 days of hub logs (2026-07-10 to 2026-07-19) there were 1,972 votes queries killed with errno 3024, and 1,966 of them (99.7%) are proposal-only, `created ASC`, first page: 1,568 at `LIMIT 0, 1000` and 397 at `LIMIT 0, 500`. They cover 157 distinct proposals; the 155 that resolve on the replica sit in four spaces (magicappstore.eth, stgdao.eth, linea-build.eth, arbitrumfoundation.eth) and run from 88k to 2.76M votes. The remaining 6 kills are space-only queries and one deep page, neither of which this PR touches.

## Fix

No schema or index change. Two halves, deliberately gated differently.

**1. Scope by space.** On a proposal query ordered by `created` that does not already carry a `space`, resolve the proposal's space with a primary-key lookup on `proposals` (`type=const`, 1 row) and add `space = ?` to the WHERE. A proposal belongs to exactly one space, so this is result-neutral, and it is where the win comes from. If the proposal does not exist there is no space to scope by and no votes to return, so the votes query is skipped entirely. The lookup is skipped when a more selective filter (`id`, `ipfs`, `voter` or their `_in` forms) is present or the sort is `vp`, where other indexes already serve the query and the extra round-trip only competes with them. The UI vote list already sends `space`, so in practice this fires for API callers passing `proposal` on its own.

**2. `FORCE INDEX`, only when the whole `where` is index-covered.** The hint takes the plan choice away from the optimizer, which is only safe while the optimizer has nothing left to choose about. It is applied only when `proposal` and `space` are both bound, the sort is `created`, and every key present in `where` is one the composite index can evaluate from the index itself:

```
space, space_in, proposal, proposal_in,
created, created_in, created_gt, created_gte, created_lt, created_lte
```

`created` is inside the index, so ranges on it stay on the fast path. Any other key (`app`, `reason`, `vp`, `vp_state` and their `_not` / `_in` / comparison forms) is a residual predicate the index cannot answer: a forced scan has to walk the whole proposal in created order and fetch every row to test it. Those queries keep the injected `space` and leave the plan to the optimizer.

This is an allow-list on purpose. The inverse, enumerating the keys that must block the hint, fails open: every filter later added to `VoteWhere` would be silently opted into the forced path.

A single-element `proposal_in` or `space_in` is collapsed to `proposal` / `space` before either gate runs, so those take the same path. Lists of two or more are left alone.

Scope: the `created DESC, id DESC` tie-break this branch originally carried landed separately in #2250. Rebased on master, the diff here is the space scope, the gated hint and the single-element collapse (2 files, +389/-5).

### The regression the allow-list avoids

An earlier revision of this branch gated the hint on "no selective filter present", which only excluded `id` / `ipfs` / `voter`. Everything else (`app`, `vp*`, `vp_state`) was forced onto the composite index with a residual predicate, turning millisecond-scale queries into 60 s kills: the same failure this PR exists to remove, relocated to a different query shape. The Snapshot UI does not send those filters, so the exposure was public API consumers of hub.snapshot.org.

Measured on the replica with `EXPLAIN ANALYZE` against the exact SQL each revision emits. The hint cannot be exercised through GraphQL against a seeded local database, so every timing in this PR is replica-direct, not endpoint-measured. stgdao.eth proposal `0xc18c…5920` (514k votes), `LIMIT 0, 1000`, every statement capped with `MAX_EXECUTION_TIME(60000)`:

| `where` (plus `proposal`, `space`) | master | deny-list revision | allow-list (this revision) |
|---|---|---|---|
| `app: "boardroom"` | 3.2 ms | **killed at 60 s** | 3.3 ms |
| `vp_gt: 1000` | 3.5 ms | **killed at 60 s** | 3.1 ms |
| `vp: 1000` | 0.1 ms | **killed at 60 s** | 0.0 ms |
| `vp_state: "pending"` | 51.7 ms | **killed at 60 s** | 50.2 ms |
| `app: "zzz-nonexistent"` | 0.0 ms | **killed at 60 s** | 0.0 ms |
| linea-build.eth `0xda4f…648e` (2.76M votes), `vp_gt: 1000000` | 0.0 ms | **killed at 60 s** | 0.0 ms |

The right-hand column is back on master's plans (`app` / `vp_state` index lookups, `idx_votes_on_proposal_vp_id` range scans). The injected `space` predicate on its own does not pull the optimizer off them.

### What the hinted shapes gain

Same method, master vs this revision:

| query | master | this revision |
|---|---|---|
| stgdao.eth `0xc18c…5920` (514k), `{proposal}` created DESC | **killed at 60 s** (reverse scan of `idx_votes_on_created_id`) | 93.8 ms |
| ens.eth `0xd810…97e4` (84k), `{proposal}` created DESC | 10.8 s | 21.3 ms |
| stgdao.eth `{proposal, created_gt}` (allow-listed, keeps the hint) | 36.2 s | 0.0 ms |

One shape gains without being hinted: stgdao.eth `{proposal, vp_gt: 0}` goes from a 60 s kill to 129 ms, because the optimizer picks `idx_votes_on_space_proposal_created_id` by itself once `space` is scoped. The hint would buy nothing there.

## What this PR does not fix

Everything below keeps master's plan and master's latency.

- **Space-only queries** (no `proposal`). Neither the lookup nor the hint fires. 5 of the 1,972 logged kills; `space` with `ORDER BY vp` still filesorts roughly 9.1M rows on arbitrumfoundation.eth.
- **`orderBy: vp`**, including on a proposal. Both halves are gated on `created`. This is the UI vote list's default sort, and on a 500k-vote proposal it filesorts the whole proposal on master and on this branch alike.
- **`proposal_in` with two or more elements.** Only a single-element list collapses, so no space is injected and no hint is applied.
- **Residual-heavy filters on a proposal**, for example `{proposal, reason_not}`, `{proposal, app_in}`, `{proposal, vp_lte: 1}`. These do get the injected `space`, which takes them from a 60 s kill to 36 to 38 s on stgdao.eth, but that is an improvement, not a fix: a residual matching most of the proposal still has to be walked, and forcing the index there would be the same walk.
- **Deep pagination.** `LIMIT offset, n` reads and discards the offset rows before returning the page, so cost grows with the offset even when the plan is right. The real fix is keyset/cursor pagination (`WHERE created < :cursor ORDER BY created DESC LIMIT n`), a larger separate change. 1 of the 1,972 logged kills, at offset 1,000.

## Test plan

- `apps/hub`: `tsc --noEmit`, eslint and prettier clean.
- `apps/hub/test/unit/votes.test.ts`, 17 cases, mysql mocked: the space lookup and the hint on a proposal query; no lookup when `space` is already given; neither without a proposal; the `vp` sort gate; the `id` / `ipfs` / `voter` gate; both single-element collapses; the lookup-failure path; and the allow-list, where `app`, `vp_gt`, `vp_state` and `reason_not` get the space scope but **not** the hint, `created_gt` still gets both, and a collapsed `proposal_in` cannot carry a non-covered key onto the forced path.
- GraphQL payload parity: a local hub against a seeded MySQL, 22 `where` / `orderBy` / paging shapes run against master and against this branch, zero payload differences, with the query log confirming which shapes emit `FORCE INDEX` and which only get `v.space = ?`. Parity only: the seeded database is far too small for the plan choice to show up in latency, which is why the timings above are all replica-direct.
- Replica `EXPLAIN ANALYZE` for both tables above.
- Log figures re-checked against Better Stack (`snapshot-hub-mainnet`, errno 3024, 2026-07-10 to 2026-07-19).

Do not merge on a reaction. Merging deploys via the hub's normal path.
