### PR TITLE
feat: support overriding and omitting contracts in network configs

### DIFF
--- a/apps/api/src/evm/protocols/governor-bravo/writers.ts
+++ b/apps/api/src/evm/protocols/governor-bravo/writers.ts
@@ -235,11 +235,14 @@ export function createWriters(
 
     const { name, symbol, treasury, governanceToken } = spaceDataEntry;
 
+    const compStrategy = evmNetworks[config.indexerName].Strategies.Comp;
+    if (!compStrategy) throw new Error('Comp strategy is not configured');
+
     space.authenticators = [
       'GovernorBravoAuthenticator',
       'GovernorBravoAuthenticatorSignature'
     ];
-    space.strategies = [evmNetworks[config.indexerName].Strategies.Comp];
+    space.strategies = [compStrategy];
     space.strategies_params = [governanceToken];
     space.strategies_indices = [0];
     space.voting_power_validation_strategy_strategies = space.strategies;

--- a/apps/api/src/evm/protocols/openzeppelin/writers.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/writers.ts
@@ -278,9 +278,12 @@ export function createWriters(
       decimals
     });
 
+    const ozVotesStrategy = evmNetworks[config.indexerName].Strategies.OZVotes;
+    if (!ozVotesStrategy) throw new Error('OZVotes strategy is not configured');
+
     const governanceInfo = getGovernanceInfo(contractAddress);
     space.authenticators = governanceInfo.authenticators;
-    space.strategies = [evmNetworks[config.indexerName].Strategies.OZVotes];
+    space.strategies = [ozVotesStrategy];
     space.strategies_params = [token];
     space.strategies_indices = [0];
     space.voting_power_validation_strategy_strategies = space.strategies;

--- a/apps/api/src/evm/protocols/snapshot-x/config.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/config.ts
@@ -182,11 +182,12 @@ export function createConfig(networkId: NetworkID): Config {
       chainId: network.Meta.eip712ChainId,
       manaRpcUrl: `${MANA_URL}/eth_rpc/${network.Meta.eip712ChainId}`,
       masterSpace: network.Meta.masterSpace,
-      masterSimpleQuorumAvatar: network.ExecutionStrategies.SimpleQuorumAvatar,
+      masterSimpleQuorumAvatar:
+        network.ExecutionStrategies.SimpleQuorumAvatar ?? null,
       masterSimpleQuorumTimelock:
-        network.ExecutionStrategies.SimpleQuorumTimelock,
+        network.ExecutionStrategies.SimpleQuorumTimelock ?? null,
       propositionPowerValidationStrategyAddress:
-        network.ProposalValidations.VotingPower,
+        network.ProposalValidations.VotingPower ?? null,
       apeGasStrategy: network.Strategies.ApeGas ?? null,
       apeGasStrategyDelay: 20 * 5 // 20 minutes, with 5 blocks per minute
     }

--- a/apps/api/src/evm/protocols/snapshot-x/utils.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/utils.ts
@@ -42,8 +42,9 @@ export async function updateProposalValidationStrategy(
   space.voting_power_validation_strategy_metadata = metadataUri;
 
   if (
+    protocolConfig.propositionPowerValidationStrategyAddress !== null &&
     strategyAddress ===
-    getAddress(protocolConfig.propositionPowerValidationStrategyAddress)
+      getAddress(protocolConfig.propositionPowerValidationStrategyAddress)
   ) {
     try {
       const [threshold, strategies] = decodeAbiParameters(

--- a/apps/api/src/evm/protocols/snapshot-x/writers.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/writers.ts
@@ -74,6 +74,13 @@ export function createWriters(
     transport: http(config.network_node_url)
   });
 
+  const masterSimpleQuorumTimelock = protocolConfig.masterSimpleQuorumTimelock
+    ? getAddress(protocolConfig.masterSimpleQuorumTimelock)
+    : null;
+  const masterSimpleQuorumAvatar = protocolConfig.masterSimpleQuorumAvatar
+    ? getAddress(protocolConfig.masterSimpleQuorumAvatar)
+    : null;
+
   const handleProxyDeployed: evm.Writer<
     typeof ProxyFactoryAbi,
     'ProxyDeployed'
@@ -93,7 +100,7 @@ export function createWriters(
         });
         break;
       }
-      case getAddress(protocolConfig.masterSimpleQuorumTimelock): {
+      case masterSimpleQuorumTimelock: {
         const [type, quorum, timelockVetoGuardian, timelockDelay] =
           await client.multicall({
             contracts: [
@@ -145,7 +152,7 @@ export function createWriters(
 
         break;
       }
-      case getAddress(protocolConfig.masterSimpleQuorumAvatar): {
+      case masterSimpleQuorumAvatar: {
         const [type, quorum, target] = await client.multicall({
           contracts: [
             {

--- a/apps/api/src/evm/types.ts
+++ b/apps/api/src/evm/types.ts
@@ -17,9 +17,9 @@ export type SnapshotXConfig = {
   chainId: number;
   manaRpcUrl: string;
   masterSpace: string;
-  masterSimpleQuorumAvatar: string;
-  masterSimpleQuorumTimelock: string;
-  propositionPowerValidationStrategyAddress: string;
+  masterSimpleQuorumAvatar: string | null;
+  masterSimpleQuorumTimelock: string | null;
+  propositionPowerValidationStrategyAddress: string | null;
   apeGasStrategy: string | null;
   apeGasStrategyDelay: number;
 };

--- a/apps/ui/src/components/FormValidation.vue
+++ b/apps/ui/src/components/FormValidation.vue
@@ -80,7 +80,10 @@ function handleStrategySave(value: Record<string, any>) {
         @delete-strategy="removeStrategy"
       />
     </div>
-    <div v-if="!model" class="flex flex-wrap gap-2">
+    <div v-if="!model && availableStrategies.length === 0">
+      No strategies available
+    </div>
+    <div v-else-if="!model" class="flex flex-wrap gap-2">
       <ButtonStrategy
         v-for="strategy in availableStrategies"
         :key="strategy.address"

--- a/apps/ui/src/networks/evm/constants.test.ts
+++ b/apps/ui/src/networks/evm/constants.test.ts
@@ -11,6 +11,13 @@ describe('EVM Constants', () => {
 ,
   `;
 
+  it('should include all editor entries for standard networks', () => {
+    expect(constants.EDITOR_AUTHENTICATORS).toHaveLength(3);
+    expect(constants.EDITOR_VOTING_STRATEGIES).toHaveLength(4);
+    expect(constants.EDITOR_PROPOSAL_VALIDATIONS).toHaveLength(1);
+    expect(constants.EDITOR_EXECUTION_STRATEGIES).toHaveLength(2);
+  });
+
   describe('EDITOR_VOTING_STRATEGIES', () => {
     describe('whitelist', () => {
       const strategy = constants.EDITOR_VOTING_STRATEGIES.find(

--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -32,28 +32,34 @@ export function createConstants(
 
   const AUTHENTICATORS_SUPPORT_INFO: Record<string, AuthenticatorSupportInfo> =
     {
-      [config.Authenticators.EthSigV2]: {
-        isSupported: true,
-        isContractSupported: true,
-        isReasonSupported: true,
-        relayerType: 'evm',
-        connectors: EVM_CONNECTORS
-      },
-      [config.Authenticators.EthSig]: {
-        priority: 1,
-        isSupported: true,
-        isContractSupported: false,
-        isReasonSupported: true,
-        relayerType: 'evm',
-        connectors: EVM_CONNECTORS
-      },
-      [config.Authenticators.EthTx]: {
-        priority: 2,
-        isSupported: true,
-        isContractSupported: true,
-        isReasonSupported: true,
-        connectors: EVM_CONNECTORS
-      },
+      ...(config.Authenticators.EthSigV2 && {
+        [config.Authenticators.EthSigV2]: {
+          isSupported: true,
+          isContractSupported: true,
+          isReasonSupported: true,
+          relayerType: 'evm',
+          connectors: EVM_CONNECTORS
+        }
+      }),
+      ...(config.Authenticators.EthSig && {
+        [config.Authenticators.EthSig]: {
+          priority: 1,
+          isSupported: true,
+          isContractSupported: false,
+          isReasonSupported: true,
+          relayerType: 'evm',
+          connectors: EVM_CONNECTORS
+        }
+      }),
+      ...(config.Authenticators.EthTx && {
+        [config.Authenticators.EthTx]: {
+          priority: 2,
+          isSupported: true,
+          isContractSupported: true,
+          isReasonSupported: true,
+          connectors: EVM_CONNECTORS
+        }
+      }),
       // Governor Bravo
       GovernorBravoAuthenticator: {
         priority: 1,
@@ -95,18 +101,30 @@ export function createConstants(
     };
 
   const SUPPORTED_STRATEGIES = {
-    [config.Strategies.Vanilla]: true,
-    [config.Strategies.Comp]: true,
-    [config.Strategies.OZVotes]: true,
-    [config.Strategies.Whitelist]: true,
+    ...(config.Strategies.Vanilla && {
+      [config.Strategies.Vanilla]: true
+    }),
+    ...(config.Strategies.Comp && {
+      [config.Strategies.Comp]: true
+    }),
+    ...(config.Strategies.OZVotes && {
+      [config.Strategies.OZVotes]: true
+    }),
+    ...(config.Strategies.Whitelist && {
+      [config.Strategies.Whitelist]: true
+    }),
     ...(config.Strategies.ApeGas && {
       [config.Strategies.ApeGas]: true
     })
   };
 
   const SUPPORTED_EXECUTORS = {
-    SimpleQuorumAvatar: true,
-    SimpleQuorumTimelock: true,
+    ...(config.ExecutionStrategies.SimpleQuorumAvatar && {
+      SimpleQuorumAvatar: true
+    }),
+    ...(config.ExecutionStrategies.SimpleQuorumTimelock && {
+      SimpleQuorumTimelock: true
+    }),
     // Governor Bravo
     GovernorBravoTimelock: true,
     // OpenZeppelin
@@ -114,20 +132,36 @@ export function createConstants(
   };
 
   const AUTHS = {
-    [config.Authenticators.EthSig]: 'Ethereum signature (deprecated)',
-    [config.Authenticators.EthSigV2]: 'Ethereum signature',
-    [config.Authenticators.EthTx]: 'Ethereum transaction'
+    ...(config.Authenticators.EthSig && {
+      [config.Authenticators.EthSig]: 'Ethereum signature (deprecated)'
+    }),
+    ...(config.Authenticators.EthSigV2 && {
+      [config.Authenticators.EthSigV2]: 'Ethereum signature'
+    }),
+    ...(config.Authenticators.EthTx && {
+      [config.Authenticators.EthTx]: 'Ethereum transaction'
+    })
   };
 
   const PROPOSAL_VALIDATIONS = {
-    [config.ProposalValidations.VotingPower]: 'Voting power'
+    ...(config.ProposalValidations.VotingPower && {
+      [config.ProposalValidations.VotingPower]: 'Voting power'
+    })
   };
 
   const STRATEGIES = {
-    [config.Strategies.Vanilla]: 'Vanilla',
-    [config.Strategies.Comp]: 'ERC-20 Votes Comp (EIP-5805)',
-    [config.Strategies.OZVotes]: 'ERC-20 Votes (EIP-5805)',
-    [config.Strategies.Whitelist]: 'Merkle whitelist',
+    ...(config.Strategies.Vanilla && {
+      [config.Strategies.Vanilla]: 'Vanilla'
+    }),
+    ...(config.Strategies.Comp && {
+      [config.Strategies.Comp]: 'ERC-20 Votes Comp (EIP-5805)'
+    }),
+    ...(config.Strategies.OZVotes && {
+      [config.Strategies.OZVotes]: 'ERC-20 Votes (EIP-5805)'
+    }),
+    ...(config.Strategies.Whitelist && {
+      [config.Strategies.Whitelist]: 'Merkle whitelist'
+    }),
     ...(config.Strategies.ApeGas && {
       [config.Strategies.ApeGas]: 'ApeChain Delegated Gas'
     })
@@ -141,380 +175,417 @@ export function createConstants(
   };
 
   const EDITOR_AUTHENTICATORS = [
-    {
-      address: config.Authenticators.EthTx,
-      name: 'Ethereum transaction',
-      about:
-        'Will authenticate a user by checking if the caller address corresponds to the author or voter address.',
-      icon: IHCube,
-      paramsDefinition: null
-    },
-    {
-      // Deprecated because of missing EIP-1271 support, superseded by EthSigV2
-      address: config.Authenticators.EthSig,
-      name: 'Ethereum signature (deprecated)',
-      deprecated: true,
-      about:
-        'Will authenticate a user based on an EIP-712 message signed by an Ethereum private key.',
-      icon: IHPencil,
-      paramsDefinition: null
-    },
-    {
-      address: config.Authenticators.EthSigV2,
-      name: 'Ethereum signature',
-      about:
-        'Will authenticate a user based on an EIP-712 message signed by an Ethereum private key.',
-      icon: IHPencil,
-      paramsDefinition: null
-    }
+    ...(config.Authenticators.EthTx
+      ? [
+          {
+            address: config.Authenticators.EthTx,
+            name: 'Ethereum transaction',
+            about:
+              'Will authenticate a user by checking if the caller address corresponds to the author or voter address.',
+            icon: IHCube,
+            paramsDefinition: null
+          }
+        ]
+      : []),
+    ...(config.Authenticators.EthSig
+      ? [
+          {
+            // Deprecated because of missing EIP-1271 support, superseded by EthSigV2
+            address: config.Authenticators.EthSig,
+            name: 'Ethereum signature (deprecated)',
+            deprecated: true,
+            about:
+              'Will authenticate a user based on an EIP-712 message signed by an Ethereum private key.',
+            icon: IHPencil,
+            paramsDefinition: null
+          }
+        ]
+      : []),
+    ...(config.Authenticators.EthSigV2
+      ? [
+          {
+            address: config.Authenticators.EthSigV2,
+            name: 'Ethereum signature',
+            about:
+              'Will authenticate a user based on an EIP-712 message signed by an Ethereum private key.',
+            icon: IHPencil,
+            paramsDefinition: null
+          }
+        ]
+      : [])
   ];
 
   const EDITOR_PROPOSAL_VALIDATIONS = [
-    {
-      address: config.ProposalValidations.VotingPower,
-      type: 'VotingPower',
-      name: 'Voting power',
-      icon: IHLightningBolt,
-      validate: (params: Record<string, any>) => {
-        return params?.strategies?.length > 0;
-      },
-      generateSummary: (params: Record<string, any>) => `(${params.threshold})`,
-      generateParams: async (params: Record<string, any>) => {
-        const abiCoder = new AbiCoder();
+    ...(config.ProposalValidations.VotingPower
+      ? [
+          {
+            address: config.ProposalValidations.VotingPower,
+            type: 'VotingPower',
+            name: 'Voting power',
+            icon: IHLightningBolt,
+            validate: (params: Record<string, any>) => {
+              return params?.strategies?.length > 0;
+            },
+            generateSummary: (params: Record<string, any>) =>
+              `(${params.threshold})`,
+            generateParams: async (params: Record<string, any>) => {
+              const abiCoder = new AbiCoder();
 
-        const strategies = await Promise.all(
-          params.strategies.map(async (strategy: StrategyConfig) => {
-            return {
-              addr: strategy.address,
-              params: strategy.generateParams
-                ? (await strategy.generateParams(strategy.params))[0]
-                : '0x00'
-            };
-          })
-        );
+              const strategies = await Promise.all(
+                params.strategies.map(async (strategy: StrategyConfig) => {
+                  return {
+                    addr: strategy.address,
+                    params: strategy.generateParams
+                      ? (await strategy.generateParams(strategy.params))[0]
+                      : '0x00'
+                  };
+                })
+              );
 
-        return [
-          abiCoder.encode(
-            ['uint256', 'tuple(address addr, bytes params)[]'],
-            [params.threshold, strategies]
-          )
-        ];
-      },
-      generateMetadata: async (params: Record<string, any>) => {
-        const strategiesMetadata = await Promise.all(
-          params.strategies.map(async (strategy: StrategyConfig) => {
-            if (!strategy.generateMetadata) return;
+              return [
+                abiCoder.encode(
+                  ['uint256', 'tuple(address addr, bytes params)[]'],
+                  [params.threshold, strategies]
+                )
+              ];
+            },
+            generateMetadata: async (params: Record<string, any>) => {
+              const strategiesMetadata = await Promise.all(
+                params.strategies.map(async (strategy: StrategyConfig) => {
+                  if (!strategy.generateMetadata) return;
 
-            const metadata = await strategy.generateMetadata(strategy.params);
-            const pinned = await pin(metadata);
+                  const metadata = await strategy.generateMetadata(
+                    strategy.params
+                  );
+                  const pinned = await pin(metadata);
 
-            return `ipfs://${pinned.cid}`;
-          })
-        );
+                  return `ipfs://${pinned.cid}`;
+                })
+              );
 
-        return {
-          strategies_metadata: strategiesMetadata
-        };
-      },
-      parseParams: async (params: string) => {
-        const abiCoder = new AbiCoder();
+              return {
+                strategies_metadata: strategiesMetadata
+              };
+            },
+            parseParams: async (params: string) => {
+              const abiCoder = new AbiCoder();
 
-        return {
-          threshold: abiCoder
-            .decode(
-              ['uint256', 'tuple(address addr, bytes params)[]'],
-              params
-            )[0]
-            .toString()
-        };
-      },
-      paramsDefinition: {
-        type: 'object',
-        title: 'Params',
-        additionalProperties: false,
-        required: ['threshold'],
-        properties: {
-          threshold: {
-            type: 'string',
-            format: 'uint256',
-            title: 'Proposal threshold',
-            examples: ['1']
+              return {
+                threshold: abiCoder
+                  .decode(
+                    ['uint256', 'tuple(address addr, bytes params)[]'],
+                    params
+                  )[0]
+                  .toString()
+              };
+            },
+            paramsDefinition: {
+              type: 'object',
+              title: 'Params',
+              additionalProperties: false,
+              required: ['threshold'],
+              properties: {
+                threshold: {
+                  type: 'string',
+                  format: 'uint256',
+                  title: 'Proposal threshold',
+                  examples: ['1']
+                }
+              }
+            }
           }
-        }
-      }
-    }
+        ]
+      : [])
   ];
 
   const EDITOR_VOTING_STRATEGIES = [
-    {
-      address: config.Strategies.Vanilla,
-      name: 'Vanilla',
-      about:
-        'A strategy that gives one voting power to anyone. It should only be used for testing purposes and not in production.',
-      link: `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#vanilla`,
-      icon: IHBeaker,
-      generateMetadata: async (params: Record<string, any>) => ({
-        name: 'Vanilla',
-        properties: {
-          symbol: params.symbol,
-          decimals: 0
-        }
-      }),
-      parseParams: async (
-        params: string,
-        metadata: StrategyParsedMetadata | null
-      ) => {
-        if (!metadata) throw new Error('Missing metadata');
+    ...(config.Strategies.Vanilla
+      ? [
+          {
+            address: config.Strategies.Vanilla,
+            name: 'Vanilla',
+            about:
+              'A strategy that gives one voting power to anyone. It should only be used for testing purposes and not in production.',
+            link: `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#vanilla`,
+            icon: IHBeaker,
+            generateMetadata: async (params: Record<string, any>) => ({
+              name: 'Vanilla',
+              properties: {
+                symbol: params.symbol,
+                decimals: 0
+              }
+            }),
+            parseParams: async (
+              params: string,
+              metadata: StrategyParsedMetadata | null
+            ) => {
+              if (!metadata) throw new Error('Missing metadata');
 
-        return {
-          symbol: metadata.symbol
-        };
-      },
-      paramsDefinition: {
-        type: 'object',
-        title: 'Params',
-        additionalProperties: false,
-        required: [],
-        properties: {
-          symbol: {
-            type: 'string',
-            maxLength: MAX_SYMBOL_LENGTH,
-            title: 'Symbol',
-            examples: ['e.g. VP']
+              return {
+                symbol: metadata.symbol
+              };
+            },
+            paramsDefinition: {
+              type: 'object',
+              title: 'Params',
+              additionalProperties: false,
+              required: [],
+              properties: {
+                symbol: {
+                  type: 'string',
+                  maxLength: MAX_SYMBOL_LENGTH,
+                  title: 'Symbol',
+                  examples: ['e.g. VP']
+                }
+              }
+            }
           }
-        }
-      }
-    },
-    {
-      address: config.Strategies.Whitelist,
-      type: 'MerkleWhitelist',
-      name: 'Whitelist',
-      about:
-        'A strategy that defines a list of addresses each with designated voting power, using a Merkle tree for verification.',
-      link: `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#whitelist`,
-      generateSummary: (params: Record<string, any>) => {
-        const length =
-          params.whitelist.trim().length === 0
-            ? 0
-            : params.whitelist
+        ]
+      : []),
+    ...(config.Strategies.Whitelist
+      ? [
+          {
+            address: config.Strategies.Whitelist,
+            type: 'MerkleWhitelist',
+            name: 'Whitelist',
+            about:
+              'A strategy that defines a list of addresses each with designated voting power, using a Merkle tree for verification.',
+            link: `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#whitelist`,
+            generateSummary: (params: Record<string, any>) => {
+              const length =
+                params.whitelist.trim().length === 0
+                  ? 0
+                  : params.whitelist
+                      .split(/[\n,]/)
+                      .filter((s: string) => s.trim().length).length;
+
+              return `(${length} ${length === 1 ? 'address' : 'addresses'})`;
+            },
+            generateParams: async (params: Record<string, any>) => {
+              const entries = params.whitelist
                 .split(/[\n,]/)
-                .filter((s: string) => s.trim().length).length;
+                .map((s: string) => s.trim())
+                .filter((s: string) => s.length);
 
-        return `(${length} ${length === 1 ? 'address' : 'addresses'})`;
-      },
-      generateParams: async (params: Record<string, any>) => {
-        const entries = params.whitelist
-          .split(/[\n,]/)
-          .map((s: string) => s.trim())
-          .filter((s: string) => s.length);
+              const requestId = await generateMerkleTree({
+                network: 'evm',
+                entries
+              });
 
-        const requestId = await generateMerkleTree({
-          network: 'evm',
-          entries
-        });
+              await sleep(500);
 
-        await sleep(500);
+              while (true) {
+                const root = await getMerkleRoot({
+                  requestId
+                });
 
-        while (true) {
-          const root = await getMerkleRoot({
-            requestId
-          });
+                if (root) {
+                  const abiCoder = new AbiCoder();
+                  return [abiCoder.encode(['bytes32'], [root])];
+                }
 
-          if (root) {
-            const abiCoder = new AbiCoder();
-            return [abiCoder.encode(['bytes32'], [root])];
+                await sleep(5000);
+              }
+            },
+            generateMetadata: async (params: Record<string, any>) => {
+              const tree = params.whitelist
+                .split(/[\n,]/)
+                .filter((s: string) => s.trim().length)
+                .map((item: string) => {
+                  const [address, votingPower] = item
+                    .split(':')
+                    .map(s => s.trim());
+
+                  return {
+                    address,
+                    votingPower: votingPower
+                  };
+                });
+
+              const pinned = await pin({ tree });
+
+              return {
+                name: 'Whitelist',
+                properties: {
+                  symbol: params.symbol,
+                  decimals: 0,
+                  payload: `ipfs://${pinned.cid}`
+                }
+              };
+            },
+            parseParams: async (
+              params: string,
+              metadata: StrategyParsedMetadata | null
+            ) => {
+              if (!metadata) throw new Error('Missing metadata');
+
+              const getWhitelist = async (payload: string) => {
+                const metadataUrl = getUrl(payload);
+
+                if (!metadataUrl) return '';
+
+                const res = await fetch(metadataUrl);
+                const { tree } = await res.json();
+                return tree
+                  .map((item: any) => `${item.address}:${item.votingPower}`)
+                  .join('\n');
+              };
+
+              return {
+                symbol: metadata.symbol,
+                whitelist: metadata.payload
+                  ? await getWhitelist(metadata.payload)
+                  : ''
+              };
+            },
+            paramsDefinition: {
+              type: 'object',
+              title: 'Params',
+              additionalProperties: false,
+              required: ['whitelist'],
+              properties: {
+                whitelist: {
+                  type: 'string',
+                  format: 'addresses-with-voting-power',
+                  title: 'Whitelist',
+                  examples: ['0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70:40']
+                },
+                symbol: {
+                  type: 'string',
+                  maxLength: 6,
+                  title: 'Symbol',
+                  examples: ['e.g. VP']
+                }
+              }
+            }
           }
+        ]
+      : []),
+    ...(config.Strategies.OZVotes
+      ? [
+          {
+            address: config.Strategies.OZVotes,
+            name: 'ERC-20 Votes (EIP-5805)',
+            about:
+              'A strategy that allows delegated balances of OpenZeppelin style checkpoint tokens to be used as voting power.',
+            link: `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#erc-20-votes-eip-5805`,
+            icon: IHCode,
+            generateSummary: (params: Record<string, any>) =>
+              `(${shorten(params.contractAddress)}, ${params.decimals})`,
+            generateParams: async (params: Record<string, any>) => [
+              params.contractAddress
+            ],
+            generateMetadata: async (params: Record<string, any>) => ({
+              name: 'ERC-20 Votes (EIP-5805)',
+              properties: {
+                symbol: params.symbol,
+                decimals: parseInt(params.decimals),
+                token: params.contractAddress
+              }
+            }),
+            parseParams: async (
+              params: string,
+              metadata: StrategyParsedMetadata | null
+            ) => {
+              if (!metadata) throw new Error('Missing metadata');
 
-          await sleep(5000);
-        }
-      },
-      generateMetadata: async (params: Record<string, any>) => {
-        const tree = params.whitelist
-          .split(/[\n,]/)
-          .filter((s: string) => s.trim().length)
-          .map((item: string) => {
-            const [address, votingPower] = item.split(':').map(s => s.trim());
-
-            return {
-              address,
-              votingPower: votingPower
-            };
-          });
-
-        const pinned = await pin({ tree });
-
-        return {
-          name: 'Whitelist',
-          properties: {
-            symbol: params.symbol,
-            decimals: 0,
-            payload: `ipfs://${pinned.cid}`
+              return {
+                contractAddress: metadata.token,
+                decimals: metadata.decimals,
+                symbol: metadata.symbol
+              };
+            },
+            paramsDefinition: {
+              type: 'object',
+              title: 'Params',
+              additionalProperties: false,
+              required: ['contractAddress', 'decimals'],
+              properties: {
+                contractAddress: {
+                  type: 'string',
+                  format: 'address',
+                  chainId: config.Meta.eip712ChainId,
+                  title: 'Token address',
+                  examples: ['0x0000…']
+                },
+                decimals: {
+                  type: 'integer',
+                  title: 'Decimals',
+                  examples: ['18']
+                },
+                symbol: {
+                  type: 'string',
+                  maxLength: MAX_SYMBOL_LENGTH,
+                  title: 'Symbol',
+                  examples: ['e.g. UNI']
+                }
+              }
+            }
           }
-        };
-      },
-      parseParams: async (
-        params: string,
-        metadata: StrategyParsedMetadata | null
-      ) => {
-        if (!metadata) throw new Error('Missing metadata');
+        ]
+      : []),
+    ...(config.Strategies.Comp
+      ? [
+          {
+            address: config.Strategies.Comp,
+            name: 'ERC-20 Votes Comp (EIP-5805)',
+            about:
+              'A strategy that allows delegated balances of Compound style checkpoint tokens to be used as voting power.',
+            icon: IHCode,
+            generateSummary: (params: Record<string, any>) =>
+              `(${shorten(params.contractAddress)}, ${params.decimals})`,
+            generateParams: async (params: Record<string, any>) => [
+              params.contractAddress
+            ],
+            generateMetadata: async (params: Record<string, any>) => ({
+              name: 'ERC-20 Votes Comp (EIP-5805)',
+              properties: {
+                symbol: params.symbol,
+                decimals: parseInt(params.decimals),
+                token: params.contractAddress
+              }
+            }),
+            parseParams: async (
+              params: string,
+              metadata: StrategyParsedMetadata | null
+            ) => {
+              if (!metadata) throw new Error('Missing metadata');
 
-        const getWhitelist = async (payload: string) => {
-          const metadataUrl = getUrl(payload);
-
-          if (!metadataUrl) return '';
-
-          const res = await fetch(metadataUrl);
-          const { tree } = await res.json();
-          return tree
-            .map((item: any) => `${item.address}:${item.votingPower}`)
-            .join('\n');
-        };
-
-        return {
-          symbol: metadata.symbol,
-          whitelist: metadata.payload
-            ? await getWhitelist(metadata.payload)
-            : ''
-        };
-      },
-      paramsDefinition: {
-        type: 'object',
-        title: 'Params',
-        additionalProperties: false,
-        required: ['whitelist'],
-        properties: {
-          whitelist: {
-            type: 'string',
-            format: 'addresses-with-voting-power',
-            title: 'Whitelist',
-            examples: ['0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70:40']
-          },
-          symbol: {
-            type: 'string',
-            maxLength: 6,
-            title: 'Symbol',
-            examples: ['e.g. VP']
+              return {
+                contractAddress: metadata.token,
+                decimals: metadata.decimals,
+                symbol: metadata.symbol
+              };
+            },
+            paramsDefinition: {
+              type: 'object',
+              title: 'Params',
+              additionalProperties: false,
+              required: ['contractAddress', 'decimals'],
+              properties: {
+                contractAddress: {
+                  type: 'string',
+                  format: 'address',
+                  chainId: config.Meta.eip712ChainId,
+                  title: 'Token address',
+                  examples: ['0x0000…']
+                },
+                decimals: {
+                  type: 'integer',
+                  title: 'Decimals',
+                  examples: ['18']
+                },
+                symbol: {
+                  type: 'string',
+                  maxLength: MAX_SYMBOL_LENGTH,
+                  title: 'Symbol',
+                  examples: ['e.g. UNI']
+                }
+              }
+            }
           }
-        }
-      }
-    },
-    {
-      address: config.Strategies.OZVotes,
-      name: 'ERC-20 Votes (EIP-5805)',
-      about:
-        'A strategy that allows delegated balances of OpenZeppelin style checkpoint tokens to be used as voting power.',
-      link: `${DOCS_URL}/snapshot-x/user-guides/voting-strategies-sx#erc-20-votes-eip-5805`,
-      icon: IHCode,
-      generateSummary: (params: Record<string, any>) =>
-        `(${shorten(params.contractAddress)}, ${params.decimals})`,
-      generateParams: async (params: Record<string, any>) => [
-        params.contractAddress
-      ],
-      generateMetadata: async (params: Record<string, any>) => ({
-        name: 'ERC-20 Votes (EIP-5805)',
-        properties: {
-          symbol: params.symbol,
-          decimals: parseInt(params.decimals),
-          token: params.contractAddress
-        }
-      }),
-      parseParams: async (
-        params: string,
-        metadata: StrategyParsedMetadata | null
-      ) => {
-        if (!metadata) throw new Error('Missing metadata');
-
-        return {
-          contractAddress: metadata.token,
-          decimals: metadata.decimals,
-          symbol: metadata.symbol
-        };
-      },
-      paramsDefinition: {
-        type: 'object',
-        title: 'Params',
-        additionalProperties: false,
-        required: ['contractAddress', 'decimals'],
-        properties: {
-          contractAddress: {
-            type: 'string',
-            format: 'address',
-            chainId: config.Meta.eip712ChainId,
-            title: 'Token address',
-            examples: ['0x0000…']
-          },
-          decimals: {
-            type: 'integer',
-            title: 'Decimals',
-            examples: ['18']
-          },
-          symbol: {
-            type: 'string',
-            maxLength: MAX_SYMBOL_LENGTH,
-            title: 'Symbol',
-            examples: ['e.g. UNI']
-          }
-        }
-      }
-    },
-    {
-      address: config.Strategies.Comp,
-      name: 'ERC-20 Votes Comp (EIP-5805)',
-      about:
-        'A strategy that allows delegated balances of Compound style checkpoint tokens to be used as voting power.',
-      icon: IHCode,
-      generateSummary: (params: Record<string, any>) =>
-        `(${shorten(params.contractAddress)}, ${params.decimals})`,
-      generateParams: async (params: Record<string, any>) => [
-        params.contractAddress
-      ],
-      generateMetadata: async (params: Record<string, any>) => ({
-        name: 'ERC-20 Votes Comp (EIP-5805)',
-        properties: {
-          symbol: params.symbol,
-          decimals: parseInt(params.decimals),
-          token: params.contractAddress
-        }
-      }),
-      parseParams: async (
-        params: string,
-        metadata: StrategyParsedMetadata | null
-      ) => {
-        if (!metadata) throw new Error('Missing metadata');
-
-        return {
-          contractAddress: metadata.token,
-          decimals: metadata.decimals,
-          symbol: metadata.symbol
-        };
-      },
-      paramsDefinition: {
-        type: 'object',
-        title: 'Params',
-        additionalProperties: false,
-        required: ['contractAddress', 'decimals'],
-        properties: {
-          contractAddress: {
-            type: 'string',
-            format: 'address',
-            chainId: config.Meta.eip712ChainId,
-            title: 'Token address',
-            examples: ['0x0000…']
-          },
-          decimals: {
-            type: 'integer',
-            title: 'Decimals',
-            examples: ['18']
-          },
-          symbol: {
-            type: 'string',
-            maxLength: MAX_SYMBOL_LENGTH,
-            title: 'Symbol',
-            examples: ['e.g. UNI']
-          }
-        }
-      }
-    },
+        ]
+      : []),
     ...(config.Strategies.ApeGas
       ? [
           {
@@ -619,122 +690,130 @@ export function createConstants(
     );
 
   const EDITOR_EXECUTION_STRATEGIES = [
-    {
-      address: '',
-      type: 'SimpleQuorumAvatar',
-      name: EXECUTORS.SimpleQuorumAvatar,
-      about:
-        'An execution strategy that allows proposals to execute transactions from a specified target Safe contract.',
-      icon: IHUserCircle,
-      generateSummary: (params: Record<string, any>) =>
-        `(${params.quorum}, ${shorten(params.contractAddress)})`,
-      deploy: async (
-        client: clients.EvmEthereumTx,
-        web3: Web3Provider,
-        controller: string,
-        spaceAddress: string,
-        params: Record<string, any>
-      ): Promise<{ address: string; txId: string }> => {
-        return client.deployAvatarExecution({
-          signer: web3.getSigner(),
-          params: {
-            controller: params.controller,
-            target: params.contractAddress,
-            spaces: [spaceAddress],
-            quorum: BigInt(params.quorum)
+    ...(config.ExecutionStrategies.SimpleQuorumAvatar
+      ? [
+          {
+            address: '',
+            type: 'SimpleQuorumAvatar',
+            name: EXECUTORS.SimpleQuorumAvatar,
+            about:
+              'An execution strategy that allows proposals to execute transactions from a specified target Safe contract.',
+            icon: IHUserCircle,
+            generateSummary: (params: Record<string, any>) =>
+              `(${params.quorum}, ${shorten(params.contractAddress)})`,
+            deploy: async (
+              client: clients.EvmEthereumTx,
+              web3: Web3Provider,
+              controller: string,
+              spaceAddress: string,
+              params: Record<string, any>
+            ): Promise<{ address: string; txId: string }> => {
+              return client.deployAvatarExecution({
+                signer: web3.getSigner(),
+                params: {
+                  controller: params.controller,
+                  target: params.contractAddress,
+                  spaces: [spaceAddress],
+                  quorum: BigInt(params.quorum)
+                }
+              });
+            },
+            paramsDefinition: {
+              type: 'object',
+              title: 'Params',
+              additionalProperties: false,
+              required: ['controller', 'quorum', 'contractAddress'],
+              properties: {
+                controller: {
+                  type: 'string',
+                  format: 'address',
+                  chainId: config.Meta.eip712ChainId,
+                  title: 'Controller address',
+                  examples: ['0x0000…']
+                },
+                quorum: {
+                  type: 'integer',
+                  title: 'Quorum',
+                  examples: ['1']
+                },
+                contractAddress: {
+                  type: 'string',
+                  format: 'address',
+                  chainId: config.Meta.eip712ChainId,
+                  title: 'Safe address',
+                  examples: ['0x0000…']
+                }
+              }
+            }
           }
-        });
-      },
-      paramsDefinition: {
-        type: 'object',
-        title: 'Params',
-        additionalProperties: false,
-        required: ['controller', 'quorum', 'contractAddress'],
-        properties: {
-          controller: {
-            type: 'string',
-            format: 'address',
-            chainId: config.Meta.eip712ChainId,
-            title: 'Controller address',
-            examples: ['0x0000…']
-          },
-          quorum: {
-            type: 'integer',
-            title: 'Quorum',
-            examples: ['1']
-          },
-          contractAddress: {
-            type: 'string',
-            format: 'address',
-            chainId: config.Meta.eip712ChainId,
-            title: 'Safe address',
-            examples: ['0x0000…']
+        ]
+      : []),
+    ...(config.ExecutionStrategies.SimpleQuorumTimelock
+      ? [
+          {
+            address: '',
+            type: 'SimpleQuorumTimelock',
+            name: EXECUTORS.SimpleQuorumTimelock,
+            about:
+              'Timelock implementation with a specified delay that queues proposal transactions for execution and includes an optional role to veto queued proposals.',
+            icon: IHClock,
+            generateSummary: (params: Record<string, any>) =>
+              `(${params.quorum}, ${params.timelockDelay})`,
+            deploy: async (
+              client: clients.EvmEthereumTx,
+              web3: Web3Provider,
+              controller: string,
+              spaceAddress: string,
+              params: Record<string, any>
+            ): Promise<{ address: string; txId: string }> => {
+              return client.deployTimelockExecution({
+                signer: web3.getSigner(),
+                params: {
+                  controller: params.controller,
+                  vetoGuardian:
+                    params.vetoGuardian ||
+                    '0x0000000000000000000000000000000000000000',
+                  spaces: [spaceAddress],
+                  timelockDelay: BigInt(params.timelockDelay),
+                  quorum: BigInt(params.quorum)
+                }
+              });
+            },
+            paramsDefinition: {
+              type: 'object',
+              title: 'Params',
+              additionalProperties: false,
+              required: ['controller', 'quorum', 'timelockDelay'],
+              properties: {
+                controller: {
+                  type: 'string',
+                  format: 'address',
+                  chainId: config.Meta.eip712ChainId,
+                  title: 'Controller address',
+                  examples: ['0x0000…']
+                },
+                quorum: {
+                  type: 'integer',
+                  title: 'Quorum',
+                  examples: ['1']
+                },
+                vetoGuardian: {
+                  type: 'string',
+                  format: 'address',
+                  chainId: config.Meta.eip712ChainId,
+                  title: 'Veto guardian address',
+                  examples: ['0x0000…']
+                },
+                timelockDelay: {
+                  type: 'integer',
+                  format: 'duration',
+                  title: 'Timelock delay'
+                }
+              }
+            }
           }
-        }
-      }
-    },
-    {
-      address: '',
-      type: 'SimpleQuorumTimelock',
-      name: EXECUTORS.SimpleQuorumTimelock,
-      about:
-        'Timelock implementation with a specified delay that queues proposal transactions for execution and includes an optional role to veto queued proposals.',
-      icon: IHClock,
-      generateSummary: (params: Record<string, any>) =>
-        `(${params.quorum}, ${params.timelockDelay})`,
-      deploy: async (
-        client: clients.EvmEthereumTx,
-        web3: Web3Provider,
-        controller: string,
-        spaceAddress: string,
-        params: Record<string, any>
-      ): Promise<{ address: string; txId: string }> => {
-        return client.deployTimelockExecution({
-          signer: web3.getSigner(),
-          params: {
-            controller: params.controller,
-            vetoGuardian:
-              params.vetoGuardian ||
-              '0x0000000000000000000000000000000000000000',
-            spaces: [spaceAddress],
-            timelockDelay: BigInt(params.timelockDelay),
-            quorum: BigInt(params.quorum)
-          }
-        });
-      },
-      paramsDefinition: {
-        type: 'object',
-        title: 'Params',
-        additionalProperties: false,
-        required: ['controller', 'quorum', 'timelockDelay'],
-        properties: {
-          controller: {
-            type: 'string',
-            format: 'address',
-            chainId: config.Meta.eip712ChainId,
-            title: 'Controller address',
-            examples: ['0x0000…']
-          },
-          quorum: {
-            type: 'integer',
-            title: 'Quorum',
-            examples: ['1']
-          },
-          vetoGuardian: {
-            type: 'string',
-            format: 'address',
-            chainId: config.Meta.eip712ChainId,
-            title: 'Veto guardian address',
-            examples: ['0x0000…']
-          },
-          timelockDelay: {
-            type: 'integer',
-            format: 'duration',
-            title: 'Timelock delay'
-          }
-        }
-      }
-    }
+        ]
+      : [])
   ];
 
   const EDITOR_VOTING_TYPES: VoteType[] = ['basic'];

--- a/packages/sx.js/src/evmNetworks.ts
+++ b/packages/sx.js/src/evmNetworks.ts
@@ -1,99 +1,122 @@
 import { BigNumberish } from '@ethersproject/bignumber';
+import { buildRegistry } from './registry';
 import { EvmNetworkConfig } from './types';
 
-type AdditionalProperties = {
+type AddressOverride = string | null;
+
+type Overrides = {
   blockTime: number;
   hasNonNativeBlockNumbers?: boolean;
   maxPriorityFeePerGas?: BigNumberish;
-  authenticators?: Record<string, string>;
+  proxyFactory?: string;
+  masterSpace?: string;
+  authenticators?: {
+    EthSig?: AddressOverride;
+    EthSigV2?: AddressOverride;
+    EthTx?: AddressOverride;
+  };
   strategies?: {
+    Vanilla?: AddressOverride;
+    Comp?: AddressOverride;
+    OZVotes?: AddressOverride;
+    Whitelist?: AddressOverride;
     ApeGas?: string;
+  };
+  proposalValidations?: {
+    VotingPower?: AddressOverride;
+  };
+  executionStrategies?: {
+    SimpleQuorumAvatar?: AddressOverride;
+    SimpleQuorumTimelock?: AddressOverride;
   };
 };
 
-function createStandardConfig(
+function resolveAddress(
+  override: AddressOverride | undefined,
+  defaultAddress: string
+): string | undefined {
+  if (override === null) return undefined;
+
+  return override ?? defaultAddress;
+}
+
+export function createStandardConfig(
   eip712ChainId: number,
-  additionalProperties: AdditionalProperties
+  overrides: Overrides
 ) {
-  const additionalAuthenticators = additionalProperties.authenticators || {};
-  const additionalStrategies = additionalProperties.strategies || {};
+  const {
+    authenticators = {},
+    strategies = {},
+    proposalValidations = {},
+    executionStrategies = {}
+  } = overrides;
 
   return {
     Meta: {
       eip712ChainId,
-      maxPriorityFeePerGas: additionalProperties.maxPriorityFeePerGas,
-      blockTime: additionalProperties.blockTime,
-      hasNonNativeBlockNumbers: additionalProperties.hasNonNativeBlockNumbers,
-      proxyFactory: '0x4B4F7f64Be813Ccc66AEFC3bFCe2baA01188631c',
-      masterSpace: '0xC3031A7d3326E47D49BfF9D374d74f364B29CE4D'
+      maxPriorityFeePerGas: overrides.maxPriorityFeePerGas,
+      blockTime: overrides.blockTime,
+      hasNonNativeBlockNumbers: overrides.hasNonNativeBlockNumbers,
+      proxyFactory:
+        overrides.proxyFactory ?? '0x4B4F7f64Be813Ccc66AEFC3bFCe2baA01188631c',
+      masterSpace:
+        overrides.masterSpace ?? '0xC3031A7d3326E47D49BfF9D374d74f364B29CE4D'
     },
     Authenticators: {
-      EthSig: '0x5f9B7D78c9a37a439D78f801E0E339C6E711e260',
-      EthSigV2: '0x95CF9B585fDb12DeB78002B5643dFF8fe67a496D',
-      EthTx: '0xBA06E6cCb877C332181A6867c05c8b746A21Aed1',
-      ...additionalAuthenticators
+      EthSig: resolveAddress(
+        authenticators.EthSig,
+        '0x5f9B7D78c9a37a439D78f801E0E339C6E711e260'
+      ),
+      EthSigV2: resolveAddress(
+        authenticators.EthSigV2,
+        '0x95CF9B585fDb12DeB78002B5643dFF8fe67a496D'
+      ),
+      EthTx: resolveAddress(
+        authenticators.EthTx,
+        '0xBA06E6cCb877C332181A6867c05c8b746A21Aed1'
+      )
     },
     Strategies: {
-      Vanilla: '0xC1245C5DCa7885C73E32294140F1e5d30688c202',
-      Comp: '0x0c2De612982Efd102803161fc7C74CcA15Db932c',
-      OZVotes: '0x2c8631584474E750CEdF2Fb6A904f2e84777Aefe',
-      Whitelist: '0x34f0AfFF5A739bBf3E285615F50e40ddAaf2A829',
-      ...additionalStrategies
+      Vanilla: resolveAddress(
+        strategies.Vanilla,
+        '0xC1245C5DCa7885C73E32294140F1e5d30688c202'
+      ),
+      Comp: resolveAddress(
+        strategies.Comp,
+        '0x0c2De612982Efd102803161fc7C74CcA15Db932c'
+      ),
+      OZVotes: resolveAddress(
+        strategies.OZVotes,
+        '0x2c8631584474E750CEdF2Fb6A904f2e84777Aefe'
+      ),
+      Whitelist: resolveAddress(
+        strategies.Whitelist,
+        '0x34f0AfFF5A739bBf3E285615F50e40ddAaf2A829'
+      ),
+      ApeGas: strategies.ApeGas
     },
     ProposalValidations: {
-      VotingPower: '0x6D9d6D08EF6b26348Bd18F1FC8D953696b7cf311'
+      VotingPower: resolveAddress(
+        proposalValidations.VotingPower,
+        '0x6D9d6D08EF6b26348Bd18F1FC8D953696b7cf311'
+      )
     },
     ExecutionStrategies: {
-      SimpleQuorumAvatar: '0xecE4f6b01a2d7FF5A9765cA44162D453fC455e42',
-      SimpleQuorumTimelock: '0xf2A1C2f2098161af98b2Cc7E382AB7F3ba86Ebc4'
+      SimpleQuorumAvatar: resolveAddress(
+        executionStrategies.SimpleQuorumAvatar,
+        '0xecE4f6b01a2d7FF5A9765cA44162D453fC455e42'
+      ),
+      SimpleQuorumTimelock: resolveAddress(
+        executionStrategies.SimpleQuorumTimelock,
+        '0xf2A1C2f2098161af98b2Cc7E382AB7F3ba86Ebc4'
+      )
     }
   };
 }
 
-function createEvmConfig(
-  networkId: keyof typeof evmNetworks
+export function createEvmConfig(
+  network: ReturnType<typeof createStandardConfig>
 ): EvmNetworkConfig {
-  const network = evmNetworks[networkId];
-
-  const authenticators = {
-    [network.Authenticators.EthSig]: {
-      type: 'ethSig'
-    },
-    [network.Authenticators.EthSigV2]: {
-      type: 'ethSigV2'
-    },
-    [network.Authenticators.EthTx]: {
-      type: 'ethTx'
-    }
-  } as const;
-
-  const strategies = {
-    [network.Strategies.Vanilla]: {
-      type: 'vanilla'
-    },
-    [network.Strategies.Comp]: {
-      type: 'comp'
-    },
-    [network.Strategies.OZVotes]: {
-      type: 'ozVotes'
-    },
-    [network.Strategies.Whitelist]: {
-      type: 'whitelist'
-    },
-    ...(network.Strategies.ApeGas
-      ? {
-          [network.Strategies.ApeGas]: {
-            type: 'apeGas' as const
-          }
-        }
-      : {})
-  } as const;
-
-  const executionStrategiesImplementations = {
-    SimpleQuorumAvatar: network.ExecutionStrategies.SimpleQuorumAvatar,
-    SimpleQuorumTimelock: network.ExecutionStrategies.SimpleQuorumTimelock
-  } as const;
-
   return {
     eip712ChainId: network.Meta.eip712ChainId,
     maxPriorityFeePerGas: network.Meta.maxPriorityFeePerGas,
@@ -101,9 +124,22 @@ function createEvmConfig(
     hasNonNativeBlockNumbers: network.Meta.hasNonNativeBlockNumbers,
     proxyFactory: network.Meta.proxyFactory,
     masterSpace: network.Meta.masterSpace,
-    authenticators,
-    strategies,
-    executionStrategiesImplementations
+    authenticators: buildRegistry([
+      [network.Authenticators.EthSig, { type: 'ethSig' }],
+      [network.Authenticators.EthSigV2, { type: 'ethSigV2' }],
+      [network.Authenticators.EthTx, { type: 'ethTx' }]
+    ]),
+    strategies: buildRegistry([
+      [network.Strategies.Vanilla, { type: 'vanilla' }],
+      [network.Strategies.Comp, { type: 'comp' }],
+      [network.Strategies.OZVotes, { type: 'ozVotes' }],
+      [network.Strategies.Whitelist, { type: 'whitelist' }],
+      [network.Strategies.ApeGas, { type: 'apeGas' }]
+    ]),
+    executionStrategiesImplementations: {
+      SimpleQuorumAvatar: network.ExecutionStrategies.SimpleQuorumAvatar,
+      SimpleQuorumTimelock: network.ExecutionStrategies.SimpleQuorumTimelock
+    }
   };
 }
 
@@ -149,14 +185,14 @@ export const evmNetworks = {
   })
 } as const;
 
-export const evmMainnet = createEvmConfig('eth');
-export const evmSepolia = createEvmConfig('sep');
-export const evmOptimism = createEvmConfig('oeth');
-export const evmPolygon = createEvmConfig('matic');
-export const evmArbitrum = createEvmConfig('arb1');
-export const evmBase = createEvmConfig('base');
-export const evmMantle = createEvmConfig('mnt');
-export const evmBnb = createEvmConfig('bnb');
-export const evmBnbt = createEvmConfig('bnbt');
-export const evmApe = createEvmConfig('ape');
-export const evmCurtis = createEvmConfig('curtis');
+export const evmMainnet = createEvmConfig(evmNetworks.eth);
+export const evmSepolia = createEvmConfig(evmNetworks.sep);
+export const evmOptimism = createEvmConfig(evmNetworks.oeth);
+export const evmPolygon = createEvmConfig(evmNetworks.matic);
+export const evmArbitrum = createEvmConfig(evmNetworks.arb1);
+export const evmBase = createEvmConfig(evmNetworks.base);
+export const evmMantle = createEvmConfig(evmNetworks.mnt);
+export const evmBnb = createEvmConfig(evmNetworks.bnb);
+export const evmBnbt = createEvmConfig(evmNetworks.bnbt);
+export const evmApe = createEvmConfig(evmNetworks.ape);
+export const evmCurtis = createEvmConfig(evmNetworks.curtis);

--- a/packages/sx.js/src/registry.ts
+++ b/packages/sx.js/src/registry.ts
@@ -1,0 +1,11 @@
+export function buildRegistry<const T>(
+  entries: [address: string | undefined, config: T][],
+  formatAddress: (address: string) => string = address => address
+): Record<string, T> {
+  const registry: Record<string, T> = {};
+  for (const [address, config] of entries) {
+    if (address) registry[formatAddress(address)] = config;
+  }
+
+  return registry;
+}

--- a/packages/sx.js/src/starknetNetworks.ts
+++ b/packages/sx.js/src/starknetNetworks.ts
@@ -1,96 +1,10 @@
 import { validateAndParseAddress } from 'starknet';
+import { buildRegistry } from './registry';
 import { NetworkConfig } from './types';
 
 function createStarknetConfig(
-  networkId: keyof typeof starknetNetworks
+  network: (typeof starknetNetworks)[keyof typeof starknetNetworks]
 ): NetworkConfig {
-  const network = starknetNetworks[networkId];
-
-  const authenticators = {
-    [validateAndParseAddress(network.Authenticators.Vanilla)]: {
-      type: 'vanilla'
-    },
-    [validateAndParseAddress(network.Authenticators.EthSig)]: {
-      type: 'ethSig'
-    },
-    [validateAndParseAddress(network.Authenticators.EthTx)]: {
-      type: 'ethTx'
-    },
-    [validateAndParseAddress(network.Authenticators.StarkSig)]: {
-      type: 'starkSig'
-    },
-    [validateAndParseAddress(network.Authenticators.StarkTx)]: {
-      type: 'starkTx'
-    }
-  } as const;
-
-  const strategies = {
-    [validateAndParseAddress(network.Strategies.MerkleWhitelist)]: {
-      type: 'whitelist'
-    },
-    [validateAndParseAddress(network.Strategies.ERC20Votes)]: {
-      type: 'erc20Votes'
-    },
-    ...(network.Strategies.EVMSlotValue
-      ? ({
-          [validateAndParseAddress(network.Strategies.EVMSlotValue)]: {
-            type: 'evmSlotValue'
-          }
-        } as const)
-      : {}),
-    ...(network.Strategies.OZVotesStorageProof
-      ? ({
-          [validateAndParseAddress(network.Strategies.OZVotesStorageProof)]: {
-            type: 'ozVotesStorageProof',
-            params: {
-              trace: 224
-            }
-          }
-        } as const)
-      : {}),
-    ...(network.Strategies.OZVotesTrace208StorageProof
-      ? ({
-          [validateAndParseAddress(
-            network.Strategies.OZVotesTrace208StorageProof
-          )]: {
-            type: 'ozVotesStorageProof',
-            params: {
-              trace: 208
-            }
-          }
-        } as const)
-      : {}),
-    ...(network.Strategies.EVMSlotValueV2
-      ? ({
-          [validateAndParseAddress(network.Strategies.EVMSlotValueV2)]: {
-            type: 'evmSlotValueV2'
-          }
-        } as const)
-      : {}),
-    ...(network.Strategies.OZVotesStorageProofV2
-      ? ({
-          [validateAndParseAddress(network.Strategies.OZVotesStorageProofV2)]: {
-            type: 'ozVotesStorageProofV2',
-            params: {
-              trace: 224
-            }
-          }
-        } as const)
-      : {}),
-    ...(network.Strategies.OZVotesTrace208StorageProofV2
-      ? ({
-          [validateAndParseAddress(
-            network.Strategies.OZVotesTrace208StorageProofV2
-          )]: {
-            type: 'ozVotesStorageProofV2',
-            params: {
-              trace: 208
-            }
-          }
-        } as const)
-      : {})
-  } as const;
-
   return {
     eip712ChainId: network.Meta.eip712ChainId,
     herodotusAccumulatesChainId: network.Meta.herodotusAccumulatesChainId,
@@ -103,8 +17,41 @@ function createStarknetConfig(
     starknetCommit: network.Meta.starknetCommit,
     starknetCore: network.Meta.starknetCore,
     feeEstimateOverride: network.Meta.feeEstimateOverride,
-    authenticators,
-    strategies
+    authenticators: buildRegistry(
+      [
+        [network.Authenticators.Vanilla, { type: 'vanilla' }],
+        [network.Authenticators.EthSig, { type: 'ethSig' }],
+        [network.Authenticators.EthTx, { type: 'ethTx' }],
+        [network.Authenticators.StarkSig, { type: 'starkSig' }],
+        [network.Authenticators.StarkTx, { type: 'starkTx' }]
+      ],
+      validateAndParseAddress
+    ),
+    strategies: buildRegistry(
+      [
+        [network.Strategies.MerkleWhitelist, { type: 'whitelist' }],
+        [network.Strategies.ERC20Votes, { type: 'erc20Votes' }],
+        [network.Strategies.EVMSlotValue, { type: 'evmSlotValue' }],
+        [
+          network.Strategies.OZVotesStorageProof,
+          { type: 'ozVotesStorageProof', params: { trace: 224 } }
+        ],
+        [
+          network.Strategies.OZVotesTrace208StorageProof,
+          { type: 'ozVotesStorageProof', params: { trace: 208 } }
+        ],
+        [network.Strategies.EVMSlotValueV2, { type: 'evmSlotValueV2' }],
+        [
+          network.Strategies.OZVotesStorageProofV2,
+          { type: 'ozVotesStorageProofV2', params: { trace: 224 } }
+        ],
+        [
+          network.Strategies.OZVotesTrace208StorageProofV2,
+          { type: 'ozVotesStorageProofV2', params: { trace: 208 } }
+        ]
+      ],
+      validateAndParseAddress
+    )
   };
 }
 
@@ -231,5 +178,9 @@ export const starknetNetworks = {
   }
 } as const;
 
-export const starknetMainnet: NetworkConfig = createStarknetConfig('sn');
-export const starknetSepolia: NetworkConfig = createStarknetConfig('sn-sep');
+export const starknetMainnet: NetworkConfig = createStarknetConfig(
+  starknetNetworks.sn
+);
+export const starknetSepolia: NetworkConfig = createStarknetConfig(
+  starknetNetworks['sn-sep']
+);

--- a/packages/sx.js/test/unit/evmNetworks.test.ts
+++ b/packages/sx.js/test/unit/evmNetworks.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createEvmConfig,
+  createStandardConfig,
+  evmNetworks
+} from '../../src/evmNetworks';
+
+describe('createStandardConfig', () => {
+  it('should return standard addresses by default', () => {
+    const config = createStandardConfig(1, { blockTime: 12 });
+
+    expect(config).toEqual({
+      Meta: {
+        eip712ChainId: 1,
+        maxPriorityFeePerGas: undefined,
+        blockTime: 12,
+        hasNonNativeBlockNumbers: undefined,
+        proxyFactory: '0x4B4F7f64Be813Ccc66AEFC3bFCe2baA01188631c',
+        masterSpace: '0xC3031A7d3326E47D49BfF9D374d74f364B29CE4D'
+      },
+      Authenticators: {
+        EthSig: '0x5f9B7D78c9a37a439D78f801E0E339C6E711e260',
+        EthSigV2: '0x95CF9B585fDb12DeB78002B5643dFF8fe67a496D',
+        EthTx: '0xBA06E6cCb877C332181A6867c05c8b746A21Aed1'
+      },
+      Strategies: {
+        Vanilla: '0xC1245C5DCa7885C73E32294140F1e5d30688c202',
+        Comp: '0x0c2De612982Efd102803161fc7C74CcA15Db932c',
+        OZVotes: '0x2c8631584474E750CEdF2Fb6A904f2e84777Aefe',
+        Whitelist: '0x34f0AfFF5A739bBf3E285615F50e40ddAaf2A829',
+        ApeGas: undefined
+      },
+      ProposalValidations: {
+        VotingPower: '0x6D9d6D08EF6b26348Bd18F1FC8D953696b7cf311'
+      },
+      ExecutionStrategies: {
+        SimpleQuorumAvatar: '0xecE4f6b01a2d7FF5A9765cA44162D453fC455e42',
+        SimpleQuorumTimelock: '0xf2A1C2f2098161af98b2Cc7E382AB7F3ba86Ebc4'
+      }
+    });
+  });
+
+  it('should apply overrides and disable nulled slots', () => {
+    const config = createStandardConfig(84532, {
+      blockTime: 2,
+      proxyFactory: '0xfDe801CFc7f9a931eB1CF026e60B08a366B13494',
+      masterSpace: '0x3F31D742D3158b07434A041e26B47e9EB94e010C',
+      authenticators: {
+        EthSig: '0x69A9c5626860f53f9b4fD5F2936d74eC93417677',
+        EthSigV2: null
+      },
+      strategies: {
+        Vanilla: '0xc501B2057E60CfD31559e4FD1e3134aF0BA9C673',
+        Comp: null,
+        OZVotes: null,
+        Whitelist: null
+      },
+      proposalValidations: {
+        VotingPower: null
+      },
+      executionStrategies: {
+        SimpleQuorumAvatar: null,
+        SimpleQuorumTimelock: null
+      }
+    });
+
+    expect(config.Meta.proxyFactory).toBe(
+      '0xfDe801CFc7f9a931eB1CF026e60B08a366B13494'
+    );
+    expect(config.Meta.masterSpace).toBe(
+      '0x3F31D742D3158b07434A041e26B47e9EB94e010C'
+    );
+    expect(config.Authenticators.EthSig).toBe(
+      '0x69A9c5626860f53f9b4fD5F2936d74eC93417677'
+    );
+    expect(config.Authenticators.EthSigV2).toBeUndefined();
+    expect(config.Authenticators.EthTx).toBe(
+      '0xBA06E6cCb877C332181A6867c05c8b746A21Aed1'
+    );
+    expect(config.Strategies.Vanilla).toBe(
+      '0xc501B2057E60CfD31559e4FD1e3134aF0BA9C673'
+    );
+    expect(config.Strategies.Comp).toBeUndefined();
+    expect(config.Strategies.OZVotes).toBeUndefined();
+    expect(config.Strategies.Whitelist).toBeUndefined();
+    expect(config.ProposalValidations.VotingPower).toBeUndefined();
+    expect(config.ExecutionStrategies.SimpleQuorumAvatar).toBeUndefined();
+    expect(config.ExecutionStrategies.SimpleQuorumTimelock).toBeUndefined();
+  });
+});
+
+describe('createEvmConfig', () => {
+  it('should build registries for standard networks', () => {
+    const evmConfig = createEvmConfig(evmNetworks.eth);
+
+    expect(evmConfig.authenticators).toEqual({
+      '0x5f9B7D78c9a37a439D78f801E0E339C6E711e260': { type: 'ethSig' },
+      '0x95CF9B585fDb12DeB78002B5643dFF8fe67a496D': { type: 'ethSigV2' },
+      '0xBA06E6cCb877C332181A6867c05c8b746A21Aed1': { type: 'ethTx' }
+    });
+    expect(evmConfig.strategies).toEqual({
+      '0xC1245C5DCa7885C73E32294140F1e5d30688c202': { type: 'vanilla' },
+      '0x0c2De612982Efd102803161fc7C74CcA15Db932c': { type: 'comp' },
+      '0x2c8631584474E750CEdF2Fb6A904f2e84777Aefe': { type: 'ozVotes' },
+      '0x34f0AfFF5A739bBf3E285615F50e40ddAaf2A829': { type: 'whitelist' }
+    });
+  });
+
+  it('should omit disabled slots from registries', () => {
+    const config = createStandardConfig(84532, {
+      blockTime: 2,
+      authenticators: { EthSigV2: null },
+      strategies: { Comp: null, OZVotes: null, Whitelist: null },
+      executionStrategies: {
+        SimpleQuorumAvatar: null,
+        SimpleQuorumTimelock: null
+      }
+    });
+
+    const evmConfig = createEvmConfig(config);
+
+    expect('undefined' in evmConfig.authenticators).toBe(false);
+    expect('undefined' in evmConfig.strategies).toBe(false);
+    expect(Object.keys(evmConfig.authenticators)).toEqual([
+      '0x5f9B7D78c9a37a439D78f801E0E339C6E711e260',
+      '0xBA06E6cCb877C332181A6867c05c8b746A21Aed1'
+    ]);
+    expect(Object.keys(evmConfig.strategies)).toEqual([
+      '0xC1245C5DCa7885C73E32294140F1e5d30688c202'
+    ]);
+    expect(
+      evmConfig.executionStrategiesImplementations.SimpleQuorumAvatar
+    ).toBeUndefined();
+    expect(
+      evmConfig.executionStrategiesImplementations.SimpleQuorumTimelock
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Summary

Some networks might (ideally temporarily) only part of standard contracts. In that case it becomes useful to initialize a network with only available contracts that will make the rest of unsupported contracts hidden in the interface.

Now createStandardNetwork accepts overrides. If some contract will be overriden as null it will be effecitvely deactived on that network.

To help with handling this we now also leverage buildRegistry helper that creates Object mapping for only those contracts that are non-null.

This will be used to integrate Inco where we will:
1. initially be missing some of the contracts on the network.
2. in the future there will be Inco specific variants of those contracts that won't be available outside of networks that support Inco.

### Test plan

1. Apply patch from below.
2. Go to http://localhost:8080/#/create/snapshot-x
3. Select Ethereum and go to Authenticators - you see both EthSig and EthTx authenticators.
4. Select Ethereum Sepolia and go to Authenticators - you only see EthTx authenticator.

```diff
diff --git a/packages/sx.js/src/evmNetworks.ts b/packages/sx.js/src/evmNetworks.ts
index b1addde2b..48f868e07 100644
--- a/packages/sx.js/src/evmNetworks.ts
+++ b/packages/sx.js/src/evmNetworks.ts
@@ -150,7 +150,10 @@ export const evmNetworks = {
   eth: createStandardConfig(1, { blockTime: ethMainnetBlockTime }),
   oeth: createStandardConfig(10, { blockTime: 2 }),
   sep: createStandardConfig(11155111, {
-    blockTime: ethSepoliaBlockTime
+    blockTime: ethSepoliaBlockTime,
+    authenticators: {
+      EthSigV2: null
+    }
   }),
   matic: createStandardConfig(137, { blockTime: 2 }),
   arb1: createStandardConfig(42161, {

```