### PR TITLE
chore: enforce consistent multi-line curly braces

### DIFF
--- a/apps/api/src/common/ipfs.ts
+++ b/apps/api/src/common/ipfs.ts
@@ -35,8 +35,9 @@ export async function handleProposalMetadata(
   const metadata: any = await getJSON(metadataUri);
   if (metadata.title) proposalMetadataItem.title = metadata.title;
   if (metadata.body) proposalMetadataItem.body = metadata.body;
-  if (metadata.discussion)
+  if (metadata.discussion) {
     proposalMetadataItem.discussion = metadata.discussion;
+  }
 
   if (metadata.execution) {
     const recoveredHash = getExecutionHash({
@@ -85,8 +86,9 @@ async function handleStrategiesParsedMetadata(
 
   const metadata: any = await getJSON(metadataUri);
   if (metadata.name) strategiesParsedMetadataItem.name = metadata.name;
-  if (metadata.description)
+  if (metadata.description) {
     strategiesParsedMetadataItem.description = metadata.description;
+  }
 
   if (metadata.properties) {
     if (metadata.properties.decimals) {
@@ -95,8 +97,9 @@ async function handleStrategiesParsedMetadata(
     if (metadata.properties.symbol) {
       strategiesParsedMetadataItem.symbol = metadata.properties.symbol;
     }
-    if (metadata.properties.token)
+    if (metadata.properties.token) {
       strategiesParsedMetadataItem.token = metadata.properties.token;
+    }
     if (metadata.properties.payload) {
       strategiesParsedMetadataItem.payload = metadata.properties.payload;
     }

--- a/apps/api/src/common/utils.ts
+++ b/apps/api/src/common/utils.ts
@@ -55,13 +55,16 @@ function getUrl(uri: string, gateway = 'pineapple.fyi') {
     !uri.startsWith('ipns://') &&
     !uri.startsWith('https://') &&
     !uri.startsWith('http://')
-  )
+  ) {
     return `${ipfsGateway}/ipfs/${uri}`;
+  }
   const uriScheme = uri.split('://')[0];
-  if (uriScheme === 'ipfs')
+  if (uriScheme === 'ipfs') {
     return uri.replace('ipfs://', `${ipfsGateway}/ipfs/`);
-  if (uriScheme === 'ipns')
+  }
+  if (uriScheme === 'ipns') {
     return uri.replace('ipns://', `${ipfsGateway}/ipns/`);
+  }
   return uri;
 }
 

--- a/apps/api/src/evm/protocols/snapshot-x/ipfs.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/ipfs.ts
@@ -43,12 +43,14 @@ export async function handleSpaceMetadata(
   if (metadata.name) spaceMetadataItem.name = metadata.name;
   if (metadata.description) spaceMetadataItem.about = metadata.description;
   if (metadata.avatar) spaceMetadataItem.avatar = metadata.avatar;
-  if (metadata.external_url)
+  if (metadata.external_url) {
     spaceMetadataItem.external_url = metadata.external_url;
+  }
 
   if (metadata.properties) {
-    if (metadata.properties.cover)
+    if (metadata.properties.cover) {
       spaceMetadataItem.cover = metadata.properties.cover;
+    }
 
     if (metadata.properties.treasuries) {
       spaceMetadataItem.treasuries = metadata.properties.treasuries.map(
@@ -65,16 +67,21 @@ export async function handleSpaceMetadata(
         (delegation: any) => JSON.stringify(delegation)
       );
     }
-    if (metadata.properties.github)
+    if (metadata.properties.github) {
       spaceMetadataItem.github = metadata.properties.github;
-    if (metadata.properties.twitter)
+    }
+    if (metadata.properties.twitter) {
       spaceMetadataItem.twitter = metadata.properties.twitter;
-    if (metadata.properties.discord)
+    }
+    if (metadata.properties.discord) {
       spaceMetadataItem.discord = metadata.properties.discord;
-    if (metadata.properties.farcaster)
+    }
+    if (metadata.properties.farcaster) {
       spaceMetadataItem.farcaster = metadata.properties.farcaster;
-    if (metadata.properties.clanker)
+    }
+    if (metadata.properties.clanker) {
       spaceMetadataItem.clanker = metadata.properties.clanker;
+    }
     if (metadata.properties.voting_power_symbol) {
       spaceMetadataItem.voting_power_symbol =
         metadata.properties.voting_power_symbol;

--- a/apps/api/src/starknet/ipfs.ts
+++ b/apps/api/src/starknet/ipfs.ts
@@ -45,12 +45,14 @@ export async function handleSpaceMetadata(
   if (metadata.name) spaceMetadataItem.name = metadata.name;
   if (metadata.description) spaceMetadataItem.about = metadata.description;
   if (metadata.avatar) spaceMetadataItem.avatar = metadata.avatar;
-  if (metadata.external_url)
+  if (metadata.external_url) {
     spaceMetadataItem.external_url = metadata.external_url;
+  }
 
   if (metadata.properties) {
-    if (metadata.properties.cover)
+    if (metadata.properties.cover) {
       spaceMetadataItem.cover = metadata.properties.cover;
+    }
 
     if (metadata.properties.treasuries) {
       spaceMetadataItem.treasuries = metadata.properties.treasuries.map(
@@ -67,16 +69,21 @@ export async function handleSpaceMetadata(
         (delegation: any) => JSON.stringify(delegation)
       );
     }
-    if (metadata.properties.github)
+    if (metadata.properties.github) {
       spaceMetadataItem.github = metadata.properties.github;
-    if (metadata.properties.twitter)
+    }
+    if (metadata.properties.twitter) {
       spaceMetadataItem.twitter = metadata.properties.twitter;
-    if (metadata.properties.discord)
+    }
+    if (metadata.properties.discord) {
       spaceMetadataItem.discord = metadata.properties.discord;
-    if (metadata.properties.farcaster)
+    }
+    if (metadata.properties.farcaster) {
       spaceMetadataItem.farcaster = metadata.properties.farcaster;
-    if (metadata.properties.clanker)
+    }
+    if (metadata.properties.clanker) {
       spaceMetadataItem.clanker = metadata.properties.clanker;
+    }
     if (metadata.properties.voting_power_symbol) {
       spaceMetadataItem.voting_power_symbol =
         metadata.properties.voting_power_symbol;
@@ -105,8 +112,9 @@ export async function handleSpaceMetadata(
           id,
           config.indexerName
         );
-        if (!executionStrategy)
+        if (!executionStrategy) {
           executionStrategy = new ExecutionStrategy(id, config.indexerName);
+        }
 
         executionStrategy.type =
           metadata.properties.execution_strategies_types[i];

--- a/apps/api/src/starknet/utils.ts
+++ b/apps/api/src/starknet/utils.ts
@@ -104,8 +104,9 @@ export async function handleExecutionStrategy(
       quorum = await executionContract.quorum();
     } else if (executionStrategyType === 'EthRelayer') {
       const [l1Destination] = payload;
-      if (!l1Destination)
+      if (!l1Destination) {
         throw new Error('Invalid payload for EthRelayer execution strategy');
+      }
       destinationAddress = formatAddress('Ethereum', l1Destination);
 
       const client = createPublicClient({

--- a/apps/delegates-api/src/evm/writers.ts
+++ b/apps/delegates-api/src/evm/writers.ts
@@ -57,8 +57,9 @@ export default function createWriters(indexerName: NetworkID) {
     if (
       event.args.previousBalance === BIGINT_ZERO &&
       event.args.newBalance > BIGINT_ZERO
-    )
+    ) {
       governance.currentDelegates += 1;
+    }
 
     if (event.args.newBalance === BIGINT_ZERO) governance.currentDelegates -= 1;
 

--- a/apps/delegates-api/src/starknet/writers.ts
+++ b/apps/delegates-api/src/starknet/writers.ts
@@ -46,8 +46,9 @@ export default function createWriters(indexerName: string) {
     delegate.delegatedVotes = formatUnits(BigInt(event.new_votes), DECIMALS);
     await delegate.save();
 
-    if (event.previous_votes == BIGINT_ZERO && event.new_votes > BIGINT_ZERO)
+    if (event.previous_votes == BIGINT_ZERO && event.new_votes > BIGINT_ZERO) {
       governance.currentDelegates += 1;
+    }
 
     if (event.new_votes == BIGINT_ZERO) governance.currentDelegates -= 1;
 

--- a/apps/highlight/src/utils.ts
+++ b/apps/highlight/src/utils.ts
@@ -13,15 +13,19 @@ export function getUrl(uri: string, gateway = IPFS_GATEWAY) {
     !uri.startsWith('swarm://') &&
     !uri.startsWith('https://') &&
     !uri.startsWith('http://')
-  )
+  ) {
     return `${ipfsGateway}/ipfs/${uri}`;
+  }
   const uriScheme = uri.split('://')[0];
-  if (uriScheme === 'ipfs')
+  if (uriScheme === 'ipfs') {
     return uri.replace('ipfs://', `${ipfsGateway}/ipfs/`);
-  if (uriScheme === 'ipns')
+  }
+  if (uriScheme === 'ipns') {
     return uri.replace('ipns://', `${ipfsGateway}/ipns/`);
-  if (uriScheme === 'swarm')
+  }
+  if (uriScheme === 'swarm') {
     return uri.replace('swarm://', `https://${SWARM_GATEWAY}/`);
+  }
   return uri;
 }
 

--- a/apps/mana/src/eth/index.ts
+++ b/apps/mana/src/eth/index.ts
@@ -45,13 +45,15 @@ router.post('/:chainId?', (req, res) => {
 
 router.get('/relayers/spaces/:space', async (req, res) => {
   const spaceArray = req.params.space.split(':');
-  if (spaceArray.length !== 2 || !spaceArray[0] || !spaceArray[1])
+  if (spaceArray.length !== 2 || !spaceArray[0] || !spaceArray[1]) {
     return rpcError(res, 400, 'Missing space parameter or invalid format', 0);
+  }
 
   const [networkId, spaceAddress] = spaceArray;
 
-  if (!validNetworkIds.includes(networkId))
+  if (!validNetworkIds.includes(networkId)) {
     return rpcError(res, 400, 'Invalid networkId', 0);
+  }
 
   const normalizedSpaceAddress = spaceAddress.toLowerCase();
   const wallet = generateSpaceEvmWallet(networkId, normalizedSpaceAddress);

--- a/apps/mana/src/stark/index.ts
+++ b/apps/mana/src/stark/index.ts
@@ -46,13 +46,15 @@ router.post('/:chainId', (req, res) => {
 
 router.get('/relayers/spaces/:space', (req, res) => {
   const spaceArray = req.params.space.split(':');
-  if (spaceArray.length !== 2 || !spaceArray[0] || !spaceArray[1])
+  if (spaceArray.length !== 2 || !spaceArray[0] || !spaceArray[1]) {
     return rpcError(res, 400, 'Missing space parameter or invalid format', 0);
+  }
 
   const [networkId, spaceAddress] = spaceArray;
 
-  if (!validNetworkIds.includes(networkId))
+  if (!validNetworkIds.includes(networkId)) {
     return rpcError(res, 400, 'Invalid networkId', 0);
+  }
 
   let normalizedSpaceAddress;
   try {

--- a/apps/mana/src/stark/networks.ts
+++ b/apps/mana/src/stark/networks.ts
@@ -43,12 +43,14 @@ export function getClient(chainId: string) {
   const getAccount = createAccountProxy(chainId, provider);
 
   const ethUrl = ETH_NODE_URLS.get(chainId);
-  if (!ethUrl)
+  if (!ethUrl) {
     throw new Error(`Missing ethereum node url for chainId ${chainId}`);
+  }
 
   const networkConfig = NETWORKS.get(chainId);
-  if (!networkConfig)
+  if (!networkConfig) {
     throw new Error(`Missing network config for chainId ${chainId}`);
+  }
 
   const client = new clients.StarknetTx({
     starkProvider: provider,

--- a/apps/sequencer/src/helpers/moderation.ts
+++ b/apps/sequencer/src/helpers/moderation.ts
@@ -66,16 +66,19 @@ export function containsFlaggedLinks(body: string): boolean {
 }
 
 export function flagEntity({ type, action, value }) {
-  if (!type || !action || !value)
+  if (!type || !action || !value) {
     throw new Error(`missing params. 'type', 'action' and 'value' required`);
+  }
   if (!['proposal', 'space'].includes(type)) throw new Error('invalid type');
-  if (type === 'proposal' && !['flag', 'unflag'].includes(action))
+  if (type === 'proposal' && !['flag', 'unflag'].includes(action)) {
     throw new Error('invalid action');
+  }
   if (
     type === 'space' &&
     !['flag', 'unflag', 'verify', 'hibernate', 'reactivate'].includes(action)
-  )
+  ) {
     throw new Error('invalid action');
+  }
 
   let query;
   switch (`${type}-${action}`) {

--- a/apps/sequencer/src/helpers/utils.ts
+++ b/apps/sequencer/src/helpers/utils.ts
@@ -150,8 +150,9 @@ export function hasStrategyOverride(strategies: any[]) {
     '"sonic-staked-balance"'
   ];
   const strategiesStr = JSON.stringify(strategies).toLowerCase();
-  if (keywords.some(keyword => strategiesStr.includes(`"name":${keyword}`)))
+  if (keywords.some(keyword => strategiesStr.includes(`"name":${keyword}`))) {
     return true;
+  }
   // Check for split-delegation with delegationOverride
   const splitDelegation = strategies.filter(
     strategy => strategy.name === 'split-delegation'
@@ -303,8 +304,9 @@ async function updateWalletConnectWhitelist(
     !domain ||
     !process.env.REOWN_SECRET ||
     !process.env.WALLETCONNECT_PROJECT_ID
-  )
+  ) {
     return false;
+  }
 
   try {
     await fetch(`https://cloud.reown.com/api/set-allowed-domains`, {

--- a/apps/sequencer/src/ingestor.ts
+++ b/apps/sequencer/src/ingestor.ts
@@ -68,14 +68,17 @@ export default async function ingestor(req) {
     const underTs = (ts - under).toFixed();
     const { domain, message, types } = body.data;
 
-    if (JSON.stringify(body).length > 1e5)
+    if (JSON.stringify(body).length > 1e5) {
       return Promise.reject('too large message');
+    }
 
-    if (message.timestamp > overTs || message.timestamp < underTs)
+    if (message.timestamp > overTs || message.timestamp < underTs) {
       return Promise.reject('wrong timestamp');
+    }
 
-    if (message.proposal && message.proposal.includes(' '))
+    if (message.proposal && message.proposal.includes(' ')) {
       return Promise.reject('proposal cannot contain whitespace');
+    }
 
     if (
       domain.name !== networkMetadata.name ||
@@ -88,8 +91,9 @@ export default async function ingestor(req) {
     delete types.EIP712Domain;
 
     const hash = sha256(JSON.stringify(types));
-    if (!Object.keys(hashTypes).includes(hash))
+    if (!Object.keys(hashTypes).includes(hash)) {
       return Promise.reject('wrong types');
+    }
     type = hashTypes[hash];
 
     try {
@@ -97,8 +101,9 @@ export default async function ingestor(req) {
         message.space &&
         (message.space.startsWith('s:') || !message.space.includes(':')) &&
         ensNormalize(message.space) !== message.space.toLowerCase()
-      )
+      ) {
         throw new Error('');
+      }
     } catch {
       return Promise.reject('Invalid space id');
     }
@@ -151,7 +156,7 @@ export default async function ingestor(req) {
 
     if (type === 'settings') payload = JSON.parse(message.settings);
 
-    if (type === 'proposal')
+    if (type === 'proposal') {
       payload = {
         name: message.title,
         body: message.body,
@@ -168,9 +173,10 @@ export default async function ingestor(req) {
         type: message.type,
         app: message.app || ''
       };
+    }
     if (type === 'alias') payload = { alias: message.alias };
     if (type === 'revoke-alias') payload = { alias: message.alias };
-    if (type === 'statement')
+    if (type === 'statement') {
       payload = {
         about: message.about,
         statement: message.statement,
@@ -178,6 +184,7 @@ export default async function ingestor(req) {
         status: message.status,
         network: message.network
       };
+    }
     if (type === 'delete-proposal') payload = { proposal: message.proposal };
     if (type === 'update-proposal') {
       payload = {
@@ -197,8 +204,9 @@ export default async function ingestor(req) {
     if (type === 'flag-proposal') payload = { proposal: message.proposal };
 
     if (['vote', 'vote-array', 'vote-string'].includes(type)) {
-      if (message.metadata && message.metadata.length > 2000)
+      if (message.metadata && message.metadata.length > 2000) {
         return Promise.reject('too large metadata');
+      }
 
       let choice = message.choice;
       if (type === 'vote-string') {

--- a/apps/sequencer/src/scores.ts
+++ b/apps/sequencer/src/scores.ts
@@ -200,8 +200,9 @@ export async function updateProposalAndVotes(
 
     // Check if voting power is final
     const withOverride = hasStrategyOverride(proposal.strategies);
-    if (vpState === 'final' && withOverride && proposal.state !== 'closed')
+    if (vpState === 'final' && withOverride && proposal.state !== 'closed') {
       vpState = 'pending';
+    }
 
     // Update votes voting power
     if (!isFinal) await updateVotesVp(votes, vpState, proposalId);

--- a/apps/sequencer/src/writer/delete-proposal.ts
+++ b/apps/sequencer/src/writer/delete-proposal.ts
@@ -15,8 +15,9 @@ export async function verify(body): Promise<any> {
     !admins.includes(body.address.toLowerCase()) &&
     !mods.includes(body.address.toLowerCase()) &&
     proposal.author.toLowerCase() !== body.address.toLowerCase()
-  )
+  ) {
     return Promise.reject('not authorized to archive proposal');
+  }
 }
 
 export async function action(body): Promise<void> {

--- a/apps/sequencer/src/writer/flag-proposal.ts
+++ b/apps/sequencer/src/writer/flag-proposal.ts
@@ -24,8 +24,9 @@ export async function verify(body): Promise<any> {
     space,
     address: body.address
   });
-  if (!isAuthorizedToFlag)
+  if (!isAuthorizedToFlag) {
     return Promise.reject('not authorized to flag proposal');
+  }
 
   return Promise.resolve(proposal);
 }

--- a/apps/sequencer/src/writer/follow.ts
+++ b/apps/sequencer/src/writer/follow.ts
@@ -20,8 +20,9 @@ export async function verify(message): Promise<any> {
   const query = `SELECT * FROM follows WHERE follower = ? AND space = ? LIMIT 1`;
   const follows = await db.queryAsync(query, [message.from, message.space]);
 
-  if (follows.length !== 0)
+  if (follows.length !== 0) {
     return Promise.reject('you are already following this space');
+  }
 
   const plan = turboUsers
     .map(user => user.toLowerCase())

--- a/apps/sequencer/src/writer/profile.ts
+++ b/apps/sequencer/src/writer/profile.ts
@@ -44,7 +44,8 @@ export async function action(message, ipfs): Promise<void> {
   await db.queryAsync('REPLACE INTO users SET ?', params);
 
   ['avatar', 'name'].forEach(async type => {
-    if (profile[type] !== existingProfile[type])
+    if (profile[type] !== existingProfile[type]) {
       await clearStampCache(type, message.from);
+    }
   });
 }

--- a/apps/sequencer/src/writer/proposal.ts
+++ b/apps/sequencer/src/writer/proposal.ts
@@ -124,8 +124,9 @@ export async function verify(body): Promise<any> {
     type: msg.payload.type,
     choices: msg.payload.choices
   });
-  if (!isChoicesValid)
+  if (!isChoicesValid) {
     return Promise.reject('wrong choices for basic type voting');
+  }
 
   // if (msg.payload.start < created) return Promise.reject('invalid start date');
 
@@ -141,8 +142,9 @@ export async function verify(body): Promise<any> {
   }
 
   if (space.voting?.type) {
-    if (msg.payload.type !== space.voting.type)
+    if (msg.payload.type !== space.voting.type) {
       return Promise.reject('invalid voting type');
+    }
   }
 
   const spacePrivacy = space.voting?.privacy ?? 'any';
@@ -164,8 +166,9 @@ export async function verify(body): Promise<any> {
     log.warn('[writer] Failed to check proposal content', err);
   }
 
-  if (flaggedAddresses.includes(addressLC))
+  if (flaggedAddresses.includes(addressLC)) {
     return Promise.reject('invalid proposal, please contact support');
+  }
 
   const onlyAuthors = space.filters?.onlyMembers;
   const members = [
@@ -175,8 +178,9 @@ export async function verify(body): Promise<any> {
   ].map(member => member.toLowerCase());
   const isAuthorized = members.includes(addressLC);
 
-  if (onlyAuthors && !isAuthorized)
+  if (onlyAuthors && !isAuthorized) {
     return Promise.reject('only space authors can propose');
+  }
   if (!isAuthorized) {
     try {
       const validationName = space.validation?.name || 'basic';
@@ -221,16 +225,18 @@ export async function verify(body): Promise<any> {
     }
   }
 
-  if (msg.payload.snapshot < networks[space.network].start)
+  if (msg.payload.snapshot < networks[space.network].start) {
     return Promise.reject('proposal snapshot must be after network start');
+  }
 
   try {
     const provider = getProvider(space.network);
     const block = await provider.getBlock(msg.payload.snapshot);
     if (!block) return Promise.reject('invalid snapshot block');
   } catch (err: any) {
-    if (err.message?.includes('invalid block hash or block tag'))
+    if (err.message?.includes('invalid block hash or block tag')) {
       return Promise.reject('invalid snapshot block');
+    }
     return Promise.reject('unable to fetch block');
   }
 
@@ -243,15 +249,17 @@ export async function verify(body): Promise<any> {
     const monthLimit =
       limits[`space.${spaceTypeWithEcosystem}.proposal_limit_per_month`];
 
-    if (dayCount >= dayLimit || monthCount >= monthLimit)
+    if (dayCount >= dayLimit || monthCount >= monthLimit) {
       return Promise.reject('proposal limit reached');
+    }
     const activeProposalLimitPerAuthor =
       limits['space.active_proposal_limit_per_author'];
     if (
       !isAuthorized &&
       activeProposalsByAuthor >= activeProposalLimitPerAuthor
-    )
+    ) {
       return Promise.reject('active proposal limit reached for author');
+    }
   } catch (err) {
     capture(err);
     return Promise.reject('failed to check proposals limit');

--- a/apps/sequencer/src/writer/settings.ts
+++ b/apps/sequencer/src/writer/settings.ts
@@ -51,10 +51,12 @@ export async function verify(body): Promise<any> {
   );
 
   if (!space?.turbo && !space?.domain) {
-    if (msg.payload.domain)
+    if (msg.payload.domain) {
       return Promise.reject('domain is a turbo feature only');
-    if (msg.payload.skinSettings)
+    }
+    if (msg.payload.skinSettings) {
       return Promise.reject('skin is a turbo feature only');
+    }
   }
 
   const anotherSpaceWithDomain = (
@@ -70,8 +72,9 @@ export async function verify(body): Promise<any> {
 
   if (!isAdmin && !isController) return Promise.reject('not allowed');
 
-  if (!isController && !isEqual(admins, newAdmins))
+  if (!isController && !isEqual(admins, newAdmins)) {
     return Promise.reject('not allowed change admins');
+  }
 
   const labels = msg.payload.labels || [];
   if (labels.length) {
@@ -115,8 +118,9 @@ export async function action(body): Promise<void> {
     return Promise.reject('failed store settings');
   }
 
-  if (existingSettings.avatar !== msg.payload.avatar)
+  if (existingSettings.avatar !== msg.payload.avatar) {
     await clearStampCache('space', space);
+  }
 
   if (existingSpace?.domain != msg.payload.domain) {
     await addToWalletConnectWhitelist(msg.payload.domain);

--- a/apps/sequencer/src/writer/unfollow.ts
+++ b/apps/sequencer/src/writer/unfollow.ts
@@ -9,8 +9,9 @@ export async function verify(message): Promise<any> {
     message.network || DEFAULT_NETWORK_ID
   ]);
 
-  if (follows.length === 0)
+  if (follows.length === 0) {
     return Promise.reject('you can only unfollow a space you follow');
+  }
 
   return true;
 }

--- a/apps/sequencer/src/writer/update-proposal.ts
+++ b/apps/sequencer/src/writer/update-proposal.ts
@@ -37,8 +37,9 @@ export async function verify(body): Promise<any> {
   if (!proposal) return Promise.reject('unknown proposal');
 
   const timestampNow = Math.floor(Date.now() / 1e3);
-  if (proposal.start < timestampNow)
+  if (proposal.start < timestampNow) {
     return Promise.reject('proposal already started');
+  }
 
   const isChoicesValid = validateChoices({
     type: msg.payload.type,
@@ -50,8 +51,9 @@ export async function verify(body): Promise<any> {
     );
   }
 
-  if (proposal.author.toLowerCase() !== body.address.toLowerCase())
+  if (proposal.author.toLowerCase() !== body.address.toLowerCase()) {
     return Promise.reject('Not the author');
+  }
 
   const spacePrivacy = space.voting?.privacy ?? 'any';
   const proposalPrivacy = msg.payload.privacy;

--- a/apps/sequencer/src/writer/vote.ts
+++ b/apps/sequencer/src/writer/vote.ts
@@ -37,25 +37,29 @@ export async function verify(body): Promise<any> {
     proposal.start > msgTs ||
     tsInt > proposal.end ||
     proposal.start > tsInt
-  )
+  ) {
     return Promise.reject('not in voting window');
+  }
 
   if (proposal.privacy === 'shutter') {
-    if (msg.payload.reason)
+    if (msg.payload.reason) {
       return Promise.reject('reason not allowed with shutter');
+    }
     if (
       typeof msg.payload.choice !== 'string' ||
       !msg.payload.choice.startsWith('0x')
-    )
+    ) {
       return Promise.reject('invalid choice');
+    }
   } else {
     if (
       !snapshot.utils.voting[proposal.type].isValidChoice(
         msg.payload.choice,
         proposal.choices
       )
-    )
+    ) {
       return Promise.reject('invalid choice');
+    }
   }
 
   if (proposal.validation?.name && proposal.validation.name !== 'any') {
@@ -63,9 +67,10 @@ export async function verify(body): Promise<any> {
       const {
         validation: { name: validationName, params: validationParams }
       } = proposal;
-      if (validationName === 'basic')
+      if (validationName === 'basic') {
         validationParams.strategies =
           validationParams.strategies ?? proposal.strategies;
+      }
 
       const validate = await snapshot.utils.validate(
         validationName,
@@ -168,8 +173,9 @@ export async function action(body, ipfs, receipt, id, context): Promise<void> {
       return Promise.reject('already voted at later time');
     } else if (votes[0].created === parseInt(msg.timestamp)) {
       const localCompare = id.localeCompare(votes[0].id);
-      if (localCompare <= 0)
+      if (localCompare <= 0) {
         return Promise.reject('already voted same time with lower index');
+      }
     }
     // Update previous vote
     log.info(`[writer] Update previous vote, ${voter}, ${proposalId}`);
@@ -216,8 +222,9 @@ export async function action(body, ipfs, receipt, id, context): Promise<void> {
   // Update proposal scores and voters vp
   try {
     const result = await updateProposalAndVotes(proposalId);
-    if (!result)
+    if (!result) {
       log.warn(`[writer] updateProposalAndVotes() false, ${proposalId}`);
+    }
   } catch (err: any) {
     captureError(
       err,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:e2e": "playwright test --config=playwright.config.ts",
     "test:e2e:headed": "playwright test --config=playwright.config.ts --headed",
     "lint": "TURBO_TELEMETRY_DISABLED=1 turbo run lint lint:scripts --filter=!auction",
-    "lint:fix": "TURBO_TELEMETRY_DISABLED=1 turbo run lint:fix && bun run lint:scripts --fix",
+    "lint:fix": "TURBO_TELEMETRY_DISABLED=1 turbo run lint:fix --filter=!auction && bun run lint:scripts --fix",
     "lint:scripts": "eslint scripts/",
     "lint:unused": "knip",
     "typecheck": "TURBO_TELEMETRY_DISABLED=1 turbo run typecheck --filter=!auction",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -22,6 +22,7 @@ export default [
       'import-x': importPlugin
     },
     rules: {
+      curly: ['error', 'multi-line', 'consistent'],
       'prefer-template': 'error',
       'lines-between-class-members': [
         'error',

--- a/packages/sx.js/src/authenticators/evm/ethSig.ts
+++ b/packages/sx.js/src/authenticators/evm/ethSig.ts
@@ -22,8 +22,9 @@ export default function createEthSigAuthenticator(
       const { signatureData, data } = envelope;
       const { space } = data;
 
-      if (!signatureData)
+      if (!signatureData) {
         throw new Error('signatureData is required for this authenticator');
+      }
 
       const { r, s, v } = getRSVFromSig(signatureData.signature);
 

--- a/packages/sx.js/src/authenticators/starknet/ethSig.ts
+++ b/packages/sx.js/src/authenticators/starknet/ethSig.ts
@@ -66,8 +66,9 @@ export default function createEthSigAuthenticator(): Authenticator {
       }
 
       const [r, s, v] = envelope.signatureData.signature;
-      if (!r || !s || !v)
+      if (!r || !s || !v) {
         throw new Error('signature needs to contain r, s and v');
+      }
 
       const compiled = callData.compile('authenticate_vote', [
         r,

--- a/packages/sx.js/src/strategies/starknet/erc20Votes.ts
+++ b/packages/sx.js/src/strategies/starknet/erc20Votes.ts
@@ -24,8 +24,9 @@ export default function createErc20VotesStrategy(): Strategy {
       clientConfig: ClientConfig
     ): Promise<string[]> {
       const isEthereumAddress = signerAddress.length === 42;
-      if (isEthereumAddress)
+      if (isEthereumAddress) {
         throw new Error('Not supported for Ethereum addresses');
+      }
 
       return [];
     },

--- a/packages/sx.js/src/strategies/starknet/evmSlotValue.ts
+++ b/packages/sx.js/src/strategies/starknet/evmSlotValue.ts
@@ -72,8 +72,9 @@ export default function createEvmSlotValueStrategy({
       clientConfig: ClientConfig
     ): Promise<string[]> {
       if (call === 'propose') throw new Error('Not supported for proposing');
-      if (signerAddress.length !== 42)
+      if (signerAddress.length !== 42) {
         throw new Error('Not supported for non-Ethereum addresses');
+      }
       if (!metadata) throw new Error('Invalid metadata');
 
       const voteEnvelope = envelope as Envelope<Vote>;

--- a/packages/sx.js/src/strategies/starknet/merkleWhitelist.ts
+++ b/packages/sx.js/src/strategies/starknet/merkleWhitelist.ts
@@ -45,8 +45,9 @@ export default function createMerkleWhitelistStrategy(): Strategy {
       );
 
       const entry = tree[voterIndex];
-      if (voterIndex === -1 || !entry)
+      if (voterIndex === -1 || !entry) {
         throw new Error('Signer is not in whitelist');
+      }
 
       const votingPowerUint256 = uint256.bnToUint256(entry.votingPower);
 

--- a/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
+++ b/packages/sx.js/src/strategies/starknet/ozVotesStorageProof.ts
@@ -96,8 +96,9 @@ export default function createOzVotesStorageProofStrategy({
       clientConfig: ClientConfig
     ): Promise<string[]> {
       if (call === 'propose') throw new Error('Not supported for proposing');
-      if (signerAddress.length !== 42)
+      if (signerAddress.length !== 42) {
         throw new Error('Not supported for non-Ethereum addresses');
+      }
       if (!metadata) throw new Error('Invalid metadata');
 
       const { starkProvider, ethUrl, networkConfig } = clientConfig;
@@ -140,8 +141,9 @@ export default function createOzVotesStorageProofStrategy({
       );
 
       const [checkpointMptProof, exclusionMptProof] = proofs;
-      if (!checkpointMptProof || !exclusionMptProof)
+      if (!checkpointMptProof || !exclusionMptProof) {
         throw new Error('Invalid proofs');
+      }
 
       // This check is only needed to look for "Slot is zero" error
       // Current storage proof contracts will revert if we try to use them
@@ -237,8 +239,9 @@ export default function createOzVotesStorageProofStrategy({
       );
 
       const [checkpointMptProof, exclusionMptProof] = proofs;
-      if (!checkpointMptProof || !exclusionMptProof)
+      if (!checkpointMptProof || !exclusionMptProof) {
         throw new Error('Invalid proofs');
+      }
 
       try {
         return await contract.get_voting_power(

--- a/packages/sx.js/src/utils/bytes.ts
+++ b/packages/sx.js/src/utils/bytes.ts
@@ -1,7 +1,8 @@
 export function hexToBytes(hex: string): number[] {
   const bytes: number[] = [];
-  for (let c = 2; c < hex.length; c += 2)
+  for (let c = 2; c < hex.length; c += 2) {
     bytes.push(parseInt(hex.substring(c, c + 2), 16));
+  }
   return bytes;
 }
 

--- a/packages/sx.js/src/utils/fees.ts
+++ b/packages/sx.js/src/utils/fees.ts
@@ -8,8 +8,9 @@ export async function estimateStarknetFee(
   networkConfig: NetworkConfig,
   calls: Call | Call[]
 ) {
-  if (networkConfig.feeEstimateOverride)
+  if (networkConfig.feeEstimateOverride) {
     return BigInt(networkConfig.feeEstimateOverride);
+  }
 
   const fee = await account.estimateFee(calls);
   return stark.estimatedFeeToMaxFee(fee.suggestedMaxFee, FEE_OVERHEAD);

--- a/packages/sx.js/src/utils/storage-proofs/proof.ts
+++ b/packages/sx.js/src/utils/storage-proofs/proof.ts
@@ -39,8 +39,9 @@ export function encodeParams(
  */
 export function decodeParams(params: string[]): string[][] {
   const [v0, v1, v2, v3] = params;
-  if (!v0 || !v1 || !v2 || !v3)
+  if (!v0 || !v1 || !v2 || !v3) {
     throw new Error('Invalid storage proof parameters');
+  }
 
   const slot: string[] = [v0, v1, v2, v3];
   const numNodes = Number(params[4]);


### PR DESCRIPTION
### Summary

This commit enables curly multi-line consistent rule.

This pretty much disallows omitting curly braces in if/else/if/while bodies unless body is on the same line as that keyword.

This is partly stylistic, but also has practical implications as adding extra statements to body without this rule are annoying as they require you to add extra braces, otherwise adding just the new statement will cause previous statement to fall out of body, possibly causing a regression.

Encountering this issue if body is on the same line is much harder in practice and single-line bodies have stylistic benefit so those are remain correct.
