### PR TITLE
fix(api): keep space metadata null when the space has no metadata uri

### DIFF
--- a/apps/api/src/common/utils.test.ts
+++ b/apps/api/src/common/utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getSpaceMetadataId } from './utils';
+
+describe('getSpaceMetadataId', () => {
+  it('strips the ipfs scheme', () => {
+    expect(getSpaceMetadataId('ipfs://bafyMetadata')).toEqual('bafyMetadata');
+  });
+
+  it('keeps a uri that is not ipfs as is', () => {
+    expect(getSpaceMetadataId('https://example.com/space.json')).toEqual(
+      'https://example.com/space.json'
+    );
+  });
+
+  it('is null for a blank uri', () => {
+    expect(getSpaceMetadataId('')).toBeNull();
+  });
+});

--- a/apps/api/src/common/utils.ts
+++ b/apps/api/src/common/utils.ts
@@ -76,6 +76,19 @@ export function dropIpfs(metadataUri: string) {
   return metadataUri.replace('ipfs://', '');
 }
 
+/**
+ * Id of the `SpaceMetadataItem` a space resolves its metadata through, which is
+ * also the value stored in `space.metadata`.
+ *
+ * A space can be deployed with a blank `metadataURI`, and then there is nothing
+ * to point at. `dropIpfs('')` is `''`, which is not an id any metadata item
+ * should own and is shared by every space deployed without a URI on the same
+ * indexer, so an absent URI has to stay null.
+ */
+export function getSpaceMetadataId(metadataUri: string): string | null {
+  return metadataUri ? dropIpfs(metadataUri) : null;
+}
+
 export function getSpaceName(address: string) {
   const seed = parseInt(
     hash.getSelectorFromName(address).toString().slice(0, 12)

--- a/apps/api/src/evm/protocols/snapshot-x/ipfs.test.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/ipfs.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleSpaceMetadata } from './ipfs';
+
+const mocks = vi.hoisted(() => ({
+  created: [] as { id: string; save: ReturnType<typeof vi.fn> }[],
+  loadEntity: vi.fn(async (): Promise<unknown> => null),
+  fetch: vi.fn()
+}));
+
+vi.mock('../../../../.checkpoint/models', () => {
+  class SpaceMetadataItem {
+    static loadEntity = mocks.loadEntity;
+    save = vi.fn(async () => {});
+
+    constructor(
+      public id: string,
+      public indexerName: string
+    ) {
+      mocks.created.push(this);
+    }
+  }
+
+  class Network {}
+  class Proposal {}
+  class ScoresTick {}
+
+  return { SpaceMetadataItem, Network, Proposal, ScoresTick };
+});
+
+const SPACE = '0xe44a9c5670Ce7C3675f389785E0C565e52730377';
+
+describe('handleSpaceMetadata', () => {
+  beforeEach(() => {
+    mocks.created.length = 0;
+    mocks.loadEntity.mockClear();
+    mocks.loadEntity.mockResolvedValue(null);
+    mocks.fetch.mockReset();
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: 'Radish DAO' })
+    });
+    vi.stubGlobal('fetch', mocks.fetch);
+  });
+
+  // A space can be deployed with a blank metadataURI. There is no metadata to
+  // index for it, and `dropIpfs('')` is `''`, an id shared by every such space
+  // on the indexer, so nothing should be written at all.
+  it('writes nothing for a blank uri', async () => {
+    const item = await handleSpaceMetadata(SPACE, '', 'eth');
+
+    expect(item).toBeUndefined();
+    expect(mocks.created).toHaveLength(0);
+    expect(mocks.loadEntity).not.toHaveBeenCalled();
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('keys the metadata item on the cid', async () => {
+    await handleSpaceMetadata(SPACE, 'ipfs://bafyMetadata', 'eth');
+
+    expect(mocks.created).toHaveLength(1);
+    expect(mocks.created[0]?.id).toEqual('bafyMetadata');
+    expect(mocks.created[0]?.save).toHaveBeenCalled();
+  });
+
+  it('reuses an already indexed metadata item', async () => {
+    mocks.loadEntity.mockResolvedValue({ id: 'bafyMetadata' });
+
+    const item = await handleSpaceMetadata(SPACE, 'ipfs://bafyMetadata', 'eth');
+
+    expect(item).toBeUndefined();
+    expect(mocks.created).toHaveLength(0);
+  });
+});

--- a/apps/api/src/evm/protocols/snapshot-x/ipfs.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/ipfs.ts
@@ -1,6 +1,10 @@
 import { getAddress } from 'viem';
 import { SpaceMetadataItem } from '../../../../.checkpoint/models';
-import { dropIpfs, getJSON, getSpaceName } from '../../../common/utils';
+import {
+  getJSON,
+  getSpaceMetadataId,
+  getSpaceName
+} from '../../../common/utils';
 import { NetworkID } from '../../types';
 
 export async function handleSpaceMetadata(
@@ -8,16 +12,13 @@ export async function handleSpaceMetadata(
   metadataUri: string,
   indexerName: NetworkID
 ) {
-  const exists = await SpaceMetadataItem.loadEntity(
-    dropIpfs(metadataUri),
-    indexerName
-  );
+  const id = getSpaceMetadataId(metadataUri);
+  if (id === null) return;
+
+  const exists = await SpaceMetadataItem.loadEntity(id, indexerName);
   if (exists) return;
 
-  const spaceMetadataItem = new SpaceMetadataItem(
-    dropIpfs(metadataUri),
-    indexerName
-  );
+  const spaceMetadataItem = new SpaceMetadataItem(id, indexerName);
   spaceMetadataItem.name = getSpaceName(space);
   spaceMetadataItem.about = '';
   spaceMetadataItem.avatar = '';
@@ -38,7 +39,7 @@ export async function handleSpaceMetadata(
   spaceMetadataItem.labels = [];
   spaceMetadataItem.delegations = [];
 
-  const metadata: any = metadataUri ? await getJSON(metadataUri) : {};
+  const metadata: any = await getJSON(metadataUri);
 
   if (metadata.name) spaceMetadataItem.name = metadata.name;
   if (metadata.description) spaceMetadataItem.about = metadata.description;

--- a/apps/api/src/evm/protocols/snapshot-x/writers.test.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/writers.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as snapshotXUtils from './utils';
+import { createWriters } from './writers';
+import * as commonUtils from '../../../common/utils';
+import { EVMConfig, SnapshotXConfig } from '../../types';
+
+const mocks = vi.hoisted(() => ({
+  spaces: [] as Record<string, unknown>[],
+  handleSpaceMetadata: vi.fn(async () => undefined)
+}));
+
+vi.mock('../../../../.checkpoint/models', () => {
+  class Space {
+    save = vi.fn(async () => {});
+
+    constructor(
+      public id: string,
+      public indexerName: string
+    ) {
+      mocks.spaces.push(this as unknown as Record<string, unknown>);
+    }
+
+    static loadEntity = vi.fn(async () => null);
+  }
+
+  class Entity {
+    save = vi.fn(async () => {});
+    static loadEntity = vi.fn(async () => null);
+  }
+
+  return {
+    ExecutionHash: Entity,
+    ExecutionStrategy: Entity,
+    Leaderboard: Entity,
+    Network: Entity,
+    Proposal: Entity,
+    ScoresTick: Entity,
+    Space,
+    SpaceMetadataItem: Entity,
+    StarknetL1Execution: Entity,
+    User: Entity,
+    Vote: Entity
+  };
+});
+
+vi.mock('./ipfs', () => ({ handleSpaceMetadata: mocks.handleSpaceMetadata }));
+
+vi.mock('./logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}));
+
+vi.mock('./utils', async importOriginal => ({
+  ...(await importOriginal<typeof snapshotXUtils>()),
+  handleCustomExecutionStrategy: vi.fn(async () => {}),
+  updateProposalValidationStrategy: vi.fn(async () => {})
+}));
+
+vi.mock('../../../common/ipfs', () => ({
+  handleProposalMetadata: vi.fn(async () => {}),
+  handleStrategiesMetadata: vi.fn(async () => ({ strategiesDecimals: [] })),
+  handleVoteMetadata: vi.fn(async () => {})
+}));
+
+vi.mock('../../../common/utils', async importOriginal => ({
+  ...(await importOriginal<typeof commonUtils>()),
+  updateCounter: vi.fn(async () => {}),
+  updateScoresTick: vi.fn(async () => {})
+}));
+
+const config = {
+  indexerName: 'eth',
+  network_node_url: 'https://rpc.invalid'
+} as unknown as EVMConfig;
+
+const protocolConfig = {
+  chainId: 1,
+  manaRpcUrl: 'https://mana.invalid',
+  masterSpace: '0x0000000000000000000000000000000000000001',
+  masterSimpleQuorumAvatar: null,
+  masterSimpleQuorumTimelock: null,
+  propositionPowerValidationStrategyAddress: null,
+  apeGasStrategy: null,
+  apeGasStrategyDelay: 0
+} satisfies SnapshotXConfig as SnapshotXConfig;
+
+const SPACE = '0xe44a9c5670Ce7C3675f389785E0C565e52730377';
+
+function createSpaceCreatedEvent(metadataURI: string) {
+  return {
+    args: {
+      space: SPACE,
+      input: {
+        owner: '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6',
+        votingDelay: 0,
+        minVotingDuration: 0,
+        maxVotingDuration: 86400,
+        proposalValidationStrategy: {
+          addr: '0x0000000000000000000000000000000000000002',
+          params: '0x'
+        },
+        proposalValidationStrategyMetadataURI: '',
+        daoURI: '',
+        metadataURI,
+        votingStrategies: [],
+        votingStrategyMetadataURIs: [],
+        authenticators: []
+      }
+    }
+  };
+}
+
+async function handleSpaceCreated(metadataURI: string) {
+  const writers = createWriters(config, protocolConfig);
+
+  await writers.handleSpaceCreated({
+    block: { timestamp: 1784649731 },
+    blockNumber: 1,
+    txId: '0xtx',
+    event: createSpaceCreatedEvent(metadataURI)
+    // The writer only reads the fields set above. Checkpoint hands it a much
+    // wider payload that is irrelevant here.
+  } as unknown as Parameters<typeof writers.handleSpaceCreated>[0]);
+
+  return mocks.spaces.at(-1);
+}
+
+describe('handleSpaceCreated', () => {
+  beforeEach(() => {
+    mocks.spaces.length = 0;
+    mocks.handleSpaceMetadata.mockClear();
+  });
+
+  // Two spaces on eth were deployed with a blank metadataURI. `dropIpfs('')` is
+  // `''`, so they were saved pointing at a metadata item that no space should
+  // own, and the relation resolver blew up on it rather than returning null.
+  it('leaves metadata null when the space has no metadata uri', async () => {
+    const space = await handleSpaceCreated('');
+
+    expect(space?.metadata).toBeNull();
+    expect(space?.save).toHaveBeenCalled();
+  });
+
+  it('points metadata at the cid when the space has a metadata uri', async () => {
+    const space = await handleSpaceCreated('ipfs://bafyMetadata');
+
+    expect(space?.metadata).toEqual('bafyMetadata');
+  });
+});

--- a/apps/api/src/evm/protocols/snapshot-x/writers.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/writers.ts
@@ -44,6 +44,7 @@ import {
   getProposalLink,
   getSpaceDecimals,
   getSpaceLink,
+  getSpaceMetadataId,
   updateCounter,
   updateScoresTick
 } from '../../../common/utils';
@@ -266,7 +267,7 @@ export function createWriters(
         config.indexerName
       );
 
-      space.metadata = dropIpfs(metadataUri);
+      space.metadata = getSpaceMetadataId(metadataUri);
     } catch (err) {
       logger.info({ err }, 'Failed to fetch space metadata');
     }
@@ -328,7 +329,7 @@ export function createWriters(
       const space = await Space.loadEntity(spaceId, config.indexerName);
       if (!space) return;
 
-      space.metadata = dropIpfs(metadataUri);
+      space.metadata = getSpaceMetadataId(metadataUri);
 
       await space.save();
     } catch (err) {

--- a/apps/api/src/starknet/ipfs.test.ts
+++ b/apps/api/src/starknet/ipfs.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FullConfig } from './config';
+import { handleSpaceMetadata } from './ipfs';
+
+const mocks = vi.hoisted(() => ({
+  created: [] as { id: string; save: ReturnType<typeof vi.fn> }[],
+  loadEntity: vi.fn(async (): Promise<unknown> => null),
+  fetch: vi.fn()
+}));
+
+vi.mock('../../.checkpoint/models', () => {
+  class SpaceMetadataItem {
+    static loadEntity = mocks.loadEntity;
+    save = vi.fn(async () => {});
+
+    constructor(
+      public id: string,
+      public indexerName: string
+    ) {
+      mocks.created.push(this);
+    }
+  }
+
+  class ExecutionStrategy {
+    static loadEntity = vi.fn(async () => null);
+    save = vi.fn(async () => {});
+  }
+
+  class Network {}
+  class Proposal {}
+  class ScoresTick {}
+
+  return {
+    ExecutionStrategy,
+    SpaceMetadataItem,
+    Network,
+    Proposal,
+    ScoresTick
+  };
+});
+
+const SPACE =
+  '0x00c5a04db85c8fcf70efb69d0b929e0b128021a5bcf3c6e447174941324f68e0';
+
+const config = { indexerName: 'sn' } as FullConfig;
+
+describe('handleSpaceMetadata', () => {
+  beforeEach(() => {
+    mocks.created.length = 0;
+    mocks.loadEntity.mockClear();
+    mocks.loadEntity.mockResolvedValue(null);
+    mocks.fetch.mockReset();
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: 'Radish DAO' })
+    });
+    vi.stubGlobal('fetch', mocks.fetch);
+  });
+
+  // A space can be deployed with a blank metadata uri. There is no metadata to
+  // index for it, and `dropIpfs('')` is `''`, an id shared by every such space
+  // on the indexer, so nothing should be written at all.
+  it('writes nothing for a blank uri', async () => {
+    await handleSpaceMetadata(SPACE, '', config);
+
+    expect(mocks.created).toHaveLength(0);
+    expect(mocks.loadEntity).not.toHaveBeenCalled();
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it('keys the metadata item on the cid', async () => {
+    await handleSpaceMetadata(SPACE, 'ipfs://bafyMetadata', config);
+
+    expect(mocks.created).toHaveLength(1);
+    expect(mocks.created[0]?.id).toEqual('bafyMetadata');
+    expect(mocks.created[0]?.save).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/starknet/ipfs.ts
+++ b/apps/api/src/starknet/ipfs.ts
@@ -3,23 +3,20 @@ import { createPublicClient, getAddress, http } from 'viem';
 import L1AvatarExectionStrategyAbi from './abis/l1/L1AvatarExectionStrategy';
 import { FullConfig } from './config';
 import { ExecutionStrategy, SpaceMetadataItem } from '../../.checkpoint/models';
-import { dropIpfs, getJSON, getSpaceName } from '../common/utils';
+import { getJSON, getSpaceMetadataId, getSpaceName } from '../common/utils';
 
 export async function handleSpaceMetadata(
   space: string,
   metadataUri: string,
   config: FullConfig
 ) {
-  const exists = await SpaceMetadataItem.loadEntity(
-    dropIpfs(metadataUri),
-    config.indexerName
-  );
+  const id = getSpaceMetadataId(metadataUri);
+  if (id === null) return;
+
+  const exists = await SpaceMetadataItem.loadEntity(id, config.indexerName);
   if (exists) return;
 
-  const spaceMetadataItem = new SpaceMetadataItem(
-    dropIpfs(metadataUri),
-    config.indexerName
-  );
+  const spaceMetadataItem = new SpaceMetadataItem(id, config.indexerName);
   spaceMetadataItem.name = getSpaceName(space);
   spaceMetadataItem.about = '';
   spaceMetadataItem.avatar = '';
@@ -40,7 +37,7 @@ export async function handleSpaceMetadata(
   spaceMetadataItem.labels = [];
   spaceMetadataItem.delegations = [];
 
-  const metadata: any = metadataUri ? await getJSON(metadataUri) : {};
+  const metadata: any = await getJSON(metadataUri);
 
   if (metadata.name) spaceMetadataItem.name = metadata.name;
   if (metadata.description) spaceMetadataItem.about = metadata.description;

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -33,6 +33,7 @@ import {
   getProposalLink,
   getSpaceDecimals,
   getSpaceLink,
+  getSpaceMetadataId,
   updateCounter,
   updateScoresTick
 } from '../common/utils';
@@ -129,7 +130,7 @@ export function createWriters(config: FullConfig) {
       );
       await handleSpaceMetadata(space.id, metadataUri, config);
 
-      space.metadata = dropIpfs(metadataUri);
+      space.metadata = getSpaceMetadataId(metadataUri);
     } catch (err) {
       logger.warn({ err }, 'Failed to handle space metadata');
     }
@@ -173,7 +174,7 @@ export function createWriters(config: FullConfig) {
       const space = await Space.loadEntity(spaceId, config.indexerName);
       if (!space) return;
 
-      space.metadata = dropIpfs(metadataUri);
+      space.metadata = getSpaceMetadataId(metadataUri);
 
       await space.save();
     } catch (err) {


### PR DESCRIPTION
A space deployed with a blank `metadataURI` is saved with `space.metadata` set to `''` rather than null, and the metadata item written alongside it takes `''` as its id. That id is not unique to the space, so every space deployed this way on an indexer shares one metadata row and the one name generated for whichever of them was indexed first.

The empty string is also not null, so the relation resolver follows it, and it collapses to `undefined` before the loader is called. Reading one of these spaces fails the whole `space.metadata` selection with `The loader.load() function must be called with a value, but got: undefined.` instead of resolving to null. The UI's Apollo client sets no `errorPolicy`, so it rejects rather than taking the partial data, and the space page throws.

`MetadataURIUpdated` has the same defect, which is the part worth worrying about. The spaces in this state today were deployed that way and are idle, but a controller of an existing space with proposals and votes who sets an empty metadata URI puts that space into the same state and its page stops loading.

As of 2026-08-14, on `eth`:

- `0xe44a9c5670Ce7C3675f389785E0C565e52730377`, created 2026-07-21
- `0x11DbAFcB0b8A966c6730Af5Cda5a7D7E5FF2Bb58`, created 2026-07-21

Both are idle, and both render in the explore list under the same fabricated name, "Radish DAO", off the shared row.

An absent URI now means an absent pointer. `getSpaceMetadataId` returns null for a blank URI, the writers persist that, and `handleSpaceMetadata` writes no metadata item at all. The EVM and Starknet writers had the same shape, so both are changed, on create and on `MetadataURIUpdated`.

Checkpoint is untouched. The resolver that turns `''` into `undefined` lives in `@snapshot-labs/checkpoint`, a published dependency, and the API serves `checkpoint.getSchema()` wholesale with no resolver layer of its own, so there is nothing to patch here. Relaxing that guard to `if (!parentResolvedValue) return null` is defensible on its own merits, but it belongs in that repo, and on its own it would still leave the empty-id metadata item being written and shared.

This changes the write path only. Rows already indexed keep their empty pointer and keep erroring, and clearing them needs a reindex or a repair pass in the shape of #2259, which mutates production rows and should be reviewed on its own.

#2266 adds the same new test files and touches the same writer hunks, so whichever of the two merges second needs a rebase. This one should go first, since it has live rows behind it.

Closes #2261
