### PR TITLE
test(ui): replace poolgroup.eth ENS fixture before it expires

### DIFF
--- a/apps/ui/src/helpers/ens.test.ts
+++ b/apps/ui/src/helpers/ens.test.ts
@@ -248,8 +248,8 @@ describe('ens', () => {
       expect(controller).toBe(EMPTY_ADDRESS);
     }, 10000);
 
-    // dblog.eth reverts onchain, poolgroup.eth through a dead CCIP gateway
-    it.each(['dblog.eth', 'poolgroup.eth'])(
+    // dblog.eth reverts onchain, opdisputegame.eth after its CCIP callback
+    it.each(['dblog.eth', 'opdisputegame.eth'])(
       'should reject instead of falling back to the owner when the resolver fails (%s)',
       async name => {
         await expect(getSpaceController(name, 11155111)).rejects.toThrow();


### PR DESCRIPTION
Follow-up to #2316. `poolgroup.eth`, the fixture covering the offchain resolver-failure path, is registered until 2026-10-24. After that the Universal Resolver reports no resolver for it, the helpers classify that as "no record", and both resolver-failure tests go red exactly the way `my-dao-test.eth` broke CI today.

`opdisputegame.eth` takes its place: registered until 2044, and its resolution also fails after the CCIP callback rather than onchain, so the two tests keep covering distinct failure paths. Its inner error is a bare revert rather than `poolgroup.eth`'s signature-verification one — no name registered past 2029 reproduces that exact failure.

## Test plan

- `cd apps/ui && bun run test src/helpers/ens.test.ts` — all pass against live Sepolia