### PR TITLE
fix(sx.js): use decoded recipient for ERC-20 transfer executions

### DIFF
--- a/.changeset/erc20-transfer-recipient.md
+++ b/.changeset/erc20-transfer-recipient.md
@@ -1,5 +1,7 @@
 ---
-'@snapshot-labs/sx': patch
+'@snapshot-labs/sx': minor
 ---
 
-Decode the real recipient for ERC-20 transfers in `convertToTransaction`. `createSendTokenTransaction` now takes an explicit `recipient` that defaults to `data.target`, and the `transfer(address,uint256)` branch of `decodeExecution` passes the decoded address instead of falling back to the target. Previously `_form.recipient` was the token contract for every ERC-20 transfer, so the UI named the token as the payee. The transaction destination (`to`) is unchanged and remains the token contract.
+Decode the real recipient for ERC-20 transfers in `convertToTransaction`. Previously `_form.recipient` was the token contract for every ERC-20 transfer, so the UI named the token as the payee. The `transfer(address,uint256)` branch of `decodeExecution` now passes the decoded address. The transaction destination (`to`) is unchanged and remains the token contract.
+
+Breaking: `createSendTokenTransaction` now takes `recipient` as a required argument, positioned before `amount` (`data, recipient, amount, token`). It previously defaulted to `data.target`, which silently produced the wrong recipient for any caller that omitted it.

--- a/.changeset/erc20-transfer-recipient.md
+++ b/.changeset/erc20-transfer-recipient.md
@@ -1,7 +1,5 @@
 ---
-'@snapshot-labs/sx': minor
+'@snapshot-labs/sx': patch
 ---
 
-Decode the real recipient for ERC-20 transfers in `convertToTransaction`. Previously `_form.recipient` was the token contract for every ERC-20 transfer, so the UI named the token as the payee. The `transfer(address,uint256)` branch of `decodeExecution` now passes the decoded address. The transaction destination (`to`) is unchanged and remains the token contract.
-
-Breaking: `createSendTokenTransaction` now takes `recipient` as a required argument, positioned before `amount` (`data, recipient, amount, token`). It previously defaulted to `data.target`, which silently produced the wrong recipient for any caller that omitted it.
+Use the decoded transfer recipient for ERC-20 sendToken executions instead of the token contract

--- a/.changeset/erc20-transfer-recipient.md
+++ b/.changeset/erc20-transfer-recipient.md
@@ -1,0 +1,5 @@
+---
+'@snapshot-labs/sx': patch
+---
+
+Decode the real recipient for ERC-20 transfers in `convertToTransaction`. `createSendTokenTransaction` now takes an explicit `recipient` that defaults to `data.target`, and the `transfer(address,uint256)` branch of `decodeExecution` passes the decoded address instead of falling back to the target. Previously `_form.recipient` was the token contract for every ERC-20 transfer, so the UI named the token as the payee. The transaction destination (`to`) is unchanged and remains the token contract.

--- a/packages/sx.js/src/utils/execution.ts
+++ b/packages/sx.js/src/utils/execution.ts
@@ -140,8 +140,6 @@ export async function decodeExecution(
           tokenContract.decimals()
         ]);
 
-      // `target` is the token contract; the recipient is the first argument
-      // of the `transfer` call.
       return createSendTokenTransaction(
         data,
         decoded[0],
@@ -186,8 +184,6 @@ export async function convertToTransaction(
   chainId: number
 ): Promise<Transaction> {
   if (data.calldata === '0x') {
-    // Native transfer: there is no calldata to decode, so `target` is the
-    // recipient rather than a token contract.
     return createSendTokenTransaction(data, data.target, data.value, {
       name: 'Ethereum',
       decimals: 18,

--- a/packages/sx.js/src/utils/execution.ts
+++ b/packages/sx.js/src/utils/execution.ts
@@ -93,12 +93,13 @@ export async function getAbi(
 export async function createSendTokenTransaction(
   data: CallInfo,
   amount: string,
-  token: SendTokenTransaction['_form']['token']
+  token: SendTokenTransaction['_form']['token'],
+  recipient: string = data.target
 ): Promise<SendTokenTransaction> {
   return {
     _type: 'sendToken',
     _form: {
-      recipient: data.target,
+      recipient,
       token,
       amount
     },
@@ -139,12 +140,17 @@ export async function decodeExecution(
           tokenContract.decimals()
         ]);
 
-      return createSendTokenTransaction(data, decoded[1].toString(), {
-        name,
-        symbol,
-        decimals,
-        address: target
-      });
+      return createSendTokenTransaction(
+        data,
+        decoded[1].toString(),
+        {
+          name,
+          symbol,
+          decimals,
+          address: target
+        },
+        decoded[0]
+      );
     }
 
     return {

--- a/packages/sx.js/src/utils/execution.ts
+++ b/packages/sx.js/src/utils/execution.ts
@@ -92,9 +92,9 @@ export async function getAbi(
 
 export async function createSendTokenTransaction(
   data: CallInfo,
+  recipient: string,
   amount: string,
-  token: SendTokenTransaction['_form']['token'],
-  recipient: string = data.target
+  token: SendTokenTransaction['_form']['token']
 ): Promise<SendTokenTransaction> {
   return {
     _type: 'sendToken',
@@ -140,16 +140,18 @@ export async function decodeExecution(
           tokenContract.decimals()
         ]);
 
+      // `target` is the token contract; the recipient is the first argument
+      // of the `transfer` call.
       return createSendTokenTransaction(
         data,
+        decoded[0],
         decoded[1].toString(),
         {
           name,
           symbol,
           decimals,
           address: target
-        },
-        decoded[0]
+        }
       );
     }
 
@@ -184,7 +186,9 @@ export async function convertToTransaction(
   chainId: number
 ): Promise<Transaction> {
   if (data.calldata === '0x') {
-    return createSendTokenTransaction(data, data.value, {
+    // Native transfer: there is no calldata to decode, so `target` is the
+    // recipient rather than a token contract.
+    return createSendTokenTransaction(data, data.target, data.value, {
       name: 'Ethereum',
       decimals: 18,
       symbol: 'ETH',

--- a/packages/sx.js/test/unit/utils/execution.test.ts
+++ b/packages/sx.js/test/unit/utils/execution.test.ts
@@ -57,6 +57,44 @@ describe('createSendTokenTransaction', () => {
       }
     `);
   });
+
+  it('should use explicit recipient while keeping target as transaction destination', async () => {
+    const result = await createSendTokenTransaction(
+      {
+        target: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        calldata: '0xa9059cbb',
+        value: '0'
+      },
+      '10000000',
+      {
+        name: 'USD Coin',
+        symbol: 'USDC',
+        decimals: 6,
+        address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+      },
+      '0x8bf6f9f91d70a9a3c2fce45df30ece735c54d624'
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "_form": {
+          "amount": "10000000",
+          "recipient": "0x8bf6f9f91d70a9a3c2fce45df30ece735c54d624",
+          "token": {
+            "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            "decimals": 6,
+            "name": "USD Coin",
+            "symbol": "USDC",
+          },
+        },
+        "_type": "sendToken",
+        "data": "0xa9059cbb",
+        "salt": "0",
+        "to": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "value": "0",
+      }
+    `);
+  });
 });
 
 describe('decodeExecution', () => {
@@ -146,7 +184,7 @@ describe('convertToTransaction', () => {
       {
         target: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         calldata:
-          '0xa9059cbb0000000000000000000000008bf6f9f91d70a9a3c2fce45df30ece735c54d62400000000000000000000000000000000000000000000000000000000009896800',
+          '0xa9059cbb0000000000000000000000008bf6f9f91d70a9a3c2fce45df30ece735c54d6240000000000000000000000000000000000000000000000000000000000989680',
         value: '0'
       },
       1
@@ -155,12 +193,51 @@ describe('convertToTransaction', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "_form": {
-          "recipient": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "amount": "10000000",
+          "recipient": "0x8Bf6F9F91D70a9a3c2FCe45dF30EcE735C54D624",
+          "token": {
+            "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            "decimals": 6,
+            "name": "USD Coin",
+            "symbol": "USDC",
+          },
         },
-        "_type": "raw",
-        "data": "0xa9059cbb0000000000000000000000008bf6f9f91d70a9a3c2fce45df30ece735c54d62400000000000000000000000000000000000000000000000000000000009896800",
+        "_type": "sendToken",
+        "data": "0xa9059cbb0000000000000000000000008bf6f9f91d70a9a3c2fce45df30ece735c54d6240000000000000000000000000000000000000000000000000000000000989680",
         "salt": "0",
         "to": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "value": "0",
+      }
+    `);
+  });
+
+  it('should use transfer recipient for ERC20 transfer, not the token contract', async () => {
+    const result = await convertToTransaction(
+      {
+        target: '0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72',
+        calldata:
+          '0xa9059cbb0000000000000000000000009c7db6b1085ec4d07f75c0bd91ad3fcd368fa19e00000000000000000000000000000000000000000000d3c21bcecceda1000000',
+        value: '0'
+      },
+      1
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "_form": {
+          "amount": "1000000000000000000000000",
+          "recipient": "0x9C7dB6B1085ec4D07f75c0BD91AD3FcD368fA19E",
+          "token": {
+            "address": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
+            "decimals": 18,
+            "name": "Ethereum Name Service",
+            "symbol": "ENS",
+          },
+        },
+        "_type": "sendToken",
+        "data": "0xa9059cbb0000000000000000000000009c7db6b1085ec4d07f75c0bd91ad3fcd368fa19e00000000000000000000000000000000000000000000d3c21bcecceda1000000",
+        "salt": "0",
+        "to": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
         "value": "0",
       }
     `);

--- a/packages/sx.js/test/unit/utils/execution.test.ts
+++ b/packages/sx.js/test/unit/utils/execution.test.ts
@@ -98,8 +98,6 @@ describe('createSendTokenTransaction', () => {
   });
 
   it('should take recipient as a required argument', () => {
-    // Function.length stops counting at the first parameter with a default, so
-    // reintroducing `recipient = data.target` drops this from 4 to 1.
     expect(createSendTokenTransaction.length).toBe(4);
   });
 });

--- a/packages/sx.js/test/unit/utils/execution.test.ts
+++ b/packages/sx.js/test/unit/utils/execution.test.ts
@@ -28,6 +28,7 @@ describe('createSendTokenTransaction', () => {
         calldata: '0xa9059cbb',
         value: '0'
       },
+      '0x8bf6f9f91d70a9a3c2fce45df30ece735c54d624',
       '10000000',
       {
         name: 'USD Coin',
@@ -65,14 +66,14 @@ describe('createSendTokenTransaction', () => {
         calldata: '0xa9059cbb',
         value: '0'
       },
+      '0x8bf6f9f91d70a9a3c2fce45df30ece735c54d624',
       '10000000',
       {
         name: 'USD Coin',
         symbol: 'USDC',
         decimals: 6,
         address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
-      },
-      '0x8bf6f9f91d70a9a3c2fce45df30ece735c54d624'
+      }
     );
 
     expect(result).toMatchInlineSnapshot(`
@@ -94,6 +95,12 @@ describe('createSendTokenTransaction', () => {
         "value": "0",
       }
     `);
+  });
+
+  it('should take recipient as a required argument', () => {
+    // Function.length stops counting at the first parameter with a default, so
+    // reintroducing `recipient = data.target` drops this from 4 to 1.
+    expect(createSendTokenTransaction.length).toBe(4);
   });
 });
 


### PR DESCRIPTION
Reported by Greg from ENS.

## What broke

`createSendTokenTransaction` in `packages/sx.js/src/utils/execution.ts` built `_form.recipient` from `data.target`:

```ts
_form: { recipient: data.target, token, amount },
to: data.target,
```

`data.target` is the recipient only on the native-ETH branch of `convertToTransaction`, where `calldata` is `0x`. On the ERC-20 branch in `decodeExecution`, `data.target` is the **token contract**. The real recipient is `decoded[0]`, which was decoded and then discarded: only `decoded[1]` (the amount) was read.

So every ERC-20 `sendToken` execution rendered the token contract as the payee. On ENS proposal [`[Executable] Next Era of ENS DAO: Empowering the ENS Foundation`](https://snapshot.box/#/eth:0x323A76393544d5ecca80cd6ef2A560C6a395b7E3/proposal/80619211450810140112687536515944199882433060764177806587986222097717655810120) the UI says the 1,000,000 ENS goes to `token.ensdao.eth` (`0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72`, the ENS token itself). The calldata says it goes to `0x9C7dB6B1085ec4D07f75c0BD91AD3FcD368fA19E`, the ENS Foundation Safe.

Scope: 141 of 184 `sendToken` transactions across 623 proposals in 6 governor spaces (Compound, Uniswap, ENS, Arbitrum Treasury, Arbitrum Core, BNB Chain). That is every ERC-20 one. The 43 correct ones are native-ETH, where `target` genuinely is the recipient.

Introduced in `2111bc32` (#1694), 2025-10-28.

## The fix

`createSendTokenTransaction` takes `recipient` as a **required** argument, ahead of `amount` (`data, recipient, amount, token`). The `isErc20Transfer` branch passes `decoded[0]`; the native-ETH branch passes `data.target` explicitly, which is correct there because with `0x` calldata there is no token contract and the target genuinely is the recipient. There is no default, so the compiler flags any call site that forgets to say who the payee is.

`to` deliberately stays `data.target` (the token contract). That is what makes the transaction valid: an ERC-20 transfer is a call *to* the token, with the recipient inside the calldata.

Execution paths are untouched. `propose` / `queue` / `execute` read only top-level `to` / `value` / `data`:

- `packages/sx.js/src/clients/openzeppelin/ethereum-tx/index.ts:70-72, 96-98, 122-124`
- `apps/ui/src/helpers/transactions.ts:204-212` (`convertToMetaTransactions`), the single entry point for `apps/ui/src/networks/{evm,starknet}/actions.ts`. `grep -rn "_form" apps/ui/src/networks/` returns nothing.

The one `_form` read in any client is `packages/sx.js/src/clients/governor-bravo/ethereum-tx/index.ts:63,70`, which branches on `'method' in execution._form`. `sendToken._form` has no `method` key before or after this change, so it still takes the `''` signature plus full `execution.data` path.

Worth flagging for review: `_form.recipient` is not purely cosmetic in two UI paths. This change fixes both rather than affecting them.

- `apps/ui/src/helpers/safe/ build.ts:38-42` (note the leading space in the filename) re-encodes `transfer(recipient, amount)` from `contractInputsValues` and `delete`s `data` for the Safe Transaction Builder export. Today that export would emit a transfer to the token contract itself.
- The edit / duplicate proposal flow prefills from `_form`: `EditorExecution.vue:74` to `Modal/SendToken.vue:193` (`form.to = initialState.recipient`) to `helpers/transactions.ts:29-53`, which re-encodes the calldata.

## How to test

Run the shipped `convertToTransaction` against the real calldata from that ENS proposal:

```ts
import { convertToTransaction } from './packages/sx.js/src/utils/execution';

const result = await convertToTransaction(
  {
    target: '0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72',
    calldata:
      '0xa9059cbb0000000000000000000000009c7db6b1085ec4d07f75c0bd91ad3fcd368fa19e00000000000000000000000000000000000000000000d3c21bcecceda1000000',
    value: '0'
  },
  1
);
console.log(JSON.stringify(result, null, 2));
```

### Before

```json
{
  "_type": "sendToken",
  "_form": {
    "recipient": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
    "token": {
      "name": "Ethereum Name Service",
      "symbol": "ENS",
      "decimals": 18,
      "address": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72"
    },
    "amount": "1000000000000000000000000"
  },
  "to": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
  "data": "0xa9059cbb0000000000000000000000009c7db6b1085ec4d07f75c0bd91ad3fcd368fa19e00000000000000000000000000000000000000000000d3c21bcecceda1000000",
  "value": "0",
  "salt": "0"
}
```

### After

```json
{
  "_type": "sendToken",
  "_form": {
    "recipient": "0x9C7dB6B1085ec4D07f75c0BD91AD3FcD368fA19E",
    "token": {
      "name": "Ethereum Name Service",
      "symbol": "ENS",
      "decimals": 18,
      "address": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72"
    },
    "amount": "1000000000000000000000000"
  },
  "to": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
  "data": "0xa9059cbb0000000000000000000000009c7db6b1085ec4d07f75c0bd91ad3fcd368fa19e00000000000000000000000000000000000000000000d3c21bcecceda1000000",
  "value": "0",
  "salt": "0"
}
```

Only `_form.recipient` moves. `to`, `data`, `value` and `salt` are byte-identical.

In UI terms, `TransactionsListItem.vue:145-151` resolves the `_NAME_` placeholder from `_form.recipient` via `getNames()`, falling back to `shorten()`. `stamp.fyi lookup_addresses` returns `token.ensdao.eth` for the token contract and no name for the Foundation Safe, so:

| | rendered title | `recipient` row in the params panel |
| --- | --- | --- |
| Before | `Send 1,000,000 ENS to token.ensdao.eth` | `0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72` |
| After | `Send 1,000,000 ENS to 0x9C7d...A19E` | `0x9C7dB6B1085ec4D07f75c0BD91AD3FcD368fA19E` |

### Native ETH is unchanged

```ts
await convertToTransaction(
  {
    target: '0x9C7dB6B1085ec4D07f75c0BD91AD3FcD368fA19E',
    calldata: '0x',
    value: '1000000000000000000'
  },
  1
);
```

gives `_form.recipient === "0x9C7dB6B1085ec4D07f75c0BD91AD3FcD368fA19E"` before and after, because that call site passes `data.target` as the recipient explicitly.

### Tests

```
cd packages/sx.js && bun run test
```

`test/unit/utils/execution.test.ts` had a test named `should handle ERC20 transfer` whose calldata was 137 hex characters, one nibble too long. Decoding threw, `convertToTransaction` fell through to its `catch {}`, and the inline snapshot asserted `_type: "raw"`. It passed while pinning the failure mode, which is why the ERC-20 branch had no coverage at all.

The calldata is corrected and its snapshot now asserts the decoded recipient. Three tests are added: one pinning that an explicit `recipient` does not move `to`, one running the real ENS calldata above, and one pinning `createSendTokenTransaction.length` at 4 so a default value cannot creep back onto `recipient`.

Checked out on this branch with only `src/utils/execution.ts` reverted to master, five tests fail:

```
 ❯ test/unit/utils/execution.test.ts (11 tests | 5 failed)
   × createSendTokenTransaction > should create a SendTokenTransaction with correct structure
   × createSendTokenTransaction > should use explicit recipient while keeping target as transaction destination
   × createSendTokenTransaction > should take recipient as a required argument
   × convertToTransaction > should handle ERC20 transfer
   × convertToTransaction > should use transfer recipient for ERC20 transfer, not the token contract
```

The two `convertToTransaction` ones fail exactly on the recipient, which is the bug itself:

```
- Expected
+ Received

  {
    "_form": {
      "amount": "1000000000000000000000000",
-     "recipient": "0x9C7dB6B1085ec4D07f75c0BD91AD3FcD368fA19E",
+     "recipient": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
```

The other three fail on the signature rather than the value, because `recipient` moved ahead of `amount`: the arity test gets 3 instead of 4, and the two direct `createSendTokenTransaction` calls slide one position, so `amount` receives the recipient and `token` receives the amount.

With the fix, `packages/sx.js` is 87 passed / 3 skipped (was 84 / 3). Repo-wide `bun run test` (11 tasks) and `bun run lint` (15 tasks) are green.

## Caveat: this does not repair the existing rows

The wrong value is **persisted**. The indexer calls `convertToTransaction` and writes the result into `proposal_metadata_items.execution`:

- `apps/api/src/evm/protocols/openzeppelin/writers.ts:433-447`
- `apps/api/src/evm/protocols/governor-bravo/writers.ts:385-399`

The ENS row served by `api.snapshot.box` today still carries `"recipient":"0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72"`. Shipping this fixes newly indexed proposals only. The 141 existing rows need a re-index or a backfill, which is deliberately **not** in this PR. Filing that as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


