### PR TITLE
feat(scripts): add autovote dataset and prediction scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "dev": "TURBO_TELEMETRY_DISABLED=1 turbo run dev --filter=ui",
     "dev:interactive": "node --experimental-strip-types --no-warnings=ExperimentalWarning ./scripts/dev-interactive.ts",
     "dev:electron": "TURBO_TELEMETRY_DISABLED=1 turbo run dev:electron",
+    "autovote": "node --experimental-strip-types --no-warnings=ExperimentalWarning ./scripts/autovote.ts",
+    "autovote:predict": "node --experimental-strip-types --no-warnings=ExperimentalWarning ./scripts/autovote-predict.ts",
     "build": "TURBO_TELEMETRY_DISABLED=1 turbo run build --filter=!auction",
     "build:electron": "TURBO_TELEMETRY_DISABLED=1 ELECTRON=true turbo run build:electron",
     "test": "TURBO_TELEMETRY_DISABLED=1 turbo run test --filter=!hub --filter=!sequencer",

--- a/scripts/autovote-predict.ts
+++ b/scripts/autovote-predict.ts
@@ -1,0 +1,371 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+// Paste your key from https://openrouter.ai/keys (falls back to the env var).
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY ?? '';
+const MODEL = process.env.OPENROUTER_MODEL ?? 'anthropic/claude-opus-5';
+
+// Opus 5 thinks by default. Low effort is plenty for this call and keeps the
+// bill down, raise it if predictions look shallow.
+const REASONING_EFFORT = 'low';
+// Voters judged in parallel. Each voter still gets their own request.
+const CONCURRENCY = 4;
+// 0 runs every voter. Set a small number for a cheap test run first.
+const MAX_VOTERS = 0;
+// Most recent votes shown per voter, and body characters per proposal.
+const HISTORY_LIMIT = 40;
+const BODY_LIMIT = 4000;
+const MAX_RETRIES = 4;
+
+const INPUT_FILE = process.env.INPUT_FILE ?? 'scripts/autovote.json';
+const OUTPUT_FILE = process.env.OUTPUT_FILE ?? 'scripts/autovote-predict.json';
+const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
+
+type Proposal = {
+  id: string;
+  title: string;
+  body: string;
+  type: string;
+  choices: string[];
+  created: number;
+  quorum: number;
+  scores: number[];
+  scores_total: number;
+};
+
+type Vote = {
+  created: number;
+  choice: unknown;
+  vp: number;
+  reason: string;
+  proposal: string;
+};
+
+type Voter = {
+  address: string;
+  vp: number;
+  profile: { name: string | null; about: string | null } | null;
+  statement: { about: string; statement: string } | null;
+  votes: Vote[];
+};
+
+type Dataset = {
+  space: string;
+  proposal: Proposal;
+  proposals: Proposal[];
+  voters: Voter[];
+};
+
+type Prediction = {
+  choice: number;
+  confidence: 'high' | 'medium' | 'low';
+  reasoning: string;
+};
+
+type Result = Prediction & { address: string; vp: number; label: string };
+
+// OpenRouter reports what it charged per request, so the fee is measured
+// rather than estimated from token counts.
+type Usage = {
+  prompt_tokens: number;
+  completion_tokens: number;
+  cost?: number;
+};
+
+const SYSTEM_PROMPT = `You predict how one specific Snapshot voter would vote on a new proposal, using only their own voting history in this space plus their public profile.
+
+Rules:
+- Pick exactly one of the numbered options. "choice" is that option's 1-based index, which is how Snapshot encodes a vote.
+- Reason from evidence: how they voted on comparable past proposals, positions they state publicly, and any consistent pattern in their behaviour.
+- Use confidence "low" when the history is thin or says nothing about this topic. Do not manufacture a rationale you cannot point to.
+- Keep "reasoning" to one or two sentences naming the specific past votes or statement text behind the prediction.`;
+
+const RESPONSE_FORMAT = {
+  type: 'json_schema',
+  json_schema: {
+    name: 'vote_prediction',
+    strict: true,
+    schema: {
+      type: 'object',
+      properties: {
+        choice: {
+          type: 'integer',
+          description: '1-based index of the chosen option'
+        },
+        confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+        reasoning: { type: 'string' }
+      },
+      required: ['choice', 'confidence', 'reasoning'],
+      additionalProperties: false
+    }
+  }
+};
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const day = (timestamp: number) =>
+  new Date(timestamp * 1000).toISOString().slice(0, 10);
+
+const round = (value: number) => Math.round(value).toLocaleString('en-US');
+
+// Runs handler over every item, keeping at most CONCURRENCY requests in flight.
+async function pool<T, R>(
+  items: T[],
+  handler: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, items.length) }, async () => {
+      while (cursor < items.length) {
+        const index = cursor++;
+        results[index] = await handler(items[index] as T, index);
+      }
+    })
+  );
+
+  return results;
+}
+
+// A vote's choice is an index, a list of indexes, or index-to-weight, depending
+// on the proposal type. Render each as the option labels behind it, keeping the
+// distinction between a ranking and an unordered set of approvals.
+function formatChoice(vote: Vote, proposal: Proposal): string {
+  const { choice } = vote;
+  const label = (index: number) => proposal.choices[index - 1] ?? `#${index}`;
+
+  if (typeof choice === 'number') return label(choice);
+  if (Array.isArray(choice)) {
+    const labels = choice.map(c => label(Number(c)));
+    return proposal.type === 'ranked-choice'
+      ? labels.join(' > ')
+      : `approved ${labels.join(', ')}`;
+  }
+  if (choice && typeof choice === 'object') {
+    return Object.entries(choice as Record<string, number>)
+      .map(([index, weight]) => `${label(Number(index))}: ${weight}`)
+      .join(', ');
+  }
+
+  return 'undisclosed';
+}
+
+function formatProposal(proposal: Proposal): string {
+  const options = proposal.choices
+    .map((choice, index) => `${index + 1}. ${choice}`)
+    .join('\n');
+
+  return [
+    `Title: ${proposal.title}`,
+    `Voting type: ${proposal.type}`,
+    `Options:\n${options}`,
+    `Body:\n${proposal.body.slice(0, BODY_LIMIT)}`
+  ].join('\n\n');
+}
+
+function formatVoter(
+  voter: Voter,
+  proposals: Record<string, Proposal>
+): string {
+  const history = [...voter.votes]
+    .sort((a, b) => b.created - a.created)
+    .slice(0, HISTORY_LIMIT)
+    .flatMap(vote => {
+      const proposal = proposals[vote.proposal];
+      if (!proposal) return [];
+
+      const reason = vote.reason.trim();
+      return [
+        `- ${day(vote.created)} "${proposal.title}" voted ${formatChoice(vote, proposal)}` +
+          ` (voting power ${round(vote.vp)})${reason ? ` reason: ${reason}` : ''}`
+      ];
+    });
+
+  const identity = [
+    voter.profile?.name && `Name: ${voter.profile.name}`,
+    voter.profile?.about && `About: ${voter.profile.about}`,
+    voter.statement?.statement &&
+      `Delegate statement: ${voter.statement.statement}`
+  ].filter(Boolean);
+
+  return [
+    `Address: ${voter.address}`,
+    `Voting power on this proposal: ${round(voter.vp)}`,
+    ...identity,
+    `Voting history in this space (${voter.votes.length} votes, most recent first):`,
+    history.length ? history.join('\n') : '- none'
+  ].join('\n');
+}
+
+async function predict(
+  voter: Voter,
+  dataset: Dataset,
+  proposals: Record<string, Proposal>,
+  apiKey: string,
+  attempt = 0
+): Promise<{ prediction: Prediction; usage: Usage }> {
+  const retry = async (delay: number) => {
+    if (attempt >= MAX_RETRIES) return null;
+    await sleep(delay * 1000);
+    return predict(voter, dataset, proposals, apiKey, attempt + 1);
+  };
+
+  let res: Response;
+
+  try {
+    res = await fetch(OPENROUTER_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        reasoning: { effort: REASONING_EFFORT },
+        response_format: RESPONSE_FORMAT,
+        provider: { require_parameters: true },
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          {
+            role: 'user',
+            content: [
+              `Space: ${dataset.space}`,
+              `\n## Proposal being voted on\n\n${formatProposal(dataset.proposal)}`,
+              `\n## The voter\n\n${formatVoter(voter, proposals)}`,
+              `\nHow does this voter vote?`
+            ].join('\n')
+          }
+        ]
+      })
+    });
+  } catch (err) {
+    const retried = await retry(2 ** attempt);
+    if (retried) return retried;
+    throw err;
+  }
+
+  if (res.status === 429 || res.status >= 500) {
+    const retryAfter = Number(res.headers.get('retry-after')) || 2 ** attempt;
+    const retried = await retry(retryAfter);
+    if (retried) return retried;
+    throw new Error(
+      `OpenRouter answered ${res.status}, gave up after ${attempt}`
+    );
+  }
+
+  const json = (await res.json()) as {
+    choices?: { message: { content: string } }[];
+    usage?: Usage;
+    error?: { message: string };
+  };
+
+  const content = json.choices?.[0]?.message.content;
+  if (!content) {
+    throw new Error(json.error?.message ?? `OpenRouter returned no choice`);
+  }
+
+  const usage = json.usage ?? { prompt_tokens: 0, completion_tokens: 0 };
+  const prediction = JSON.parse(content) as Prediction;
+
+  // strict json_schema cannot express a numeric range, so check it here.
+  if (!dataset.proposal.choices[prediction.choice - 1]) {
+    const retried = await retry(1);
+    if (retried) return retried;
+    throw new Error(`Model returned out of range choice ${prediction.choice}`);
+  }
+
+  return { prediction, usage };
+}
+
+async function run() {
+  const apiKey = OPENROUTER_API_KEY || process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'No OpenRouter key. Set OPENROUTER_API_KEY at the top of this file.'
+    );
+  }
+
+  const dataset = JSON.parse(await readFile(INPUT_FILE, 'utf8')) as Dataset;
+  const proposals = Object.fromEntries(
+    dataset.proposals.map(proposal => [proposal.id, proposal])
+  );
+  const voters = MAX_VOTERS
+    ? dataset.voters.slice(0, MAX_VOTERS)
+    : dataset.voters;
+
+  console.log(`Proposal: ${dataset.proposal.title}`);
+  console.log(`Options: ${dataset.proposal.choices.join(' | ')}`);
+  console.log(`Predicting ${voters.length} voters with ${MODEL}\n`);
+
+  const totals = { cost: 0, input: 0, output: 0, failed: 0 };
+
+  const results = await pool(voters, async (voter, index) => {
+    const position = `[${index + 1}/${voters.length}]`;
+
+    try {
+      const { prediction, usage } = await predict(
+        voter,
+        dataset,
+        proposals,
+        apiKey
+      );
+
+      totals.cost += usage.cost ?? 0;
+      totals.input += usage.prompt_tokens;
+      totals.output += usage.completion_tokens;
+
+      const label = dataset.proposal.choices[prediction.choice - 1] as string;
+      console.log(
+        `${position} ${voter.address} ${label} (${prediction.confidence})`
+      );
+
+      return { ...prediction, address: voter.address, vp: voter.vp, label };
+    } catch (err) {
+      totals.failed++;
+      console.log(`${position} ${voter.address} failed: ${err}`);
+      return null;
+    }
+  });
+
+  const predictions = results.filter((result): result is Result => !!result);
+
+  await writeFile(
+    OUTPUT_FILE,
+    JSON.stringify(
+      {
+        space: dataset.space,
+        proposal: dataset.proposal.id,
+        model: MODEL,
+        fee: totals.cost,
+        predictions
+      },
+      null,
+      2
+    )
+  );
+
+  console.log(`\nResult by choice (voters / voting power):`);
+  dataset.proposal.choices.forEach((choice, index) => {
+    const picked = predictions.filter(p => p.choice === index + 1);
+    const power = picked.reduce((total, p) => total + p.vp, 0);
+    console.log(`  ${choice}: ${picked.length} / ${round(power)}`);
+  });
+
+  const byConfidence = (level: string) =>
+    predictions.filter(p => p.confidence === level).length;
+  console.log(
+    `\nConfidence: ${byConfidence('high')} high, ${byConfidence('medium')} medium, ${byConfidence('low')} low`
+  );
+  console.log(`Predicted: ${predictions.length}/${voters.length}`);
+  if (totals.failed) console.log(`Failed: ${totals.failed}`);
+  console.log(`Tokens: ${round(totals.input)} in, ${round(totals.output)} out`);
+  console.log(`Fee paid: $${totals.cost.toFixed(4)}`);
+  console.log(`Saved to ${OUTPUT_FILE}`);
+
+  return { predictions, fee: totals.cost };
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/autovote.ts
+++ b/scripts/autovote.ts
@@ -1,0 +1,428 @@
+import { writeFile } from 'node:fs/promises';
+
+const space = 'shutterdao0x36.eth';
+const proposal =
+  '0xff3507480f855f6512a909b67be0764f2116a2c7da4af022712bc2c8b74ace2c';
+
+// Number of voting power requests run in parallel.
+const CONCURRENCY = 8;
+
+const OUTPUT_FILE = process.env.OUTPUT_FILE ?? 'scripts/autovote.json';
+const SNAPSHOT_API_URL =
+  process.env.SNAPSHOT_API_URL ?? 'https://hub.snapshot.org/graphql';
+// Hub limits: 1000 items per page, 5000 on skip, 100 entries in an id_in.
+const PAGE_SIZE = 1000;
+const ID_IN_LIMIT = 100;
+const MAX_RETRIES = 4;
+
+type SpaceProposal = {
+  id: string;
+  title: string;
+  body: string;
+  author: string;
+  discussion: string;
+  type: string;
+  choices: string[];
+  created: number;
+  start: number;
+  end: number;
+  state: string;
+  votes: number;
+  quorum: number;
+  scores: number[];
+  scores_total: number;
+  scores_state: string;
+};
+
+// Delegate statement, the voter's own description of how they vote.
+type Statement = {
+  about: string;
+  statement: string;
+  discourse: string;
+  status: string;
+  created: number;
+};
+
+// Snapshot profile. Counts and lastVote are global, not scoped to the space.
+type Profile = {
+  name: string | null;
+  about: string | null;
+  avatar: string | null;
+  twitter: string | null;
+  github: string | null;
+  farcaster: string | null;
+  lens: string | null;
+  created: number | null;
+  votesCount: number;
+  proposalsCount: number;
+  lastVote: number;
+};
+
+// A vote cast in the space, the history an agent learns preferences from.
+// Proposal details live in the top level proposals list, each vote only keeps
+// the id to join on.
+type UserVote = {
+  created: number;
+  choice: unknown;
+  vp: number;
+  reason: string;
+  proposal: string;
+};
+
+type Voter = {
+  address: string;
+  vp: number;
+  profile: Profile | null;
+  statement: Statement | null;
+  votes: UserVote[];
+};
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const lower = (address: string) => address.toLowerCase();
+
+async function gql<T>(
+  query: string,
+  variables?: Record<string, unknown>,
+  attempt = 0
+): Promise<T> {
+  let res: Response;
+
+  try {
+    res = await fetch(SNAPSHOT_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(process.env.SNAPSHOT_API_KEY && {
+          'x-api-key': process.env.SNAPSHOT_API_KEY
+        })
+      },
+      body: JSON.stringify({ query, variables })
+    });
+  } catch (err) {
+    if (attempt >= MAX_RETRIES) throw err;
+    await sleep(2 ** attempt * 1000);
+    return gql<T>(query, variables, attempt + 1);
+  }
+
+  // Throttled or hub hiccup, back off and retry rather than lose the run.
+  if (res.status === 429 || res.status >= 500) {
+    if (attempt >= MAX_RETRIES) {
+      throw new Error(`Hub answered ${res.status}, gave up after ${attempt}`);
+    }
+
+    const retryAfter = Number(res.headers.get('retry-after')) || 2 ** attempt;
+    await sleep(retryAfter * 1000);
+    return gql<T>(query, variables, attempt + 1);
+  }
+
+  const json = (await res.json()) as {
+    data: T | null;
+    errors?: { message: string }[];
+  };
+
+  // The hub answers 200 with a null field on partial errors, fail loudly
+  // instead of silently returning nothing.
+  if (!json.data || json.errors?.length) {
+    throw new Error(json.errors?.[0]?.message ?? 'GraphQL returned no data');
+  }
+
+  return json.data;
+}
+
+// Walks a paginated hub collection until a partial page comes back.
+async function paginate<T>(
+  key: string,
+  query: string,
+  variables: Record<string, unknown> = {}
+): Promise<T[]> {
+  const items: T[] = [];
+
+  for (let skip = 0; ; skip += PAGE_SIZE) {
+    const data = await gql<Record<string, T[]>>(query, {
+      ...variables,
+      first: PAGE_SIZE,
+      skip
+    });
+    items.push(...(data[key] ?? []));
+
+    if ((data[key] ?? []).length < PAGE_SIZE) return items;
+  }
+}
+
+// Runs handler over every item, keeping at most CONCURRENCY requests in flight.
+async function pool<T, R>(
+  items: T[],
+  handler: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, items.length) }, async () => {
+      while (cursor < items.length) {
+        const index = cursor++;
+        results[index] = await handler(items[index] as T, index);
+      }
+    })
+  );
+
+  return results;
+}
+
+const PROPOSAL_FIELDS = `
+  id
+  title
+  body
+  author
+  discussion
+  type
+  choices
+  created
+  start
+  end
+  state
+  votes
+  quorum
+  scores
+  scores_total
+  scores_state
+`;
+
+async function getProposal(): Promise<SpaceProposal> {
+  const data = await gql<{
+    proposal: (SpaceProposal & { space: { id: string } }) | null;
+  }>(
+    `query ($proposal: String!) {
+      proposal(id: $proposal) {
+        ${PROPOSAL_FIELDS}
+        space {
+          id
+        }
+      }
+    }`,
+    { proposal }
+  );
+
+  if (!data.proposal) throw new Error(`Proposal ${proposal} not found`);
+
+  const { space: proposalSpace, ...target } = data.proposal;
+  if (proposalSpace.id !== space) {
+    throw new Error(`Proposal ${proposal} belongs to ${proposalSpace.id}`);
+  }
+
+  return target;
+}
+
+// Closed proposals only, the settled history an agent can learn from. Flagged
+// (spam) proposals are left out.
+async function getSpaceProposals(): Promise<SpaceProposal[]> {
+  return paginate<SpaceProposal>(
+    'proposals',
+    `query ($space: String!, $first: Int!, $skip: Int!) {
+      proposals(
+        first: $first
+        skip: $skip
+        orderBy: "created"
+        orderDirection: desc
+        where: {
+          space: $space
+          votes_gt: 0
+          flagged: false
+          state: "closed"
+        }
+      ) { ${PROPOSAL_FIELDS} }
+    }`,
+    { space }
+  );
+}
+
+async function getStatements(): Promise<Record<string, Statement>> {
+  const statements = await paginate<Statement & { delegate: string }>(
+    'statements',
+    `query ($space: String!, $first: Int!, $skip: Int!) {
+      statements(first: $first, skip: $skip, where: { space: $space }) {
+        delegate
+        about
+        statement
+        discourse
+        status
+        created
+      }
+    }`,
+    { space }
+  );
+
+  return Object.fromEntries(
+    statements.map(({ delegate, ...statement }) => [lower(delegate), statement])
+  );
+}
+
+async function getProfiles(
+  addresses: string[]
+): Promise<Record<string, Profile>> {
+  const batches = Array.from(
+    { length: Math.ceil(addresses.length / ID_IN_LIMIT) },
+    (_, i) => addresses.slice(i * ID_IN_LIMIT, (i + 1) * ID_IN_LIMIT)
+  );
+
+  const users = await pool(batches, batch =>
+    paginate<Profile & { id: string }>(
+      'users',
+      `query ($addresses: [String], $first: Int!, $skip: Int!) {
+        users(first: $first, skip: $skip, where: { id_in: $addresses }) {
+          id
+          name
+          about
+          avatar
+          twitter
+          github
+          farcaster
+          lens
+          created
+          votesCount
+          proposalsCount
+          lastVote
+        }
+      }`,
+      { addresses: batch }
+    )
+  );
+
+  return Object.fromEntries(
+    users.flat().map(({ id, ...profile }) => [lower(id), profile])
+  );
+}
+
+// Every vote cast in the space, in one sweep rather than one query per voter.
+// Cursor paginated on `created` because the hub refuses a skip above 5000, and
+// deduped by id since a page boundary can land inside a single timestamp.
+async function getSpaceVotes(): Promise<(UserVote & { voter: string })[]> {
+  const votes: (UserVote & { voter: string })[] = [];
+  const seen = new Set<string>();
+  let created: number | undefined;
+
+  for (;;) {
+    const data = await gql<{
+      votes: (Omit<UserVote, 'proposal'> & {
+        id: string;
+        voter: string;
+        proposal: { id: string };
+      })[];
+    }>(
+      `query ($space: String!, $created: Int, $first: Int!) {
+        votes(
+          first: $first
+          orderBy: "created"
+          orderDirection: desc
+          where: { space: $space, created_lte: $created }
+        ) {
+          id
+          voter
+          created
+          choice
+          vp
+          reason
+          proposal {
+            id
+          }
+        }
+      }`,
+      { space, created, first: PAGE_SIZE }
+    );
+
+    const fresh = data.votes.filter(vote => !seen.has(vote.id));
+    for (const { id, proposal: votedOn, ...vote } of fresh) {
+      seen.add(id);
+      votes.push({ ...vote, proposal: votedOn.id });
+    }
+
+    // A full page of duplicates would mean 1000 votes share one timestamp,
+    // stop rather than loop forever on the same cursor.
+    if (data.votes.length < PAGE_SIZE || !fresh.length) return votes;
+
+    created = data.votes[data.votes.length - 1]?.created;
+  }
+}
+
+async function getVotingPower(voter: string): Promise<number> {
+  const data = await gql<{ vp: { vp: number } | null }>(
+    `query ($voter: String!, $space: String!, $proposal: String) {
+      vp(voter: $voter, space: $space, proposal: $proposal) {
+        vp
+      }
+    }`,
+    { voter, space, proposal }
+  );
+
+  return data.vp?.vp ?? 0;
+}
+
+async function run() {
+  console.log(`Loading ${space}...`);
+  const target = await getProposal();
+
+  const [proposals, statements, spaceVotes] = await Promise.all([
+    getSpaceProposals(),
+    getStatements(),
+    getSpaceVotes()
+  ]);
+
+  // Keep every address that ever voted, but only the votes cast on proposals
+  // that made the cut, so no vote points at a proposal we dropped.
+  const addresses = Array.from(
+    new Map(spaceVotes.map(vote => [lower(vote.voter), vote.voter])).values()
+  );
+  const kept = new Set(proposals.map(p => p.id));
+  const history: Record<string, UserVote[]> = {};
+  for (const { voter, ...vote } of spaceVotes) {
+    if (kept.has(vote.proposal)) (history[lower(voter)] ??= []).push(vote);
+  }
+
+  const profiles = await getProfiles(addresses);
+  console.log(
+    `Found ${addresses.length} unique voters, ${proposals.length} closed proposals, ` +
+      `${Object.keys(statements).length} statements, ${Object.keys(profiles).length} profiles\n`
+  );
+
+  console.log(`Loading voting power on ${proposal}...`);
+  const powers = await pool(addresses, async (address, index) => {
+    const vp = await getVotingPower(address);
+    console.log(`[${index + 1}/${addresses.length}] ${address} ${vp}`);
+    return vp;
+  });
+
+  const voters: Voter[] = addresses
+    .map((address, index) => ({
+      address,
+      vp: powers[index] ?? 0,
+      profile: profiles[lower(address)] ?? null,
+      statement: statements[lower(address)] ?? null,
+      votes: history[lower(address)] ?? []
+    }))
+    .filter(voter => voter.vp > 0)
+    .sort((a, b) => b.vp - a.vp);
+
+  const dataset = { space, proposal: target, proposals, voters };
+  await writeFile(OUTPUT_FILE, JSON.stringify(dataset, null, 2));
+
+  console.log(`\nClosed proposals: ${proposals.length}`);
+  console.log(
+    `Addresses with voting power: ${voters.length}/${addresses.length}`
+  );
+  console.log(`Voters with a profile: ${voters.filter(v => v.profile).length}`);
+  console.log(
+    `Voters with a statement: ${voters.filter(v => v.statement).length}`
+  );
+  console.log(
+    `Votes loaded: ${voters.reduce((total, v) => total + v.votes.length, 0)}`
+  );
+  console.log(`Saved to ${OUTPUT_FILE}`);
+
+  return dataset;
+}
+
+run().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Groundwork for **autovote**, a feature a space could enable to have agents vote on behalf of everyone who ever voted there, predicting each voter's next vote from their history.

Two scripts, run in sequence. Nothing here casts a vote — this is the read and predict half.

### `bun run autovote`

Collects the dataset for a space and proposal (both consts at the top of the file) and writes `scripts/autovote.json`:

- every unique voter in the space, and their voting power on the target proposal
- their Snapshot profile (including the global `votesCount` / `lastVote`) and delegate statement
- their full vote history in the space
- the closed, unflagged proposals those votes point at, with body, author, discussion link, quorum and scores

Votes are filtered to the proposals that made the cut, so nothing points at a proposal that isn't in the file.

### `bun run autovote:predict`

Reads that file and asks an LLM through OpenRouter (`anthropic/claude-opus-5` by default) how each voter would vote — one request per voter — using a strict JSON schema that returns `{choice, confidence, reasoning}`. Each voter's dossier renders their past votes as option labels rather than raw indices, keeping ranked-choice (`A > B > C`) distinct from approval (`approved A, B, C`).

Reports the fee **actually charged**, summed from OpenRouter's per-request `usage.cost` rather than estimated from token counts.

The OpenRouter key is a const at the top of the file (falling back to `OPENROUTER_API_KEY`), alongside `MODEL`, `REASONING_EFFORT`, `CONCURRENCY` and `MAX_VOTERS`. **Set `MAX_VOTERS` to 2-3 for a cheap first run** — a full 158-voter run costs roughly $2-6.

### Notes on the hub queries

- Unique voters are derived from a single sweep of the space's votes, grouped locally, rather than one query per voter — 345 requests down to ~190, and a full collection run from 3m20s to about 1 minute.
- Vote pagination is cursor based on `created` with id dedup, because the hub rejects `skip` above 5000. Skip-based paging silently caps a space at 5000 votes.
- The hub answers 200 with a null field on partial errors, so `gql` throws when `errors` is present. Without that, an over-limit `id_in` filter returns an empty page and the run writes a file full of nulls with no warning.

`scripts/autovote.json` is deliberately not committed — it's generated output (~670K) and reproducible with `bun run autovote`.

## Test plan

- [x] `bun run lint` passes on both scripts
- [x] `tsc --noEmit --strict --noUncheckedIndexedAccess` clean on both
- [x] Full collection run against `shutterdao0x36.eth`: 158 voters, 59 closed proposals, 12 statements, 158 profiles, 1472 votes, no dangling proposal references and no encrypted choices in the output
- [x] Cursor pagination validated against `safe.eth` — fetched all 23,583 votes across 24 pages, exactly matching the space's `votesCount`, where skip-based paging would have stopped at 5,000
- [x] Guards tested: a proposal id from another space errors with `Proposal 0x943e… belongs to ens.eth`, an unknown id with `not found`
- [x] Retry path tested against an unreachable host — fails cleanly after backoff rather than hanging
- [x] Prediction script exercised end to end with an invalid key: all 158 dossiers build, concurrency works, a failed voter is isolated rather than killing the run, summary and fee reporting print
- [ ] **Not verified:** the OpenRouter model call, structured-output parsing, and cost accounting — needs a real API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)
