### PR TITLE
feat(api): add proposal scores arrays

### DIFF
--- a/apps/api/src/common/utils.ts
+++ b/apps/api/src/common/utils.ts
@@ -144,6 +144,39 @@ export function getParsedVP(value: string, decimals: number) {
   return parsedValue / 10 ** decimals;
 }
 
+export function updateProposalScores(
+  proposal: Proposal,
+  choice: number,
+  vp: bigint
+) {
+  const scores = [...proposal.scores];
+  const scoresParsed = [...proposal.scores_parsed];
+
+  while (scores.length < choice) {
+    scores.push('0');
+    scoresParsed.push(0);
+  }
+
+  const updatedScore = (BigInt(scores[choice - 1] ?? '0') + vp).toString();
+  const updatedScoreParsed = getParsedVP(updatedScore, proposal.vp_decimals);
+  scores[choice - 1] = updatedScore;
+  scoresParsed[choice - 1] = updatedScoreParsed;
+
+  proposal.scores = scores;
+  proposal.scores_parsed = scoresParsed;
+
+  if (choice === 1 || choice === 2 || choice === 3) {
+    proposal[`scores_${choice}`] = updatedScore;
+    proposal[`scores_${choice}_parsed`] = updatedScoreParsed;
+  }
+
+  proposal.scores_total = (BigInt(proposal.scores_total) + vp).toString();
+  proposal.scores_total_parsed = getParsedVP(
+    proposal.scores_total,
+    proposal.vp_decimals
+  );
+}
+
 export async function updateScoresTick(
   proposal: Proposal,
   timestamp: number,
@@ -160,6 +193,7 @@ export async function updateScoresTick(
   }
 
   tick.timestamp = hourTimestamp;
+  tick.scores = proposal.scores;
   tick.scores_1 = proposal.scores_1;
   tick.scores_2 = proposal.scores_2;
   tick.scores_3 = proposal.scores_3;

--- a/apps/api/src/evm/protocols/governor-bravo/writers.ts
+++ b/apps/api/src/evm/protocols/governor-bravo/writers.ts
@@ -23,6 +23,7 @@ import {
   getParsedVP,
   getProposalLink,
   getSpaceLink,
+  updateProposalScores,
   updateScoresTick
 } from '../../../common/utils';
 import { EVMConfig, GovernorBravoConfig } from '../../types';
@@ -356,6 +357,8 @@ export function createWriters(
     proposal.execution_strategy_details = executionStrategy.id;
     proposal.vp_decimals = spaceDataEntry.decimals;
     proposal.type = 'basic';
+    proposal.scores = ['0', '0', '0'];
+    proposal.scores_parsed = [0, 0, 0];
     proposal.quorum_type = 'for_only';
     proposal.created = Number(block?.timestamp ?? getCurrentTimestamp());
     proposal.tx = txId;
@@ -536,20 +539,7 @@ export function createWriters(
     vote.created = Number(block?.timestamp ?? getCurrentTimestamp());
     vote.tx = txId;
 
-    proposal.scores_total = (
-      BigInt(proposal.scores_total) + BigInt(vote.vp)
-    ).toString();
-    proposal.scores_total_parsed = getParsedVP(
-      proposal.scores_total,
-      proposal.vp_decimals
-    );
-    proposal[`scores_${choice}`] = (
-      BigInt(proposal[`scores_${choice}`]) + BigInt(vote.vp)
-    ).toString();
-    proposal[`scores_${choice}_parsed`] = getParsedVP(
-      proposal[`scores_${choice}`],
-      proposal.vp_decimals
-    );
+    updateProposalScores(proposal, choice, BigInt(vote.vp));
 
     let leaderboardItem = await Leaderboard.loadEntity(
       leaderboardId,

--- a/apps/api/src/evm/protocols/openzeppelin/writers.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/writers.ts
@@ -36,6 +36,7 @@ import {
   getParsedVP,
   getProposalLink,
   getSpaceLink,
+  updateProposalScores,
   updateScoresTick
 } from '../../../common/utils';
 import { EVMConfig, OpenZeppelinConfig } from '../../types';
@@ -415,6 +416,8 @@ export function createWriters(
     proposal.execution_strategy_details = executionStrategy.id;
     proposal.vp_decimals = strategyParsedMetadataDataItem.decimals;
     proposal.type = 'basic';
+    proposal.scores = ['0', '0', '0'];
+    proposal.scores_parsed = [0, 0, 0];
     proposal.quorum_type = getGovernanceInfo(spaceAddress).quorumType || null;
     proposal.created = Number(block?.timestamp ?? getCurrentTimestamp());
     proposal.tx = txId;
@@ -631,20 +634,7 @@ export function createWriters(
     vote.created = Number(block?.timestamp ?? getCurrentTimestamp());
     vote.tx = txId;
 
-    proposal.scores_total = (
-      BigInt(proposal.scores_total) + BigInt(vote.vp)
-    ).toString();
-    proposal.scores_total_parsed = getParsedVP(
-      proposal.scores_total,
-      proposal.vp_decimals
-    );
-    proposal[`scores_${choice}`] = (
-      BigInt(proposal[`scores_${choice}`]) + BigInt(vote.vp)
-    ).toString();
-    proposal[`scores_${choice}_parsed`] = getParsedVP(
-      proposal[`scores_${choice}`],
-      proposal.vp_decimals
-    );
+    updateProposalScores(proposal, choice, BigInt(vote.vp));
 
     let leaderboardItem = await Leaderboard.loadEntity(
       leaderboardId,

--- a/apps/api/src/evm/protocols/snapshot-x/writers.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/writers.ts
@@ -45,6 +45,7 @@ import {
   getSpaceDecimals,
   getSpaceLink,
   updateCounter,
+  updateProposalScores,
   updateScoresTick
 } from '../../../common/utils';
 import { EVMConfig, SnapshotXConfig } from '../../types';
@@ -639,6 +640,8 @@ export function createWriters(
     );
     proposal.snapshot = BigInt(event.args.proposal.startBlockNumber);
     proposal.type = 'basic';
+    proposal.scores = ['0', '0', '0'];
+    proposal.scores_parsed = [0, 0, 0];
     proposal.scores_1 = '0';
     proposal.scores_1_parsed = 0;
     proposal.scores_2 = '0';
@@ -1044,20 +1047,7 @@ export function createWriters(
     }
 
     proposal.vote_count += 1;
-    proposal.scores_total = (
-      BigInt(proposal.scores_total) + BigInt(vote.vp)
-    ).toString();
-    proposal.scores_total_parsed = getParsedVP(
-      proposal.scores_total,
-      proposal.vp_decimals
-    );
-    proposal[`scores_${choice}`] = (
-      BigInt(proposal[`scores_${choice}`]) + BigInt(vote.vp)
-    ).toString();
-    proposal[`scores_${choice}_parsed`] = getParsedVP(
-      proposal[`scores_${choice}`],
-      proposal.vp_decimals
-    );
+    updateProposalScores(proposal, choice, BigInt(vote.vp));
 
     await updateScoresTick(proposal, created, config.indexerName);
     await proposal.save();

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -275,7 +275,11 @@ type Proposal {
   vp_decimals: Int!
   "Type of proposal (e.g., 'basic', 'single-choice')"
   type: String!
-  "Voting power for choice 1"
+  "Array of voting power totals per choice (index 0 = choice 1)"
+  scores: [BigDecimalVP!]!
+  "Array of parsed voting power totals per choice as floats"
+  scores_parsed: [Float!]!
+  "Voting power for choice 1 (deprecated: use scores)"
   scores_1: BigDecimalVP!
   "Parsed voting power for choice 1 as float"
   scores_1_parsed: Float!
@@ -385,7 +389,9 @@ type ScoresTick {
   proposal: Proposal!
   "Unix timestamp of when scores were recorded"
   timestamp: Int!
-  "Voting power for choice 1 at this timestamp"
+  "Array of voting power totals per choice at this timestamp (index 0 = choice 1)"
+  scores: [BigDecimalVP!]!
+  "Voting power for choice 1 at this timestamp (deprecated: use scores)"
   scores_1: BigDecimalVP!
   "Voting power for choice 2 at this timestamp"
   scores_2: BigDecimalVP!

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -34,6 +34,7 @@ import {
   getSpaceDecimals,
   getSpaceLink,
   updateCounter,
+  updateProposalScores,
   updateScoresTick
 } from '../common/utils';
 
@@ -468,6 +469,8 @@ export function createWriters(config: FullConfig) {
     );
     proposal.execution_strategy_type = 'none';
     proposal.type = 'basic';
+    proposal.scores = ['0', '0', '0'];
+    proposal.scores_parsed = [0, 0, 0];
     proposal.scores_1 = '0';
     proposal.scores_1_parsed = 0;
     proposal.scores_2 = '0';
@@ -850,20 +853,7 @@ export function createWriters(config: FullConfig) {
     }
 
     proposal.vote_count += 1;
-    proposal.scores_total = (
-      BigInt(proposal.scores_total) + BigInt(vote.vp)
-    ).toString();
-    proposal.scores_total_parsed = getParsedVP(
-      proposal.scores_total,
-      proposal.vp_decimals
-    );
-    proposal[`scores_${choice}`] = (
-      BigInt(proposal[`scores_${choice}`]) + BigInt(vote.vp)
-    ).toString();
-    proposal[`scores_${choice}_parsed`] = getParsedVP(
-      proposal[`scores_${choice}`],
-      proposal.vp_decimals
-    );
+    updateProposalScores(proposal, choice, BigInt(vote.vp));
 
     await updateScoresTick(proposal, created, config.indexerName);
     await proposal.save();


### PR DESCRIPTION
## Summary

Companion to #2229 (choices array): moves the SX-API score model from the fixed `scores_1/2/3` fields to variable-length arrays, needed for offchain proposal ingestion and future multi-choice voting. **Purely additive**: the legacy fields stay and keep being written, so this is safe to merge and deploy in any order relative to the UI (and independently of #2229).

New fields on `Proposal`:

- `scores: [BigDecimalVP!]!` and `scores_parsed: [Float!]!`: voting power per choice (index 0 = choice 1), maintained in lockstep with `scores_1/2/3` (marked deprecated in the schema docs now).

`ScoresTick` gets the same additive `scores` array.

The per-choice accumulation logic, previously duplicated across the four protocol writers (snapshot-x EVM, Starknet, governor-bravo, OpenZeppelin), is now a shared `updateProposalScores()` helper in `common/utils.ts` that maintains both representations.

## Rollout plan (expand/migrate/contract)

1. **This PR + #2229**: add the arrays alongside the legacy fields. No consumer changes needed.
2. After deploy: a UI PR switches fragments/mappings from `scores_1/2/3` to `scores`/`choices`.
3. Once no deployed consumer reads them: remove `scores_1/2/3`.

## Deploy note

New columns only exist after table recreation, which happens through the standard reindex on deploy (`syncVersion` version tag changes with `GIT_COMMIT`).

## Test plan

- `tsc`, eslint, vitest pass; zero UI files touched
- Verified on a from-scratch local Sepolia reindex with real onchain data (on the pre-split branch, which contained these same scores changes): `scores`/`scores_parsed` consistent with `scores_1/2/3` and `scores_total` after real `VoteCast` events, and `scores_ticks` carrying both representations:

```json
{
  "id": "0xbFF55fd2A671288316956A0Cae8f1d24BA7E5C9B/1",
  "scores": ["1", "0", "0"],
  "scores_parsed": [1, 0, 0],
  "scores_1": "1",
  "scores_total": "1",
  "scores_ticks": [{ "scores": ["1", "0", "0"], "scores_1": "1" }]
}
```

## Note on CI

The `getSpaceController` shib test may still fail: `stamp.fyi`'s `get_owner` for Shibarium returns `500 unauthorized` (D3 partner API rejecting the key). Unrelated to this diff, fails identically on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
