### PR TITLE
fix(api): GMX governor signs OZ 4.x ballots, not 5.x

### DIFF
--- a/apps/api/src/evm/protocols/openzeppelin/governances.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/governances.ts
@@ -143,7 +143,7 @@ export const GOVERNANCES: Partial<
       address: '0x03e8f708e9C85EDCEaa6AD7Cd06824CeB82A7E68',
       authenticators: [
         'OpenZeppelinAuthenticator',
-        'OpenZeppelinAuthenticatorSignatureV5'
+        'OpenZeppelinAuthenticatorSignatureV4'
       ],
       quorumType: 'for_only',
       startBlock: 204249812


### PR DESCRIPTION
GMX's registry entry assigns `OpenZeppelinAuthenticatorSignatureV5`, but the governor is OZ 4.x. Every signature vote on GMX currently fails; one-line fix to V4.

Verified four independent ways:

- `BALLOT_TYPEHASH()` on `0x03e8f708…` (arb1) returns `0x150214d7…` = `keccak("Ballot(uint256 proposalId,uint8 support)")`, the 4.x shape — 5.x (with `Nonces`) would be `0xf2aad550…`
- bytecode carries the 4.x `castVoteBySig(uint256,uint8,uint8,bytes32,bytes32)` selector and not the 5.x `castVoteBySig(uint256,uint8,address,bytes)`
- `nonces(address)` reverts — the V5 sig client (`sx.js` `openzeppelin/ethereum-sig`) reads `nonces(voter)` before signing, so the flow breaks at the first step, and any signature built with the V5 ballot type would be rejected by the contract anyway
- sweeping `BALLOT_TYPEHASH` across all 47 mainnet registry entries: every other space's assigned authenticator matches the contract (V4 hash ⇔ V4 authenticator, V5 hash + `nonces` present ⇔ V5); GMX is the sole mismatch

GMX entered the registry in #1995 as a review drive-by and its authenticator combination was never exercised. Indexing is unaffected — authenticators only drive vote relaying.

## Test plan

- Sweep above (registry vs on-chain typehash): 47/47 match after this change
- Signature vote on GMX via the UI signs the V4 ballot type and `castVoteBySig` accepts it
