### PR TITLE
test(ui): replace expired ENS fixture in resolver-failure tests

### DIFF
--- a/apps/ui/src/helpers/ens.test.ts
+++ b/apps/ui/src/helpers/ens.test.ts
@@ -178,7 +178,7 @@ describe('ens', () => {
 
     it('should reject when the resolver fails', async () => {
       await expect(
-        getEnsTextRecord('my-dao-test.eth', 'snapshot', 11155111)
+        getEnsTextRecord('dblog.eth', 'snapshot', 11155111)
       ).rejects.toThrow();
     }, 10000);
 
@@ -248,7 +248,8 @@ describe('ens', () => {
       expect(controller).toBe(EMPTY_ADDRESS);
     }, 10000);
 
-    it.each(['my-dao-test.eth', 'poolgroup.eth'])(
+    // dblog.eth reverts onchain, poolgroup.eth through a dead CCIP gateway
+    it.each(['dblog.eth', 'poolgroup.eth'])(
       'should reject instead of falling back to the owner when the resolver fails (%s)',
       async name => {
         await expect(getSpaceController(name, 11155111)).rejects.toThrow();


### PR DESCRIPTION
CI is red on master and every branch: the ENS helper tests assert that `my-dao-test.eth` makes the resolver fail, but that Sepolia registration expired earlier today. The Universal Resolver now reports no resolver at all and reverts `RESOLVER_NOT_FOUND`, which the helpers legitimately classify as "no record" — so the text-record read returns `null` and the space controller falls back to the stale v1 registry owner instead of throwing. No code change caused it; the expectation simply no longer describes reality.

The two names in these tests cover different failure modes — a resolver that reverts onchain, and one whose CCIP gateway is dead — so the expired one is replaced rather than dropped. `dblog.eth` reverts onchain the same way, and is registered until 2044.

## Test plan

- `cd apps/ui && bun run test src/helpers/ens.test.ts` — all pass against live Sepolia