### PR TITLE
fix(api): retry a transient metadata fetch instead of losing the metadata

### DIFF
--- a/apps/api/src/common/utils.test.ts
+++ b/apps/api/src/common/utils.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getJSON } from './utils';
+
+const fetchMock = vi.fn();
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, statusText: 'OK', json: async () => body };
+}
+
+function status(code: number, statusText: string) {
+  return {
+    ok: false,
+    status: code,
+    statusText,
+    json: async () => {
+      throw new Error('not json');
+    }
+  };
+}
+
+describe('getJSON', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('returns the body when the gateway answers', async () => {
+    fetchMock.mockResolvedValue(ok({ name: 'Emerge' }));
+
+    await expect(getJSON('ipfs://bafyMetadata')).resolves.toEqual({
+      name: 'Emerge'
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // The metadata of a space whose fetch fails here is lost for good: the writer
+  // leaves the pointer null and nothing ever revisits it. A gateway that is
+  // briefly unavailable must not cost us the row.
+  it('retries a gateway failure and keeps the metadata', async () => {
+    fetchMock
+      .mockResolvedValueOnce(status(503, 'Service Unavailable'))
+      .mockResolvedValueOnce(ok({ name: 'Emerge' }));
+
+    await expect(getJSON('ipfs://bafyMetadata')).resolves.toEqual({
+      name: 'Emerge'
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a request that never reached the gateway', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(ok({ name: 'Emerge' }));
+
+    await expect(getJSON('ipfs://bafyMetadata')).resolves.toEqual({
+      name: 'Emerge'
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a timeout', async () => {
+    const timeout = new DOMException('The operation timed out', 'TimeoutError');
+
+    fetchMock
+      .mockRejectedValueOnce(timeout)
+      .mockResolvedValueOnce(ok({ name: 'Emerge' }));
+
+    await expect(getJSON('ipfs://bafyMetadata')).resolves.toEqual({
+      name: 'Emerge'
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  // A 404 is the gateway telling us what it has, and it will say the same thing
+  // however many times we ask. Retrying it only stalls the block.
+  it('does not retry a definite answer', async () => {
+    fetchMock.mockResolvedValue(status(404, 'Not Found'));
+
+    await expect(getJSON('ipfs://bafyMetadata')).rejects.toThrow('Not Found');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up rather than retrying forever', async () => {
+    fetchMock.mockResolvedValue(status(503, 'Service Unavailable'));
+
+    await expect(getJSON('ipfs://bafyMetadata')).rejects.toThrow(
+      'Service Unavailable'
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not reach the network for a blank uri', async () => {
+    await expect(getJSON('')).rejects.toThrow('Invalid URI');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/common/utils.ts
+++ b/apps/api/src/common/utils.ts
@@ -85,19 +85,64 @@ export function getSpaceName(address: string) {
   return `${noun.charAt(0).toUpperCase()}${noun.slice(1)} DAO`;
 }
 
+const FETCH_TIMEOUT = 15000;
+const FETCH_ATTEMPTS = 3;
+const BASE_RETRY_DELAY = 500;
+const MAX_RETRY_DELAY = 5000;
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function getRetryDelay(attempt: number) {
+  return Math.min(BASE_RETRY_DELAY * 2 ** attempt, MAX_RETRY_DELAY);
+}
+
+/**
+ * A gateway that rate limits us or fails on its own side will usually serve the
+ * same content a moment later. Any other status is an answer about the content
+ * itself and will read the same however many times we ask.
+ */
+function isRetriableStatus(status: number) {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+/**
+ * A metadata fetch that fails here leaves the entity it belongs to with a null
+ * pointer, and nothing revisits it afterwards, so a gateway blip is permanent
+ * data loss. Transient failures are retried; a definite answer is not.
+ */
 export async function getJSON(uri: string) {
   const url = getUrl(uri);
   if (!url) throw new Error('Invalid URI');
 
-  const res = await fetch(url, {
-    signal: AbortSignal.timeout(15000)
-  });
+  for (let attempt = 0; ; attempt++) {
+    const lastAttempt = attempt === FETCH_ATTEMPTS - 1;
 
-  if (!res.ok) {
-    throw new Error(`Failed to fetch JSON from ${url}: ${res.statusText}`);
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT)
+      });
+    } catch (err) {
+      // The gateway was unreachable, or took longer than we waited.
+      if (lastAttempt) throw err;
+
+      await sleep(getRetryDelay(attempt));
+      continue;
+    }
+
+    if (!res.ok) {
+      if (lastAttempt || !isRetriableStatus(res.status)) {
+        throw new Error(`Failed to fetch JSON from ${url}: ${res.statusText}`);
+      }
+
+      await sleep(getRetryDelay(attempt));
+      continue;
+    }
+
+    return res.json();
   }
-
-  return res.json();
 }
 
 export function getExecutionHash({

--- a/apps/api/src/evm/protocols/snapshot-x/writers.test.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/writers.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as snapshotXUtils from './utils';
+import { createWriters } from './writers';
+import * as commonUtils from '../../../common/utils';
+import { EVMConfig, SnapshotXConfig } from '../../types';
+
+const mocks = vi.hoisted(() => ({
+  spaces: [] as Record<string, unknown>[],
+  handleSpaceMetadata: vi.fn(),
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  }
+}));
+
+vi.mock('../../../../.checkpoint/models', () => {
+  class Space {
+    save = vi.fn(async () => {});
+
+    constructor(
+      public id: string,
+      public indexerName: string
+    ) {
+      mocks.spaces.push(this as unknown as Record<string, unknown>);
+    }
+
+    static loadEntity = vi.fn(async () => null);
+  }
+
+  class Entity {
+    save = vi.fn(async () => {});
+    static loadEntity = vi.fn(async () => null);
+  }
+
+  return {
+    ExecutionHash: Entity,
+    ExecutionStrategy: Entity,
+    Leaderboard: Entity,
+    Network: Entity,
+    Proposal: Entity,
+    ScoresTick: Entity,
+    Space,
+    SpaceMetadataItem: Entity,
+    StarknetL1Execution: Entity,
+    User: Entity,
+    Vote: Entity
+  };
+});
+
+vi.mock('./ipfs', () => ({ handleSpaceMetadata: mocks.handleSpaceMetadata }));
+
+vi.mock('./logger', () => ({ default: mocks.logger }));
+
+vi.mock('./utils', async importOriginal => ({
+  ...(await importOriginal<typeof snapshotXUtils>()),
+  handleCustomExecutionStrategy: vi.fn(async () => {}),
+  updateProposalValidationStrategy: vi.fn(async () => {})
+}));
+
+vi.mock('../../../common/ipfs', () => ({
+  handleProposalMetadata: vi.fn(async () => {}),
+  handleStrategiesMetadata: vi.fn(async () => ({ strategiesDecimals: [] })),
+  handleVoteMetadata: vi.fn(async () => {})
+}));
+
+vi.mock('../../../common/utils', async importOriginal => ({
+  ...(await importOriginal<typeof commonUtils>()),
+  updateCounter: vi.fn(async () => {}),
+  updateScoresTick: vi.fn(async () => {})
+}));
+
+const config = {
+  indexerName: 'base',
+  network_node_url: 'https://rpc.invalid'
+} as unknown as EVMConfig;
+
+const protocolConfig = {
+  chainId: 8453,
+  manaRpcUrl: 'https://mana.invalid',
+  masterSpace: '0x0000000000000000000000000000000000000001',
+  masterSimpleQuorumAvatar: null,
+  masterSimpleQuorumTimelock: null,
+  propositionPowerValidationStrategyAddress: null,
+  apeGasStrategy: null,
+  apeGasStrategyDelay: 0
+} satisfies SnapshotXConfig as SnapshotXConfig;
+
+const SPACE = '0x59396568e4eF96801F9F771bF8247Fe1442d6B42';
+
+async function handleSpaceCreated() {
+  const writers = createWriters(config, protocolConfig);
+
+  await writers.handleSpaceCreated({
+    block: { timestamp: 1762399613 },
+    blockNumber: 1,
+    txId: '0xtx',
+    // The writer only reads the fields set here. Checkpoint hands it a much
+    // wider payload that is irrelevant to this path.
+    event: {
+      args: {
+        space: SPACE,
+        input: {
+          owner: '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6',
+          votingDelay: 0,
+          minVotingDuration: 0,
+          maxVotingDuration: 86400,
+          proposalValidationStrategy: {
+            addr: '0x0000000000000000000000000000000000000002',
+            params: '0x'
+          },
+          proposalValidationStrategyMetadataURI: '',
+          daoURI: '',
+          metadataURI: 'ipfs://QmY9SU6dap8ExQsd9CVb1XPgzZymmojnMAMpQ1eitBAAUc',
+          votingStrategies: [],
+          votingStrategyMetadataURIs: [],
+          authenticators: []
+        }
+      }
+    }
+  } as unknown as Parameters<typeof writers.handleSpaceCreated>[0]);
+
+  return mocks.spaces.at(-1);
+}
+
+describe('handleSpaceCreated', () => {
+  beforeEach(() => {
+    mocks.spaces.length = 0;
+    mocks.handleSpaceMetadata.mockReset();
+    mocks.logger.info.mockReset();
+    mocks.logger.warn.mockReset();
+    mocks.logger.error.mockReset();
+  });
+
+  // The space is still saved when its metadata cannot be fetched, with a null
+  // pointer that nothing revisits. Logging that below error hid it from
+  // alerting, so spaces went missing with no signal at all.
+  it('reports a metadata fetch failure at error level', async () => {
+    mocks.handleSpaceMetadata.mockRejectedValue(new Error('gateway down'));
+
+    const space = await handleSpaceCreated();
+
+    expect(space?.metadata).toBeNull();
+    expect(space?.save).toHaveBeenCalled();
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'Failed to fetch space metadata'
+    );
+  });
+
+  it('says nothing when the metadata resolves', async () => {
+    mocks.handleSpaceMetadata.mockResolvedValue(undefined);
+
+    const space = await handleSpaceCreated();
+
+    expect(space?.metadata).toEqual(
+      'QmY9SU6dap8ExQsd9CVb1XPgzZymmojnMAMpQ1eitBAAUc'
+    );
+    expect(mocks.logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/evm/protocols/snapshot-x/writers.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/writers.ts
@@ -268,7 +268,7 @@ export function createWriters(
 
       space.metadata = dropIpfs(metadataUri);
     } catch (err) {
-      logger.info({ err }, 'Failed to fetch space metadata');
+      logger.error({ err }, 'Failed to fetch space metadata');
     }
 
     if (spaceMetadataItem) {
@@ -332,7 +332,7 @@ export function createWriters(
 
       await space.save();
     } catch (err) {
-      logger.info({ err }, 'Failed to fetch space metadata');
+      logger.error({ err }, 'Failed to fetch space metadata');
     }
 
     if (spaceMetadataItem) {

--- a/apps/api/src/starknet/writers.ts
+++ b/apps/api/src/starknet/writers.ts
@@ -131,7 +131,7 @@ export function createWriters(config: FullConfig) {
 
       space.metadata = dropIpfs(metadataUri);
     } catch (err) {
-      logger.warn({ err }, 'Failed to handle space metadata');
+      logger.error({ err }, 'Failed to handle space metadata');
     }
 
     try {
@@ -177,7 +177,7 @@ export function createWriters(config: FullConfig) {
 
       await space.save();
     } catch (err) {
-      logger.warn({ err }, 'Failed to handle space metadata');
+      logger.error({ err }, 'Failed to handle space metadata');
     }
   };
 


### PR DESCRIPTION
A space whose `metadataURI` fetch failed while it was being indexed is saved with a null metadata pointer, and nothing revisits it afterwards. The only thing that would ever heal it is a later `MetadataURIUpdated` event, which an owner has no reason to send. The UI reads a space with no metadata as no space at all, so the space quietly disappears, governance activity and all. `getJSON` was a single attempt against a single gateway, which made a momentary blip permanent data loss.

Unlike #2261, this fails silently. There is no `errors` key in the response, `metadata` is simply null, and there is nothing to alert on or grep for.

As of 2026-08-14, on `base`, all created 2025-11-06 and all idle:

- `0x59396568e4eF96801F9F771bF8247Fe1442d6B42`
- `0xC81E95d09892D6eF74265f1d551bf2746fCCAE06`
- `0xeDE605cba3E7c2A6E469937a3E11783Cb9BedBE6`

And on `sn`, `0x00c5a04db85c8fcf70efb69d0b929e0b128021a5bcf3c6e447174941324f68e0`, "1inch (demo)", created 2024-05-14, which has proposals and a vote sitting behind the null pointer. Every one of those CIDs still resolves through the gateway the indexer uses, which is what says the failures were transient rather than the content being gone.

`getJSON` now distinguishes the two kinds of failure. A request that never reached the gateway, a timeout, a rate limit or a server-side error is transient and is retried with backoff. Any other status is the gateway telling us what it has, and it will say the same thing however many times we ask, so that still fails immediately rather than stalling the block. The retry sits in `getJSON` rather than at the space call site, so proposal, vote and strategy metadata get the same protection.

A failure that survives the retries is now logged at `error`. It was `info` on the EVM path and `warn` on the Starknet one, neither of which anything watches, which is why this ran silently for as long as it did.

One honest caveat: 404 is deliberately not retried, and there are no logs left from the dates those spaces were indexed. If those fetches were 404s from content that had not propagated yet, this would not have saved them.

Letting the writer rethrow was considered and not done. Checkpoint re-processes a block whose writer throws, rolling back the entity buffer and retrying the same block, so propagating a transient failure would guarantee the space is eventually indexed correctly. It would also wedge the indexer at that block for as long as the gateway stays down, trading indexing liveness for it. That is a bigger call than this fix.

This changes the write path only. The spaces already indexed keep their null pointer, and filling them in needs a reindex or a repair pass in the shape of #2259, which mutates production rows and should be reviewed on its own.

Closes #2263
