### PR TITLE
fix(ui): show sub-space proposals on space pages

### DIFF
--- a/apps/ui/src/queries/proposals.ts
+++ b/apps/ui/src/queries/proposals.ts
@@ -74,6 +74,9 @@ export const PROPOSALS_KEYS = {
 };
 
 function getSpaceIdsWithSubSpaces(space: Space): string[] {
+  const { isWhiteLabel } = useWhiteLabel();
+  if (isWhiteLabel.value) return [space.id];
+
   return [space.id, ...space.children.map(child => child.id)];
 }
 

--- a/apps/ui/src/queries/proposals.ts
+++ b/apps/ui/src/queries/proposals.ts
@@ -9,7 +9,7 @@ import { getNames } from '@/helpers/stamp';
 import { getNetwork, offchainNetworks } from '@/networks';
 import { SCORES_TICKS_MAX_VOTES } from '@/networks/offchain/api';
 import { ProposalsFilter } from '@/networks/types';
-import { NetworkID, Proposal } from '@/types';
+import { NetworkID, Proposal, Space } from '@/types';
 
 type Filters = {
   state?: MaybeRefOrGetter<NonNullable<ProposalsFilter['state']>>;
@@ -72,6 +72,10 @@ export const PROPOSALS_KEYS = {
       'scoresTicks'
     ] as const
 };
+
+function getSpaceIdsWithSubSpaces(space: Space): string[] {
+  return [space.id, ...space.children.map(child => child.id)];
+}
 
 async function withAuthorNames(proposals: Proposal[]) {
   const names = await getNames(proposals.map(proposal => proposal.author.id));
@@ -182,15 +186,21 @@ export function useHomeProposalsQuery(
 }
 
 export function useProposalsQuery(
-  networkId: MaybeRefOrGetter<NetworkID>,
-  spaceId: MaybeRefOrGetter<string>,
+  space: MaybeRefOrGetter<Space>,
   filters: Filters,
   query?: MaybeRefOrGetter<string>
 ) {
+  const networkId = toRef(() => toValue(space).network);
+
   return getProposalsQuery(
-    PROPOSALS_KEYS.spaceList(networkId, spaceId, filters, query),
+    PROPOSALS_KEYS.spaceList(
+      networkId,
+      toRef(() => toValue(space).id),
+      filters,
+      query
+    ),
     networkId,
-    toRef(() => [toValue(spaceId)]),
+    toRef(() => getSpaceIdsWithSubSpaces(toValue(space))),
     filters,
     query
   );
@@ -198,35 +208,40 @@ export function useProposalsQuery(
 
 export function proposalsSummaryQueryFn(
   queryClient: QueryClient,
-  networkId: NetworkID,
-  spaceId: string
+  space: Space
 ) {
   return async () => {
-    const proposals = await getProposals([spaceId], networkId, {
-      skip: 0,
-      limit: PROPOSALS_SUMMARY_LIMIT
-    });
+    const proposals = await getProposals(
+      getSpaceIdsWithSubSpaces(space),
+      space.network,
+      {
+        skip: 0,
+        limit: PROPOSALS_SUMMARY_LIMIT
+      }
+    );
 
-    setProposalsDetails(queryClient, networkId, proposals);
+    setProposalsDetails(queryClient, space.network, proposals);
 
     return proposals;
   };
 }
 
 export function useProposalsSummaryQuery(
-  networkId: MaybeRefOrGetter<NetworkID>,
-  spaceId: MaybeRefOrGetter<string>,
+  space: MaybeRefOrGetter<Space>,
   enabled: MaybeRefOrGetter<boolean> = true
 ) {
   const queryClient = useQueryClient();
 
+  const queryFn = computed(() =>
+    proposalsSummaryQueryFn(queryClient, toValue(space))
+  );
+
   return useQuery({
-    queryKey: PROPOSALS_KEYS.spaceSummary(networkId, spaceId),
-    queryFn: proposalsSummaryQueryFn(
-      queryClient,
-      toValue(networkId),
-      toValue(spaceId)
+    queryKey: PROPOSALS_KEYS.spaceSummary(
+      toRef(() => toValue(space).network),
+      toRef(() => toValue(space).id)
     ),
+    queryFn,
     enabled: () => toValue(enabled)
   });
 }

--- a/apps/ui/src/views/Organization/Overview.vue
+++ b/apps/ui/src/views/Organization/Overview.vue
@@ -23,7 +23,7 @@ const proposalQueries = useQueries({
   queries: computed(() =>
     (organization.value?.spaces ?? []).map(s => ({
       queryKey: PROPOSALS_KEYS.spaceSummary(s.network, s.id),
-      queryFn: proposalsSummaryQueryFn(queryClient, s.network, s.id)
+      queryFn: proposalsSummaryQueryFn(queryClient, s)
     }))
   )
 });

--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -29,8 +29,7 @@ const isOffchainSpace = computed(() =>
 const socials = computed(() => getSocialNetworksLink(props.space));
 
 const { data, isPending, isError } = useProposalsSummaryQuery(
-  toRef(() => props.space.network),
-  toRef(() => props.space.id),
+  toRef(props, 'space'),
   toRef(() => spaceType.value === 'proposalsSpace')
 );
 const {

--- a/apps/ui/src/views/Space/Overview.vue
+++ b/apps/ui/src/views/Space/Overview.vue
@@ -203,7 +203,11 @@ watchEffect(() => setTitle(props.space.name));
           params: { space: `${space.network}:${space.id}` },
           linkTitle: 'See more'
         }"
-      />
+      >
+        <template #item-meta="{ proposal }">
+          {{ space.children.length > 0 ? proposal.space.name : '' }}
+        </template>
+      </ProposalsList>
       <TownhallTopicsList
         v-else-if="spaceType === 'discussionsSpace'"
         title="Latest topics"

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -53,8 +53,7 @@ const {
   isError,
   isFetchingNextPage
 } = useProposalsQuery(
-  toRef(() => props.space.network),
-  toRef(() => props.space.id),
+  toRef(props, 'space'),
   {
     state,
     labels

--- a/apps/ui/src/views/Space/Proposals.vue
+++ b/apps/ui/src/views/Space/Proposals.vue
@@ -241,6 +241,10 @@ watchEffect(() => setTitle(`${proposalsLabel.value} - ${props.space.name}`));
       :loading-more="isFetchingNextPage"
       :proposals="data?.pages.flat() ?? []"
       @end-reached="handleEndReached"
-    />
+    >
+      <template #item-meta="{ proposal }">
+        {{ space.children.length > 0 ? proposal.space.name : '' }}
+      </template>
+    </ProposalsList>
   </div>
 </template>


### PR DESCRIPTION
## Summary

[horizenfoundation.eth](https://snapshot.org/#/s:horizenfoundation.eth) says *"There are no proposals here."* It owns 0 proposals — all 17 live in its two sub-spaces, and we never fetched them. The query only ever asked for the space's own id, even though the [docs](https://docs.snapshot.box/user-guides/spaces/sub-spaces) promise sub-space proposals show up in the parent and [v1 did it](https://github.com/snapshot-labs/snapshot-v1/blob/master/src/views/SpaceProposals.vue#L78).

While fixing that I hit a second bug. `useProposalsSummaryQuery` resolved the space at setup, so its queryFn stayed pinned to whichever space mounted first while the cache key kept updating. Bounce between two spaces and you get one space's proposals under another's name — or nothing at all.

| Bug | Regression? | Origin |
|---|---|---|
| Sub-space proposals not fetched | No — never existed in sx | Never ported from v1; traces to sx-ui [#313](https://github.com/snapshot-labs/sx-ui/pull/313) |
| Wrong space's proposals when navigating back and forth | Yes — since #1999 (Mar 2026) | Extracting `proposalsSummaryQueryFn` hoisted `toValue()` out of the queryFn; #1190 had it correct |

## How to reproduce (on prod)

1. Open [horizenfoundation.eth](https://snapshot.org/#/s:horizenfoundation.eth) → *"There are no proposals here."*
2. Click into a sub-space, e.g. [Horizen Technical](https://snapshot.org/#/s:horizenfoundationtechnical.eth) → 5 proposals
3. Go back to the parent → it suddenly shows 5 proposals. They're Technical's — visit Non-Technical instead and the same page shows different ones.
4. Go back to the sub-space → **0 proposals**. Its page is now querying the parent's id (visible in the Network tab: `space_in: ["horizenfoundation.eth"]`).
5. Keep bouncing: parent → [Non-Technical](https://snapshot.org/#/s:horizenfoundationnontechnical.eth) → back to [Technical](https://snapshot.org/#/s:horizenfoundationtechnical.eth) → Technical's page now lists **Non-Technical's proposals** ("Special Council Elections", "ZenIP 42408"…). Every hop shows the previous space's data under the current URL.

## How to test

**1. Parent space shows sub-space proposals**

| Before ([prod](https://snapshot.org/#/s:horizenfoundation.eth/proposals)) | After ([preview](https://deploy-preview-2255--snapshot-livenet.netlify.app/#/s:horizenfoundation.eth/proposals)) |
|---|---|
| "There are no proposals here." | 17 proposals, both sub-spaces interleaved by date |

**2. Repeat the repro steps on the [preview](https://deploy-preview-2255--snapshot-livenet.netlify.app/#/s:horizenfoundation.eth)**

| Step | Before (prod) | After (preview) |
|---|---|---|
| parent | empty | 5 proposals |
| → technical | 5 proposals | 5 proposals |
| → parent again | Technical's 5 rows | 5 from both sub-spaces |
| → technical again | **0 rows** | 5 proposals |

**3. Ordinary spaces unchanged**

| Space | Before | After |
|---|---|---|
| aavedao.eth | [20 proposals](https://snapshot.org/#/s:aavedao.eth/proposals) | [same 20](https://deploy-preview-2255--snapshot-livenet.netlify.app/#/s:aavedao.eth/proposals) |
| stgdao.eth | [20 proposals](https://snapshot.org/#/s:stgdao.eth/proposals) | [same 20](https://deploy-preview-2255--snapshot-livenet.netlify.app/#/s:stgdao.eth/proposals) |

Onchain spaces have no children, so they're untouched.

Heads up: `ens.eth` has a sub-space too, so [org/ens → ens.eth proposals](https://deploy-preview-2255--snapshot-livenet.netlify.app/#/org/ens/s:ens.eth/proposals) now includes `wg.ensnominations.eth`. Correct per its settings, but say the word if org pages should stay curated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
