### PR TITLE
fix(ui): don't let one failing space break the whole organization page

### DIFF
--- a/apps/ui/src/composables/useOrganization.test.ts
+++ b/apps/ui/src/composables/useOrganization.test.ts
@@ -1,0 +1,193 @@
+// @vitest-environment happy-dom
+import { QueryClient, VUE_QUERY_CLIENT } from '@tanstack/vue-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp, reactive } from 'vue';
+
+const SX_SPACE = { id: '0xSX', network: 'eth' };
+const OFFCHAIN_SPACE = { id: 'testorg.eth', network: 's' };
+
+const ORG_CONFIG = {
+  id: 'testorg',
+  name: 'Test Org',
+  spaceIds: [
+    { network: 'eth', id: '0xSX' },
+    { network: 's', id: 'testorg.eth' }
+  ]
+};
+
+let mockRoute: { params: Record<string, string>; matched: { name: string }[] };
+const loadSpaceMock = vi.fn();
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute
+}));
+
+vi.mock('@/queries/spaces', () => ({
+  SPACES_KEYS: {
+    all: ['spaces'],
+    detail: (spaceId: string) => ['spaces', 'detail', spaceId]
+  },
+  spaceQueryFn: (networkId: string, spaceId: string) => () =>
+    loadSpaceMock(networkId, spaceId)
+}));
+
+vi.mock('@/helpers/organizations', () => ({
+  getOrganizationConfigByDomain: () => null,
+  getOrganizationConfigById: (id: string) =>
+    id === ORG_CONFIG.id ? ORG_CONFIG : null
+}));
+
+let queryClient: QueryClient;
+let testApp: ReturnType<typeof createApp>;
+
+async function withSetup() {
+  const { useOrganization } = await import('./useOrganization');
+
+  let result!: ReturnType<typeof useOrganization>;
+  testApp = createApp({
+    setup() {
+      result = useOrganization();
+      return () => null;
+    }
+  });
+  testApp.provide(VUE_QUERY_CLIENT, queryClient);
+  testApp.mount(document.createElement('div'));
+  return result;
+}
+
+beforeEach(() => {
+  // useOrganization is a shared composable, so it must be re-imported per test
+  vi.resetModules();
+  loadSpaceMock.mockReset();
+  mockRoute = reactive({
+    params: { org: ORG_CONFIG.id },
+    matched: [{ name: 'org' }]
+  });
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } }
+  });
+});
+
+afterEach(() => {
+  testApp?.unmount();
+  queryClient.clear();
+});
+
+describe('useOrganization', () => {
+  it('should load every space of the organization', async () => {
+    loadSpaceMock.mockImplementation(async (networkId: string) =>
+      networkId === 'eth' ? SX_SPACE : OFFCHAIN_SPACE
+    );
+
+    const { organization } = await withSetup();
+
+    await vi.waitFor(() => expect(organization.value).not.toBe(null));
+    expect(organization.value?.spaces).toEqual([SX_SPACE, OFFCHAIN_SPACE]);
+  });
+
+  it('should cache every space under its space detail query key', async () => {
+    loadSpaceMock.mockImplementation(async (networkId: string) =>
+      networkId === 'eth' ? SX_SPACE : OFFCHAIN_SPACE
+    );
+
+    const { organization } = await withSetup();
+
+    await vi.waitFor(() => expect(organization.value).not.toBe(null));
+    expect(queryClient.getQueryData(['spaces', 'detail', 'eth:0xSX'])).toEqual(
+      SX_SPACE
+    );
+    expect(
+      queryClient.getQueryData(['spaces', 'detail', 's:testorg.eth'])
+    ).toEqual(OFFCHAIN_SPACE);
+  });
+
+  it('should keep remaining spaces when one space resolves to null', async () => {
+    loadSpaceMock.mockImplementation(async (networkId: string) =>
+      networkId === 'eth' ? null : OFFCHAIN_SPACE
+    );
+
+    const { organization } = await withSetup();
+
+    await vi.waitFor(() => expect(organization.value).not.toBe(null));
+    expect(organization.value?.spaces).toEqual([OFFCHAIN_SPACE]);
+  });
+
+  // Regression: a rejecting space query (e.g. space metadata not indexed yet)
+  // used to reject the whole Promise.all, leaving organization null forever.
+  it('should keep remaining spaces when one space fails to load', async () => {
+    loadSpaceMock.mockImplementation(async (networkId: string) => {
+      if (networkId === 'eth') throw new Error('metadata not indexed');
+      return OFFCHAIN_SPACE;
+    });
+
+    const { organization, isLoading } = await withSetup();
+
+    await vi.waitFor(() => expect(organization.value).not.toBe(null));
+    expect(organization.value?.spaces).toEqual([OFFCHAIN_SPACE]);
+    expect(isLoading.value).toBe(false);
+  });
+
+  it('should resolve with no spaces when every space fails to load', async () => {
+    loadSpaceMock.mockRejectedValue(new Error('API down'));
+
+    const { organization, isLoading } = await withSetup();
+
+    await vi.waitFor(() => expect(organization.value).not.toBe(null));
+    expect(organization.value?.spaces).toEqual([]);
+    expect(isLoading.value).toBe(false);
+  });
+
+  it('should not wait for the retries of a space that failed', async () => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: 3, retryDelay: 60_000, gcTime: Infinity }
+      }
+    });
+    loadSpaceMock.mockImplementation(async (networkId: string) => {
+      if (networkId === 'eth') throw new Error('metadata not indexed');
+      return OFFCHAIN_SPACE;
+    });
+
+    const { organization, isLoading } = await withSetup();
+
+    await vi.waitFor(() => expect(organization.value).not.toBe(null));
+    expect(organization.value?.spaces).toEqual([OFFCHAIN_SPACE]);
+    expect(isLoading.value).toBe(false);
+  });
+
+  it('should not expose an empty organization before its queries are created', async () => {
+    mockRoute = reactive({ params: {}, matched: [{ name: 'home' }] });
+    loadSpaceMock.mockResolvedValue(OFFCHAIN_SPACE);
+
+    const { organization, isLoading } = await withSetup();
+    expect(organization.value).toBe(null);
+
+    mockRoute.matched = [{ name: 'org' }];
+    mockRoute.params = { org: ORG_CONFIG.id };
+
+    expect(isLoading.value).toBe(true);
+    expect(organization.value).toBe(null);
+  });
+
+  it('should not expose the organization until every space settled', async () => {
+    let resolveOffchainSpace!: (space: unknown) => void;
+    loadSpaceMock.mockImplementation(async (networkId: string) => {
+      if (networkId === 'eth') return SX_SPACE;
+
+      return new Promise(resolve => {
+        resolveOffchainSpace = resolve;
+      });
+    });
+
+    const { organization, isLoading } = await withSetup();
+
+    await vi.waitFor(() => expect(loadSpaceMock).toHaveBeenCalledTimes(2));
+    expect(organization.value).toBe(null);
+    expect(isLoading.value).toBe(true);
+
+    resolveOffchainSpace(OFFCHAIN_SPACE);
+
+    await vi.waitFor(() => expect(organization.value).not.toBe(null));
+    expect(organization.value?.spaces).toEqual([SX_SPACE, OFFCHAIN_SPACE]);
+  });
+});

--- a/apps/ui/src/composables/useOrganization.ts
+++ b/apps/ui/src/composables/useOrganization.ts
@@ -1,18 +1,17 @@
-import { useQuery, useQueryClient } from '@tanstack/vue-query';
+import { useQueries } from '@tanstack/vue-query';
 import {
   getOrganizationConfigByDomain,
   getOrganizationConfigById,
   Organization,
   OrganizationConfig
 } from '@/helpers/organizations';
-import { getNetwork } from '@/networks';
+import { spaceQueryFn, SPACES_KEYS } from '@/queries/spaces';
 import { Space } from '@/types';
 
 const domain = window.location.hostname;
 
 function setup() {
   const route = useRoute();
-  const queryClient = useQueryClient();
 
   const config = computed<OrganizationConfig | null>(() => {
     const byDomain = getOrganizationConfigByDomain(domain);
@@ -22,42 +21,43 @@ function setup() {
     return getOrganizationConfigById(route.params.org as string);
   });
 
-  const { data: spaces, isLoading } = useQuery({
-    queryKey: ['org', 'spaces', () => config.value?.id],
-    queryFn: async () => {
-      const cfg = config.value;
-      if (!cfg) return [];
+  // One query per space, sharing the space detail query, so that a space which
+  // fails to load (e.g. an API error on its metadata) only fails its own query
+  // instead of taking the rest of the organization down with it.
+  const spaceQueries = useQueries({
+    queries: computed(() =>
+      (config.value?.spaceIds ?? []).map(({ network: networkId, id }) => ({
+        queryKey: SPACES_KEYS.detail(`${networkId}:${id}`),
+        queryFn: spaceQueryFn(networkId, id)
+      }))
+    )
+  });
 
-      const loadedSpaces = await Promise.all(
-        cfg.spaceIds.map(async ({ network: networkId, id }) => {
-          const network = getNetwork(networkId);
-          const space = await network.api.loadSpace(id);
+  // The organization is exposed only once every space query settled, so that
+  // the primary space, and the nav derived from it, does not change while the
+  // remaining spaces are still loading. A space that already failed an attempt
+  // is not waited for: its retries keep running in the background and it joins
+  // the organization if one of them succeeds.
+  const isLoading = computed(() => {
+    const cfg = config.value;
+    if (!cfg) return false;
 
-          if (!space) {
-            console.warn(
-              `Failed to load space ${networkId}:${id} for organization ${cfg.id}`
-            );
-            return null;
-          }
-
-          queryClient.setQueryData(
-            ['spaces', 'detail', `${space.network}:${space.id}`],
-            space
-          );
-
-          return space;
-        })
-      );
-
-      return loadedSpaces.filter((s): s is Space => !!s);
-    },
-    enabled: () => config.value !== null
+    return (
+      spaceQueries.value.length !== cfg.spaceIds.length ||
+      spaceQueries.value.some(query => query.isLoading && !query.failureCount)
+    );
   });
 
   const organization = computed<Organization | null>(() => {
-    const org = config.value;
-    if (!org || !spaces.value) return null;
-    return { ...org, spaces: spaces.value };
+    const cfg = config.value;
+    if (!cfg || isLoading.value) return null;
+
+    return {
+      ...cfg,
+      spaces: spaceQueries.value
+        .map(query => query.data)
+        .filter((space): space is Space => !!space)
+    };
   });
 
   return {

--- a/apps/ui/src/queries/spaces.ts
+++ b/apps/ui/src/queries/spaces.ts
@@ -13,6 +13,12 @@ import { NetworkID, Space } from '@/types';
 
 type SpaceCategory = 'all' | (typeof SPACE_CATEGORIES)[number]['id'];
 
+export const SPACES_KEYS = {
+  all: ['spaces'] as const,
+  detail: (spaceId: MaybeRefOrGetter<string>) =>
+    [...SPACES_KEYS.all, 'detail', spaceId] as const
+};
+
 // NOTE: this is used for followed spaces
 export async function getSpaces(filter?: SpacesFilter) {
   const results = await Promise.all(
@@ -79,11 +85,9 @@ export function useFollowedSpacesQuery({
     return async (): Promise<Space[]> => {
       const [existingSpaces, unavailableIds] = ids.reduce(
         (acc, id) => {
-          const existingData = queryClient.getQueryData<Space>([
-            'spaces',
-            'detail',
-            id
-          ]);
+          const existingData = queryClient.getQueryData<Space>(
+            SPACES_KEYS.detail(id)
+          );
 
           if (existingData) {
             acc[0].push(existingData);
@@ -102,7 +106,7 @@ export function useFollowedSpacesQuery({
 
       for (const space of spaces) {
         queryClient.setQueryData<Space>(
-          ['spaces', 'detail', `${space.network}:${space.id}`],
+          SPACES_KEYS.detail(`${space.network}:${space.id}`),
           space
         );
       }
@@ -118,6 +122,16 @@ export function useFollowedSpacesQuery({
   });
 }
 
+export function spaceQueryFn(networkId: NetworkID, spaceId: string) {
+  return async (): Promise<Space | null> => {
+    const metaStore = useMetaStore();
+
+    await metaStore.fetchBlock(networkId);
+
+    return getNetwork(networkId).api.loadSpace(spaceId);
+  };
+}
+
 export function useSpaceQuery({
   networkId,
   spaceId
@@ -125,24 +139,17 @@ export function useSpaceQuery({
   networkId: MaybeRefOrGetter<NetworkID | null>;
   spaceId: MaybeRefOrGetter<string | null>;
 }) {
-  const metaStore = useMetaStore();
-
   return useQuery({
-    queryKey: [
-      'spaces',
-      'detail',
+    queryKey: SPACES_KEYS.detail(
       () => `${toValue(networkId)}:${toValue(spaceId)}`
-    ],
+    ),
     queryFn: async () => {
       const networkIdValue = toValue(networkId);
       const spaceIdValue = toValue(spaceId);
 
       if (!networkIdValue || !spaceIdValue) return null;
 
-      await metaStore.fetchBlock(networkIdValue);
-      const network = getNetwork(networkIdValue);
-
-      return network.api.loadSpace(spaceIdValue);
+      return spaceQueryFn(networkIdValue, spaceIdValue)();
     },
     enabled: () => toValue(networkId) !== null && toValue(spaceId) !== null
   });
@@ -195,7 +202,7 @@ export function useExploreSpacesQuery({
 
       for (const space of results) {
         queryClient.setQueryData(
-          ['spaces', 'detail', `${space.network}:${space.id}`],
+          SPACES_KEYS.detail(`${space.network}:${space.id}`),
           space
         );
       }


### PR DESCRIPTION
Split out of #2246 at @wa0x6e's request: that PR is now only the Shutter PEN org config (one file, +14/-0) and is stacked on this branch, because the org it adds contains one of the spaces that triggers this bug.

This is the UI half only. The indexer-side cause of the failing `space.metadata` (spaces deployed with a blank `metadataURI`) is tracked separately in #2261, but fixing that would not make this PR unnecessary, since any org with a transiently failing space API goes blank the same way.

## The bug

`useOrganization` loads every space of an organization inside a single query's `Promise.all`. The per-space `null` check and `console.warn` in there show the intent was already to tolerate a space that cannot be loaded, but `loadSpace` **rejects** rather than resolving to `null` when the API returns a GraphQL error (Apollo's default `errorPolicy` is `none`), so the `isSpaceWithMetadata` guard is never reached and one failing space rejects the whole batch. The org query errors, `spaces` stays `undefined`, `organization` stays `null`, and the org page renders neither its loading state nor its content: a blank page under the app shell.

Any org containing a space whose API is failing goes blank this way. It is not specific to one org.

## It reproduces today

`api.snapshot.box` errors on `space.metadata` for two spaces deployed on 2026-07-21, verified 2026-08-10:

```
$ curl -s https://api.snapshot.box/graphql -H 'Content-Type: application/json' \
  -d '{"query":"query($indexer:String!,$id:String!){space(indexer:$indexer,id:$id){id created metadata{id name}}}",
       "variables":{"indexer":"eth","id":"0xe44a9c5670Ce7C3675f389785E0C565e52730377"}}'

{"errors":[{"message":"The loader.load() function must be called with a value, but got: undefined.",
  "path":["space","metadata"],"extensions":{"code":"INTERNAL_SERVER_ERROR"}}],
 "data":{"space":{"id":"0xe44a9c5670Ce7C3675f389785E0C565e52730377","created":1784649731,"metadata":null}}}
```

`0x11DbAFcB0b8A966c6730Af5Cda5a7D7E5FF2Bb58` fails identically. Note the ids are case-sensitive. The space row itself resolves (`created`, `proposal_count`, `protocol`); only the `metadata` relation errors, so this is a null metadata pointer on the indexer side rather than an outage. It has persisted 20 days now, so it is not transient indexing lag and is worth a separate look at the indexer; this PR only stops the UI from going blank because of it.

## The fix

Replace the `Promise.all` with `useQueries`, one query per space, reusing the space detail query key and fetcher now exported from `queries/spaces.ts` as `SPACES_KEYS` and `spaceQueryFn`. This is the shape `Organization/Overview.vue` already uses for its per-space proposal queries.

- The failure is isolated by construction: a space that errors fails only its own query, the org renders with the spaces that did load, and it picks the failing space up once it recovers.
- The manual `queryClient.setQueryData(['spaces', 'detail', …])` seeding is gone, because the org's spaces now *are* those cache entries. The org page dedupes with the space page's own query, and the `invalidateQueries` in space settings refreshes the org's copy of a space.
- A transient failure retries per space instead of being swallowed for the lifetime of the org query.

`isLoading` stays batch-like: the org is exposed only once every space query has settled, so the primary space and the nav derived from it do not change while the rest are still loading, but it does not wait on a space that already failed an attempt. Without that the org page would sit through the failing space's retry backoff before rendering the spaces that did load (measured: first render at ~8.7s instead of ~1.6s). Those retries keep running in the background and the space joins the org if one succeeds.

`useSpaceQuery` is refactored onto the same `SPACES_KEYS` / `spaceQueryFn` pair, so the key and the fetcher have one definition each.

## Tests

`useOrganization.test.ts` is added with 8 tests covering the per-space isolation, the retry behaviour and the loading gate. They are mutation-checked, not just green:

- against the original `Promise.all` batching, **5 of 8 fail**, including both core regressions (`should keep remaining spaces when one space fails to load`, `should resolve with no spaces when every space fails to load`);
- against a variant whose `isLoading` waits on retries (dropping `&& !query.failureCount`), exactly **1 fails** (`should not wait for the retries of a space that failed`).

The org config is fully mocked in the test, so this file does not depend on the Shutter PEN org in #2246.

## Gate

bun 1.3.14, all from a clean tree:

| step | result |
| --- | --- |
| `bun run build` | 15/15 tasks successful |
| `bun run typecheck` | 16/16 tasks successful (also re-run with `--force`, 0 cached) |
| `bun run lint` | 15/15 tasks successful |
| `bun run lint:unused` | clean (only the pre-existing `**/auto-imports.d.ts` config hint from `knip.config.ts`, which this PR does not touch) |
| `bun run test` | 24 files, 214 passed / 1 skipped |

Browser check on the deploy preview, existing orgs are unaffected: `/#/org/ens` renders in 2.1s, `/#/org/starknet` in 1.7s, `/#/org/arbitrum` in 1.5s, no page errors on any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
