### PR TITLE
fix(ui): stale space in proposals summary query after in-app navigation

### DIFF
--- a/apps/ui/src/queries/proposals.test.ts
+++ b/apps/ui/src/queries/proposals.test.ts
@@ -118,10 +118,9 @@ describe('useProposalsSummaryQuery', () => {
 
   it('should not fetch while disabled', async () => {
     const isEnabled = ref(false);
-    const spaceId = ref('space-a.eth');
 
     const { data, fetchStatus } = withSetup(() =>
-      useProposalsSummaryQuery(ref('s'), spaceId, isEnabled)
+      useProposalsSummaryQuery(ref('s'), ref('space-a.eth'), isEnabled)
     );
 
     await nextTick();

--- a/apps/ui/src/queries/proposals.test.ts
+++ b/apps/ui/src/queries/proposals.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+import { QueryClient, VUE_QUERY_CLIENT } from '@tanstack/vue-query';
+import { createPinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp, nextTick, ref } from 'vue';
+import {
+  PROPOSALS_KEYS,
+  PROPOSALS_SUMMARY_LIMIT,
+  useProposalsSummaryQuery
+} from './proposals';
+
+const loadProposalsMock = vi.fn();
+
+vi.mock('@/networks', () => ({
+  getNetwork: () => ({
+    currentChainId: 1,
+    api: { loadProposals: (...args: any[]) => loadProposalsMock(...args) }
+  }),
+  offchainNetworks: ['s'],
+  evmNetworks: []
+}));
+
+vi.mock('@/helpers/provider', () => ({
+  getProvider: () => ({ getBlockNumber: async () => 1 })
+}));
+
+vi.mock('@/helpers/stamp', () => ({
+  getNames: async () => ({})
+}));
+
+function proposalOf(spaceId: string) {
+  return {
+    id: `${spaceId}-1`,
+    proposal_id: 1,
+    space: { id: spaceId },
+    author: { id: '0xauthor' }
+  };
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } }
+});
+
+let testApp: ReturnType<typeof createApp>;
+
+function withSetup<T>(composable: () => T): T {
+  let result!: T;
+  testApp = createApp({
+    setup() {
+      result = composable();
+      return () => null;
+    }
+  });
+  testApp.use(createPinia());
+  testApp.provide(VUE_QUERY_CLIENT, queryClient);
+  testApp.mount(document.createElement('div'));
+  return result;
+}
+
+beforeEach(() => {
+  queryClient.clear();
+  loadProposalsMock.mockReset();
+  loadProposalsMock.mockImplementation(async (spaceIds: string[]) => [
+    proposalOf(spaceIds[0])
+  ]);
+});
+
+afterEach(() => {
+  testApp?.unmount();
+});
+
+describe('useProposalsSummaryQuery', () => {
+  it('should fetch the proposals of the space it is given', async () => {
+    const { data } = withSetup(() =>
+      useProposalsSummaryQuery(ref('s'), ref('space-a.eth'))
+    );
+
+    await vi.waitFor(() => {
+      expect(data.value).toEqual([proposalOf('space-a.eth')]);
+    });
+    expect(loadProposalsMock).toHaveBeenCalledWith(
+      ['space-a.eth'],
+      { limit: PROPOSALS_SUMMARY_LIMIT, skip: 0 },
+      expect.any(Number),
+      undefined,
+      undefined
+    );
+  });
+
+  it('should follow the space when it changes without the consumer remounting', async () => {
+    const spaceId = ref('space-a.eth');
+
+    const { data } = withSetup(() =>
+      useProposalsSummaryQuery(ref('s'), spaceId)
+    );
+
+    await vi.waitFor(() => {
+      expect(data.value).toEqual([proposalOf('space-a.eth')]);
+    });
+
+    spaceId.value = 'space-b.eth';
+
+    await vi.waitFor(() => {
+      expect(data.value).toEqual([proposalOf('space-b.eth')]);
+    });
+
+    expect(loadProposalsMock).toHaveBeenLastCalledWith(
+      ['space-b.eth'],
+      { limit: PROPOSALS_SUMMARY_LIMIT, skip: 0 },
+      expect.any(Number),
+      undefined,
+      undefined
+    );
+    expect(
+      queryClient.getQueryData(PROPOSALS_KEYS.spaceSummary('s', 'space-b.eth'))
+    ).toEqual([proposalOf('space-b.eth')]);
+  });
+
+  it('should not fetch while disabled', async () => {
+    const isEnabled = ref(false);
+    const spaceId = ref('space-a.eth');
+
+    const { data, fetchStatus } = withSetup(() =>
+      useProposalsSummaryQuery(ref('s'), spaceId, isEnabled)
+    );
+
+    await nextTick();
+    expect(fetchStatus.value).toBe('idle');
+    expect(loadProposalsMock).not.toHaveBeenCalled();
+
+    isEnabled.value = true;
+
+    await vi.waitFor(() => {
+      expect(data.value).toEqual([proposalOf('space-a.eth')]);
+    });
+  });
+});

--- a/apps/ui/src/queries/proposals.ts
+++ b/apps/ui/src/queries/proposals.ts
@@ -198,16 +198,18 @@ export function useProposalsQuery(
 
 export function proposalsSummaryQueryFn(
   queryClient: QueryClient,
-  networkId: NetworkID,
-  spaceId: string
+  networkId: MaybeRefOrGetter<NetworkID>,
+  spaceId: MaybeRefOrGetter<string>
 ) {
   return async () => {
-    const proposals = await getProposals([spaceId], networkId, {
+    const networkIdValue = toValue(networkId);
+
+    const proposals = await getProposals([toValue(spaceId)], networkIdValue, {
       skip: 0,
       limit: PROPOSALS_SUMMARY_LIMIT
     });
 
-    setProposalsDetails(queryClient, networkId, proposals);
+    setProposalsDetails(queryClient, networkIdValue, proposals);
 
     return proposals;
   };
@@ -222,11 +224,7 @@ export function useProposalsSummaryQuery(
 
   return useQuery({
     queryKey: PROPOSALS_KEYS.spaceSummary(networkId, spaceId),
-    queryFn: proposalsSummaryQueryFn(
-      queryClient,
-      toValue(networkId),
-      toValue(spaceId)
-    ),
+    queryFn: proposalsSummaryQueryFn(queryClient, networkId, spaceId),
     enabled: () => toValue(enabled)
   });
 }


### PR DESCRIPTION
### Summary

The proposals list on a space's overview page can show the **wrong space's proposals** — or nothing — after you navigate between spaces inside the app.

`useProposalsSummaryQuery` called `toValue(networkId)` / `toValue(spaceId)` once at setup and handed the plain strings to `proposalsSummaryQueryFn`. The query *key* kept following the route, but the *fetch* stayed pinned to whichever space the component was first mounted with. Vue Router reuses the space page between space routes, so every in-app hop (parent ↔ sub-space links, back button, editing the URL) re-fetched the old space under the new key.

Fix: pass the refs through and resolve them inside the fetch — same as `getProposalsQuery` right above it already does.

Regressed in #1999 (Mar 2026), when `proposalsSummaryQueryFn` was extracted and the `toValue()` calls got hoisted out. #1190 had it right. This is the second half of #2255, split out on its own — no sub-space aggregation here.

Also adds `queries/proposals.test.ts` — the "follows the space when it changes without remounting" case fails on master and passes here.

### How to reproduce (on prod)

1. Open [Horizen Technical](https://snapshot.org/#/s:horizenfoundationtechnical.eth) → 5 proposals
2. Click the parent link (Horizen Foundation) → empty, expected
3. Click Horizen Technical in the sub-space list → **still empty**. Network tab shows the page querying `space_in: ["horizenfoundation.eth"]`.
4. Now go parent → [Non-Technical](https://snapshot.org/#/s:horizenfoundationnontechnical.eth) → Technical: Technical's page lists **Non-Technical's** proposals ("Special Council Elections", "ZenIP 42408"…)

### How to test

Same in-app hops on prod vs the [preview](https://deploy-preview-2271--snapshot-livenet.netlify.app/#/s:horizenfoundationtechnical.eth). Reload between cases so each starts cold.

**1. Sub-space → parent → sub-space** (the original report)

| Step | Before ([prod](https://snapshot.org/#/s:horizenfoundationtechnical.eth)) | After ([preview](https://deploy-preview-2271--snapshot-livenet.netlify.app/#/s:horizenfoundationtechnical.eth)) |
|---|---|---|
| Technical (cold) | 5 proposals | 5 proposals |
| → parent | empty | empty |
| → Technical | **0 rows**, queries parent id | 5 proposals |

**2. Parent → Non-Technical → Technical**

| Step | Before ([prod](https://snapshot.org/#/s:horizenfoundation.eth)) | After ([preview](https://deploy-preview-2271--snapshot-livenet.netlify.app/#/s:horizenfoundation.eth)) |
|---|---|---|
| parent (cold) | empty | empty |
| → Non-Technical | 5 proposals | 5 proposals |
| → Technical | **Non-Technical's 5 proposals** | Technical's 5 |

**3. Back button** (continue from case 2)

| Step | Before | After |
|---|---|---|
| ← back to Non-Technical | 5 proposals | 5 proposals |
| ← back to parent | empty, but queries `nontechnical` | empty, queries parent |

**4. Any two spaces** — open [stgdao.eth](https://snapshot.org/#/s:stgdao.eth), then change the URL hash to `#/s:horizenfoundationtechnical.eth`

| Step | Before ([prod](https://snapshot.org/#/s:stgdao.eth)) | After ([preview](https://deploy-preview-2271--snapshot-livenet.netlify.app/#/s:stgdao.eth)) |
|---|---|---|
| stgdao (cold) | 20 proposals | 20 proposals |
| → Technical | **stgdao's proposals** under Technical's URL | Technical's 5 |

**5. Unchanged** — cold loads and pages that never used the stale closure

| Page | Before | After |
|---|---|---|
| [Technical](https://snapshot.org/#/s:horizenfoundationtechnical.eth) cold | 5 | [5](https://deploy-preview-2271--snapshot-livenet.netlify.app/#/s:horizenfoundationtechnical.eth) |
| [stgdao.eth](https://snapshot.org/#/s:stgdao.eth) cold | 20 | [20](https://deploy-preview-2271--snapshot-livenet.netlify.app/#/s:stgdao.eth) |
| [Technical /proposals](https://snapshot.org/#/s:horizenfoundationtechnical.eth/proposals) → parent → Technical | 18 / 0 / 18 | [same](https://deploy-preview-2271--snapshot-livenet.netlify.app/#/s:horizenfoundationtechnical.eth/proposals) |
| [org/ens](https://snapshot.org/#/org/ens) | 6 | [6](https://deploy-preview-2271--snapshot-livenet.netlify.app/#/org/ens) |
| [org/ens proposals](https://snapshot.org/#/org/ens/s:ens.eth/proposals) | 20 | [20](https://deploy-preview-2271--snapshot-livenet.netlify.app/#/org/ens/s:ens.eth/proposals) |

**6. Unit tests** — `bun run test src/queries/proposals.test.ts` in `apps/ui`: 3 pass here; the middle one fails on master with `space-a` proposals returned for `space-b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXLoS9TmN38gfay4J9dr3G
