### PR TITLE
build(deps): bump @snapshot-labs/snapshot.js from 0.16.0 to 0.17.0

### DIFF
--- a/apps/auction/package.json
+++ b/apps/auction/package.json
@@ -31,7 +31,7 @@
     "@headlessui/vue": "^1.7.23",
     "@snapshot-labs/lock": "0.3.2",
     "@snapshot-labs/pineapple": "^1.2.1",
-    "@snapshot-labs/snapshot.js": "^0.16.0",
+    "@snapshot-labs/snapshot.js": "^0.17.0",
     "@snapshot-labs/tune": "0.1.0",
     "@tanstack/vue-query": "^5.64.2",
     "@vueuse/core": "^10.4.1",

--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -21,7 +21,7 @@
     "@snapshot-labs/keycard": "^0.5.1",
     "@snapshot-labs/snapshot-metrics": "^2.0.0",
     "@snapshot-labs/snapshot-sentry": "^3.1.0",
-    "@snapshot-labs/snapshot.js": "^0.16.0",
+    "@snapshot-labs/snapshot.js": "^0.17.0",
     "bluebird": "^3.7.2",
     "connection-string": "^1.0.1",
     "cors": "^2.8.5",

--- a/apps/sequencer/package.json
+++ b/apps/sequencer/package.json
@@ -29,7 +29,7 @@
     "@snapshot-labs/pineapple": "^1.2.1",
     "@snapshot-labs/snapshot-metrics": "^2.0.0",
     "@snapshot-labs/snapshot-sentry": "^3.1.0",
-    "@snapshot-labs/snapshot.js": "^0.16.0",
+    "@snapshot-labs/snapshot.js": "^0.17.0",
     "ajv": "8.11.0",
     "bluebird": "^3.7.2",
     "connection-string": "^1.0.1",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -46,7 +46,7 @@
     "@snapshot-labs/lock": "0.3.2",
     "@snapshot-labs/tune": "0.1.0",
     "@snapshot-labs/pineapple": "^1.2.1",
-    "@snapshot-labs/snapshot.js": "^0.16.0",
+    "@snapshot-labs/snapshot.js": "^0.17.0",
     "@snapshot-labs/sx": "^0.1.11",
     "@tanstack/vue-query": "^5.64.2",
     "@tiptap/core": "^3.4.1",

--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
         "@headlessui/vue": "^1.7.23",
         "@snapshot-labs/lock": "0.3.2",
         "@snapshot-labs/pineapple": "^1.2.1",
-        "@snapshot-labs/snapshot.js": "^0.16.0",
+        "@snapshot-labs/snapshot.js": "^0.17.0",
         "@snapshot-labs/tune": "0.1.0",
         "@tanstack/vue-query": "^5.64.2",
         "@vueuse/core": "^10.4.1",
@@ -174,7 +174,7 @@
         "@snapshot-labs/keycard": "^0.5.1",
         "@snapshot-labs/snapshot-metrics": "^2.0.0",
         "@snapshot-labs/snapshot-sentry": "^3.1.0",
-        "@snapshot-labs/snapshot.js": "^0.16.0",
+        "@snapshot-labs/snapshot.js": "^0.17.0",
         "bluebird": "^3.7.2",
         "connection-string": "^1.0.1",
         "cors": "^2.8.5",
@@ -278,7 +278,7 @@
         "@snapshot-labs/pineapple": "^1.2.1",
         "@snapshot-labs/snapshot-metrics": "^2.0.0",
         "@snapshot-labs/snapshot-sentry": "^3.1.0",
-        "@snapshot-labs/snapshot.js": "^0.16.0",
+        "@snapshot-labs/snapshot.js": "^0.17.0",
         "ajv": "8.11.0",
         "bluebird": "^3.7.2",
         "connection-string": "^1.0.1",
@@ -333,7 +333,7 @@
         "@snapshot-labs/highlight": "^0.1.0-beta.2",
         "@snapshot-labs/lock": "0.3.2",
         "@snapshot-labs/pineapple": "^1.2.1",
-        "@snapshot-labs/snapshot.js": "^0.16.0",
+        "@snapshot-labs/snapshot.js": "^0.17.0",
         "@snapshot-labs/sx": "^0.1.11",
         "@snapshot-labs/tune": "0.1.0",
         "@tanstack/vue-query": "^5.64.2",
@@ -1896,7 +1896,7 @@
 
     "@snapshot-labs/snapshot-sentry": ["@snapshot-labs/snapshot-sentry@3.1.0", "", { "dependencies": { "@sentry/node": "^10.52.0" } }, "sha512-MIIQyW0GZisXa93JvDWFdMO0Ycu9JXBH0P3ca0qJ7HhbxfNrzqLOr1dzhKdhXT0e+sTWO7UCxdeQTGF3dV0l7w=="],
 
-    "@snapshot-labs/snapshot.js": ["@snapshot-labs/snapshot.js@0.16.0", "", { "dependencies": { "@ethersproject/abi": "^5.6.4", "@ethersproject/address": "^5.6.1", "@ethersproject/bignumber": "^5.7.0", "@ethersproject/bytes": "^5.6.1", "@ethersproject/contracts": "^5.6.2", "@ethersproject/hash": "^5.7.0", "@ethersproject/providers": "^5.6.8", "@ethersproject/units": "^5.7.0", "@ethersproject/wallet": "^5.6.2", "ajv": "8.11.0", "ajv-errors": "^3.0.0", "ajv-formats": "^2.1.1", "cross-fetch": "^3.1.6", "json-to-graphql-query": "^2.2.4", "lodash.set": "^4.3.2", "starknet": "^6.21.0", "viem": "^2.55.11" } }, "sha512-Ml2rMEQeYHADfK+rB1CcHB8OXpUBquQO8Ti7hPYBVaoI+AxlQIrS/0iQASY4LrR4xiu7nKL+OzU1WMWduc7DfA=="],
+    "@snapshot-labs/snapshot.js": ["@snapshot-labs/snapshot.js@0.17.0", "", { "dependencies": { "@ethersproject/abi": "^5.6.4", "@ethersproject/address": "^5.6.1", "@ethersproject/bignumber": "^5.7.0", "@ethersproject/bytes": "^5.6.1", "@ethersproject/contracts": "^5.6.2", "@ethersproject/hash": "^5.7.0", "@ethersproject/providers": "^5.6.8", "@ethersproject/units": "^5.7.0", "@ethersproject/wallet": "^5.6.2", "ajv": "8.11.0", "ajv-errors": "^3.0.0", "ajv-formats": "^2.1.1", "cross-fetch": "^3.1.6", "json-to-graphql-query": "^2.2.4", "lodash.set": "^4.3.2", "starknet": "^6.21.0", "viem": "^2.55.11" } }, "sha512-/c/0BTHhq9vGpsP600SUvGdCtnjggiZe8oCK2I117fudmpjF6Cd+bwD7PDUsrqUB7CklXfYmzRZ+ttahGZprmA=="],
 
     "@snapshot-labs/sx": ["@snapshot-labs/sx@workspace:packages/sx.js"],
 


### PR DESCRIPTION
### Summary

Bumps `@snapshot-labs/snapshot.js` from 0.16.0 to 0.17.0 across the workspace. Same change dependabot would open on its next daily run — raised manually so the sequencer picks up ENSv2 resolution now.

0.17.0 (snapshot-labs/snapshot.js#1230) resolves ENS through the Universal Resolver:

- **ENSv2 owners on Sepolia** via `findOwner`, with the v1 registry fallback for names that have not migrated. Mainnet is untouched — ENSv2 is not deployed there, so it stays on the v1 registry path.
- **Strict record reads**: a failed lookup (dead CCIP gateway, RPC error) now throws instead of silently resolving the name owner as controller. Genuine "no record" answers still resolve as before.

This is what unblocks Sepolia ENSv2 space creation (snapshot-labs/workflow#823) — `getSpaceController('test123.eth', '11155111')` returns `0x1208a26FAa0F4AC65B42098419EB4dAA5e580AC6` on 0.17.0 where 0.16.0 returned the empty address.

**Consumer safety** — the throwing behaviour only reaches code that calls the ENS helpers:

| app | calls ENS helpers | handled |
|---|---|---|
| sequencer | `settings.ts`, `delete-space.ts`, `poke.ts` | yes — #2273 (merged) catches, captures to Sentry, rejects a clean `ServerError` |
| hub | none | n/a |
| auction | none | n/a |
| ui | none — `apps/ui/src/helpers/ens.ts` is an independent implementation | n/a |

### How to test

```
bun install
cd apps/sequencer && bun run typecheck && bun run lint && bun run test:unit
```

Live controller resolution on 0.17.0 (run from `apps/sequencer`):

| space | network | before (0.16.0) | after (0.17.0) |
|---|---|---|---|
| `test123.eth` | Sepolia | `0x0000…0000` | `0x1208a26FAa0F4AC65B42098419EB4dAA5e580AC6` |
| `ens.eth` | mainnet | `0xb6E0…8cd9` | `0xb6E0…8cd9` (unchanged) |
| `stakedao.eth` | mainnet | `0xB055…C765` | `0xB055…C765` (unchanged) |
| `defi.app` | mainnet | `0x7aeB…c7eB` | `0x7aeB…c7eB` (unchanged) |
| `ethplay.org` | Sepolia | `0x8D85…5958` | `0x8D85…5958` (unchanged) |

Verified locally: typecheck, lint, 95 unit tests and the integration suite all pass against 0.17.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
