### PR TITLE
fix(mcp): log CDP account-creation failures in authorize()

### DIFF
--- a/apps/mcp/src/auth.ts
+++ b/apps/mcp/src/auth.ts
@@ -13,6 +13,7 @@ import { type Request, type Response } from 'express';
 import { type JWTPayload, jwtVerify, SignJWT } from 'jose';
 import { createFreshAccount } from './cdp.js';
 import { resolveUserFromAlias } from './hub.js';
+import logger from './logger.js';
 
 const ALG = 'HS256';
 
@@ -100,7 +101,10 @@ export class SnapshotOAuthProvider implements OAuthServerProvider {
     params: AuthorizationParams,
     res: Response
   ): Promise<void> {
-    const { signerKey, signerAddress } = await createFreshAccount();
+    const { signerKey, signerAddress } = await createFreshAccount().catch((e: unknown) => {
+      logger.error({ err: e }, 'authorize: CDP account creation failed');
+      throw e;
+    });
     const sessionToken = await sign(
       {
         redirectUri: params.redirectUri,

--- a/apps/mcp/tests/auth-error-logging.test.ts
+++ b/apps/mcp/tests/auth-error-logging.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import { CLIENT_METADATA, makeRes, PKCE_CHALLENGE, REDIRECT_URI } from './helpers.js';
+import { SnapshotOAuthProvider } from '../src/auth.js';
+import * as cdp from '../src/cdp.js';
+import logger from '../src/logger.js';
+
+describe('authorize() surfaces CDP account-creation failures', () => {
+  let provider: SnapshotOAuthProvider;
+
+  beforeEach(() => {
+    provider = new SnapshotOAuthProvider();
+  });
+
+  test('logs the CDP error with full fidelity, then rethrows it unchanged', async () => {
+    const cdpError = Object.assign(new Error('Account limit exceeded'), {
+      name: 'APIError',
+      statusCode: 429,
+      errorType: 'account_limit_exceeded',
+      correlationId: 'corr-abc-123'
+    });
+
+    const createSpy = spyOn(cdp, 'createFreshAccount').mockRejectedValueOnce(cdpError);
+    const logSpy = spyOn(logger, 'error').mockImplementation(() => undefined as never);
+
+    const client = await provider.clientsStore.registerClient!(CLIENT_METADATA);
+
+    await expect(
+      provider.authorize(
+        client,
+        {
+          redirectUri: REDIRECT_URI,
+          state: 'x',
+          codeChallenge: PKCE_CHALLENGE,
+          codeChallengeMethod: 'S256',
+          scopes: []
+        } as any,
+        makeRes() as any
+      )
+    ).rejects.toBe(cdpError);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const [fields, msg] = logSpy.mock.calls[0] as unknown as [{ err: unknown }, string];
+    expect(fields.err).toBe(cdpError);
+    expect(msg).toContain('CDP account creation failed');
+
+    createSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+});

--- a/apps/mcp/tests/auth-error-logging.test.ts
+++ b/apps/mcp/tests/auth-error-logging.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, spyOn, test } from 'bun:test';
-import { CLIENT_METADATA, makeRes, PKCE_CHALLENGE, REDIRECT_URI } from './helpers.js';
+import { startAuthFlow } from './helpers.js';
 import { SnapshotOAuthProvider } from '../src/auth.js';
 import * as cdp from '../src/cdp.js';
 import logger from '../src/logger.js';
@@ -22,21 +22,7 @@ describe('authorize() surfaces CDP account-creation failures', () => {
     const createSpy = spyOn(cdp, 'createFreshAccount').mockRejectedValueOnce(cdpError);
     const logSpy = spyOn(logger, 'error').mockImplementation(() => undefined as never);
 
-    const client = await provider.clientsStore.registerClient!(CLIENT_METADATA);
-
-    await expect(
-      provider.authorize(
-        client,
-        {
-          redirectUri: REDIRECT_URI,
-          state: 'x',
-          codeChallenge: PKCE_CHALLENGE,
-          codeChallengeMethod: 'S256',
-          scopes: []
-        } as any,
-        makeRes() as any
-      )
-    ).rejects.toBe(cdpError);
+    await expect(startAuthFlow(provider)).rejects.toBe(cdpError);
 
     expect(logSpy).toHaveBeenCalledTimes(1);
     const [fields, msg] = logSpy.mock.calls[0] as unknown as [{ err: unknown }, string];


### PR DESCRIPTION
## Problem

`mcp.snapshot.box/authorize` has been 500ing (redirecting to `?error=server_error`) on every attempt, reported in snapshot-labs/workflow#839. `SnapshotOAuthProvider.authorize()` mints a fresh Coinbase CDP account per hit before it can redirect the user to authorize an alias, and that CDP call has been failing.

The failure was invisible in our own logs: the MCP SDK's `authorizationHandler` catches whatever `provider.authorize()` throws and redirects straight to the client's `redirect_uri` with the generic error params, without ever calling Express's `next(err)`. Our app-level error handler and pino/Logtail logging only fire for errors that reach `next()`, so a CDP failure here never got logged anywhere, even though it was reproducible on every single request.

## Fix

Catch the `createFreshAccount()` failure at the one point in the request path where it's still observable - inside `authorize()`, before the SDK's handler swallows it - log it with full CDP fidelity (the existing pino `err` serializer already surfaces `errorType`, `statusCode`, `correlationId` since they're enumerable properties on CDP's `APIError`), then rethrow the same error unchanged so the client-facing behavior (redirect with `error=server_error`) is untouched.

This does not change *why* CDP account creation is failing - `createFreshAccount()` mints a brand-new, uncached wallet on every single `/authorize` hit (confirmed intentional: `apps/mcp/tests/auth.test.ts` pins "each authorize() call mints a different per-session alias" as a security invariant, so pooling/reuse isn't a safe drive-by change here). If the underlying cause turns out to be a Coinbase CDP account or billing limit, that needs action on the CDP Portal, not a code fix - this PR is scoped to making that failure observable so it doesn't happen silently again.