### PR TITLE
chore(hub): do not autofix on lint

### DIFF
--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "lint": "bun run lint:nofix --fix",
-    "lint:nofix": "eslint . --ext .ts",
+    "lint": "eslint . --ext .ts",
+    "lint:fix": "bun run lint --fix",
     "typecheck": "tsc --noEmit",
     "dev": "nodemon src/index.ts",
     "build": "tsc && copyfiles src/graphql/*.gql dist/",

--- a/apps/hub/src/graphql/helpers.ts
+++ b/apps/hub/src/graphql/helpers.ts
@@ -68,10 +68,11 @@ export function checkLimits(args: any = {}, type) {
     const whereLimitReached = key.endsWith('_in')
       ? where[key]?.length > limit
       : where[key] > limit;
-    if (firstLimitReached || skipLimitReached || whereLimitReached)
+    if (firstLimitReached || skipLimitReached || whereLimitReached) {
       throw new PublicError(
         `The \`${key}\` argument must not be greater than ${limit}`
       );
+    }
 
     if (['first', 'skip'].includes(key) && args[key] < 0) {
       throw new PublicError(`The \`${key}\` argument must be positive`);

--- a/apps/hub/src/graphql/operations/roles.ts
+++ b/apps/hub/src/graphql/operations/roles.ts
@@ -31,8 +31,9 @@ export default async function (parent, args) {
       );
 
       if (admins.includes(address.toLowerCase())) permissions.push('admin');
-      if (moderators.includes(address.toLowerCase()))
+      if (moderators.includes(address.toLowerCase())) {
         permissions.push('moderator');
+      }
       if (members.includes(address.toLowerCase())) permissions.push('author');
 
       return { space: space.id, permissions };


### PR DESCRIPTION
### Summary

Previously lint autofixed in hub which caused issues to be ignored on CI, because those would be autofixed. Hub had lint (with autofix), and lint:nofix (without autofix) instead of standard lint (no autofix), and lint:fix (with autofix).
