### PR TITLE
chore: add alias from aviator-dao.eth to airfox-dao.eth [DO NOT MERGE until migration is run]

### DIFF
--- a/apps/ui/src/helpers/aliases.json
+++ b/apps/ui/src/helpers/aliases.json
@@ -80,5 +80,6 @@
   "aave.eth": "aavedao.eth",
   "mimo.eth": "parallel-protocol.eth",
   "aventus.eth": "aventus-gov.eth",
-  "maple.eth": "mapledao.eth"
+  "maple.eth": "mapledao.eth",
+  "aviator-dao.eth": "airfox-dao.eth"
 }


### PR DESCRIPTION
## ⛔ DO NOT MERGE until the migration queries have run

This is step 2 of the space migration runbook for `aviator-dao.eth` → `airfox-dao.eth`. The runbook is explicit that this entry is added first but merged **only once the migration is complete**:

> Add an entry to `apps/ui/src/helpers/aliases.json` with `"oldspace.eth": "newspace.eth"` and create a new PR and **make sure to merge it once the migration is complete**
> ([Support workflow → Space migration](https://app.notion.com/p/15c9e15286c44c27b7f036dcbafae2d0))

Merging early would send every `/aviator-dao.eth/*` URL to `/s:airfox-dao.eth/*` while the old space still holds all 38 proposals, its votes and its 91 followers. Anyone following an existing link would land on a near-empty space. The redirect must only go live *after* the `UPDATE ... SET space = 'airfox-dao.eth'` statements have moved the data.

Please leave this open until whoever runs the migration confirms the queries are done.

## What this does

Adds one entry to the router alias map:

```json
"aviator-dao.eth": "airfox-dao.eth"
```

Appended at the end of the file, matching the existing insertion-order convention (the file is not alphabetised; each migration appends). 82 entries before, 83 after.

Consumed by `apps/ui/src/routes/index.ts:56`:

```ts
spaceName = aliases[spaceName] || spaceName;
```

Key is the old slug as it appears in the URL, value is the redirect target, so the direction here is old → new. `airfox-dao.eth` is not itself a key in the map, so there is no alias chain.

## Context

Both spaces are named `Airfox DAO`. `aviator-dao.eth` is the original (created 2023-07-15, 38 proposals, 91 followers, verified). `airfox-dao.eth` is the new ENS (created 2026-07-15, verified) and shares an admin with the old space (`0x1cFd452EB369a7B9475B07D1457dd1d0500fD788`).

Migration runbook: [Support workflow → Space migration](https://app.notion.com/p/15c9e15286c44c27b7f036dcbafae2d0)

## Checks run locally

| Gate | Result |
| --- | --- |
| `turbo run build --filter=ui` | 7 successful, 7 total |
| `turbo run typecheck --filter=ui` | 7 successful, 7 total |
| `turbo run lint --filter=ui` | 1 successful, 1 total |
| `turbo run test --filter=ui` | 23 files, 206 passed / 1 skipped |
| `prettier --check` on the changed file | All matched files use Prettier code style |

Also confirmed the entry is compiled into the production bundle (`dist/assets/index-*.js` contains `aviator-dao.eth":"airfox-dao.eth"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
