### PR TITLE
fix(ui): resolve ENSv2 name owners on Sepolia

### DIFF
--- a/apps/ui/src/helpers/ens.test.ts
+++ b/apps/ui/src/helpers/ens.test.ts
@@ -48,20 +48,21 @@ describe('ens', () => {
         expect(owner).toBe('0x385517332F46b20B4F7340a80c011b2973ac622e');
       }, 10000);
 
-      it('should encode a label longer than 63 bytes', async () => {
-        const owner = await getNameOwner(`${'a'.repeat(84)}.eth`, 11155111);
-        expect(owner).toBe('0x0000000000000000000000000000000000000000');
-      }, 10000);
-
-      it('should encode a label longer than 255 bytes as its labelhash', async () => {
-        const owner = await getNameOwner(`${'a'.repeat(256)}.eth`, 11155111);
-        expect(owner).toBe('0x0000000000000000000000000000000000000000');
-      }, 10000);
-
-      it('should encode a multi-byte emoji label', async () => {
-        const owner = await getNameOwner('🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂.eth', 11155111);
-        expect(owner).toBe('0x0000000000000000000000000000000000000000');
-      }, 10000);
+      it.each([
+        ['a label longer than 63 bytes', `${'a'.repeat(84)}.eth`],
+        [
+          'a label longer than 255 bytes as its labelhash',
+          `${'a'.repeat(256)}.eth`
+        ],
+        ['a multi-byte emoji label', '🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂.eth']
+      ])(
+        'should encode %s',
+        async (label, name) => {
+          const owner = await getNameOwner(name, 11155111);
+          expect(owner).toBe('0x0000000000000000000000000000000000000000');
+        },
+        10000
+      );
     });
 
     describe('for names using the onchain resolver', () => {

--- a/apps/ui/src/helpers/ens.test.ts
+++ b/apps/ui/src/helpers/ens.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import { getNameOwner } from './ens';
+import { getNameOwner, getSpaceController } from './ens';
 
 describe('ens', () => {
   describe('getNameOwner', () => {
+    describe('for names migrated to ENSv2', () => {
+      // ownership does not bridge v1 to v2: the legacy registry has no owner
+      it('should return the owner of a migrated name on testnet', async () => {
+        const owner = await getNameOwner('test123.eth', 11155111);
+        expect(owner).toBe('0x1208a26FAa0F4AC65B42098419EB4dAA5e580AC6');
+      }, 10000);
+
+      it('should resolve the same address as the space controller', async () => {
+        const controller = await getSpaceController('test123.eth', 11155111);
+        expect(controller).toBe('0x1208a26FAa0F4AC65B42098419EB4dAA5e580AC6');
+      }, 10000);
+    });
+
     describe('for names using the onchain resolver', () => {
       it('should return the owner of the name on mainnet', async () => {
         const owner = await getNameOwner('ens.eth', 1);

--- a/apps/ui/src/helpers/ens.test.ts
+++ b/apps/ui/src/helpers/ens.test.ts
@@ -4,7 +4,6 @@ import { getNameOwner, getSpaceController } from './ens';
 describe('ens', () => {
   describe('getNameOwner', () => {
     describe('for names migrated to ENSv2', () => {
-      // ownership does not bridge v1 to v2: the legacy registry has no owner
       it('should return the owner of a migrated name on testnet', async () => {
         const owner = await getNameOwner('test123.eth', 11155111);
         expect(owner).toBe('0x1208a26FAa0F4AC65B42098419EB4dAA5e580AC6');
@@ -13,6 +12,28 @@ describe('ens', () => {
       it('should resolve the same address as the space controller', async () => {
         const controller = await getSpaceController('test123.eth', 11155111);
         expect(controller).toBe('0x1208a26FAa0F4AC65B42098419EB4dAA5e580AC6');
+      }, 10000);
+    });
+
+    describe('for names not migrated to ENSv2 on testnet', () => {
+      it('should still resolve a DNS-imported domain through its DNS owner', async () => {
+        const owner = await getNameOwner('ethplay.org', 11155111);
+        expect(owner).toBe('0x8D852E6cC57A855D0D75E1e2af57C9679D555958');
+      }, 10000);
+
+      it('should still resolve a subdomain through the registry', async () => {
+        const owner = await getNameOwner('vote.vptest2.eth', 11155111);
+        expect(owner).toBe('0x385517332F46b20B4F7340a80c011b2973ac622e');
+      }, 10000);
+
+      it('should encode a label longer than 63 bytes', async () => {
+        const owner = await getNameOwner(`${'a'.repeat(84)}.eth`, 11155111);
+        expect(owner).toBe('0x0000000000000000000000000000000000000000');
+      }, 10000);
+
+      it('should encode a multi-byte emoji label', async () => {
+        const owner = await getNameOwner('🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂.eth', 11155111);
+        expect(owner).toBe('0x0000000000000000000000000000000000000000');
       }, 10000);
     });
 

--- a/apps/ui/src/helpers/ens.test.ts
+++ b/apps/ui/src/helpers/ens.test.ts
@@ -36,6 +36,11 @@ describe('ens', () => {
         expect(owner).toBe('0x0000000000000000000000000000000000000000');
       }, 10000);
 
+      it('should encode a label longer than 255 bytes as its labelhash', async () => {
+        const owner = await getNameOwner(`${'a'.repeat(256)}.eth`, 11155111);
+        expect(owner).toBe('0x0000000000000000000000000000000000000000');
+      }, 10000);
+
       it('should encode a multi-byte emoji label', async () => {
         const owner = await getNameOwner('🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂🧛🏻‍♂.eth', 11155111);
         expect(owner).toBe('0x0000000000000000000000000000000000000000');

--- a/apps/ui/src/helpers/ens.test.ts
+++ b/apps/ui/src/helpers/ens.test.ts
@@ -9,6 +9,11 @@ describe('ens', () => {
         expect(owner).toBe('0x1208a26FAa0F4AC65B42098419EB4dAA5e580AC6');
       }, 10000);
 
+      it('should resolve a case variant to the same owner', async () => {
+        const owner = await getNameOwner('TEST123.eth', 11155111);
+        expect(owner).toBe('0x1208a26FAa0F4AC65B42098419EB4dAA5e580AC6');
+      }, 10000);
+
       it('should resolve the same address as the space controller', async () => {
         const controller = await getSpaceController('test123.eth', 11155111);
         expect(controller).toBe('0x1208a26FAa0F4AC65B42098419EB4dAA5e580AC6');

--- a/apps/ui/src/helpers/ens.test.ts
+++ b/apps/ui/src/helpers/ens.test.ts
@@ -1,7 +1,24 @@
 import { describe, expect, it } from 'vitest';
-import { getNameOwner, getSpaceController } from './ens';
+import { dnsEncodeName, getNameOwner, getSpaceController } from './ens';
 
 describe('ens', () => {
+  describe('dnsEncodeName', () => {
+    it('should encode each label with a raw length byte', () => {
+      expect(dnsEncodeName('test123.eth')).toBe('0x07746573743132330365746800');
+      expect(dnsEncodeName(`${'a'.repeat(84)}.eth`)).toBe(
+        `0x54${'61'.repeat(84)}0365746800`
+      );
+    });
+
+    it('should encode a label longer than 255 bytes as its labelhash', () => {
+      expect(dnsEncodeName(`${'a'.repeat(256)}.eth`)).toBe(
+        `0x42${Buffer.from(
+          '[1daa7034adab66d9ec9e03e2c89201b83a7497e85dc5b971aa9dae2ccbb7a208]'
+        ).toString('hex')}0365746800`
+      );
+    });
+  });
+
   describe('getNameOwner', () => {
     describe('for names migrated to ENSv2', () => {
       it('should return the owner of a migrated name on testnet', async () => {

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -1,7 +1,9 @@
 import { Signer } from '@ethersproject/abstract-signer';
 import { getAddress, isAddress } from '@ethersproject/address';
+import { concat, hexlify } from '@ethersproject/bytes';
 import { Contract } from '@ethersproject/contracts';
 import { ensNormalize, namehash } from '@ethersproject/hash';
+import { toUtf8Bytes } from '@ethersproject/strings';
 import { call } from './call';
 import { EVM_EMPTY_ADDRESS } from './constants';
 import { getProvider } from './provider';
@@ -14,6 +16,8 @@ type ENSContracts = {
   registryAbi: string[];
   resolvers: Record<ENSChainId, string[]>;
   resolverAbi: string[];
+  universalResolver: string;
+  universalResolverAbi: string[];
   nameWrappers: Record<ENSChainId, string>;
   nameWrapperAbi: string[];
 };
@@ -28,6 +32,11 @@ const ENS_CONTRACTS: ENSContracts = {
     'function addr(bytes32 node) view returns (address r)',
     'function text(bytes32 node, string key) view returns (string)',
     'function setText(bytes32 node, string key, string value)'
+  ],
+  // see https://docs.ens.domains/resolvers/universal
+  universalResolver: '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe',
+  universalResolverAbi: [
+    'function findOwner(bytes name) view returns (address)'
   ],
   nameWrapperAbi: ['function ownerOf(uint256) view returns (address)'],
   resolvers: {
@@ -46,6 +55,19 @@ const ENS_CONTRACTS: ENSContracts = {
     11155111: '0x0635513f179D50A207757E05759CbD106d7dFcE8'
   }
 };
+
+// not @ethersproject/hash's dnsEncode: that rejects labels over 63 bytes,
+// which the Universal Resolver accepts and some live space names need
+function dnsEncodeName(name: string): string {
+  const labels = name.split('.').map(label => toUtf8Bytes(label));
+
+  return hexlify(
+    concat([
+      ...labels.flatMap(label => [Uint8Array.of(label.length), label]),
+      Uint8Array.of(0)
+    ])
+  );
+}
 
 // see https://docs.ens.domains/registry/dns#gasless-import
 async function getDNSOwner(domain: string): Promise<string> {
@@ -174,6 +196,19 @@ export async function setEnsTextRecord(
 export async function getNameOwner(name: string, chainId: ENSChainId) {
   const provider = getProvider(chainId);
   const ensHash = namehash(name);
+
+  // findOwner is ENSv2-only, live on Sepolia and not yet on mainnet. A name
+  // absent from ENSv2 resolves the empty address successfully, so any revert
+  // is a genuine failure and must throw, never resolve a stale v1 owner
+  if (chainId === 11155111) {
+    const ensOwnerV2 = await call(
+      provider,
+      ENS_CONTRACTS.universalResolverAbi,
+      [ENS_CONTRACTS.universalResolver, 'findOwner', [dnsEncodeName(name)]]
+    );
+
+    if (ensOwnerV2 && ensOwnerV2 !== EVM_EMPTY_ADDRESS) return ensOwnerV2;
+  }
 
   let owner = await call(
     provider,

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -3,6 +3,7 @@ import { getAddress, isAddress } from '@ethersproject/address';
 import { concat, hexlify } from '@ethersproject/bytes';
 import { Contract } from '@ethersproject/contracts';
 import { ensNormalize, namehash } from '@ethersproject/hash';
+import { keccak256 } from '@ethersproject/keccak256';
 import { toUtf8Bytes } from '@ethersproject/strings';
 import { call } from './call';
 import { EVM_EMPTY_ADDRESS } from './constants';
@@ -55,9 +56,16 @@ const ENS_CONTRACTS: ENSContracts = {
   }
 };
 
-// dnsEncode from @ethersproject/hash rejects labels over 63 bytes
+// dnsEncode from @ethersproject/hash rejects labels over 63 bytes; labels
+// over 255 bytes carry their labelhash instead, as viem encodes them
 function dnsEncodeName(name: string): string {
-  const labels = name.split('.').map(label => toUtf8Bytes(label));
+  const value = name.replace(/^\.|\.$/g, '');
+  const labels = (value ? value.split('.') : []).map(label => {
+    const bytes = toUtf8Bytes(label);
+    return bytes.length > 255
+      ? toUtf8Bytes(`[${keccak256(bytes).slice(2)}]`)
+      : bytes;
+  });
 
   return hexlify(
     concat([

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -193,7 +193,8 @@ export async function setEnsTextRecord(
 
 export async function getNameOwner(name: string, chainId: ENSChainId) {
   const provider = getProvider(chainId);
-  const ensHash = namehash(name);
+  const normalized = ensNormalize(name);
+  const ensHash = namehash(normalized);
 
   // findOwner is ENSv2-only; an unmigrated name returns the empty address,
   // so a revert is a failure and must not fall back to a stale v1 owner
@@ -201,7 +202,11 @@ export async function getNameOwner(name: string, chainId: ENSChainId) {
     const ensOwnerV2 = await call(
       provider,
       ENS_CONTRACTS.universalResolverAbi,
-      [ENS_CONTRACTS.universalResolver, 'findOwner', [dnsEncodeName(name)]]
+      [
+        ENS_CONTRACTS.universalResolver,
+        'findOwner',
+        [dnsEncodeName(normalized)]
+      ]
     );
 
     if (ensOwnerV2 && ensOwnerV2 !== EVM_EMPTY_ADDRESS) return ensOwnerV2;
@@ -216,14 +221,16 @@ export async function getNameOwner(name: string, chainId: ENSChainId) {
     }
   );
 
-  if (!name.endsWith('.eth') && owner === EVM_EMPTY_ADDRESS) {
-    const resolvedAddress = (await getAddresses([name], chainId))[name];
-    const nameTokens = name.split('.');
+  if (!normalized.endsWith('.eth') && owner === EVM_EMPTY_ADDRESS) {
+    const resolvedAddress = (await getAddresses([normalized], chainId))[
+      normalized
+    ];
+    const nameTokens = normalized.split('.');
 
     if (nameTokens.length > 2) {
       owner = resolvedAddress || EVM_EMPTY_ADDRESS;
     } else if (nameTokens.length === 2 && resolvedAddress) {
-      owner = await getDNSOwner(name);
+      owner = await getDNSOwner(normalized);
     }
   }
 

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -17,7 +17,7 @@ type ENSContracts = {
   registryAbi: string[];
   resolvers: Record<ENSChainId, string[]>;
   resolverAbi: string[];
-  universalResolver: string;
+  universalResolver: Partial<Record<ENSChainId, string>>;
   universalResolverAbi: string[];
   nameWrappers: Record<ENSChainId, string>;
   nameWrapperAbi: string[];
@@ -34,7 +34,9 @@ const ENS_CONTRACTS: ENSContracts = {
     'function text(bytes32 node, string key) view returns (string)',
     'function setText(bytes32 node, string key, string value)'
   ],
-  universalResolver: '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe',
+  universalResolver: {
+    11155111: '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe'
+  },
   universalResolverAbi: [
     'function findOwner(bytes name) view returns (address)'
   ],
@@ -56,8 +58,6 @@ const ENS_CONTRACTS: ENSContracts = {
   }
 };
 
-// dnsEncode from @ethersproject/hash rejects labels over 63 bytes; labels
-// over 255 bytes carry their labelhash instead, as viem encodes them
 export function dnsEncodeName(name: string): string {
   const value = name.replace(/^\.|\.$/g, '');
   const labels = (value ? value.split('.') : []).map(label => {
@@ -202,23 +202,21 @@ export async function setEnsTextRecord(
 export async function getNameOwner(name: string, chainId: ENSChainId) {
   const provider = getProvider(chainId);
   const normalized = ensNormalize(name);
-  const ensHash = namehash(normalized);
 
+  const universalResolver = ENS_CONTRACTS.universalResolver[chainId];
   // findOwner is ENSv2-only; an unmigrated name returns the empty address,
   // so a revert is a failure and must not fall back to a stale v1 owner
-  if (chainId === 11155111) {
+  if (universalResolver) {
     const ensOwnerV2 = await call(
       provider,
       ENS_CONTRACTS.universalResolverAbi,
-      [
-        ENS_CONTRACTS.universalResolver,
-        'findOwner',
-        [dnsEncodeName(normalized)]
-      ]
+      [universalResolver, 'findOwner', [dnsEncodeName(normalized)]]
     );
 
     if (ensOwnerV2 && ensOwnerV2 !== EVM_EMPTY_ADDRESS) return ensOwnerV2;
   }
+
+  const ensHash = namehash(normalized);
 
   let owner = await call(
     provider,

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -58,7 +58,7 @@ const ENS_CONTRACTS: ENSContracts = {
 
 // dnsEncode from @ethersproject/hash rejects labels over 63 bytes; labels
 // over 255 bytes carry their labelhash instead, as viem encodes them
-function dnsEncodeName(name: string): string {
+export function dnsEncodeName(name: string): string {
   const value = name.replace(/^\.|\.$/g, '');
   const labels = (value ? value.split('.') : []).map(label => {
     const bytes = toUtf8Bytes(label);

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -33,7 +33,6 @@ const ENS_CONTRACTS: ENSContracts = {
     'function text(bytes32 node, string key) view returns (string)',
     'function setText(bytes32 node, string key, string value)'
   ],
-  // see https://docs.ens.domains/resolvers/universal
   universalResolver: '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe',
   universalResolverAbi: [
     'function findOwner(bytes name) view returns (address)'
@@ -56,8 +55,7 @@ const ENS_CONTRACTS: ENSContracts = {
   }
 };
 
-// not @ethersproject/hash's dnsEncode: that rejects labels over 63 bytes,
-// which the Universal Resolver accepts and some live space names need
+// dnsEncode from @ethersproject/hash rejects labels over 63 bytes
 function dnsEncodeName(name: string): string {
   const labels = name.split('.').map(label => toUtf8Bytes(label));
 
@@ -197,9 +195,8 @@ export async function getNameOwner(name: string, chainId: ENSChainId) {
   const provider = getProvider(chainId);
   const ensHash = namehash(name);
 
-  // findOwner is ENSv2-only, live on Sepolia and not yet on mainnet. A name
-  // absent from ENSv2 resolves the empty address successfully, so any revert
-  // is a genuine failure and must throw, never resolve a stale v1 owner
+  // findOwner is ENSv2-only; an unmigrated name returns the empty address,
+  // so a revert is a failure and must not fall back to a stale v1 owner
   if (chainId === 11155111) {
     const ensOwnerV2 = await call(
       provider,


### PR DESCRIPTION
### Summary

A name migrated to ENSv2 on Sepolia reads back as unowned from the v1 registry, so the UI does not recognise its creator as controller: with snapshot.js 0.17.0 the sequencer accepts the space, but its creator cannot open or save Settings (the mismatch flagged on #2276).

- `getNameOwner` now asks the Universal Resolver's `findOwner` on Sepolia first, falling back to the v1 registry + NameWrapper for unmigrated names. Mainnet is untouched — ENSv2 is not deployed there. A revert throws rather than silently resolving a stale v1 owner, matching snapshot.js.
- The name is normalized (ENSIP-15) before hashing and encoding, so case variants resolve identically.
- `dnsEncodeName` produces the DNS wire format byte-for-byte as viem's `packetToBytes` (fuzz-verified on 17 inputs): raw length byte per label — ethers' `dnsEncode` rejects labels over 63 bytes that live space names use — and the `[labelhash]` form for labels over 255 bytes.

Purely additive (+50 lines of code, the rest tests); record reads, the resolver allowlist and the DNS/subdomain fallbacks are unchanged. #2279 follows up with resolver-agnostic reads and the ENSv2 write path.

### How to test

```
cd apps/ui && bun run test src/helpers/ens.test.ts
```

20 tests: the 10 pre-existing live cases unchanged, plus ENSv2 regression (`test123.eth`, its `TEST123.eth` case variant, controller parity), unmigrated Sepolia names (DNS import, subdomain), and exact wire-encoding vectors (84-byte and 256-byte labels).

In the app: run `bun run dev` against testnet, open a Sepolia space whose ENS name is migrated to ENSv2 while connected as its owner.

| | before | after |
|---|---|---|
| `getNameOwner('test123.eth', 11155111)` | `0x0000…0000` | `0x1208a26FAa0F4AC65B42098419EB4dAA5e580AC6` |
| Settings nav item for the creator | hidden | visible |
| Saving Settings | rejected | works |

**Known limitation:** writing the `snapshot` record for an ENSv2 name still targets the v1 resolver (not authorised for v2 owners) — the record can be set in the ENS v2 app meanwhile; #2279 adds the v2 write path.
