### PR TITLE
fix(hub): restore fast query plans on the votes and proposals lists

### DIFF
--- a/apps/hub/src/graphql/operations/proposals.ts
+++ b/apps/hub/src/graphql/operations/proposals.ts
@@ -104,7 +104,7 @@ export default async function (parent, args) {
     FROM proposals p
     INNER JOIN spaces ON spaces.id = p.space
     LEFT JOIN skins ON spaces.id = skins.id
-    WHERE spaces.deleted = 0 ${queryStr} ${searchSql}
+    WHERE p.space NOT IN (SELECT id FROM spaces WHERE deleted = 1) ${queryStr} ${searchSql}
     ORDER BY ${orderBy} ${orderDirection}, p.id ASC LIMIT ?, ?
   `;
   params.push(skip, first);

--- a/apps/hub/src/graphql/operations/votes.ts
+++ b/apps/hub/src/graphql/operations/votes.ts
@@ -47,7 +47,7 @@ async function query(parent, args, context?, info?) {
     SELECT v.* FROM votes v
     WHERE v.space NOT IN (SELECT id FROM spaces WHERE deleted = 1)
       AND v.cb != -3 ${queryStr}
-    ORDER BY ${orderBy} ${orderDirection}, v.id ASC LIMIT ?, ?
+    ORDER BY ${orderBy} ${orderDirection}, v.id ${orderDirection} LIMIT ?, ?
   `;
   params.push(skip, first);
   try {

--- a/apps/hub/src/graphql/operations/votes.ts
+++ b/apps/hub/src/graphql/operations/votes.ts
@@ -45,8 +45,8 @@ async function query(parent, args, context?, info?) {
   // cb = -3 marks votes of deleted proposals, pending deletion by the sequencer
   const query = `
     SELECT v.* FROM votes v
-    INNER JOIN spaces ON spaces.id = v.space
-    WHERE spaces.deleted = 0 AND v.cb != -3 ${queryStr}
+    WHERE v.space NOT IN (SELECT id FROM spaces WHERE deleted = 1)
+      AND v.cb != -3 ${queryStr}
     ORDER BY ${orderBy} ${orderDirection}, v.id ASC LIMIT ?, ?
   `;
   params.push(skip, first);


### PR DESCRIPTION
Follow-up to #2218. Two commits, both on the hub list queries, and they only work together.

1. `fix(hub): use an anti-set subquery for the deleted-space filter`
2. `fix(hub): match the votes tiebreak to the sort direction`

#2218 is correct in intent, but its `INNER JOIN spaces ... WHERE spaces.deleted = 0` flips the query plan on the two large-table list queries. Commit 1 keeps the exclusion and restores the pre-#2218 plan. Commit 2 then closes the remaining hole that #2218 neither caused nor fixed, and that commit 1 alone leaves open.

```diff
-    SELECT v.* FROM votes v
-    INNER JOIN spaces ON spaces.id = v.space
-    WHERE spaces.deleted = 0 AND v.cb != -3 ${queryStr}
-    ORDER BY ${orderBy} ${orderDirection}, v.id ASC LIMIT ?, ?
+    SELECT v.* FROM votes v
+    WHERE v.space NOT IN (SELECT id FROM spaces WHERE deleted = 1)
+      AND v.cb != -3 ${queryStr}
+    ORDER BY ${orderBy} ${orderDirection}, v.id ${orderDirection} LIMIT ?, ?
```

`proposals` keeps its `INNER JOIN spaces` (the SELECT list reads `spaces.settings`, `spaces.domain`, ...); only the `deleted` test moves off the join. `proposals` also keeps `p.id ASC`, see "Why proposals is not flipped".

## Headline

Two shapes were returning `ER_QUERY_TIMEOUT` at a 60s cap. Both are default paths.

| shape | before | after |
|---|---|---|
| unfiltered, `created DESC` (`orderDirection` default) | **60476 ms, ER_QUERY_TIMEOUT** | **80 ms** |
| `space` + `proposal`, `vp DESC` (UI proposal votes tab, default sort) | **60135 ms, ER_QUERY_TIMEOUT** | **88 ms** |

The second one was not in the original diagnosis and is the more user-visible of the two: `loadProposalVotes` defaults to `sortBy: 'vp-desc'`, so the votes tab of any large proposal was timing out.

## Why the join flips the plan (commit 1)

Two statistics, both read from the production DB:

| | recorded | actual |
|---|---|---|
| `spaces.deleted` index cardinality | **1** | 2 distinct values |
| `votes.space` index cardinality | **1,162,175** | 78,332 distinct values |
| `spaces` rows | 73,387 (PK cardinality) | 91,787 |

`spaces.deleted` is a cardinality-1 index and is the lure that makes `spaces` look like a cheap driving table. Combined with the ~15x overestimate on `votes.space`, the optimizer thinks the join produces ~1M rows when the truth is ~65M, and costs the bad plan *lower* than the good one. This is why an index cannot fix it: `proposals` already has the ideal `idx_proposals_on_created_desc_id_asc_space` and regressed anyway.

1,265 of 91,787 spaces are deleted (**1.4%**), so test the small set instead of joining the large one. The subquery materialises to 1,265 rows and is probed per candidate row with `eq_ref <auto_distinct_key> ... Using where; Not exists`.

```
all_spaces | deleted_1 | deleted_0 | deleted_other
-----------+-----------+-----------+--------------
     91787 |      1265 |     90522 |             0
```

## Why the tiebreak is broken (commit 2)

`ORDER BY <col> DESC, v.id ASC` is a mixed-direction sort. Every index on `votes` stores `id` ascending, so MySQL can neither walk one forward nor backward to satisfy it, and falls back to a filesort over the whole candidate set. `orderDirection` defaults to `desc`, so this is the default path.

Making the tiebreak follow `orderDirection` makes both directions match an existing index. No new index, no migration.

`orderDirection` is validated to exactly `'ASC'` or `'DESC'` immediately above the template (lines 40 to 41), so interpolating it a second time adds no new input surface.

## The two fixes are not separable

This is why commit 2 is in this PR and not its own.

**Commit 2 alone is a literal no-op.** On `master`, with #2218's `INNER JOIN` still in place, flipping the tiebreak produces a byte-identical plan, because the optimizer drives from `spaces` and never considers an index on `votes` for ordering at all:

```
-- master shape, ORDER BY v.created DESC, v.id ASC
spaces | ref | deleted          | 36696 | Using index; Using temporary; Using filesort
v      | ref | space_created_id |    56 | Using index condition; Using where

-- master shape, ORDER BY v.created DESC, v.id DESC   (identical)
spaces | ref | deleted          | 36696 | Using index; Using temporary; Using filesort
v      | ref | space_created_id |    56 | Using index condition; Using where
```

**Commit 1 alone still full-scans the default path.** The anti-set lets the optimizer drive from `votes`, but the mixed-direction sort still forbids an ordered walk:

```
v | ALL | NULL | 65623513 | Using where; Using filesort     -> 60476 ms, ER_QUERY_TIMEOUT
```

Only both together produce the ordered, early-terminating scan. Splitting them would land a provably inert change in one PR and leave `master` with a timing-out default query in between.

## EXPLAIN evidence

All against the production DB, read-only, every statement carrying `MAX_EXECUTION_TIME(60000)`. Truncated to the columns that matter.

### `votes` unfiltered, `created DESC`, `LIMIT 20`

Before (this PR's commit 1 only):
```
table       | type   | key                 | rows     | Extra
------------+--------+---------------------+----------+----------------------------
v           | ALL    | NULL                | 65623513 | Using where; Using filesort
<subquery2> | eq_ref | <auto_distinct_key> |        1 | Using where; Not exists
spaces      | ref    | deleted [MATERIAL.] |     1265 | Using index
```

After (commit 2):
```
table       | type   | key                     | rows | Extra
------------+--------+-------------------------+------+-----------------------------------
v           | index  | idx_votes_on_created_id |   39 | Using where; Backward index scan
<subquery2> | eq_ref | <auto_distinct_key>     |    1 | Using where; Not exists
spaces      | ref    | deleted [MATERIALIZED]  | 1265 | Using index
```

`rows` goes from 65,623,513 to 39, `Using filesort` disappears, and `Backward index scan` appears: the ordered index is walked from the tail and stops at the LIMIT.

`created ASC` is unchanged, as expected, since `id ASC` already matched: `v index idx_votes_on_created_id rows=39 Extra='Using where'`.

### `votes` filtered by `space` + `proposal`, `vp DESC`, `LIMIT 20`

Against `linea-build.eth` / `0xda4f...648e` (2,764,428 votes).

Before:
```
v | ref | idx_votes_on_space_proposal_created_id | 4169562 | Using where; Using filesort
```

After:
```
v | range | idx_votes_on_proposal_vp_id | 4542828 | Using index condition; Using where; Backward index scan
```

The `rows` estimate stays high because the range is the whole proposal, but `Using filesort` is gone, so the walk stops at the LIMIT instead of sorting 4.17M rows. 60135 ms to 88 ms.

`vp ASC` was already fine and is unchanged: `v range idx_votes_on_proposal_vp_id rows=4542828 Using index condition; Using where`.

## Measured timings

Median of n runs against the production replica, `MAX_EXECUTION_TIME(60000)` on every statement, `LIMIT 20`.

| shape | before (`id ASC`) | after (`id <dir>`) |
|---|---|---|
| unfiltered, `created DESC` | **60476 ms, ER_QUERY_TIMEOUT** (n=1) | **80 ms** (n=14, 72 to 95) |
| unfiltered, `created ASC` | 80 ms (n=7, 73 to 96) | unchanged, same statement |
| unfiltered, `created DESC`, `skip=4980` | not measurable, times out | 224 ms (n=5, 197 to 1117) |
| `space`+`proposal`, `vp DESC` | **60135 ms, ER_QUERY_TIMEOUT** (n=5, all 5 timed out) | **88 ms** (n=5, 80 to 130) |
| `space`+`proposal`, `created DESC` | 643 ms (n=5, 539 to 5031) | 86 ms (n=5, 76 to 129) |
| `space = 'ens.eth'`, `created DESC` | 94 ms (n=5, 75 to 99) | 82 ms (n=5, 76 to 95) |
| `voter = 0x1F3C...`, `created DESC` | 76 ms (n=5, 67 to 97) | 77 ms (n=5, 75 to 93) |

No shape regressed. The two `space` and `voter` filtered shapes are flat within noise, which is the important negative result: `idx_votes_on_space_created_desc_id` is `(space, created DESC, id ASC)` and was the one index the old tiebreak matched exactly, so it was the obvious regression candidate. It does not regress, because the optimizer switches to a backward scan of `idx_votes_on_space_proposal_created_id` and gets both equality columns instead of one.

## The ordering change, and why it is safe

Flipping the tiebreak reorders rows that share a `created` value. That is a real behavioural change, not a theoretical one, so here are the numbers.

### How many ties exist

Exact counts, `GROUP BY created` over the full table in non-overlapping ranges (the full-table aggregate does not fit in the 60s cap, so it was chunked):

| period | rows | rows sharing a `created` | max tie group |
|---|---|---|---|
| 2020 | 87,824 | 2,145 (2.4%) | 3 |
| 2021 | 2,175,009 | 748,675 (34.4%) | 486 |
| 2022 | 6,187,810 | 2,062,438 (33.3%) | 195 |
| 2023 Q1 | 3,225,939 | 1,715,955 (53.2%) | 213 |
| 2023 Q2 | 9,530,438 | 7,745,422 (81.3%) | 351 |
| 2023-07 | 4,591,403 | 3,967,837 (86.4%) | 290 |
| 2023-08 | 8,434,024 | 7,788,521 (92.3%) | 386 |
| 2023-09 | 11,206,294 | 10,757,903 (96.0%) | 376 |
| 2023 Q4 | 13,256,593 | 12,126,615 (91.5%) | 557 |
| 2024 Q1 | 4,137,164 | 3,007,092 (72.7%) | 95 |
| 2024 Q2 | 3,276,044 | 2,322,568 (70.9%) | **4,933** |
| 2024 Q3 | 398,842 | 79,893 (20.0%) | 95 |
| 2024 Q4 | 463,471 | 62,135 (13.4%) | 130 |
| 2025 | 1,105,250 | 141,733 (12.8%) | 44 |
| 2026 | 108,722 | 3,670 (3.4%) | 12 |
| **total** | **68,184,827** | **52,532,602 (77.0%)** | **4,933** |

So ties are pervasive: 77% of all vote rows share their `created` second with at least one other row, and one second in 2024 Q2 holds 4,933 votes. This is a visible reordering, and it should be called out in the changelog rather than described as cosmetic.

It is much milder at the head of the `DESC` listing, which is what page 1 actually shows: over the last 30 days, 145 of 9,230 rows are in a tie (1.6%), largest group 9.

(Total counted is 68,184,827 against `information_schema.TABLE_ROWS` of 65,623,513; the latter is InnoDB's sampled estimate, which is also what the optimizer's `rows=65623513` comes from.)

### Cursor pagination: the tiebreak cannot participate

The tiebreak column cannot appear in any cursor the API exposes. In `buildWhereQuery`, `_gt` / `_gte` / `_lt` / `_lte` are generated only for fields typed `'number'`. In `votes.ts` the fields map has `created: 'number'` but `id: 'string'`, so `created_lt` exists and `id_lt` does not. A cursor can only ever be `created < <ts>`.

That has three consequences:

- **No duplication is possible, before or after.** `created_lt` is strict, so once a `created` value is passed it can never be returned again.
- **The tiebreak direction cannot change the skip behaviour.** A `created`-only cursor already drops the remainder of a tie group that straddles a page boundary: if page 1 ends after 5 of the 9 rows at `created = T`, the next request is `created_lt: T` and the other 4 are lost. That is a pre-existing property of the `created`-only cursor recipe and is unchanged here. Flipping the tiebreak changes *which* 5 of the 9 you get, not *how many* you lose.
- **The in-repo UI does not cursor-paginate votes at all.** `useProposalVotesQuery` uses `useInfiniteQuery` with `pageParam` fed straight into `skip`, i.e. offset pagination (`LIMIT ?, ?`). A grep for `created_lt` / `created_gt` across `apps` and `packages` finds no hit on votes; the only `created_gt` use is on `aliases`.

For the offset pagination the UI does use, correctness needs the ORDER BY to be a **total** order, which both the old and the new one are: the `id` secondary index has cardinality 65,623,512 against ~65.6M rows, so `id` is effectively unique and `(created, id)` is unique in either direction. Every page is generated by the same code path, so a client paginating start to finish sees each row exactly once.

The one genuine, bounded risk: a client that fetches page N under the old ordering and page N+1 under the new one, across the deploy instant. It can only reorder inside a tie group, so at most one straddling group per in-flight paginator is affected. There is no persistent skip or duplicate.

### `id` is not monotonic, so this is not "newest first"

Worth being explicit, because it is the argument one would *expect* to make here and it does not hold. `votes.id` is `varchar(66)`, not an auto-increment, and it holds two unrelated formats:

```
oldest rows: QmcJWegmf1KfqaiHmsB9AkPgpQpFwTgm5JaB6vcCwAf5Gb   (IPFS CIDv0, base58)
newest rows: 0xf9866beb6219ab73d7f81c96f0288055838fca9d026498d841aa4cffee4a9326
```

Both are content hashes, so ordering by `id` within a tie is arbitrary with respect to insertion order. `id DESC` is therefore **not** more correct than `id ASC` for a `DESC` listing, it is just deterministic, stable, and index-aligned. The justification for this change is the plan, not the semantics.

The format changed over during 2021 (that year holds 686,339 `0x` ids and 1,488,670 `Qm` ids), and the collation is `utf8mb4_0900_as_cs`, so `'0'` sorts before `'Q'` and the two formats sort as two blocks. Tie groups containing both formats do exist: **28,464 such groups in 2021, covering 125,648 rows, largest 41**. In those the flip moves the whole `0x` block from the front of the group to the back rather than shuffling within it. Still a reordering confined to a single `created` second, but it is block-structured there rather than pseudo-random.

## Why `proposals` is not flipped

`proposals` has `idx_proposals_on_created_desc_id_asc_space (created DESC, id ASC, space)`, purpose-built for `created DESC, id ASC`. Flipping it would break that match and lose the covering index:

```
-- ORDER BY p.created DESC, p.id ASC   (kept)
p | index | idx_proposals_on_created_desc_id_asc_space | 20 | Using index

-- ORDER BY p.created DESC, p.id DESC  (if flipped)
p | index | idx_proposals_on_created                   | 20 | Backward index scan
```

`Using index` is lost, so `proposals` keeps `p.id ASC`. Commit 2 touches `votes.ts` only.

## Semantic equivalence (commit 1)

**Deleted spaces are still excluded**, and `v.cb != -3` is untouched. Verified by executing both shapes against a seeded copy of `apps/hub/src/helpers/schema.sql` (a live space, a deleted space, an orphan space; votes with `cb = 0` and `cb = -3` in each):

```
votes BEFORE (INNER JOIN)          votes AFTER (anti-set)
+----------+----------+----+       +----------+-----------+----+
| id       | space    | cb |       | id       | space     | cb |
+----------+----------+----+       +----------+-----------+----+
| v-live   | live.eth |  0 |       | v-live   | live.eth  |  0 |
+----------+----------+----+       | v-orphan | ghost.eth |  0 |
                                   +----------+-----------+----+

symmetric difference: v-orphan, only in AFTER
rows from a deleted space present in AFTER: 0
proposals symmetric difference: empty
```

Commit 2 changes no `WHERE` clause, so the result *set* is identical by construction; only the order, and therefore the page boundaries, move.

Two edge cases were checked explicitly:

**Orphan rows** (a `space` value with no `spaces` row). `INNER JOIN` drops them, `NOT IN` keeps them, the one behavioural difference. In production there are **none**:

```sql
SELECT COUNT(*) AS distinct_vote_spaces, SUM(s.id IS NULL) AS orphan_space_values
  FROM (SELECT DISTINCT space FROM votes) d LEFT JOIN spaces s ON s.id = d.space;
-- distinct_vote_spaces = 78332, orphan_space_values = 0

SELECT COUNT(*) AS total, SUM(s.id IS NULL) AS orphans
  FROM proposals p LEFT JOIN spaces s ON s.id = p.space;
-- total = 429525, orphans = 0
```

So the two shapes return identical rows on the current data. Where they could ever differ, the anti-set matches the pre-#2218 behaviour (`WHERE 1 = 1` returned orphan votes) and matches #2218's stated intent, which is to exclude *deleted* spaces, not to drop rows whose space row is missing. `proposals` is unaffected either way since it keeps its `INNER JOIN`.

**`NOT IN` with NULLs.** If `spaces.id` could be NULL the subquery would return no rows for everything. It cannot: `id VARCHAR(64) NOT NULL, PRIMARY KEY (id)`, and `SELECT COUNT(*) - COUNT(id) FROM spaces` = 0. The left-hand sides are `NOT NULL` too (`votes.space VARCHAR(100) NOT NULL`, `proposals.space VARCHAR(64) NOT NULL`), so no row can evaluate to UNKNOWN and be silently dropped. Both sides also share `utf8mb4_0900_as_cs`, so the PK index is usable for the probe.

## Left alone

- **The other seven files #2218 touched** (`follows`, `statements`, `subscriptions`, `proposal`, `statement`, `vp`, `roles`). EXPLAIN'd all of them: no flip. The list queries keep their small ordered driving table (`f`/`s index created ... Backward index scan`) with `eq_ref PRIMARY` into `spaces`; the rest are point lookups by id. No change needed.
- **A new `(created DESC, id ASC)` index on `votes`.** The earlier revision of this PR listed this as the deferred remainder. It is no longer needed: matching the tiebreak to the sort direction makes the existing `idx_votes_on_created_id` usable as a backward scan, which is the same plan at no storage or write cost on a 65M row table.

## Gates

```
turbo run typecheck lint --filter=hub   ->  Tasks: 2 successful, 2 total
knip (lint:unused)                      ->  1 finding, @graphql-typed-document-node/core
                                            in apps/ui. Pre-existing, and in a package
                                            neither commit touches.
apps/hub bun run test                   ->  Test Suites: 2 passed, 2 total
                                            Tests: 1 todo, 5 passed, 6 total
                                            (run for commit 1. The hub suite is e2e only
                                            and needs a live server on :3030, which the
                                            environment for commit 2 could not start, so
                                            it was not re-run. Commit 2 is a one-token
                                            change to an ORDER BY, and both directions of
                                            the generated SQL were executed directly
                                            against the production replica, see above.)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
