### PR TITLE
chore: sync hub schema.sql with production indexes

### DIFF
--- a/apps/hub/src/helpers/schema.sql
+++ b/apps/hub/src/helpers/schema.sql
@@ -6,6 +6,7 @@ CREATE TABLE spaces (
   deleted INT NOT NULL DEFAULT '0',
   flagged INT NOT NULL DEFAULT '0',
   hibernated INT NOT NULL DEFAULT '0',
+  turbo INT NOT NULL DEFAULT '0',
   turbo_expiration BIGINT NOT NULL DEFAULT '0',
   proposal_count INT NOT NULL DEFAULT '0',
   vote_count INT NOT NULL DEFAULT '0',
@@ -19,6 +20,7 @@ CREATE TABLE spaces (
   INDEX verified (verified),
   INDEX flagged (flagged),
   INDEX hibernated (hibernated),
+  INDEX turbo (turbo),
   INDEX proposal_count (proposal_count),
   INDEX vote_count (vote_count),
   INDEX follower_count (follower_count),
@@ -61,7 +63,7 @@ CREATE TABLE proposals (
   scores_state VARCHAR(24) NOT NULL DEFAULT '',
   scores_total DECIMAL(64,30) NOT NULL,
   scores_updated INT(11) NOT NULL,
-  scores_total_value DECIMAL(64,30) NOT NULL DEFAULT '0.000000000000000000000000000000',
+  scores_total_value DECIMAL(13,3) NOT NULL DEFAULT '0.000',
   vp_value_by_strategy json NOT NULL,
   votes INT(12) NOT NULL,
   flagged INT NOT NULL DEFAULT 0,
@@ -69,10 +71,8 @@ CREATE TABLE proposals (
   PRIMARY KEY (id),
   INDEX ipfs (ipfs),
   INDEX author (author),
-  INDEX created (created),
   INDEX updated (updated),
   INDEX network (network),
-  INDEX space (space),
   INDEX start (start),
   INDEX end (end),
   INDEX app (app),
@@ -80,7 +80,12 @@ CREATE TABLE proposals (
   INDEX scores_updated (scores_updated),
   INDEX votes (votes),
   INDEX flagged (flagged),
-  INDEX cb (cb)
+  INDEX cb (cb),
+  INDEX idx_proposals_on_created_desc_id_asc_space (created DESC, id, space),
+  INDEX idx_proposals_on_space_created_desc_id_asc (space, created DESC, id),
+  INDEX idx_proposals_on_created (created),
+  INDEX idx_proposals_on_end_desc_id (end DESC, id),
+  INDEX idx_proposals_on_scores_total_value (scores_total_value)
 );
 
 CREATE TABLE votes (
@@ -98,17 +103,21 @@ CREATE TABLE votes (
   vp_by_strategy JSON NOT NULL,
   vp_state VARCHAR(24) NOT NULL,
   cb INT(11) NOT NULL,
+  vp_value DECIMAL(13,3) NOT NULL DEFAULT '0.000',
   PRIMARY KEY (voter, space, proposal),
-  UNIQUE KEY id (id),
+  INDEX id (id),
   INDEX ipfs (ipfs),
-  INDEX voter (voter),
-  INDEX created (created),
-  INDEX space (space),
-  INDEX proposal (proposal),
   INDEX app (app),
   INDEX vp (vp),
   INDEX vp_state (vp_state),
-  INDEX cb (cb)
+  INDEX cb (cb),
+  INDEX space_created_id (space, created, id),
+  INDEX idx_votes_on_space_proposal_created_id (space, proposal, created, id),
+  INDEX idx_votes_on_created_id (created, id),
+  INDEX idx_votes_on_proposal_vp_id (proposal, vp, id),
+  INDEX idx_votes_on_vp_value (vp_value),
+  INDEX idx_votes_on_space_created_desc_id (space, created DESC, id),
+  INDEX idx_votes_on_cb_proposal (cb, proposal)
 );
 
 CREATE TABLE follows (
@@ -132,7 +141,9 @@ CREATE TABLE aliases (
   alias VARCHAR(100) NOT NULL,
   created INT(11) NOT NULL,
   PRIMARY KEY (address, alias),
-  INDEX ipfs (ipfs)
+  UNIQUE KEY alias (alias),
+  INDEX ipfs (ipfs),
+  INDEX idx_aliases_on_id (id)
 );
 
 CREATE TABLE subscriptions (
@@ -185,11 +196,13 @@ CREATE TABLE leaderboard (
   vote_count SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   proposal_count SMALLINT UNSIGNED NOT NULL DEFAULT '0',
   last_vote BIGINT,
+  vp_value DECIMAL(13,3) NOT NULL DEFAULT '0.000',
   PRIMARY KEY user_space (user,space),
-  INDEX space (space),
   INDEX vote_count (vote_count),
   INDEX proposal_count (proposal_count),
-  INDEX last_vote (last_vote)
+  INDEX last_vote (last_vote),
+  INDEX idx_leaderboard_on_space_mixed (space, vote_count, proposal_count, last_vote, user),
+  INDEX vp_value (vp_value)
 );
 
 CREATE TABLE options (

--- a/apps/sequencer/test/schema.sql
+++ b/apps/sequencer/test/schema.sql
@@ -21,7 +21,6 @@ CREATE TABLE spaces (
   INDEX flagged (flagged),
   INDEX hibernated (hibernated),
   INDEX turbo (turbo),
-  INDEX turbo_expiration (turbo_expiration),
   INDEX proposal_count (proposal_count),
   INDEX vote_count (vote_count),
   INDEX follower_count (follower_count),
@@ -72,10 +71,8 @@ CREATE TABLE proposals (
   PRIMARY KEY (id),
   INDEX ipfs (ipfs),
   INDEX author (author),
-  INDEX created (created),
   INDEX updated (updated),
   INDEX network (network),
-  INDEX space (space),
   INDEX start (start),
   INDEX end (end),
   INDEX app (app),
@@ -83,7 +80,12 @@ CREATE TABLE proposals (
   INDEX scores_updated (scores_updated),
   INDEX votes (votes),
   INDEX flagged (flagged),
-  INDEX cb (cb)
+  INDEX cb (cb),
+  INDEX idx_proposals_on_created_desc_id_asc_space (created DESC, id, space),
+  INDEX idx_proposals_on_space_created_desc_id_asc (space, created DESC, id),
+  INDEX idx_proposals_on_created (created),
+  INDEX idx_proposals_on_end_desc_id (end DESC, id),
+  INDEX idx_proposals_on_scores_total_value (scores_total_value)
 );
 
 CREATE TABLE votes (
@@ -140,7 +142,8 @@ CREATE TABLE aliases (
   created INT(11) NOT NULL,
   PRIMARY KEY (address, alias),
   UNIQUE KEY alias (alias),
-  INDEX ipfs (ipfs)
+  INDEX ipfs (ipfs),
+  INDEX idx_aliases_on_id (id)
 );
 
 CREATE TABLE subscriptions (
@@ -195,10 +198,10 @@ CREATE TABLE leaderboard (
   last_vote BIGINT,
   vp_value DECIMAL(13,3) NOT NULL DEFAULT 0.000,
   PRIMARY KEY user_space (user,space),
-  INDEX space (space),
   INDEX vote_count (vote_count),
   INDEX proposal_count (proposal_count),
   INDEX last_vote (last_vote),
+  INDEX idx_leaderboard_on_space_mixed (space, vote_count, proposal_count, last_vote, user),
   INDEX vp_value (vp_value)
 );
 


### PR DESCRIPTION
The hub `.sql` schema files had drifted from the PlanetScale production database. Over time a number of indexes and columns were added directly on prod and never reflected back into the checked-in schema, so a fresh DB built from these files did not match production. This syncs them back up using `SHOW CREATE TABLE` on prod as the source of truth.

Concrete changes, per table:

- **votes**: add `vp_value`; drop the standalone `voter`/`created`/`space`/`proposal` indexes and the `id` unique key (prod has a plain key on `id`); add `space_created_id`, `idx_votes_on_space_proposal_created_id`, `idx_votes_on_created_id`, `idx_votes_on_proposal_vp_id`, `idx_votes_on_vp_value`, `idx_votes_on_space_created_desc_id`, `idx_votes_on_cb_proposal`.
- **proposals**: `scores_total_value` is `decimal(13,3)` (was `decimal(64,30)`); drop standalone `space` index; rename `created` to `idx_proposals_on_created`; add `idx_proposals_on_created_desc_id_asc_space`, `idx_proposals_on_space_created_desc_id_asc`, `idx_proposals_on_end_desc_id`, `idx_proposals_on_scores_total_value`.
- **spaces**: add the `turbo` column and its index.
- **leaderboard**: add `vp_value`; drop standalone `space` index; add `idx_leaderboard_on_space_mixed` and the `vp_value` index.
- **aliases**: add the `alias` unique key and `idx_aliases_on_id`.

The same fixes are applied to `apps/sequencer/test/schema.sql`, which carries a copy of the hub tables for the sequencer test DB (it was already partly synced; this finishes it and also drops a stray `turbo_expiration` index that isn't on prod).

`idx_votes_on_space_proposal_created_id` exists in prod but was missing from the `.sql`, which is exactly the index PR #2237's `FORCE INDEX` depends on, so that change is invalid against the current checked-in schema until this lands.

I left the documented legacy deviations alone (the note on `proposals.id`/`ipfs` having no default) and did not chase cosmetic-only differences like `int` display widths or explicit charset/collation clauses. The `messages`-only sequencer runtime schema was not touched because its table lives in a separate DB that isn't reachable from this connection, so there was nothing to verify it against.

Verified by applying both files to a throwaway MySQL 8 container and diffing `SHOW CREATE TABLE` for all 12 hub tables against prod: index sets and the new column types (`turbo int`, `vp_value`/`scores_total_value` `decimal(13,3)`) match.