### PR TITLE
feat: add ability to create proposal out of space settings

### DIFF
--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -611,6 +611,42 @@ export function useActions() {
     );
   }
 
+  async function getUpdateSettingsTransaction(
+    space: Space,
+    metadata: SpaceMetadata,
+    authenticatorsToAdd: StrategyConfig[],
+    authenticatorsToRemove: number[],
+    votingStrategiesToAdd: StrategyConfig[],
+    votingStrategiesToRemove: number[],
+    validationStrategy: StrategyConfig,
+    executionStrategies: StrategyConfig[],
+    votingDelay: number | null,
+    minVotingDuration: number | null,
+    maxVotingDuration: number | null
+  ) {
+    const network = getReadWriteNetwork(space.network);
+
+    return network.actions.getUpdateSettingsTransaction(
+      space,
+      metadata,
+      authenticatorsToAdd,
+      authenticatorsToRemove,
+      votingStrategiesToAdd,
+      votingStrategiesToRemove,
+      validationStrategy,
+      executionStrategies,
+      votingDelay !== null
+        ? getCurrentFromDuration(space.network, votingDelay)
+        : null,
+      minVotingDuration !== null
+        ? getCurrentFromDuration(space.network, minVotingDuration)
+        : null,
+      maxVotingDuration !== null
+        ? getCurrentFromDuration(space.network, maxVotingDuration)
+        : null
+    );
+  }
+
   async function updateSettingsRaw(space: Space, settings: string) {
     if (!auth.value) {
       await forceLogin();
@@ -808,6 +844,7 @@ export function useActions() {
     vetoProposal: wrapWithErrors(vetoProposal),
     transferOwnership: wrapWithErrors(transferOwnership),
     updateSettings: wrapWithErrors(updateSettings),
+    getUpdateSettingsTransaction: wrapWithErrors(getUpdateSettingsTransaction),
     updateSettingsRaw: wrapWithErrors(updateSettingsRaw),
     deleteSpace: wrapWithErrors(deleteSpace),
     delegate: wrapWithErrors(delegate),

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -100,6 +100,7 @@ export function useSpaceSettings(space: Ref<Space>) {
   const { getDurationFromCurrent } = useMetaStore();
   const {
     updateSettings,
+    getUpdateSettingsTransaction,
     updateSettingsRaw,
     transferOwnership,
     deleteSpace: deleteSpaceAction
@@ -681,7 +682,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     return updateSettingsRaw(space.value, JSON.stringify(prunedSaveData));
   }
 
-  async function saveOnchain() {
+  async function getOnchainSettingsChanges() {
     if (!validationStrategy.value) {
       throw new Error('Validation strategy is missing');
     }
@@ -700,14 +701,44 @@ export function useSpaceSettings(space: Ref<Space>) {
       space.value.strategies_parsed_metadata
     );
 
-    return updateSettings(
-      space.value,
-      form.value,
+    return {
       authenticatorsToAdd,
       authenticatorsToRemove,
       strategiesToAdd,
       strategiesToRemove,
-      validationStrategy.value,
+      validationStrategy: validationStrategy.value
+    };
+  }
+
+  async function saveOnchain() {
+    const changes = await getOnchainSettingsChanges();
+
+    return updateSettings(
+      space.value,
+      form.value,
+      changes.authenticatorsToAdd,
+      changes.authenticatorsToRemove,
+      changes.strategiesToAdd,
+      changes.strategiesToRemove,
+      changes.validationStrategy,
+      executionStrategies.value,
+      votingDelay.value,
+      minVotingPeriod.value,
+      maxVotingPeriod.value
+    );
+  }
+
+  async function getSettingsUpdateTransaction() {
+    const changes = await getOnchainSettingsChanges();
+
+    return getUpdateSettingsTransaction(
+      space.value,
+      form.value,
+      changes.authenticatorsToAdd,
+      changes.authenticatorsToRemove,
+      changes.strategiesToAdd,
+      changes.strategiesToRemove,
+      changes.validationStrategy,
       executionStrategies.value,
       votingDelay.value,
       minVotingPeriod.value,
@@ -1091,6 +1122,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     isPrivate,
     skinSettings,
     save,
+    getSettingsUpdateTransaction,
     saveController,
     deleteSpace,
     reset

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -1,7 +1,12 @@
 import objectHash from 'object-hash';
 import { Ref } from 'vue';
 import { ENSChainId, getNameOwner } from '@/helpers/ens';
-import { clone, compareAddresses, omit } from '@/helpers/utils';
+import {
+  clone,
+  compareAddresses,
+  getUserFacingErrorMessage,
+  omit
+} from '@/helpers/utils';
 import { evmNetworks, getNetwork, offchainNetworks } from '@/networks';
 import { ApiSpace as OffchainApiSpace } from '@/networks/offchain/api/types';
 import {
@@ -107,6 +112,7 @@ export function useSpaceSettings(space: Ref<Space>) {
   } = useActions();
   const { isWhiteLabel } = useWhiteLabel();
   const { setSkin } = useSkin();
+  const uiStore = useUiStore();
 
   const loading = ref(true);
   const isModifiedEvaluating = ref(false);
@@ -683,31 +689,39 @@ export function useSpaceSettings(space: Ref<Space>) {
   }
 
   async function getOnchainSettingsChanges() {
-    if (!validationStrategy.value) {
-      throw new Error('Validation strategy is missing');
+    try {
+      if (!validationStrategy.value) {
+        throw new Error('Validation strategy is missing');
+      }
+
+      const [authenticatorsToAdd, authenticatorsToRemove] =
+        await processChanges(
+          authenticators.value,
+          space.value.authenticators,
+          [],
+          []
+        );
+
+      const [strategiesToAdd, strategiesToRemove] = await processChanges(
+        votingStrategies.value,
+        space.value.strategies,
+        space.value.strategies_params,
+        space.value.strategies_parsed_metadata
+      );
+
+      return {
+        authenticatorsToAdd,
+        authenticatorsToRemove,
+        strategiesToAdd,
+        strategiesToRemove,
+        validationStrategy: validationStrategy.value
+      };
+    } catch (err) {
+      console.error(err);
+      uiStore.addNotification('error', getUserFacingErrorMessage(err));
+
+      throw err;
     }
-
-    const [authenticatorsToAdd, authenticatorsToRemove] = await processChanges(
-      authenticators.value,
-      space.value.authenticators,
-      [],
-      []
-    );
-
-    const [strategiesToAdd, strategiesToRemove] = await processChanges(
-      votingStrategies.value,
-      space.value.strategies,
-      space.value.strategies_params,
-      space.value.strategies_parsed_metadata
-    );
-
-    return {
-      authenticatorsToAdd,
-      authenticatorsToRemove,
-      strategiesToAdd,
-      strategiesToRemove,
-      validationStrategy: validationStrategy.value
-    };
   }
 
   async function saveOnchain() {

--- a/apps/ui/src/helpers/__snapshots__/transactions.test.ts.snap
+++ b/apps/ui/src/helpers/__snapshots__/transactions.test.ts.snap
@@ -82,6 +82,27 @@ exports[`transactions > createContractCallTransaction > should create contract c
 }
 `;
 
+exports[`transactions > createContractCallTransaction > should create contract call transaction with tuple 1`] = `
+{
+  "_form": {
+    "abi": [
+      "function swap((uint256 amountIn, address[] path) trade)",
+    ],
+    "amount": undefined,
+    "args": {
+      "trade": "{"amountIn":"1","path":["0x000000000000000000000000000000000000dead"]}",
+    },
+    "method": "swap((uint256,address[]))",
+    "recipient": "0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844",
+  },
+  "_type": "contractCall",
+  "data": "0xd32ef6360000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000dead",
+  "salt": "0x000000000000000000000000000000000000000000000000000000000000",
+  "to": "0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844",
+  "value": "0",
+}
+`;
+
 exports[`transactions > createSendNftTransaction > should create erc721 transaction 1`] = `
 {
   "_form": {

--- a/apps/ui/src/helpers/transactions.test.ts
+++ b/apps/ui/src/helpers/transactions.test.ts
@@ -3,7 +3,8 @@ import {
   createContractCallTransaction,
   createSendNftTransaction,
   createSendTokenTransaction,
-  createStakeTokenTransaction
+  createStakeTokenTransaction,
+  getContractCallFormArgs
 } from './transactions';
 
 describe('transactions', () => {
@@ -165,6 +166,56 @@ describe('transactions', () => {
       });
 
       expect(tx).toMatchSnapshot();
+    });
+
+    it('should create contract call transaction with tuple', async () => {
+      const tx = await createContractCallTransaction({
+        form: {
+          to: '0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844',
+          abi: ['function swap((uint256 amountIn, address[] path) trade)'],
+          method: 'swap((uint256,address[]))',
+          args: {
+            trade: JSON.stringify({
+              amountIn: '1',
+              path: ['0x000000000000000000000000000000000000dead']
+            })
+          }
+        }
+      });
+
+      expect(tx).toMatchSnapshot();
+    });
+  });
+
+  describe('getContractCallFormArgs', () => {
+    it('should serialize tuple and array arguments', () => {
+      const args = getContractCallFormArgs({
+        abi: [
+          'function swap((uint256 amountIn, address[] path) trade, address[] receivers, uint256 deadline)'
+        ],
+        method: 'swap((uint256,address[]),address[],uint256)',
+        args: {
+          trade: {
+            amountIn: '1',
+            path: ['0x000000000000000000000000000000000000dead']
+          },
+          receivers: ['0x000000000000000000000000000000000000dead'],
+          deadline: 1
+        }
+      });
+
+      expect(args).toEqual({
+        trade: JSON.stringify(
+          {
+            amountIn: '1',
+            path: ['0x000000000000000000000000000000000000dead']
+          },
+          null,
+          2
+        ),
+        receivers: '0x000000000000000000000000000000000000dead',
+        deadline: '1'
+      });
     });
   });
 

--- a/apps/ui/src/helpers/transactions.ts
+++ b/apps/ui/src/helpers/transactions.ts
@@ -119,6 +119,32 @@ export async function createSendNftTransaction({
   };
 }
 
+export function getContractCallFormArgs({
+  abi,
+  method,
+  args
+}: {
+  abi: any[];
+  method: string;
+  args: Record<string, any>;
+}): Record<string, string> {
+  const methodAbi = new Interface(abi).getFunction(method);
+
+  return Object.fromEntries(
+    methodAbi.inputs.map(input => {
+      const value = args[input.name];
+
+      if (input.type.includes('tuple')) {
+        return [input.name, JSON.stringify(value, null, 2)];
+      }
+
+      if (input.type.endsWith('[]')) return [input.name, value.join(', ')];
+
+      return [input.name, String(value)];
+    })
+  );
+}
+
 export async function createContractCallTransaction({
   form
 }): Promise<ContractCallTransaction> {
@@ -140,7 +166,9 @@ export async function createContractCallTransaction({
 
     await Promise.all(
       methodAbi.inputs.map(async (input, i) => {
-        if (input.type === 'address') {
+        if (input.type.includes('tuple')) {
+          args[i] = JSON.parse(args[i]);
+        } else if (input.type === 'address') {
           const resolved = await resolver.resolveName(args[i]);
           if (resolved?.address) args[i] = resolved.address;
         } else if (input.type.endsWith('[]')) {

--- a/apps/ui/src/helpers/utils.test.ts
+++ b/apps/ui/src/helpers/utils.test.ts
@@ -462,5 +462,29 @@ describe('utils', () => {
         type: 'object'
       });
     });
+
+    it('should use JSON input for tuples', () => {
+      const iface = new Interface([
+        'function swap((uint256 amountIn, address[] path) trade, uint256 deadline)'
+      ]);
+
+      const definition = abiToDefinition(iface.getFunction('swap'), 1);
+
+      expect(definition.properties).toEqual({
+        trade: {
+          abiType: 'tuple(uint256 amountIn, address[] path) trade',
+          examples: ['{ "key": "value" }'],
+          format: 'long',
+          title: 'trade (tuple)',
+          type: 'string'
+        },
+        deadline: {
+          examples: ['0'],
+          format: 'uint256',
+          title: 'deadline (uint256)',
+          type: 'string'
+        }
+      });
+    });
   });
 });

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -1,5 +1,5 @@
 import { sanitizeUrl as baseSanitizeUrl } from '@braintree/sanitize-url';
-import { FunctionFragment } from '@ethersproject/abi';
+import { FormatTypes, FunctionFragment } from '@ethersproject/abi';
 import { getAddress, isAddress } from '@ethersproject/address';
 import { namehash } from '@ethersproject/hash';
 import { upload as pin } from '@snapshot-labs/pineapple';
@@ -313,7 +313,11 @@ export function abiToDefinition(abi: FunctionFragment, chainId?: ChainId) {
         definition.properties[inputName].chainId = chainId;
       }
     }
-    if (input.type.endsWith('[]')) {
+    if (input.type.includes('tuple')) {
+      definition.properties[inputName].format = 'long';
+      definition.properties[inputName].abiType = input.format(FormatTypes.full);
+      definition.properties[inputName].examples = ['{ "key": "value" }'];
+    } else if (input.type.endsWith('[]')) {
       definition.properties[inputName].format = input.type;
       definition.properties[inputName].examples = ['0x0, 0x1'];
     }

--- a/apps/ui/src/helpers/validation.test.ts
+++ b/apps/ui/src/helpers/validation.test.ts
@@ -184,3 +184,45 @@ describe('ens-or-address', () => {
     });
   });
 });
+
+describe('abiType', () => {
+  const schema = {
+    type: 'object',
+    properties: {
+      trade: {
+        type: 'string',
+        abiType: 'tuple(uint256 amountIn, address[] path) trade'
+      }
+    }
+  };
+  const validator = getValidator(schema);
+
+  it('should accept a JSON value matching the tuple', () => {
+    const result = validator.validate({
+      trade: JSON.stringify({
+        amountIn: '1',
+        path: ['0x395ed61716b48dc904140b515e9f682e33330154']
+      })
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it('should reject a JSON value with missing components', () => {
+    const result = validator.validate({
+      trade: JSON.stringify({ amountIn: '1' })
+    });
+
+    expect(result).toEqual({
+      trade: 'Must be a JSON value matching the parameter type.'
+    });
+  });
+
+  it('should reject a value that is not JSON', () => {
+    const result = validator.validate({ trade: 'not-json' });
+
+    expect(result).toEqual({
+      trade: 'Must be a JSON value matching the parameter type.'
+    });
+  });
+});

--- a/apps/ui/src/helpers/validation.ts
+++ b/apps/ui/src/helpers/validation.ts
@@ -1,4 +1,4 @@
-import { Interface } from '@ethersproject/abi';
+import { defaultAbiCoder, Interface, ParamType } from '@ethersproject/abi';
 import { isAddress } from '@ethersproject/address';
 import Ajv, { AnySchema, ErrorObject } from 'ajv';
 import ajvErrors from 'ajv-errors';
@@ -278,6 +278,21 @@ ajv.addKeyword({
     }
   }
 });
+ajv.addKeyword({
+  keyword: 'abiType',
+  type: 'string',
+  schemaType: 'string',
+  validate: (schema: string, data: string) => {
+    if (!data) return false;
+
+    try {
+      defaultAbiCoder.encode([ParamType.from(schema)], [JSON.parse(data)]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+});
 ajv.addKeyword('options');
 ajv.addKeyword('tooltip');
 ajv.addKeyword('showControls');
@@ -338,6 +353,10 @@ function getErrorMessage(errorObject: Partial<ErrorObject>): string {
       default:
         return 'Invalid format.';
     }
+  }
+
+  if (errorObject.keyword === 'abiType') {
+    return 'Must be a JSON value matching the parameter type.';
   }
 
   if (errorObject.keyword === 'maxLength') {

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -27,7 +27,10 @@ import { getSwapLink } from '@/helpers/link';
 import { executionCall, getRelayerInfo, MANA_URL } from '@/helpers/mana';
 import Multicaller from '@/helpers/multicaller';
 import { getProvider } from '@/helpers/provider';
-import { convertToMetaTransactions } from '@/helpers/transactions';
+import {
+  convertToMetaTransactions,
+  getContractCallFormArgs
+} from '@/helpers/transactions';
 import {
   createErc1155Metadata,
   getChainIdKind,
@@ -1063,7 +1066,7 @@ export function createActions(
           abi: call.abi,
           recipient: space.id,
           method: call.method,
-          args: call.args
+          args: getContractCallFormArgs(call)
         }
       };
     },

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -28,7 +28,11 @@ import { executionCall, getRelayerInfo, MANA_URL } from '@/helpers/mana';
 import Multicaller from '@/helpers/multicaller';
 import { getProvider } from '@/helpers/provider';
 import { convertToMetaTransactions } from '@/helpers/transactions';
-import { createErc1155Metadata, getChainIdKind } from '@/helpers/utils';
+import {
+  createErc1155Metadata,
+  getChainIdKind,
+  getSalt
+} from '@/helpers/utils';
 import { verifyNetwork } from '@/helpers/walletNetworks';
 import { WHITELIST_SERVER_URL } from '@/helpers/whitelistServer';
 import {
@@ -58,6 +62,7 @@ import {
   SpaceMetadata,
   SpaceMetadataDelegation,
   StrategyParsedMetadata,
+  Transaction,
   VoteType
 } from '@/types';
 import { EDITOR_APP_NAME } from '../common/constants';
@@ -132,6 +137,75 @@ export function createActions(
     };
 
     return signer;
+  };
+
+  const buildUpdateSettingsInput = async (
+    space: Space,
+    metadata: SpaceMetadata,
+    authenticatorsToAdd: StrategyConfig[],
+    authenticatorsToRemove: number[],
+    votingStrategiesToAdd: StrategyConfig[],
+    votingStrategiesToRemove: number[],
+    validationStrategy: StrategyConfig,
+    executionStrategies: StrategyConfig[],
+    votingDelay: number | null,
+    minVotingDuration: number | null,
+    maxVotingDuration: number | null
+  ) => {
+    const pinned = await helpers.pin(
+      createErc1155Metadata(metadata, {
+        execution_strategies: executionStrategies.map(config => config.address),
+        execution_strategies_types: executionStrategies.map(
+          config => config.type
+        ),
+        execution_destinations: executionStrategies.map(
+          (_, i) => space.executors_destinations[i] ?? ''
+        )
+      })
+    );
+
+    const metadataUris = await Promise.all(
+      votingStrategiesToAdd.map(config => buildMetadata(helpers, config))
+    );
+
+    const proposalValidationStrategyMetadataUri = await buildMetadata(
+      helpers,
+      validationStrategy
+    );
+
+    return {
+      metadataUri: `ipfs://${pinned.cid}`,
+      authenticatorsToAdd: authenticatorsToAdd.map(config => config.address),
+      authenticatorsToRemove: space.authenticators.filter(
+        (authenticator, index) => authenticatorsToRemove.includes(index)
+      ),
+      votingStrategiesToAdd: await Promise.all(
+        votingStrategiesToAdd.map(async config => ({
+          addr: config.address,
+          params: config.generateParams
+            ? (await config.generateParams(config.params))[0]
+            : '0x'
+        }))
+      ),
+      votingStrategiesToRemove: votingStrategiesToRemove.map(
+        index => space.strategies_indices[index]
+      ),
+      votingStrategyMetadataUrisToAdd: metadataUris,
+      proposalValidationStrategy: {
+        addr: validationStrategy.address,
+        params: validationStrategy.generateParams
+          ? (
+              await validationStrategy.generateParams(validationStrategy.params)
+            )[0]
+          : '0x'
+      },
+      proposalValidationStrategyMetadataUri,
+      votingDelay: votingDelay !== null ? votingDelay : undefined,
+      minVotingDuration:
+        minVotingDuration !== null ? minVotingDuration : undefined,
+      maxVotingDuration:
+        maxVotingDuration !== null ? maxVotingDuration : undefined
+    };
   };
 
   return {
@@ -927,73 +1001,71 @@ export function createActions(
       const address = await web3.getSigner().getAddress();
       const isContract = await getIsContract(address, connectorType);
 
-      const pinned = await helpers.pin(
-        createErc1155Metadata(metadata, {
-          execution_strategies: executionStrategies.map(
-            config => config.address
-          ),
-          execution_strategies_types: executionStrategies.map(
-            config => config.type
-          ),
-          execution_destinations: executionStrategies.map(
-            (_, i) => space.executors_destinations[i] ?? ''
-          )
-        })
-      );
-
-      const metadataUris = await Promise.all(
-        votingStrategiesToAdd.map(config => buildMetadata(helpers, config))
-      );
-
-      const proposalValidationStrategyMetadataUri = await buildMetadata(
-        helpers,
-        validationStrategy
+      const settings = await buildUpdateSettingsInput(
+        space,
+        metadata,
+        authenticatorsToAdd,
+        authenticatorsToRemove,
+        votingStrategiesToAdd,
+        votingStrategiesToRemove,
+        validationStrategy,
+        executionStrategies,
+        votingDelay,
+        minVotingDuration,
+        maxVotingDuration
       );
 
       return client.updateSettings(
         {
           signer: getSigner(web3),
           space: space.id,
-          settings: {
-            metadataUri: `ipfs://${pinned.cid}`,
-            authenticatorsToAdd: authenticatorsToAdd.map(
-              config => config.address
-            ),
-            authenticatorsToRemove: space.authenticators.filter(
-              (authenticator, index) => authenticatorsToRemove.includes(index)
-            ),
-            votingStrategiesToAdd: await Promise.all(
-              votingStrategiesToAdd.map(async config => ({
-                addr: config.address,
-                params: config.generateParams
-                  ? (await config.generateParams(config.params))[0]
-                  : '0x'
-              }))
-            ),
-            votingStrategiesToRemove: votingStrategiesToRemove.map(
-              index => space.strategies_indices[index]
-            ),
-            votingStrategyMetadataUrisToAdd: metadataUris,
-            proposalValidationStrategy: {
-              addr: validationStrategy.address,
-              params: validationStrategy.generateParams
-                ? (
-                    await validationStrategy.generateParams(
-                      validationStrategy.params
-                    )
-                  )[0]
-                : '0x'
-            },
-            proposalValidationStrategyMetadataUri,
-            votingDelay: votingDelay !== null ? votingDelay : undefined,
-            minVotingDuration:
-              minVotingDuration !== null ? minVotingDuration : undefined,
-            maxVotingDuration:
-              maxVotingDuration !== null ? maxVotingDuration : undefined
-          }
+          settings
         },
         { noWait: isContract && connectorType !== 'sequence' }
       );
+    },
+    getUpdateSettingsTransaction: async (
+      space: Space,
+      metadata: SpaceMetadata,
+      authenticatorsToAdd: StrategyConfig[],
+      authenticatorsToRemove: number[],
+      votingStrategiesToAdd: StrategyConfig[],
+      votingStrategiesToRemove: number[],
+      validationStrategy: StrategyConfig,
+      executionStrategies: StrategyConfig[],
+      votingDelay: number | null,
+      minVotingDuration: number | null,
+      maxVotingDuration: number | null
+    ): Promise<Transaction> => {
+      const settings = await buildUpdateSettingsInput(
+        space,
+        metadata,
+        authenticatorsToAdd,
+        authenticatorsToRemove,
+        votingStrategiesToAdd,
+        votingStrategiesToRemove,
+        validationStrategy,
+        executionStrategies,
+        votingDelay,
+        minVotingDuration,
+        maxVotingDuration
+      );
+
+      const call = client.getUpdateSettingsCall({ settings });
+
+      return {
+        _type: 'contractCall',
+        to: space.id,
+        data: call.data,
+        value: '0',
+        salt: getSalt(),
+        _form: {
+          abi: call.abi,
+          recipient: space.id,
+          method: call.method,
+          args: call.args
+        }
+      };
     },
     updateSettingsRaw: () => {
       throw new Error('Not implemented');

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -867,6 +867,9 @@ export function createActions(
     updateSettingsRaw: () => {
       throw new Error('Not implemented');
     },
+    getUpdateSettingsTransaction: () => {
+      throw new Error('Not implemented');
+    },
     createSpaceRaw: () => {
       throw new Error('Not implemented');
     },

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -283,6 +283,19 @@ export type NetworkActions = ReadOnlyNetworkActions & {
     minVotingDuration: number | null,
     maxVotingDuration: number | null
   );
+  getUpdateSettingsTransaction(
+    space: Space,
+    metadata: SpaceMetadata,
+    authenticatorsToAdd: StrategyConfig[],
+    authenticatorsToRemove: number[],
+    votingStrategiesToAdd: StrategyConfig[],
+    votingStrategiesToRemove: number[],
+    validationStrategy: StrategyConfig,
+    executionStrategies: StrategyConfig[],
+    votingDelay: number | null,
+    minVotingDuration: number | null,
+    maxVotingDuration: number | null
+  ): Promise<Transaction>;
   delegate(
     web3: Web3Provider,
     space: Space,

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -6,6 +6,7 @@ import {
   DISABLED_STRATEGIES,
   OVERRIDING_STRATEGIES
 } from '@/helpers/constants';
+import { compareAddresses } from '@/helpers/utils';
 import { evmNetworks, getNetwork, offchainNetworks } from '@/networks';
 import { Space } from '@/types';
 
@@ -50,11 +51,14 @@ const {
   isPrivate,
   skinSettings,
   save,
+  getSettingsUpdateTransaction,
   saveController,
   deleteSpace,
   reset
 } = useSpaceSettings(toRef(props, 'space'));
 const { invalidateController } = useSpaceController(toRef(props, 'space'));
+const { strategiesWithTreasuries } = useTreasuries(props.space);
+const { createDraft } = useEditor();
 
 const uiStore = useUiStore();
 const queryClient = useQueryClient();
@@ -76,6 +80,7 @@ const hasAdvancedErrors = ref(false);
 
 const executeFn = ref(save);
 const saving = ref(false);
+const proposing = ref(false);
 const customStrategyModalOpen = ref(false);
 
 type Tab = {
@@ -171,6 +176,28 @@ const activeTab: Ref<Tab['id']> = computed(() => {
 });
 const network = computed(() => getNetwork(props.space.network));
 
+const selfGovernedExecution = computed(() => {
+  if (!evmNetworks.includes(props.space.network)) return null;
+
+  return (
+    strategiesWithTreasuries.value?.find(
+      strategy =>
+        strategy.type !== 'ReadOnlyExecution' &&
+        (compareAddresses(strategy.address, props.space.controller) ||
+          (String(strategy.treasury.chainId) ===
+            String(network.value.chainId) &&
+            compareAddresses(
+              strategy.treasury.address,
+              props.space.controller
+            )))
+    ) ?? null
+  );
+});
+
+const canProposeSettingsChanges = computed(
+  () => !canModifySettings.value && selfGovernedExecution.value !== null
+);
+
 const isTicketValid = computed(() => {
   return !(
     strategies.value.some(s => s.address === 'ticket') &&
@@ -228,10 +255,20 @@ const showToolbar = computed(() => {
   return (
     (isModified.value &&
       isAdvancedFormResolved.value &&
-      canModifySettings.value) ||
+      (canModifySettings.value || canProposeSettingsChanges.value)) ||
     error.value ||
     props.space.additionalRawData?.hibernated
   );
+});
+
+const saveLabel = computed(() => {
+  if (props.space.additionalRawData?.hibernated && !isModified.value) {
+    return 'Reactivate';
+  }
+
+  if (canProposeSettingsChanges.value) return 'Propose changes';
+
+  return 'Save';
 });
 
 // Live space with minimum properties for alerts
@@ -264,6 +301,32 @@ async function reloadSpaceAndReset() {
   await invalidateController();
 
   await reset({ force: true });
+}
+
+async function handleProposeSettingsChanges() {
+  if (!selfGovernedExecution.value) return;
+
+  proposing.value = true;
+
+  try {
+    const transaction = await getSettingsUpdateTransaction();
+
+    const spaceKey = `${props.space.network}:${props.space.id}`;
+    const draftId = await createDraft(spaceKey, {
+      title: 'Update space settings',
+      executions: {
+        [selfGovernedExecution.value.address]: [transaction]
+      }
+    });
+
+    router.push({
+      name: 'space-editor',
+      params: { space: spaceKey, key: draftId }
+    });
+  } catch {
+  } finally {
+    proposing.value = false;
+  }
 }
 
 async function handleSettingsSave() {
@@ -591,11 +654,13 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
     ref="el"
     :error="error"
     :is-modified="!!isModified"
-    :saving="saving"
-    :save-label="
-      space.additionalRawData?.hibernated && !isModified ? 'Reactivate' : 'Save'
+    :saving="saving || proposing"
+    :save-label="saveLabel"
+    @save="
+      canProposeSettingsChanges
+        ? handleProposeSettingsChanges()
+        : handleSettingsSave()
     "
-    @save="handleSettingsSave"
     @reset="reset()"
   />
   <teleport to="#modal">

--- a/packages/sx.js/src/clients/evm/ethereum-tx/index.ts
+++ b/packages/sx.js/src/clients/evm/ethereum-tx/index.ts
@@ -1,4 +1,4 @@
-import { AbiCoder, Interface } from '@ethersproject/abi';
+import { AbiCoder, FormatTypes, Interface } from '@ethersproject/abi';
 import { Signer } from '@ethersproject/abstract-signer';
 import { Contract } from '@ethersproject/contracts';
 import { keccak256 } from '@ethersproject/solidity';
@@ -549,6 +549,41 @@ export class EthereumTx {
     return spaceContract.getProposalStatus(proposal);
   }
 
+  getUpdateSettingsPayload(settings: UpdateSettingsInput) {
+    return {
+      minVotingDuration: settings.minVotingDuration ?? NO_UPDATE_UINT32,
+      maxVotingDuration: settings.maxVotingDuration ?? NO_UPDATE_UINT32,
+      votingDelay: settings.votingDelay ?? NO_UPDATE_UINT32,
+      metadataURI: settings.metadataUri ?? NO_UPDATE_STRING,
+      daoURI: settings.daoUri ?? NO_UPDATE_STRING,
+      proposalValidationStrategy: settings.proposalValidationStrategy ?? {
+        addr: NO_UPDATE_ADDRESS,
+        params: '0x00'
+      },
+      proposalValidationStrategyMetadataURI:
+        settings.proposalValidationStrategyMetadataUri ?? '',
+      authenticatorsToAdd: settings.authenticatorsToAdd ?? [],
+      authenticatorsToRemove: settings.authenticatorsToRemove ?? [],
+      votingStrategiesToAdd: settings.votingStrategiesToAdd ?? [],
+      votingStrategiesToRemove: settings.votingStrategiesToRemove ?? [],
+      votingStrategyMetadataURIsToAdd:
+        settings.votingStrategyMetadataUrisToAdd ?? []
+    };
+  }
+
+  getUpdateSettingsCall({ settings }: { settings: UpdateSettingsInput }) {
+    const spaceInterface = new Interface(SpaceAbi);
+    const updateSettingsFunction = spaceInterface.getFunction('updateSettings');
+    const payload = this.getUpdateSettingsPayload(settings);
+
+    return {
+      abi: [JSON.parse(updateSettingsFunction.format(FormatTypes.json))],
+      method: updateSettingsFunction.format(),
+      args: { [updateSettingsFunction.inputs[0]?.name ?? 'input']: payload },
+      data: spaceInterface.encodeFunctionData(updateSettingsFunction, [payload])
+    };
+  }
+
   async updateSettings(
     {
       signer,
@@ -563,25 +598,7 @@ export class EthereumTx {
   ) {
     const spaceContract = new Contract(space, SpaceAbi, signer);
     const promise = spaceContract.updateSettings(
-      {
-        minVotingDuration: settings.minVotingDuration ?? NO_UPDATE_UINT32,
-        maxVotingDuration: settings.maxVotingDuration ?? NO_UPDATE_UINT32,
-        votingDelay: settings.votingDelay ?? NO_UPDATE_UINT32,
-        metadataURI: settings.metadataUri ?? NO_UPDATE_STRING,
-        daoURI: settings.daoUri ?? NO_UPDATE_STRING,
-        proposalValidationStrategy: settings.proposalValidationStrategy ?? {
-          addr: NO_UPDATE_ADDRESS,
-          params: '0x00'
-        },
-        proposalValidationStrategyMetadataURI:
-          settings.proposalValidationStrategyMetadataUri ?? '',
-        authenticatorsToAdd: settings.authenticatorsToAdd ?? [],
-        authenticatorsToRemove: settings.authenticatorsToRemove ?? [],
-        votingStrategiesToAdd: settings.votingStrategiesToAdd ?? [],
-        votingStrategiesToRemove: settings.votingStrategiesToRemove ?? [],
-        votingStrategyMetadataURIsToAdd:
-          settings.votingStrategyMetadataUrisToAdd ?? []
-      },
+      this.getUpdateSettingsPayload(settings),
       this.defaultTransactionOverrides
     );
 


### PR DESCRIPTION
### Summary

On EVM we now support creation of proposal out of changes of space settings if space is self-governed (avatar or timelock is controller and it's added as treasury).

When user edits /settings page it will prompt them to Propose changes. Clicking it will kick-off a proposal with proper `updateSettings` call.

Closes: https://github.com/snapshot-labs/sx-monorepo/issues/1423

### How to test

1. Go to http://localhost:8080/#/sep:0xdf980675F07c1ff94B93DdDB4e7E7D8A9ac3d643/settings
2. Edit some settings.
3. You get prompt to Propose changes.
4. When you click it you are taken to editor with execution attached.

### Screenshots

<img width="1428" height="972" alt="image" src="https://github.com/user-attachments/assets/a0c87eb2-0f93-47f3-a402-383a902a6889" />
<img width="1366" height="972" alt="image" src="https://github.com/user-attachments/assets/5a846573-1517-4a13-b92e-0e044c08cb51" />
