### PR TITLE
fix(ui): resolve addresses through the Universal Resolver on ENSv2 chains

### DIFF
--- a/apps/ui/src/helpers/ens.test.ts
+++ b/apps/ui/src/helpers/ens.test.ts
@@ -129,6 +129,11 @@ describe('ens', () => {
         const owner = await getNameOwner('lucemans-test-not-exist.cbars.id', 1);
         expect(owner).toBe('0x0000000000000000000000000000000000000000');
       }, 10000);
+
+      it('should not answer a DNS domain on testnet from mainnet', async () => {
+        const owner = await getNameOwner('defi.app', 11155111);
+        expect(owner).toBe('0x0000000000000000000000000000000000000000');
+      }, 10000);
     });
   });
 

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -333,7 +333,7 @@ export async function getNameOwner(name: string, chainId: ENSChainId) {
   );
 
   if (!normalized.endsWith('.eth') && owner === EVM_EMPTY_ADDRESS) {
-    const resolvedAddress = ENS_CONTRACTS.universalResolver[chainId]
+    const resolvedAddress = universalResolver
       ? await resolveName(normalized, chainId)
       : (await getAddresses([normalized], chainId))[normalized];
     const nameTokens = normalized.split('.');

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -235,14 +235,15 @@ async function deepResolve(
 }
 
 export async function resolveName(name: string, chainId: ENSChainId) {
-  const resolver = ENS_CONTRACTS.resolvers[chainId];
-  if (!resolver) throw new Error('Unsupported chainId');
+  if (!ENS_CONTRACTS.resolvers[chainId]) throw new Error('Unsupported chainId');
 
   const node = namehash(name);
+  const universalResolver = ENS_CONTRACTS.universalResolver[chainId];
+  const address: string | null = universalResolver
+    ? await resolveRecord(name, chainId, universalResolver, 'addr', [node])
+    : await deepResolve(chainId, node, 'addr', [node]);
 
-  const address: string = await deepResolve(chainId, node, 'addr', [node]);
-
-  if (address === EVM_EMPTY_ADDRESS) return null;
+  if (!address || address === EVM_EMPTY_ADDRESS) return null;
 
   return address;
 }
@@ -332,9 +333,9 @@ export async function getNameOwner(name: string, chainId: ENSChainId) {
   );
 
   if (!normalized.endsWith('.eth') && owner === EVM_EMPTY_ADDRESS) {
-    const resolvedAddress = (await getAddresses([normalized], chainId))[
-      normalized
-    ];
+    const resolvedAddress = ENS_CONTRACTS.universalResolver[chainId]
+      ? await resolveName(normalized, chainId)
+      : (await getAddresses([normalized], chainId))[normalized];
     const nameTokens = normalized.split('.');
 
     if (nameTokens.length > 2) {


### PR DESCRIPTION
### Summary

Second of three PRs finishing the UI's ENSv2 parity, after #2279 moved the `snapshot` record read to the Universal Resolver. This one covers address resolution and the owner fallback for non-`.eth` names. Same switch as #2279: only chains listed in `ENS_CONTRACTS.universalResolver` (Sepolia today) change; mainnet is untouched.

- **`resolveName` reads `addr` through the Universal Resolver** on those chains, with the same fail-closed revert classification as the record read, so addresses served by ENSv2 and offchain (CCIP-read) resolvers resolve. Other chains keep `deepResolve`.
- **The owner fallback for non-`.eth` names becomes chain-aware.** It gated on stamp's address lookup, which always answers from mainnet, so on Sepolia a DNS name that only exists on mainnet showed mainnet's DNS owner as controller while the sequencer reports it unowned. On Universal Resolver chains it now resolves on the same chain; other chains keep stamp.

Behaviour change to be aware of, Sepolia only: a name whose resolver reverts with data (e.g. a subdomain of a DNS domain like `web3.wanki.moe`) now rejects instead of reading as unowned — the sequencer already rejects it. No testnet space is affected.

### How to test

```
cd apps/ui && bun run test src/helpers/ens.test.ts
```

33 tests — the 32 from #2279 untouched, plus `defi.app` on Sepolia resolving to the empty address.

**Parity with the sequencer:** `getSpaceController` on Sepolia through this branch vs snapshot.js 0.17.1 for every non-`.eth` testnet space (`alvara.xyz`, `ethplay.org` — both unchanged) plus `defi.app`, `facebook.com`, `web3.wanki.moe`, `lucemans.cb.id`, `boorger.eth`, `test123.eth`: **8/8 identical**, including the two that reject on both sides.

| `/settings/controller` on Sepolia | before | after |
|---|---|---|
| [`s-tn:defi.app`](https://testnet.snapshot.box/#/s-tn:defi.app/settings/controller) | `0x7aeB…` — mainnet's DNS owner, via stamp | `0x0000…`, matching the sequencer |
| [`s-tn:alvara.xyz`](https://testnet.snapshot.box/#/s-tn:alvara.xyz/settings/controller), [`s-tn:ethplay.org`](https://testnet.snapshot.box/#/s-tn:ethplay.org/settings/controller) | DNS owner | same |
| any `.eth` space, mainnet spaces | unchanged | unchanged |

### To-Do

- [ ] **ENSv2 write path** (#2298) — `setEnsTextRecord` writes to the name's v2 resolver via `findResolver`, so a v2 space can set its controller from our UI. Includes the testnet register link → `app.ens.dev`.
- [ ] Close snapshot-labs/workflow#823 once it is in.
