### PR TITLE
fix(api): read voting delay and period on-chain at Governor space init

### DIFF
--- a/apps/api/src/evm/protocols/openzeppelin/writers.ts
+++ b/apps/api/src/evm/protocols/openzeppelin/writers.ts
@@ -207,7 +207,14 @@ export function createWriters(
     space.created = Number(block?.timestamp ?? getCurrentTimestamp());
 
     // Strategies & authentication
-    const [quorum, timelock, token, proposalThreshold] = await Promise.all([
+    const [
+      quorum,
+      timelock,
+      token,
+      proposalThreshold,
+      votingDelay,
+      votingPeriod
+    ] = await Promise.all([
       getQuorum({
         address: contractAddress,
         blockNumber
@@ -228,6 +235,18 @@ export function createWriters(
         address: contractAddress,
         abi: IGovernorAbi,
         functionName: 'proposalThreshold',
+        blockNumber: BigInt(blockNumber)
+      }),
+      client.readContract({
+        address: contractAddress,
+        abi: IGovernorAbi,
+        functionName: 'votingDelay',
+        blockNumber: BigInt(blockNumber)
+      }),
+      client.readContract({
+        address: contractAddress,
+        abi: IGovernorAbi,
+        functionName: 'votingPeriod',
         blockNumber: BigInt(blockNumber)
       })
     ]);
@@ -293,6 +312,9 @@ export function createWriters(
       votingPowerStrategyParsedMetadata.id
     ];
     space.proposal_threshold = proposalThreshold.toString();
+    space.voting_delay = votingDelay;
+    space.min_voting_period = votingPeriod;
+    space.max_voting_period = votingPeriod;
 
     const spaceMetadata = new SpaceMetadataItem(metadataId, config.indexerName);
     spaceMetadata.name = governanceInfo.name;


### PR DESCRIPTION
Fix the governor spaces indexing after #2260 , on spaces created with incomplete setup, then updated/fixed in later block.

Read `votingDelay()` and `votingPeriod()` on-chain when initializing a Governor space, so the three timing fields no longer depend on catching the constructor events.

`voting_delay`, `min_voting_period` and `max_voting_period` were only ever written by the `VotingDelaySet` / `VotingPeriodSet` handlers. Governors emit those from the constructor, so the values were only correct when a space's `startBlock` was exactly its deployment block — otherwise they stayed at `0n` forever. A governor that hardcodes the settings instead of using the `GovernorSettings` extension never emits them at all.

Both reads go into the `Promise.all` batch that already reads `proposalThreshold` against the same address. Handlers are unchanged, so a settings change after `startBlock` still emits and replays over the init value.

Closes #2277

### Notes for reviewers

- **Why init-read + event-replay is enough:** a `GovernorSettings` governor emits on every change, so if the value read at `startBlock` is stale, the change happened after `startBlock` and its event replays over it. A hardcoded governor never changes, so the read is final. Only a proxy that rewrites settings storage without emitting would slip through.

### Test plan

Re-index the governor spaces on eth (after applying the fix #2281), no more reverting error on Femboy DAO