### PR TITLE
fix(eslint-config-vue): do not apply Prettier overrides twice

### DIFF
--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -64,8 +64,9 @@ function handleSearchSubmit(event: Event) {
 
   if (!searchConfig.value) return;
 
-  if (!searchValue.value)
+  if (!searchValue.value) {
     return router.push({ name: searchConfig.value.defaultRoute });
+  }
 
   router.push({
     name: searchConfig.value.searchRoute,

--- a/apps/ui/src/components/Breadcrumb.vue
+++ b/apps/ui/src/components/Breadcrumb.vue
@@ -22,8 +22,9 @@ const previewLogoUrl = computed(() => {
     !isWhiteLabel.value ||
     !logo.value ||
     logo.value === skinSettings.value?.logo
-  )
+  ) {
     return;
+  }
   return getUrl(logo.value);
 });
 
@@ -32,8 +33,9 @@ const onchainLogoUrl = computed(() => {
     !space.value ||
     offchainNetworks.includes(space.value.network) ||
     !skinSettings.value?.logo
-  )
+  ) {
     return;
+  }
   return getUrl(skinSettings.value?.logo);
 });
 

--- a/apps/ui/src/components/Layout/App.vue
+++ b/apps/ui/src/components/Layout/App.vue
@@ -98,8 +98,9 @@ async function handleTransactionAccept() {
     !walletConnectSpaceKey.value ||
     !executionStrategy.value ||
     !transaction.value
-  )
+  ) {
     return;
+  }
 
   const executions = {} as Record<string, Transaction[]>;
   executions[executionStrategy.value.address] = [transaction.value];
@@ -141,8 +142,9 @@ watch(isSwiping, () => {
     !sidebarSwipeEnabled.value ||
     !isSwiping.value ||
     modalOpen.value
-  )
+  ) {
     return;
+  }
 
   if (
     (direction.value === 'right' && !uiStore.sideMenuOpen) ||

--- a/apps/ui/src/components/Modal/Delegate.vue
+++ b/apps/ui/src/components/Modal/Delegate.vue
@@ -177,8 +177,9 @@ async function handleSubmit() {
     !auth.value ||
     !selectedDelegation.value ||
     !isDelegationSupportedByConnectedWallet(selectedDelegation.value)
-  )
+  ) {
     return;
+  }
 
   try {
     isSending.value = true;

--- a/apps/ui/src/components/Modal/LinkWalletConnect.vue
+++ b/apps/ui/src/components/Modal/LinkWalletConnect.vue
@@ -74,8 +74,9 @@ async function handleSubmit() {
 function handleApprove(approved: boolean) {
   approveFn.value?.(approved);
 
-  if (approved) approving.value = true;
-  else {
+  if (approved) {
+    approving.value = true;
+  } else {
     form.pairingCode = '';
     step.value = 'INIT';
   }

--- a/apps/ui/src/components/Modal/SendToken.vue
+++ b/apps/ui/src/components/Modal/SendToken.vue
@@ -53,10 +53,11 @@ const allAssets = computed(() => [...assets.value, ...customTokens.value]);
 
 const currentToken = computed(() => {
   let token = assetsMap.value?.get(form.token);
-  if (!token)
+  if (!token) {
     token = customTokens.value.find(
       existing => existing.contractAddress === form.token
     );
+  }
 
   const metadata = METADATA_BY_CHAIN_ID.get(props.network);
 

--- a/apps/ui/src/components/Modal/Share.vue
+++ b/apps/ui/src/components/Modal/Share.vue
@@ -37,8 +37,12 @@ watch(
   async (to, from) => {
     if (props.type !== 'vote') return;
 
-    if (props.open && (to as Vote).proposal.id !== (from as Vote)?.proposal.id)
+    if (
+      props.open &&
+      (to as Vote).proposal.id !== (from as Vote)?.proposal.id
+    ) {
       emit('close');
+    }
   },
   { immediate: true }
 );

--- a/apps/ui/src/components/Modal/Strategies.vue
+++ b/apps/ui/src/components/Modal/Strategies.vue
@@ -26,8 +26,9 @@ const hasError = ref(false);
 const network = computed(() => getNetwork(props.networkId));
 const filteredStrategies = computed(() => {
   return strategies.value.filter(strategy => {
-    if (props.hiddenStrategies?.includes(strategy.name) || strategy.disabled)
+    if (props.hiddenStrategies?.includes(strategy.name) || strategy.disabled) {
       return false;
+    }
 
     if (!searchValue.value) return true;
 

--- a/apps/ui/src/components/OnboardingUser.vue
+++ b/apps/ui/src/components/OnboardingUser.vue
@@ -61,8 +61,9 @@ watch(
 
 onMounted(async () => {
   const pending = lsGet('showOnboarding')?.[web3.value.account] ?? true;
-  if (pending && web3.value.account)
+  if (pending && web3.value.account) {
     await usersStore.fetchUser(web3.value.account, true);
+  }
 });
 </script>
 

--- a/apps/ui/src/components/SetupStrategiesConfiguratorOffchain.vue
+++ b/apps/ui/src/components/SetupStrategiesConfiguratorOffchain.vue
@@ -76,8 +76,9 @@ function handlePopularStrategyClick(id: string) {
 }
 
 function handleSaveStrategy(value: StrategyConfig['params'], chainId: ChainId) {
-  if (!editStrategyModalStrategy.value || !editStrategyModalStrategyId.value)
+  if (!editStrategyModalStrategy.value || !editStrategyModalStrategyId.value) {
     return;
+  }
 
   const strategy: StrategyConfig = {
     ...editStrategyModalStrategy.value,

--- a/apps/ui/src/composables/useActions.ts
+++ b/apps/ui/src/composables/useActions.ts
@@ -525,8 +525,9 @@ export function useActions() {
   async function vetoProposal(proposal: Proposal) {
     if (!auth.value) return await forceLogin();
 
-    if (auth.value.connector.type === 'argentx')
+    if (auth.value.connector.type === 'argentx') {
       throw new Error('ArgentX is not supported');
+    }
 
     const network = getReadWriteNetwork(proposal.network);
 

--- a/apps/ui/src/composables/useAliasAuthorize.ts
+++ b/apps/ui/src/composables/useAliasAuthorize.ts
@@ -100,8 +100,9 @@ export function useAliasAuthorize(aliasAddress: MaybeRefOrGetter<string>) {
   });
 
   const error = computed(() => {
-    if (!mutationError.value || isUserAbortError(mutationError.value))
+    if (!mutationError.value || isUserAbortError(mutationError.value)) {
       return null;
+    }
     return (mutationError.value as Error).message || 'Authorization failed';
   });
 

--- a/apps/ui/src/composables/useSpaceAlerts.ts
+++ b/apps/ui/src/composables/useSpaceAlerts.ts
@@ -81,8 +81,9 @@ export function useSpaceAlerts(
       !space.value.snapshot_chain_id ||
       !networksLoaded.value ||
       space.value.turbo
-    )
+    ) {
       return [];
+    }
 
     const ids = new Set<string>([
       space.value.snapshot_chain_id,

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -226,8 +226,9 @@ export function useSpaceSettings(space: Ref<Space>) {
 
       if (metadata.name) result.name = metadata.name;
       if (metadata.description) result.description = metadata.description;
-      if (metadata.payload !== null)
+      if (metadata.payload !== null) {
         result.properties.payload = metadata.payload;
+      }
       if (metadata.token !== null) result.properties.token = metadata.token;
 
       return result;

--- a/apps/ui/src/helpers/discourse.ts
+++ b/apps/ui/src/helpers/discourse.ts
@@ -104,8 +104,9 @@ export async function loadTopics(url: string): Promise<Topic[]> {
       .map(poster => data.users.find(user => user.id === poster.user_id))
       .map(user => {
         user.avatar_template = user.avatar_template.replace('{size}', '64');
-        if (user.avatar_template.startsWith('/'))
+        if (user.avatar_template.startsWith('/')) {
           user.avatar_template = `${baseUrl}${user.avatar_template}`;
+        }
         return user;
       });
     return topic;
@@ -117,8 +118,9 @@ function formatPosts(posts: any[], baseUrl: string): Reply[] {
 
   return posts.map(post => {
     post.avatar_template = post.avatar_template.replace('{size}', '64');
-    if (post.avatar_template.startsWith('/'))
+    if (post.avatar_template.startsWith('/')) {
       post.avatar_template = `${baseUrl}${post.avatar_template}`;
+    }
 
     post.name = post.display_username || post.name || post.username;
     post.like_count = post.actions_summary.find(a => a.id === 2)?.count || 0;

--- a/apps/ui/src/helpers/ens.ts
+++ b/apps/ui/src/helpers/ens.ts
@@ -159,8 +159,9 @@ export async function setEnsTextRecord(
     [ENS_CONTRACTS.registry, 'resolver', [ensHash]]
   );
 
-  if (!resolverAddress || resolverAddress === EVM_EMPTY_ADDRESS)
+  if (!resolverAddress || resolverAddress === EVM_EMPTY_ADDRESS) {
     throw new Error('No resolver set for name');
+  }
 
   const contract = new Contract(
     resolverAddress,

--- a/apps/ui/src/helpers/organizations/router.ts
+++ b/apps/ui/src/helpers/organizations/router.ts
@@ -141,8 +141,13 @@ export function resolveOrgLocation(
   router: Router,
   whiteLabelOrg?: OrganizationConfig | null
 ): RouteLocationRaw {
-  if (typeof to === 'string' || !('name' in to) || typeof to.name !== 'string')
+  if (
+    typeof to === 'string' ||
+    !('name' in to) ||
+    typeof to.name !== 'string'
+  ) {
     return to;
+  }
 
   const params = (to.params ?? {}) as RouteParams;
   whiteLabelOrg ??= getOrganizationConfigByDomain(window.location.hostname);

--- a/apps/ui/src/helpers/utils.ts
+++ b/apps/ui/src/helpers/utils.ts
@@ -75,10 +75,12 @@ export function getUrl(uri: string) {
   }
 
   const uriScheme = uri.split('://')[0];
-  if (uriScheme === 'ipfs')
+  if (uriScheme === 'ipfs') {
     return uri.replace('ipfs://', `${ipfsGateway}/ipfs/`);
-  if (uriScheme === 'ipns')
+  }
+  if (uriScheme === 'ipns') {
     return uri.replace('ipns://', `${ipfsGateway}/ipns/`);
+  }
   return uri;
 }
 
@@ -105,8 +107,9 @@ export function shorten(
   if (key === 'symbol') limit = MAX_SYMBOL_LENGTH;
   if (key === 'name') limit = 64;
   if (key === 'choice') limit = 12;
-  if (limit)
+  if (limit) {
     return str.length > limit ? `${str.slice(0, limit).trim()}...` : str;
+  }
   return shortenAddress(str);
 }
 

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -962,8 +962,9 @@ export function createActions(
       delegator: string
     ) => {
       const { contractAddress } = delegation;
-      if (!contractAddress || !delegation.chainId || !isAddress(delegator))
+      if (!contractAddress || !delegation.chainId || !isAddress(delegator)) {
         return null;
+      }
 
       const multi = new Multicaller(
         delegation.chainId,
@@ -1095,7 +1096,7 @@ export function createActions(
       return Promise.all(
         strategiesAddresses.map(async (address, i) => {
           const strategy = getEvmStrategy(address, networkConfig);
-          if (!strategy)
+          if (!strategy) {
             return {
               address,
               value: 0n,
@@ -1104,6 +1105,7 @@ export function createActions(
               token: null,
               symbol: ''
             };
+          }
 
           const strategyMetadata = await parseStrategyMetadata(
             strategiesMetadata[i].payload

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -85,10 +85,13 @@ export function createEvmNetwork(networkId: NetworkID): Network {
       }),
     getExplorerUrl: (id, type, chainIdOverride) => {
       let dataType: 'tx' | 'address' | 'token' | 'block' = 'tx';
-      if (type === 'token') dataType = 'token';
-      else if (type === 'block') dataType = 'block';
-      else if (['address', 'contract', 'strategy'].includes(type))
+      if (type === 'token') {
+        dataType = 'token';
+      } else if (type === 'block') {
+        dataType = 'block';
+      } else if (['address', 'contract', 'strategy'].includes(type)) {
         dataType = 'address';
+      }
 
       if (dataType === 'address') id = formatAddress(id);
 

--- a/apps/ui/src/networks/index.ts
+++ b/apps/ui/src/networks/index.ts
@@ -71,8 +71,9 @@ export const metadataNetwork: NetworkID =
   import.meta.env.VITE_METADATA_NETWORK || 's';
 
 export const getNetwork = (id: NetworkID) => {
-  if (!enabledNetworks.includes(id))
+  if (!enabledNetworks.includes(id)) {
     throw new Error(`Network ${id} is not enabled`);
+  }
 
   if (id === 's') return snapshotNetwork;
   if (id === 's-tn') return snapshotTestnetNetwork;

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -131,12 +131,15 @@ function getAuthorRole(
     members: string[];
   }
 ): Member['role'] | null {
-  if (admins.some(address => compareAddresses(address, authorAddress)))
+  if (admins.some(address => compareAddresses(address, authorAddress))) {
     return 'admin';
-  if (moderators.some(address => compareAddresses(address, authorAddress)))
+  }
+  if (moderators.some(address => compareAddresses(address, authorAddress))) {
     return 'moderator';
-  if (members.some(address => compareAddresses(address, authorAddress)))
+  }
+  if (members.some(address => compareAddresses(address, authorAddress))) {
     return 'author';
+  }
 
   return null;
 }

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -573,8 +573,9 @@ export function createActions(
       });
     },
     executeQueuedProposal: async (web3: any, proposal: Proposal) => {
-      if (!proposal.execution_destination)
+      if (!proposal.execution_destination) {
         throw new Error('Execution destination is missing');
+      }
 
       const activeVotingStrategies = proposal.strategies_indices.reduce(
         (acc, index) => {
@@ -821,7 +822,7 @@ export function createActions(
       return Promise.all(
         strategiesAddresses.map(async (address, i) => {
           const strategy = getStarknetStrategy(address, networkConfig);
-          if (!strategy)
+          if (!strategy) {
             return {
               address,
               value: 0n,
@@ -830,6 +831,7 @@ export function createActions(
               token: null,
               symbol: ''
             };
+          }
 
           const strategyMetadata = await parseStrategyMetadata(
             strategiesMetadata[i].payload

--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -115,10 +115,13 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
       }),
     getExplorerUrl: (id, type) => {
       let dataType: 'tx' | 'contract' | 'token' | 'block' = 'tx';
-      if (type === 'token') dataType = 'token';
-      else if (type === 'block') dataType = 'block';
-      else if (['address', 'contract', 'strategy'].includes(type))
+      if (type === 'token') {
+        dataType = 'token';
+      } else if (type === 'block') {
+        dataType = 'block';
+      } else if (['address', 'contract', 'strategy'].includes(type)) {
         dataType = 'contract';
+      }
 
       if (dataType === 'contract') id = formatAddress(id);
 

--- a/apps/ui/src/routes/index.ts
+++ b/apps/ui/src/routes/index.ts
@@ -27,8 +27,9 @@ const router = createRouter({
       to.name === 'space-treasury' &&
       to.params.index === from.params.index &&
       to.params.tab !== from.params.tab
-    )
+    ) {
       return {};
+    }
     if (to.hash) {
       return { el: to.hash, behavior: 'smooth' };
     }

--- a/apps/ui/src/stores/meta.ts
+++ b/apps/ui/src/stores/meta.ts
@@ -17,8 +17,9 @@ export const useMetaStore = defineStore('meta', () => {
   }
 
   function getCurrent(networkId: NetworkID): number | undefined {
-    if (evmNetworks.includes(networkId))
+    if (evmNetworks.includes(networkId)) {
       return currentBlocks.value.get(networkId);
+    }
     return currentTs.value.get(networkId);
   }
 

--- a/apps/ui/src/views/Proposal/Overview.vue
+++ b/apps/ui/src/views/Proposal/Overview.vue
@@ -303,8 +303,9 @@ async function handleAiSpeechClick() {
   try {
     await fetchAiSpeech();
 
-    if (aiSpeechState.value.errored || aiSpeechContent.value === null)
+    if (aiSpeechState.value.errored || aiSpeechContent.value === null) {
       throw new Error();
+    }
 
     await initAudio(aiSpeechContent.value);
     playAudio();

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -285,8 +285,9 @@ const spaceType = computed(() => {
 });
 
 const spaceTypeForProposalLimit = computed(() => {
-  if (lists.value['space.ecosystem.list'].includes(props.space.id))
+  if (lists.value['space.ecosystem.list'].includes(props.space.id)) {
     return 'ecosystem';
+  }
   if (props.space.additionalRawData?.flagged) return 'flagged';
   return spaceType.value;
 });
@@ -461,8 +462,9 @@ function handleTransactionAccept() {
     !walletConnectTransactionExecutionStrategy.value ||
     !transaction.value ||
     !proposal.value
-  )
+  ) {
     return;
+  }
 
   const transactions =
     proposal.value.executions[

--- a/apps/ui/src/views/Space/Pro.vue
+++ b/apps/ui/src/views/Space/Pro.vue
@@ -196,8 +196,9 @@ const features = computed<Feature[]>(() => {
 });
 
 function calculator(amount: number, quantity: number): number {
-  if (subscriptionLength.value === 'yearly')
+  if (subscriptionLength.value === 'yearly') {
     return Number((amount * quantity).toFixed(2));
+  }
 
   return Number(
     (
@@ -284,8 +285,9 @@ onMounted(() => {
   if (
     !selectedSpace.value ||
     offchainNetworks.includes(selectedSpace.value.network)
-  )
+  ) {
     return;
+  }
 
   router.push({
     name: 'space-overview',

--- a/apps/ui/src/views/Topic.vue
+++ b/apps/ui/src/views/Topic.vue
@@ -24,10 +24,11 @@ const topicId = computed(() => route.params.topic as string);
 
 const discussion = computed(() => {
   if (props.proposal) return sanitizeUrl(props.proposal.discussion);
-  if (props.space)
+  if (props.space) {
     return SPACES_DISCUSSIONS[
       `${props.space.network}:${props.space.id}`
     ]?.replace(/\/c\/[^\/]+\/\d+$/, `/t/${topicId.value}`);
+  }
   return '';
 });
 

--- a/apps/ui/src/views/Townhall/Topic.vue
+++ b/apps/ui/src/views/Townhall/Topic.vue
@@ -73,11 +73,13 @@ const results: ComputedRef<Post[]> = computed(() =>
   clone(topic.value?.posts ?? [])
     .filter(s => !s.hidden && getPostVoteCount(s.post_id) > 0)
     .sort((a, b) => {
-      if (sortBy.value === 'agree')
+      if (sortBy.value === 'agree') {
         return b.scores_1 / b.vote_count - a.scores_1 / a.vote_count;
+      }
 
-      if (sortBy.value === 'disagree')
+      if (sortBy.value === 'disagree') {
         return b.scores_2 / b.vote_count - a.scores_2 / a.vote_count;
+      }
 
       if (sortBy.value === 'recent') return b.created - a.created;
 

--- a/bun.lock
+++ b/bun.lock
@@ -488,7 +488,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@snapshot-labs/eslint-config": "^0.1.0",
-        "eslint-config-prettier": "^10.1.1",
         "eslint-plugin-vue": "^10.0.0",
         "typescript-eslint": "^8.29.1",
         "vue-eslint-parser": "^10.1.3",

--- a/packages/eslint-config-vue/index.js
+++ b/packages/eslint-config-vue/index.js
@@ -1,12 +1,11 @@
 import baseConfig from '@snapshot-labs/eslint-config';
-import prettierConfig from 'eslint-config-prettier';
 import pluginVue from 'eslint-plugin-vue';
 import tseslint from 'typescript-eslint';
 import vueParser from 'vue-eslint-parser';
 
 export default [
-  ...baseConfig,
   ...pluginVue.configs['flat/recommended'],
+  ...baseConfig,
   {
     files: ['**/*.vue'],
     languageOptions: {
@@ -23,6 +22,5 @@ export default [
       'vue/no-v-html': 'off',
       'vue/custom-event-name-casing': ['error', 'camelCase']
     }
-  },
-  prettierConfig
+  }
 ];

--- a/packages/eslint-config-vue/package.json
+++ b/packages/eslint-config-vue/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@snapshot-labs/eslint-config": "^0.1.0",
-    "eslint-config-prettier": "^10.1.1",
     "typescript-eslint": "^8.29.1",
     "eslint-plugin-vue": "^10.0.0",
     "vue-eslint-parser": "^10.1.3"


### PR DESCRIPTION
### Summary

Previously we applied Prettier overrides twice, once in the base config, second in Vue config. Because of that some of our base config rules were overwritten by Prettier only in vue variant.

For example this applies to curly rule which we enabled there: https://github.com/snapshot-labs/sx-monorepo/pull/2254 But because of that double override it didn't work in UI.
