### PR TITLE
fix(api): ignore duplicate proposal cancellation events

### DIFF
--- a/apps/api/src/evm/protocols/governor-bravo/writers.ts
+++ b/apps/api/src/evm/protocols/governor-bravo/writers.ts
@@ -383,6 +383,7 @@ export function createWriters(
       Space.loadEntity(spaceAddress, config.indexerName)
     ]);
     if (!proposal || !space) return;
+    if (proposal.cancelled) return;
 
     proposal.cancelled = true;
     space.proposal_count -= 1;


### PR DESCRIPTION
Fixes #2286

Make the proposal cancellation handler idempotent, so repeated `ProposalCanceled` events stop draining `space.proposal_count` and `space.vote_count`.

Governor Bravo lets anyone call `cancel()` on an already cancelled proposal, so the event can be emitted many times for the same proposal. The other protocols reject it on-chain, so only the Governor Bravo writer needs the guard. Measurements and scope in #2286.

Existing drift does not self-heal — recovering it needs a reindex or a backfill.