### PR TITLE
feat(hub): add historical archive access gate

### DIFF
--- a/apps/hub/.env.example
+++ b/apps/hub/.env.example
@@ -6,6 +6,13 @@ SEQUENCER_URL=https://testnet.seq.snapshot.org
 STAMP_URL=https://stamp.fyi
 KEYCARD_URL=https://keycard.snapshot.org
 KEYCARD_SECRET=
+# Historical archive access is disabled unless explicitly enabled.
+# `observe` records gated-resource classes without changing results; `enforce` limits
+# non-entitled requests to the configured recent-data window.
+HISTORICAL_DATA_ACCESS_MODE=off
+HISTORICAL_DATA_CUTOFF_DAYS=365
+# Comma-separated SHA-256 hashes of valid Keycard API keys for manual pilots.
+HISTORICAL_DATA_API_KEY_HASHES=
 SCORE_API_URL=https://score.snapshot.org
 # If you need unlimited access to score-api, use `https://score.snapshot.org?apiKey=...`
 SIDEKICK_URL=https://sh5.co

--- a/apps/hub/README.md
+++ b/apps/hub/README.md
@@ -47,6 +47,23 @@ bun start
 
 To load a space settings in the database you can go on this endpoint <http://localhost:3000/api/spaces/yam.eth/poke> (change yam.eth with the space you want to activate).
 
+## Historical archive access
+
+Historical access is disabled by default. `HISTORICAL_DATA_ACCESS_MODE=observe`
+records low-cardinality gated-resource classifications without changing
+responses.
+`enforce` limits non-entitled requests to the recent window configured by
+`HISTORICAL_DATA_CUTOFF_DAYS`. Manual pilot entitlements are full SHA-256 API
+key hashes in `HISTORICAL_DATA_API_KEY_HASHES`; a key must also be valid in
+Keycard. The internal `KEYCARD_SECRET` remains entitled.
+
+The first scope covers proposal, vote, and message history in GraphQL, nested
+proposals returned with votes, and EIP-4824 proposal/activity lists. It does not
+cover aliases, follows, subscriptions, statements, users, all-time aggregate
+queries, IPFS, exports, subgraphs, or independently hosted APIs. This is an
+access-control seam for preferential Hub access, not a data-secrecy boundary or
+a billing system.
+
 ## Flag codes
 
 The hub uses flag codes (`flagCode`) to mark proposals and spaces for various reasons:

--- a/apps/hub/src/eip4824.ts
+++ b/apps/hub/src/eip4824.ts
@@ -1,4 +1,8 @@
 import express from 'express';
+import {
+  applyHistoricalCollectionBoundary,
+  getHistoricalAccessContext
+} from './helpers/historicalAccess';
 import db, { sequencerDB } from './helpers/mysql';
 import { getSpace } from './helpers/spaces';
 
@@ -72,9 +76,15 @@ router.get('/:space/proposals', async (req, res) => {
 
     if (!space.verified) return res.status(400).json({ error: 'INVALID' });
 
+    const args = applyHistoricalCollectionBoundary(
+      { where: {} },
+      getHistoricalAccessContext(req, res),
+      'eip4824_proposals'
+    );
+    const cutoff = args.where?.created_gte;
     proposals = await db.queryAsync(
-      'SELECT id, title, start, end, body, author, ipfs, discussion FROM proposals WHERE space = ? ORDER BY created DESC LIMIT 20',
-      [id]
+      `SELECT id, title, start, end, body, author, ipfs, discussion FROM proposals WHERE space = ?${cutoff ? ' AND created >= ?' : ''} ORDER BY created DESC LIMIT 20`,
+      cutoff ? [id, cutoff] : [id]
     );
   } catch {
     return res.status(404).json({ error: 'NOT_FOUND' });
@@ -115,9 +125,16 @@ router.get('/:space/activities', async (req, res) => {
 
     if (!space.verified) return res.status(400).json({ error: 'INVALID' });
 
+    const args = applyHistoricalCollectionBoundary(
+      { where: {} },
+      getHistoricalAccessContext(req, res),
+      'eip4824_activities',
+      'timestamp'
+    );
+    const cutoff = args.where?.timestamp_gte;
     messages = await sequencerDB.queryAsync(
-      'SELECT id, type, address FROM messages WHERE space = ? ORDER BY timestamp DESC LIMIT 20',
-      [id]
+      `SELECT id, type, address FROM messages WHERE space = ?${cutoff ? ' AND timestamp >= ?' : ''} ORDER BY timestamp DESC LIMIT 20`,
+      cutoff ? [id, cutoff] : [id]
     );
   } catch {
     return res.status(404).json({ error: 'NOT_FOUND' });

--- a/apps/hub/src/graphql/index.ts
+++ b/apps/hub/src/graphql/index.ts
@@ -6,15 +6,19 @@ import depthLimit from 'graphql-depth-limit';
 import queryCountLimit from 'graphql-query-count-limit';
 import defaultQuery from './examples';
 import Query from './operations';
+import { getHistoricalAccessContext } from '../helpers/historicalAccess';
 
 const schemaFile = path.join(__dirname, './schema.gql');
 const typeDefs = fs.readFileSync(schemaFile, 'utf8');
 const rootValue = { Query };
 const schema = makeExecutableSchema({ typeDefs, resolvers: rootValue });
 
-export default graphqlHTTP({
+export default graphqlHTTP((req, res) => ({
   schema,
   rootValue,
+  context: {
+    historicalAccess: getHistoricalAccessContext(req, res)
+  },
   graphiql: { defaultQuery, headerEditorEnabled: true },
   validationRules: [queryCountLimit(5, 5), depthLimit(5)]
-});
+}));

--- a/apps/hub/src/graphql/operations/messages.ts
+++ b/apps/hub/src/graphql/operations/messages.ts
@@ -1,9 +1,16 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import { applyHistoricalCollectionBoundary } from '../../helpers/historicalAccess';
 import log from '../../helpers/log';
 import { sequencerDB } from '../../helpers/mysql';
 import { buildWhereQuery, checkLimits } from '../helpers';
 
-export default async function (parent, args) {
+export default async function (parent, args, context?) {
+  args = applyHistoricalCollectionBoundary(
+    args,
+    context?.historicalAccess,
+    'messages',
+    'timestamp'
+  );
   const { first, skip, where = {} } = args;
 
   checkLimits(args, 'messages');

--- a/apps/hub/src/graphql/operations/proposal.ts
+++ b/apps/hub/src/graphql/operations/proposal.ts
@@ -1,9 +1,10 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import { enforceHistoricalEntityBoundary } from '../../helpers/historicalAccess';
 import log from '../../helpers/log';
 import db from '../../helpers/mysql';
 import { formatProposal } from '../helpers';
 
-export default async function (parent, { id }) {
+export default async function (parent, { id }, context?) {
   const query = `
     SELECT
       p.*,
@@ -22,12 +23,25 @@ export default async function (parent, { id }) {
     WHERE p.id = ? AND spaces.deleted = 0 AND spaces.settings IS NOT NULL
     LIMIT 1
   `;
+  let proposals;
   try {
-    const proposals = await db.queryAsync(query, [id]);
-    return proposals.map(proposal => formatProposal(proposal))[0] || null;
+    proposals = await db.queryAsync(query, [id]);
   } catch (err: any) {
     log.error(`[graphql] proposal, ${JSON.stringify(err)}`);
     capture(err, { id });
     return Promise.reject(new Error('request failed'));
   }
+
+  const proposal = proposals[0];
+  if (!proposal) return null;
+  if (
+    !enforceHistoricalEntityBoundary(
+      proposal.created,
+      context?.historicalAccess,
+      'proposal'
+    )
+  ) {
+    return null;
+  }
+  return formatProposal(proposal);
 }

--- a/apps/hub/src/graphql/operations/proposals.ts
+++ b/apps/hub/src/graphql/operations/proposals.ts
@@ -1,9 +1,15 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import { applyHistoricalCollectionBoundary } from '../../helpers/historicalAccess';
 import log from '../../helpers/log';
 import db from '../../helpers/mysql';
 import { buildWhereQuery, checkLimits, formatProposal } from '../helpers';
 
-export default async function (parent, args) {
+export default async function (parent, args, context?) {
+  args = applyHistoricalCollectionBoundary(
+    args,
+    context?.historicalAccess,
+    'proposals'
+  );
   const { first, skip, where = {} } = args;
 
   checkLimits(args, 'proposals');

--- a/apps/hub/src/graphql/operations/votes.ts
+++ b/apps/hub/src/graphql/operations/votes.ts
@@ -1,5 +1,6 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import graphqlFields from 'graphql-fields';
+import { applyHistoricalCollectionBoundary } from '../../helpers/historicalAccess';
 import log from '../../helpers/log';
 import db from '../../helpers/mysql';
 import serve from '../../helpers/requestDeduplicator';
@@ -27,7 +28,27 @@ const INDEX_COVERED_WHERE_KEYS = new Set([
   'created_lte'
 ]);
 
-async function query(parent, args, context?, info?) {
+export function getVotesRequestDeduplicationKey(
+  args,
+  requestedFields,
+  context?
+) {
+  const historicalAccess = context?.historicalAccess;
+  return JSON.stringify({
+    args,
+    requestedFields,
+    historicalAccess:
+      historicalAccess?.mode === 'enforce'
+        ? {
+            mode: historicalAccess.mode,
+            cutoff: historicalAccess.cutoff,
+            isEntitled: historicalAccess.isEntitled
+          }
+        : undefined
+  });
+}
+
+async function query(parent, args, context?, info?, proposalCutoff?) {
   const requestedFields = info ? graphqlFields(info) : {};
   const { first, skip } = args;
   const where = { ...(args.where || {}) };
@@ -189,9 +210,13 @@ async function query(parent, args, context?, info?) {
       INNER JOIN spaces ON spaces.id = p.space
       LEFT JOIN skins ON spaces.id = skins.id
       WHERE spaces.deleted = 0 AND spaces.settings IS NOT NULL AND p.id IN (?)
+        ${proposalCutoff ? 'AND p.created >= ?' : ''}
     `;
     try {
-      let proposals = await db.queryAsync(query, [proposalIds]);
+      let proposals = await db.queryAsync(
+        query,
+        proposalCutoff ? [proposalIds, proposalCutoff] : [proposalIds]
+      );
       proposals = Object.fromEntries(
         proposals.map(proposal => [proposal.id, formatProposal(proposal)])
       );
@@ -212,11 +237,22 @@ async function query(parent, args, context?, info?) {
 }
 
 export default async function (parent, args, context?, info?) {
-  const requestedFields = info ? graphqlFields(info) : {};
-  return await serve(JSON.stringify({ args, requestedFields }), query, [
-    parent,
+  args = applyHistoricalCollectionBoundary(
     args,
-    context,
-    info
-  ]);
+    context?.historicalAccess,
+    'votes'
+  );
+  const requestedFields = info ? graphqlFields(info) : {};
+  const proposalCutoff = requestedFields.proposal
+    ? applyHistoricalCollectionBoundary(
+        { where: {} },
+        context?.historicalAccess,
+        'vote_proposals'
+      ).where?.created_gte
+    : undefined;
+  return await serve(
+    getVotesRequestDeduplicationKey(args, requestedFields, context),
+    query,
+    [parent, args, context, info, proposalCutoff]
+  );
 }

--- a/apps/hub/src/helpers/historicalAccess.ts
+++ b/apps/hub/src/helpers/historicalAccess.ts
@@ -1,0 +1,327 @@
+import { sha256 } from './utils';
+
+const DAY_IN_SECONDS = 24 * 60 * 60;
+const DEFAULT_CUTOFF_DAYS = 365;
+
+export type HistoricalAccessMode = 'off' | 'observe' | 'enforce';
+export type HistoricalAccessKeyState =
+  | 'anonymous'
+  | 'keyed'
+  | 'entitled'
+  | 'internal';
+export type HistoricalAccessRequestClass =
+  | 'recent_bounded'
+  | 'explicit_history'
+  | 'unbounded';
+export type HistoricalAccessOutcome = 'allowed' | 'observed' | 'restricted';
+
+export type HistoricalAccessConfig = {
+  mode: HistoricalAccessMode;
+  cutoffDays: number;
+  entitledKeyHashes: Set<string>;
+  internalKey?: string;
+};
+
+type HistoricalAccessResponse = {
+  locals?: { keycardData?: { valid?: boolean } };
+  getHeader?: (name: string) => number | string | string[] | undefined;
+  setHeader?: (
+    name: string,
+    value: number | string | readonly string[]
+  ) => unknown;
+};
+
+export type HistoricalAccessContext = {
+  mode: HistoricalAccessMode;
+  cutoff: number;
+  keyState: HistoricalAccessKeyState;
+  isEntitled: boolean;
+  onGated?: () => void;
+  onRestricted?: () => void;
+};
+
+export type HistoricalAccessMetric = {
+  resource: string;
+  key_state: HistoricalAccessKeyState;
+  request_class: HistoricalAccessRequestClass;
+  mode: HistoricalAccessMode;
+  outcome: HistoricalAccessOutcome;
+};
+
+type HistoricalAccessRecorder = (metric: HistoricalAccessMetric) => void;
+
+let recordAccess: HistoricalAccessRecorder = () => undefined;
+
+export function setHistoricalAccessRecorder(
+  recorder?: HistoricalAccessRecorder
+) {
+  recordAccess = recorder ?? (() => undefined);
+}
+
+function parseMode(value?: string): HistoricalAccessMode {
+  const normalized = value?.trim();
+  if (!normalized) return 'off';
+  if (
+    normalized === 'off' ||
+    normalized === 'observe' ||
+    normalized === 'enforce'
+  ) {
+    return normalized;
+  }
+  throw new Error(
+    'HISTORICAL_DATA_ACCESS_MODE must be off, observe, or enforce'
+  );
+}
+
+function parseCutoffDays(value?: string): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_CUTOFF_DAYS;
+}
+
+function parseKeyHashes(value?: string): Set<string> {
+  return new Set(
+    (value ?? '')
+      .split(',')
+      .map(hash => hash.trim().toLowerCase())
+      .filter(hash => /^[a-f0-9]{64}$/.test(hash))
+  );
+}
+
+export function getHistoricalAccessConfig(
+  env: NodeJS.ProcessEnv = process.env
+): HistoricalAccessConfig {
+  return {
+    mode: parseMode(env.HISTORICAL_DATA_ACCESS_MODE),
+    cutoffDays: parseCutoffDays(env.HISTORICAL_DATA_CUTOFF_DAYS),
+    entitledKeyHashes: parseKeyHashes(env.HISTORICAL_DATA_API_KEY_HASHES),
+    internalKey: env.KEYCARD_SECRET || undefined
+  };
+}
+
+function getApiKey(req): string | undefined {
+  const headerKey = req?.headers?.['x-api-key'];
+  if (typeof headerKey === 'string' && headerKey.trim()) {
+    return headerKey.trim();
+  }
+  if (Array.isArray(headerKey) && headerKey[0]?.trim()) {
+    return headerKey[0].trim();
+  }
+
+  const queryKey = req?.query?.apiKey;
+  if (typeof queryKey === 'string' && queryKey.trim()) {
+    return queryKey.trim();
+  }
+  return undefined;
+}
+
+export function getHistoricalAccessContext(
+  req,
+  response?: HistoricalAccessResponse,
+  options: {
+    config?: HistoricalAccessConfig;
+    now?: number;
+  } = {}
+): HistoricalAccessContext {
+  const config = options.config ?? getHistoricalAccessConfig();
+  const now = options.now ?? Math.floor(Date.now() / 1000);
+  const cutoff = now - config.cutoffDays * DAY_IN_SECONDS;
+
+  if (config.mode === 'off') {
+    return {
+      mode: 'off',
+      cutoff,
+      keyState: 'anonymous',
+      isEntitled: false
+    };
+  }
+
+  const apiKey = getApiKey(req);
+  const hasValidKey = response?.locals?.keycardData?.valid === true;
+  const isInternal = Boolean(
+    apiKey && config.internalKey && apiKey === config.internalKey
+  );
+  const hasEntitledHash = Boolean(
+    apiKey &&
+      hasValidKey &&
+      config.entitledKeyHashes.has(sha256(apiKey).toLowerCase())
+  );
+  const keyState: HistoricalAccessKeyState = isInternal
+    ? 'internal'
+    : hasEntitledHash
+      ? 'entitled'
+      : hasValidKey
+        ? 'keyed'
+        : 'anonymous';
+
+  const onGated = () => {
+    const vary = response?.getHeader?.('Vary');
+    const values = Array.isArray(vary)
+      ? vary
+      : String(vary ?? '')
+          .split(',')
+          .map(value => value.trim())
+          .filter(Boolean);
+    if (
+      !values.includes('*') &&
+      !values.some(value => value.toLowerCase() === 'x-api-key')
+    ) {
+      response?.setHeader?.('Vary', [...values, 'X-Api-Key'].join(', '));
+    }
+    response?.setHeader?.('Cache-Control', 'private, no-store');
+  };
+  const onRestricted = () => {
+    onGated();
+    response?.setHeader?.('X-Historical-Data-Access', 'restricted');
+    response?.setHeader?.('X-Historical-Data-Cutoff', cutoff.toString());
+  };
+
+  return {
+    mode: config.mode,
+    cutoff,
+    keyState,
+    isEntitled: isInternal || hasEntitledHash,
+    onGated: config.mode === 'enforce' ? onGated : undefined,
+    onRestricted: config.mode === 'enforce' ? onRestricted : undefined
+  };
+}
+
+function toFiniteNumbers(value: unknown): number[] {
+  const values = Array.isArray(value) ? value : [value];
+  return values.filter(
+    (candidate): candidate is number =>
+      typeof candidate === 'number' && Number.isFinite(candidate)
+  );
+}
+
+export function classifyHistoricalRequest(
+  where: Record<string, unknown> = {},
+  cutoff: number,
+  timestampField = 'created'
+): HistoricalAccessRequestClass {
+  const exact = toFiniteNumbers(where[timestampField]);
+  const included = toFiniteNumbers(where[`${timestampField}_in`]);
+  const gte = toFiniteNumbers(where[`${timestampField}_gte`]);
+  const gt = toFiniteNumbers(where[`${timestampField}_gt`]);
+  const upperBounds = [
+    ...toFiniteNumbers(where[`${timestampField}_lte`]),
+    ...toFiniteNumbers(where[`${timestampField}_lt`])
+  ];
+
+  if (
+    exact.some(value => value < cutoff) ||
+    included.some(value => value < cutoff) ||
+    gte.some(value => value < cutoff) ||
+    gt.some(value => value < cutoff)
+  ) {
+    return 'explicit_history';
+  }
+
+  if (
+    exact.some(value => value >= cutoff) ||
+    (included.length > 0 && included.every(value => value >= cutoff)) ||
+    gte.some(value => value >= cutoff) ||
+    gt.some(value => value >= cutoff)
+  ) {
+    return 'recent_bounded';
+  }
+
+  // An upper bound alone still permits every row before the cutoff.
+  if (upperBounds.length > 0) return 'explicit_history';
+
+  return 'unbounded';
+}
+
+function record(
+  context: HistoricalAccessContext,
+  resource: string,
+  requestClass: HistoricalAccessRequestClass,
+  outcome: HistoricalAccessOutcome
+) {
+  if (context.mode === 'off') return;
+  recordAccess({
+    resource,
+    key_state: context.keyState,
+    request_class: requestClass,
+    mode: context.mode,
+    outcome
+  });
+}
+
+function markRestricted(context: HistoricalAccessContext) {
+  context.onRestricted?.();
+}
+
+export function applyHistoricalCollectionBoundary(
+  args: Record<string, any>,
+  context: HistoricalAccessContext | undefined,
+  resource: string,
+  timestampField = 'created'
+): Record<string, any> {
+  if (!context || context.mode === 'off') return args;
+
+  const where = args.where ?? {};
+  const requestClass = classifyHistoricalRequest(
+    where,
+    context.cutoff,
+    timestampField
+  );
+
+  if (context.mode === 'observe') {
+    record(context, resource, requestClass, 'observed');
+    return args;
+  }
+
+  context.onGated?.();
+
+  if (context.isEntitled) {
+    record(context, resource, requestClass, 'allowed');
+    return args;
+  }
+
+  if (requestClass === 'recent_bounded') {
+    record(context, resource, requestClass, 'allowed');
+    return args;
+  }
+
+  const restrictedWhere = {
+    ...where,
+    [`${timestampField}_gte`]: context.cutoff
+  };
+  markRestricted(context);
+  record(context, resource, requestClass, 'restricted');
+  return { ...args, where: restrictedWhere };
+}
+
+export function enforceHistoricalEntityBoundary(
+  timestamp: unknown,
+  context: HistoricalAccessContext | undefined,
+  resource: string
+): boolean {
+  if (!context || context.mode === 'off') return true;
+
+  const hasValidTimestamp =
+    typeof timestamp === 'number' && Number.isFinite(timestamp);
+  const requestClass: HistoricalAccessRequestClass = !hasValidTimestamp
+    ? 'unbounded'
+    : timestamp < context.cutoff
+      ? 'explicit_history'
+      : 'recent_bounded';
+
+  if (context.mode === 'observe') {
+    record(context, resource, requestClass, 'observed');
+    return true;
+  }
+
+  context.onGated?.();
+  if (context.isEntitled) {
+    record(context, resource, requestClass, 'allowed');
+    return true;
+  }
+  if (!hasValidTimestamp || timestamp < context.cutoff) {
+    markRestricted(context);
+    record(context, resource, requestClass, 'restricted');
+    return false;
+  }
+  record(context, resource, requestClass, 'allowed');
+  return true;
+}

--- a/apps/hub/src/helpers/historicalAccess.ts
+++ b/apps/hub/src/helpers/historicalAccess.ts
@@ -3,17 +3,13 @@ import { sha256 } from './utils';
 const DAY_IN_SECONDS = 24 * 60 * 60;
 const DEFAULT_CUTOFF_DAYS = 365;
 
-export type HistoricalAccessMode = 'off' | 'observe' | 'enforce';
-export type HistoricalAccessKeyState =
-  | 'anonymous'
-  | 'keyed'
-  | 'entitled'
-  | 'internal';
+type HistoricalAccessMode = 'off' | 'observe' | 'enforce';
+type HistoricalAccessKeyState = 'anonymous' | 'keyed' | 'entitled' | 'internal';
 export type HistoricalAccessRequestClass =
   | 'recent_bounded'
   | 'explicit_history'
   | 'unbounded';
-export type HistoricalAccessOutcome = 'allowed' | 'observed' | 'restricted';
+type HistoricalAccessOutcome = 'allowed' | 'observed' | 'restricted';
 
 export type HistoricalAccessConfig = {
   mode: HistoricalAccessMode;
@@ -40,7 +36,7 @@ export type HistoricalAccessContext = {
   onRestricted?: () => void;
 };
 
-export type HistoricalAccessMetric = {
+type HistoricalAccessMetric = {
   resource: string;
   key_state: HistoricalAccessKeyState;
   request_class: HistoricalAccessRequestClass;

--- a/apps/hub/src/helpers/metrics.ts
+++ b/apps/hub/src/helpers/metrics.ts
@@ -2,6 +2,7 @@ import init, { client } from '@snapshot-labs/snapshot-metrics';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { Express, Request, Response } from 'express';
 import { GraphQLError, parse } from 'graphql';
+import { setHistoricalAccessRecorder } from './historicalAccess';
 import db from './mysql';
 import { networkSpaceCounts, spacesMetadata } from './spaces';
 import { strategies } from './strategies';
@@ -21,6 +22,12 @@ const rateLimitedRequestsCount = new client.Counter({
   labelNames: ['rate_limited']
 });
 
+const historicalDataAccessOperationsCount = new client.Counter({
+  name: 'historical_data_access_operations_count',
+  help: 'Gated resource access decisions by historical-data classification',
+  labelNames: ['resource', 'key_state', 'request_class', 'mode', 'outcome']
+});
+
 function instrumentRateLimitedRequests(req, res, next) {
   res.on('finish', () => {
     if (whitelistedPath.some(path => path.test(req.path))) {
@@ -35,6 +42,10 @@ function instrumentRateLimitedRequests(req, res, next) {
 
 export default function initMetrics(app: Express) {
   const GRAPHQL_TYPES = Object.keys(operations);
+
+  setHistoricalAccessRecorder(metric => {
+    historicalDataAccessOperationsCount.inc(metric);
+  });
 
   const { stop } = init(app, {
     normalizedPath: [

--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -6,6 +6,7 @@ import express from 'express';
 import api from './api';
 import eip4824 from './eip4824';
 import graphql from './graphql';
+import { getHistoricalAccessConfig } from './helpers/historicalAccess';
 import { checkKeycard } from './helpers/keycard';
 import log from './helpers/log';
 import initMetrics from './helpers/metrics';
@@ -26,13 +27,21 @@ setInterval(() => {
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+// Validate rollout configuration at startup instead of failing open per request.
+getHistoricalAccessConfig();
+
 const { stop: stopMetrics } = initMetrics(app);
 refreshSpacesCache();
 
 app.disable('x-powered-by');
 app.use(express.json({ limit: '20mb' }));
 app.use(express.urlencoded({ limit: '20mb', extended: false }));
-app.use(cors({ maxAge: 86400 }));
+app.use(
+  cors({
+    maxAge: 86400,
+    exposedHeaders: ['X-Historical-Data-Access', 'X-Historical-Data-Cutoff']
+  })
+);
 app.set('trust proxy', 1);
 app.use(checkKeycard, rateLimit);
 app.use('/api', api);

--- a/apps/hub/test/unit/eip4824HistoricalAccess.test.ts
+++ b/apps/hub/test/unit/eip4824HistoricalAccess.test.ts
@@ -1,0 +1,105 @@
+import router from '../../src/eip4824';
+import db, { sequencerDB } from '../../src/helpers/mysql';
+import { getSpace } from '../../src/helpers/spaces';
+import { sha256 } from '../../src/helpers/utils';
+
+jest.mock('../../src/helpers/mysql', () => ({
+  __esModule: true,
+  default: { queryAsync: jest.fn() },
+  sequencerDB: { queryAsync: jest.fn() }
+}));
+
+jest.mock('../../src/helpers/spaces', () => ({
+  getSpace: jest.fn()
+}));
+
+const queryAsync = db.queryAsync as jest.Mock;
+const sequencerQueryAsync = sequencerDB.queryAsync as jest.Mock;
+const getSpaceMock = getSpace as jest.Mock;
+
+function routeHandler(path: string) {
+  const layer = (router as any).stack.find(layer => layer.route?.path === path);
+  return layer.route.stack[0].handle;
+}
+
+function request(apiKey?: string) {
+  return {
+    params: { space: 'example.eth' },
+    headers: apiKey ? { 'x-api-key': apiKey } : {},
+    query: {}
+  };
+}
+
+function response(valid = false) {
+  const headers: Record<string, string> = {};
+  const res: any = {
+    headers,
+    locals: { keycardData: { valid } },
+    getHeader: jest.fn((name: string) => headers[name]),
+    setHeader: jest.fn((name: string, value: string) => {
+      headers[name] = String(value);
+    }),
+    json: jest.fn()
+  };
+  res.status = jest.fn(() => res);
+  return res;
+}
+
+describe('EIP-4824 historical access', () => {
+  beforeEach(() => {
+    process.env.HISTORICAL_DATA_ACCESS_MODE = 'enforce';
+    process.env.HISTORICAL_DATA_CUTOFF_DAYS = '365';
+    delete process.env.HISTORICAL_DATA_API_KEY_HASHES;
+    queryAsync.mockReset();
+    sequencerQueryAsync.mockReset();
+    getSpaceMock.mockReset().mockResolvedValue({
+      verified: true,
+      name: 'Example'
+    });
+  });
+
+  afterAll(() => {
+    delete process.env.HISTORICAL_DATA_ACCESS_MODE;
+    delete process.env.HISTORICAL_DATA_CUTOFF_DAYS;
+    delete process.env.HISTORICAL_DATA_API_KEY_HASHES;
+  });
+
+  it.each([
+    ['/:space/proposals', queryAsync, 'created'],
+    ['/:space/activities', sequencerQueryAsync, 'timestamp']
+  ])(
+    'adds the cutoff before pagination on %s',
+    async (path, databaseQuery, timestampField) => {
+      databaseQuery.mockResolvedValueOnce([]);
+      const res = response();
+
+      await routeHandler(path)(request(), res);
+
+      const [sql, params] = databaseQuery.mock.calls[0];
+      expect(sql).toContain(`AND ${timestampField} >= ?`);
+      expect(params[0]).toBe('example.eth');
+      expect(params[1]).toEqual(expect.any(Number));
+      expect(res.headers['X-Historical-Data-Access']).toBe('restricted');
+    }
+  );
+
+  it.each([
+    ['/:space/proposals', queryAsync, 'created'],
+    ['/:space/activities', sequencerQueryAsync, 'timestamp']
+  ])(
+    'keeps full history on %s for an entitled Keycard key',
+    async (path, databaseQuery, timestampField) => {
+      process.env.HISTORICAL_DATA_API_KEY_HASHES = sha256('paid-key');
+      databaseQuery.mockResolvedValueOnce([]);
+      const res = response(true);
+
+      await routeHandler(path)(request('paid-key'), res);
+
+      const [sql, params] = databaseQuery.mock.calls[0];
+      expect(sql).not.toContain(`AND ${timestampField} >= ?`);
+      expect(params).toEqual(['example.eth']);
+      expect(res.headers['X-Historical-Data-Access']).toBeUndefined();
+      expect(res.headers['Cache-Control']).toBe('private, no-store');
+    }
+  );
+});

--- a/apps/hub/test/unit/historicalAccess.test.ts
+++ b/apps/hub/test/unit/historicalAccess.test.ts
@@ -1,0 +1,254 @@
+import {
+  applyHistoricalCollectionBoundary,
+  classifyHistoricalRequest,
+  enforceHistoricalEntityBoundary,
+  getHistoricalAccessConfig,
+  getHistoricalAccessContext,
+  HistoricalAccessConfig,
+  setHistoricalAccessRecorder
+} from '../../src/helpers/historicalAccess';
+import { sha256 } from '../../src/helpers/utils';
+
+const NOW = 1_800_000_000;
+const CUTOFF_DAYS = 365;
+const CUTOFF = NOW - CUTOFF_DAYS * 24 * 60 * 60;
+
+function makeConfig(
+  overrides: Partial<HistoricalAccessConfig> = {}
+): HistoricalAccessConfig {
+  return {
+    mode: 'enforce',
+    cutoffDays: CUTOFF_DAYS,
+    entitledKeyHashes: new Set(),
+    ...overrides
+  };
+}
+
+function makeResponse(valid = false) {
+  const headers: Record<string, string> = {};
+  return {
+    headers,
+    locals: { keycardData: { valid } },
+    getHeader: jest.fn((field: string) => headers[field]),
+    setHeader: jest.fn(
+      (field: string, value: number | string | readonly string[]) => {
+        headers[field] = Array.isArray(value)
+          ? value.join(', ')
+          : String(value);
+      }
+    )
+  };
+}
+
+function makeContext(
+  overrides: Partial<HistoricalAccessConfig> = {},
+  apiKey?: string,
+  valid = false
+) {
+  const response = makeResponse(valid);
+  const req = apiKey ? { headers: { 'x-api-key': apiKey } } : { headers: {} };
+  const context = getHistoricalAccessContext(req, response, {
+    config: makeConfig(overrides),
+    now: NOW
+  });
+  return { context, response };
+}
+
+describe('historical-data access', () => {
+  afterEach(() => setHistoricalAccessRecorder());
+
+  it('is disabled by default and rejects invalid activation modes', () => {
+    expect(getHistoricalAccessConfig({}).mode).toBe('off');
+    expect(() =>
+      getHistoricalAccessConfig({ HISTORICAL_DATA_ACCESS_MODE: 'invalid' })
+    ).toThrow('HISTORICAL_DATA_ACCESS_MODE');
+  });
+
+  it('parses the cutoff and only accepts complete SHA-256 hashes', () => {
+    const hash = sha256('paid-key');
+    const config = getHistoricalAccessConfig({
+      HISTORICAL_DATA_ACCESS_MODE: 'observe',
+      HISTORICAL_DATA_CUTOFF_DAYS: '90',
+      HISTORICAL_DATA_API_KEY_HASHES: `${hash},bad-hash`
+    });
+
+    expect(config.mode).toBe('observe');
+    expect(config.cutoffDays).toBe(90);
+    expect(config.entitledKeyHashes).toEqual(new Set([hash]));
+    expect(
+      getHistoricalAccessConfig({ HISTORICAL_DATA_CUTOFF_DAYS: '1.5' })
+        .cutoffDays
+    ).toBe(CUTOFF_DAYS);
+  });
+
+  it.each([
+    [{}, undefined, false, 'anonymous', false],
+    [{}, 'free-key', true, 'keyed', false],
+    [
+      { entitledKeyHashes: new Set([sha256('paid-key')]) },
+      'paid-key',
+      true,
+      'entitled',
+      true
+    ],
+    [{ internalKey: 'internal-key' }, 'internal-key', false, 'internal', true]
+  ])(
+    'classifies key access state',
+    (overrides, apiKey, valid, keyState, isEntitled) => {
+      const { context } = makeContext(overrides, apiKey, valid);
+      expect(context.keyState).toBe(keyState);
+      expect(context.isEntitled).toBe(isEntitled);
+      expect(context.cutoff).toBe(CUTOFF);
+    }
+  );
+
+  it('requires the allowlisted key to be valid in Keycard', () => {
+    const { context } = makeContext(
+      { entitledKeyHashes: new Set([sha256('paid-key')]) },
+      'paid-key',
+      false
+    );
+
+    expect(context.keyState).toBe('anonymous');
+    expect(context.isEntitled).toBe(false);
+  });
+
+  it('supports query-param keys without retaining the raw key in context', () => {
+    const response = makeResponse(true);
+    (response as any).req = {
+      headers: { 'x-api-key': 'must-not-appear' }
+    };
+    const context = getHistoricalAccessContext(
+      { headers: {}, query: { apiKey: 'paid-key' } },
+      response,
+      {
+        config: makeConfig({
+          entitledKeyHashes: new Set([sha256('paid-key')])
+        }),
+        now: NOW
+      }
+    );
+
+    expect(context.keyState).toBe('entitled');
+    expect(JSON.stringify(context)).not.toContain('paid-key');
+  });
+
+  it.each([
+    [{ created: CUTOFF - 1 }, 'explicit_history'],
+    [{ created_in: [CUTOFF, CUTOFF + 1] }, 'recent_bounded'],
+    [{ created_in: [CUTOFF - 1, CUTOFF] }, 'explicit_history'],
+    [{ created_gte: CUTOFF }, 'recent_bounded'],
+    [{ created_gt: CUTOFF - 1 }, 'explicit_history'],
+    [{ created_lte: NOW }, 'explicit_history'],
+    [{}, 'unbounded']
+  ])('classifies timestamp filters', (where, expected) => {
+    expect(classifyHistoricalRequest(where, CUTOFF)).toBe(expected);
+  });
+
+  it('does not inspect or mutate requests while disabled', () => {
+    const { context, response } = makeContext({ mode: 'off' });
+    const args = { first: 20, where: {} };
+
+    expect(applyHistoricalCollectionBoundary(args, context, 'proposals')).toBe(
+      args
+    );
+    expect(response.setHeader).not.toHaveBeenCalled();
+  });
+
+  it('observes an unbounded request without changing its query', () => {
+    const metrics = jest.fn();
+    setHistoricalAccessRecorder(metrics);
+    const { context, response } = makeContext({ mode: 'observe' });
+    const args = { first: 20, where: {} };
+
+    expect(applyHistoricalCollectionBoundary(args, context, 'proposals')).toBe(
+      args
+    );
+    expect(response.setHeader).not.toHaveBeenCalled();
+    expect(metrics).toHaveBeenCalledWith({
+      resource: 'proposals',
+      key_state: 'anonymous',
+      request_class: 'unbounded',
+      mode: 'observe',
+      outcome: 'observed'
+    });
+  });
+
+  it('leaves entitled historical requests unchanged', () => {
+    const { context, response } = makeContext(
+      { entitledKeyHashes: new Set([sha256('paid-key')]) },
+      'paid-key',
+      true
+    );
+    const args = { where: { created_lte: CUTOFF - 1 } };
+
+    expect(applyHistoricalCollectionBoundary(args, context, 'proposals')).toBe(
+      args
+    );
+    expect(response.headers).toMatchObject({
+      Vary: 'X-Api-Key',
+      'Cache-Control': 'private, no-store'
+    });
+  });
+
+  it('clamps unbounded enforcement queries without mutating the caller', () => {
+    const { context, response } = makeContext();
+    const args = { first: 20, where: { space: 'example.eth' } };
+
+    const bounded = applyHistoricalCollectionBoundary(
+      args,
+      context,
+      'proposals'
+    );
+
+    expect(bounded).toEqual({
+      first: 20,
+      where: { space: 'example.eth', created_gte: CUTOFF }
+    });
+    expect(args.where).toEqual({ space: 'example.eth' });
+    expect(response.headers).toMatchObject({
+      'Cache-Control': 'private, no-store',
+      'X-Historical-Data-Access': 'restricted',
+      'X-Historical-Data-Cutoff': CUTOFF.toString()
+    });
+  });
+
+  it('allows recent bounded enforcement queries', () => {
+    const { context, response } = makeContext();
+    const args = { where: { created_gte: CUTOFF } };
+
+    expect(applyHistoricalCollectionBoundary(args, context, 'proposals')).toBe(
+      args
+    );
+    expect(response.headers['X-Historical-Data-Access']).toBeUndefined();
+  });
+
+  it('adds a conjunctive cutoff to explicit historical filters', () => {
+    const { context, response } = makeContext();
+
+    expect(
+      applyHistoricalCollectionBoundary(
+        { where: { created_lte: CUTOFF - 1 } },
+        context,
+        'proposals'
+      )
+    ).toEqual({
+      where: { created_lte: CUTOFF - 1, created_gte: CUTOFF }
+    });
+    expect(response.headers['X-Historical-Data-Access']).toBe('restricted');
+  });
+
+  it('enforces the same boundary for exact historical entities', () => {
+    const { context } = makeContext();
+
+    expect(
+      enforceHistoricalEntityBoundary(CUTOFF - 1, context, 'proposal')
+    ).toBe(false);
+    expect(enforceHistoricalEntityBoundary(CUTOFF, context, 'proposal')).toBe(
+      true
+    );
+    expect(
+      enforceHistoricalEntityBoundary('invalid', context, 'proposal')
+    ).toBe(false);
+  });
+});

--- a/apps/hub/test/unit/historicalOperations.test.ts
+++ b/apps/hub/test/unit/historicalOperations.test.ts
@@ -1,0 +1,114 @@
+import fetchMessages from '../../src/graphql/operations/messages';
+import fetchProposal from '../../src/graphql/operations/proposal';
+import fetchProposals from '../../src/graphql/operations/proposals';
+import db, { sequencerDB } from '../../src/helpers/mysql';
+
+jest.mock('../../src/helpers/mysql', () => ({
+  __esModule: true,
+  default: { queryAsync: jest.fn() },
+  sequencerDB: { queryAsync: jest.fn() }
+}));
+
+const queryAsync = db.queryAsync as jest.Mock;
+const sequencerQueryAsync = sequencerDB.queryAsync as jest.Mock;
+const CUTOFF = 1700000000;
+
+function context(isEntitled: boolean) {
+  return {
+    historicalAccess: {
+      mode: 'enforce',
+      cutoff: CUTOFF,
+      keyState: isEntitled ? 'entitled' : 'anonymous',
+      isEntitled,
+      onGated: jest.fn(),
+      onRestricted: jest.fn()
+    }
+  };
+}
+
+function proposalRow(created: unknown) {
+  return {
+    id: 'proposal-1',
+    space: 'example.eth',
+    created,
+    start: CUTOFF,
+    end: CUTOFF + 100,
+    choices: '[]',
+    labels: '[]',
+    strategies: '[]',
+    validation: '{}',
+    plugins: '{}',
+    settings: '{}'
+  };
+}
+
+describe('historical resolver wiring', () => {
+  beforeEach(() => {
+    queryAsync.mockReset();
+    sequencerQueryAsync.mockReset();
+  });
+
+  it.each([
+    ['restricted', false, true, 3],
+    ['entitled', true, false, 2]
+  ])(
+    'applies the proposal SQL cutoff for %s collection access',
+    async (_label, isEntitled, expectsCutoff, expectedParamCount) => {
+      queryAsync.mockResolvedValueOnce([]);
+
+      await fetchProposals(
+        null,
+        { first: 20, skip: 0, where: {} },
+        context(isEntitled)
+      );
+
+      const [sql, params] = queryAsync.mock.calls[0];
+      expect(sql.includes('p.created >= ?')).toBe(expectsCutoff);
+      expect(params).toHaveLength(expectedParamCount);
+      if (expectsCutoff) expect(params[0]).toBe(CUTOFF);
+      expect(params.slice(-2)).toEqual([0, 20]);
+    }
+  );
+
+  it.each([
+    ['restricted', false, true, 3],
+    ['entitled', true, false, 2]
+  ])(
+    'applies the message SQL cutoff for %s collection access',
+    async (_label, isEntitled, expectsCutoff, expectedParamCount) => {
+      sequencerQueryAsync.mockResolvedValueOnce([]);
+
+      await fetchMessages(
+        null,
+        { first: 20, skip: 0, where: {} },
+        context(isEntitled)
+      );
+
+      const [sql, params] = sequencerQueryAsync.mock.calls[0];
+      expect(sql.includes('m.timestamp >= ?')).toBe(expectsCutoff);
+      expect(params).toHaveLength(expectedParamCount);
+      if (expectsCutoff) expect(params[0]).toBe(CUTOFF);
+      expect(params.slice(-2)).toEqual([0, 20]);
+    }
+  );
+
+  it('returns null for a restricted exact historical proposal', async () => {
+    queryAsync.mockResolvedValueOnce([proposalRow(CUTOFF - 1)]);
+    const restrictedContext = context(false);
+
+    await expect(
+      fetchProposal(null, { id: 'proposal-1' }, restrictedContext)
+    ).resolves.toBeNull();
+    expect(
+      restrictedContext.historicalAccess.onRestricted
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an exact historical proposal to an entitled key', async () => {
+    queryAsync.mockResolvedValueOnce([proposalRow(CUTOFF - 1)]);
+
+    await expect(
+      fetchProposal(null, { id: 'proposal-1' }, context(true))
+    ).resolves.toMatchObject({ id: 'proposal-1', created: CUTOFF - 1 });
+  });
+});

--- a/apps/hub/test/unit/requestDeduplicator.test.ts
+++ b/apps/hub/test/unit/requestDeduplicator.test.ts
@@ -1,0 +1,39 @@
+jest.mock('../../src/helpers/metrics', () => ({
+  requestDeduplicatorSize: { set: jest.fn() }
+}));
+
+import serve from '../../src/helpers/requestDeduplicator';
+
+describe('request deduplication', () => {
+  it('coalesces concurrent requests with the same scoped key', async () => {
+    let release: (value: string) => void = () => undefined;
+    const action = jest.fn(
+      () =>
+        new Promise<string>(resolve => {
+          release = resolve;
+        })
+    );
+
+    const first = serve('same-access-scope', action, []);
+    const second = serve('same-access-scope', action, []);
+
+    expect(action).toHaveBeenCalledTimes(1);
+    release('shared-result');
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      'shared-result',
+      'shared-result'
+    ]);
+  });
+
+  it('does not coalesce requests from different entitlement scopes', async () => {
+    const action = jest.fn(async result => result);
+
+    const results = await Promise.all([
+      serve('{"isEntitled":false}', action, ['restricted']),
+      serve('{"isEntitled":true}', action, ['full-history'])
+    ]);
+
+    expect(action).toHaveBeenCalledTimes(2);
+    expect(results).toEqual(['restricted', 'full-history']);
+  });
+});

--- a/apps/hub/test/unit/votes.test.ts
+++ b/apps/hub/test/unit/votes.test.ts
@@ -1,4 +1,7 @@
-import fetchVotes from '../../src/graphql/operations/votes';
+import { parse } from 'graphql';
+import fetchVotes, {
+  getVotesRequestDeduplicationKey
+} from '../../src/graphql/operations/votes';
 import db from '../../src/helpers/mysql';
 
 jest.mock('../../src/helpers/mysql', () => ({
@@ -15,6 +18,36 @@ const queryAsync = db.queryAsync as jest.Mock;
 
 const PROPOSAL =
   '0x67d414042da88026e2c718284e90a5d79e1c0a32d322a288b373e0d7a21f4cef';
+
+function proposalInfo() {
+  const document: any = parse('query { votes { id proposal { id } } }');
+  const operation: any = document.definitions[0];
+  return {
+    fieldNodes: [operation.selectionSet.selections[0]],
+    fragments: {},
+    variableValues: {}
+  };
+}
+
+function voteRow() {
+  return {
+    id: 'vote-1',
+    ipfs: 'ipfs-1',
+    voter: '0x0000000000000000000000000000000000000001',
+    space: 'example.eth',
+    proposal: PROPOSAL,
+    reason: '',
+    app: 'snapshot',
+    created: 1700000001,
+    vp: 1,
+    vp_state: 'final',
+    vp_value: 1,
+    choice: '1',
+    metadata: '{}',
+    vp_by_strategy: '[]',
+    settings: '{}'
+  };
+}
 
 describe('votes resolver index usage', () => {
   beforeEach(() => queryAsync.mockReset());
@@ -302,4 +335,87 @@ describe('votes resolver index usage', () => {
       'ORDER BY v.created ASC, v.id ASC'
     );
   });
+
+  it('separates entitled and restricted requests in the deduplication key', () => {
+    const args = { first: 20, where: { created_gte: 1700000000 } };
+    const restricted = getVotesRequestDeduplicationKey(
+      args,
+      {},
+      {
+        historicalAccess: {
+          mode: 'enforce',
+          cutoff: 1700000000,
+          isEntitled: false,
+          response: { rawKey: 'must-not-appear' }
+        }
+      }
+    );
+    const entitled = getVotesRequestDeduplicationKey(
+      args,
+      {},
+      {
+        historicalAccess: {
+          mode: 'enforce',
+          cutoff: 1700000000,
+          isEntitled: true,
+          response: { rawKey: 'must-not-appear' }
+        }
+      }
+    );
+
+    expect(restricted).not.toBe(entitled);
+    expect(restricted).not.toContain('must-not-appear');
+    expect(entitled).not.toContain('must-not-appear');
+  });
+
+  it('preserves the existing deduplication key while off or observing', () => {
+    const args = { first: 20, where: {} };
+    const original = getVotesRequestDeduplicationKey(args, {}, undefined);
+
+    for (const mode of ['off', 'observe']) {
+      expect(
+        getVotesRequestDeduplicationKey(
+          args,
+          {},
+          {
+            historicalAccess: {
+              mode,
+              cutoff: 1700000000,
+              isEntitled: false
+            }
+          }
+        )
+      ).toBe(original);
+    }
+  });
+
+  it.each([
+    [false, true, 2],
+    [true, false, 1]
+  ])(
+    'applies the archive boundary to nested proposals (entitled=%s)',
+    async (isEntitled, expectsCutoff, expectedParamCount) => {
+      const cutoff = 1700000000;
+      queryAsync.mockResolvedValueOnce([voteRow()]).mockResolvedValueOnce([]);
+
+      await fetchVotes(
+        null,
+        { first: 20, skip: 0, where: { created_gte: cutoff } },
+        {
+          historicalAccess: {
+            mode: 'enforce',
+            cutoff,
+            keyState: isEntitled ? 'entitled' : 'anonymous',
+            isEntitled
+          }
+        },
+        proposalInfo()
+      );
+
+      const [proposalSql, proposalParams] = queryAsync.mock.calls[1];
+      expect(proposalSql.includes('p.created >= ?')).toBe(expectsCutoff);
+      expect(proposalParams).toHaveLength(expectedParamCount);
+      if (expectsCutoff) expect(proposalParams[1]).toBe(cutoff);
+    }
+  );
 });

--- a/apps/hub/test/unit/votesHistoricalDedup.test.ts
+++ b/apps/hub/test/unit/votesHistoricalDedup.test.ts
@@ -1,0 +1,94 @@
+import { parse } from 'graphql';
+import fetchVotes from '../../src/graphql/operations/votes';
+import db from '../../src/helpers/mysql';
+
+jest.mock('../../src/helpers/mysql', () => ({
+  __esModule: true,
+  default: { queryAsync: jest.fn() }
+}));
+
+jest.mock('../../src/helpers/metrics', () => ({
+  requestDeduplicatorSize: { set: jest.fn() }
+}));
+
+const queryAsync = db.queryAsync as jest.Mock;
+const CUTOFF = 1700000000;
+
+function proposalInfo() {
+  const document: any = parse('query { votes { id proposal { id } } }');
+  const operation: any = document.definitions[0];
+  return {
+    fieldNodes: [operation.selectionSet.selections[0]],
+    fragments: {},
+    variableValues: {}
+  };
+}
+
+function voteRow() {
+  return {
+    id: 'vote-1',
+    ipfs: 'ipfs-1',
+    voter: '0x0000000000000000000000000000000000000001',
+    space: 'example.eth',
+    proposal: 'proposal-1',
+    reason: '',
+    app: 'snapshot',
+    created: CUTOFF,
+    vp: 1,
+    vp_state: 'final',
+    vp_value: 1,
+    choice: '1',
+    metadata: '{}',
+    vp_by_strategy: '[]',
+    settings: '{}'
+  };
+}
+
+function context() {
+  return {
+    historicalAccess: {
+      mode: 'enforce',
+      cutoff: CUTOFF,
+      keyState: 'anonymous',
+      isEntitled: false,
+      onGated: jest.fn(),
+      onRestricted: jest.fn()
+    }
+  };
+}
+
+describe('votes historical deduplication', () => {
+  beforeEach(() => queryAsync.mockReset());
+
+  it('marks every concurrent caller when nested proposals are restricted', async () => {
+    let release: (rows: any[]) => void = () => undefined;
+    queryAsync
+      .mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            release = resolve;
+          })
+      )
+      .mockResolvedValueOnce([]);
+    const firstContext = context();
+    const secondContext = context();
+    const args = {
+      first: 20,
+      skip: 0,
+      where: { created_gte: CUTOFF }
+    };
+    const info = proposalInfo();
+
+    const first = fetchVotes(null, args, firstContext, info);
+    const second = fetchVotes(null, args, secondContext, info);
+
+    expect(firstContext.historicalAccess.onRestricted).toHaveBeenCalledTimes(1);
+    expect(secondContext.historicalAccess.onRestricted).toHaveBeenCalledTimes(
+      1
+    );
+
+    release([voteRow()]);
+    await expect(Promise.all([first, second])).resolves.toEqual([[], []]);
+    expect(queryAsync).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Adds a default-off historical archive access seam to the offchain Hub.

- supports `off`, response-neutral `observe`, and explicit `enforce` modes
- applies the cutoff before pagination for GraphQL proposals, votes, nested vote proposals, messages, and EIP-4824 proposal/activity lists
- grants manual pilot access only to valid Keycard keys whose full SHA-256 hashes are allowlisted; the internal Keycard secret remains exempt
- keeps concurrent vote deduplication isolated by enforcement scope and preserves per-caller restriction headers
- records low-cardinality gated-resource operations without key identifiers

Safety:

- missing mode stays off; invalid non-empty modes stop startup
- observe mode does not alter results, status, pagination, ordering, or cache headers
- enforce responses are private/no-store and expose restriction/cutoff headers through CORS
- no billing, price, payment, or automatic entitlement logic is included
- README documents the deliberately limited first scope and external archive bypasses

Verification:

- `cd apps/hub && bun run typecheck`
- `cd apps/hub && bun run build`
- `cd apps/hub && bun run test:unit` (56 passed)
- ESLint on every changed TypeScript file
- `git diff --check`