### PR TITLE
chore(ui): rebuild UI dependencies when running bun dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "scripts": {
-    "dev": "TURBO_TELEMETRY_DISABLED=1 turbo run dev --filter=ui",
+    "dev": "TURBO_TELEMETRY_DISABLED=1 turbo run dev --filter=ui...",
     "dev:interactive": "node --experimental-strip-types --no-warnings=ExperimentalWarning ./scripts/dev-interactive.ts",
     "dev:electron": "TURBO_TELEMETRY_DISABLED=1 turbo run dev:electron",
     "build": "TURBO_TELEMETRY_DISABLED=1 turbo run build --filter=!auction",


### PR DESCRIPTION
### Summary

After https://github.com/snapshot-labs/sx-monorepo/pull/2091 bun dev only runs UI and ignores its dependencies (sx.js).

We need to also watch its dependencies to rebuild them as they change so full restart is not needed when modifying sx.js.

### How to test

1. Run `bun dev`.
2. Open http://localhost:8080/
3. Make change in sx.js
4. App reloads.
