### PR TITLE
fix(ui): broken Terms of Service link in payment modal

### DIFF
--- a/apps/ui/src/components/Modal/Payment.vue
+++ b/apps/ui/src/components/Modal/Payment.vue
@@ -243,7 +243,6 @@ watch(
             I have read and agree to the
             <span @click.stop>
               <AppLink
-                is-external
                 :to="
                   isWhiteLabel
                     ? 'https://snapshot.box/#/terms-of-use'


### PR DESCRIPTION
## Summary

The **"Terms of service"** link in the payment modal was broken — it rendered `href="[object Object]"` instead of a real URL, so clicking it went nowhere.

`AppLink` had `is-external` set unconditionally, but the normal (non‑white‑label) case passes a **route object** (`{ name: 'site-terms' }`). `is-external` forces `AppLink` to render a plain `<a :href="to">`, so the route object got stringified to `[object Object]`.

The fix simply removes the unconditional `is-external`. `AppLink` already auto‑detects `http…` strings as external, which covers both cases:

- **White‑label build:** `https://snapshot.box/#/terms-of-use` (string) → external link ✓
- **Normal build:** `{ name: 'site-terms' }` (route object) → internal router link to `/terms-of-use` ✓

This mirrors how the site footer already links to the same route (`<AppLink :to="{ name: 'site-terms' }">`, without `is-external`).

This is a pre‑existing bug on `master`, unrelated to any in‑flight feature — it was noticed while testing the payment modal.

## How to test

1. Open a space's payment modal (e.g. the Pro upgrade / crypto payment flow).
2. Find the *"I have read and agree to the **Terms of service**"* checkbox at the bottom.
3. Inspect / click the **Terms of service** link.

| Build | Before | After |
|---|---|---|
| Normal | `href="[object Object]"` — link is dead | `href=".../terms-of-use"` — opens the Terms page ✓ |
| White‑label | `https://snapshot.box/#/terms-of-use` ✓ | `https://snapshot.box/#/terms-of-use` ✓ (unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
