### PR TITLE
refactor(sx.js): replace deprecated micro-starknet

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -544,7 +544,6 @@
         "@openzeppelin/merkle-tree": "^1.0.5",
         "@shutter-network/shutter-crypto": "1.0.1",
         "bn.js": "^5.2.1",
-        "micro-starknet": "^0.2.3",
         "randombytes": "^2.1.0",
         "starknet": "7.6.4",
       },

--- a/packages/sx.js/package.json
+++ b/packages/sx.js/package.json
@@ -54,7 +54,6 @@
     "@openzeppelin/merkle-tree": "^1.0.5",
     "@shutter-network/shutter-crypto": "1.0.1",
     "bn.js": "^5.2.1",
-    "micro-starknet": "^0.2.3",
     "randombytes": "^2.1.0",
     "starknet": "7.6.4"
   },

--- a/packages/sx.js/src/clients/starknet/ethereum-tx/index.ts
+++ b/packages/sx.js/src/clients/starknet/ethereum-tx/index.ts
@@ -1,7 +1,6 @@
 import { Signer } from '@ethersproject/abstract-signer';
 import { Contract } from '@ethersproject/contracts';
-import { poseidonHashMany } from 'micro-starknet';
-import { CallData, shortString } from 'starknet';
+import { CallData, hash, shortString } from 'starknet';
 import StarknetCommitAbi from './abis/StarknetCommit.json';
 import { getChoiceEnum } from '../../../utils/starknet-enums';
 import { getStrategiesWithParams } from '../../../utils/strategies';
@@ -272,7 +271,7 @@ export class EthereumTx {
       })
     ]);
 
-    return `0x${poseidonHashMany(compiled.map(v => BigInt(v))).toString(16)}`;
+    return hash.computePoseidonHashOnElements(compiled);
   }
 
   async getVoteHash(address: string, data: Vote) {
@@ -295,7 +294,7 @@ export class EthereumTx {
       shortString.splitLongString(data.metadataUri)
     ]);
 
-    return `0x${poseidonHashMany(compiled.map(v => BigInt(v))).toString(16)}`;
+    return hash.computePoseidonHashOnElements(compiled);
   }
 
   async getUpdateProposalHash(address: string, data: UpdateProposal) {
@@ -312,7 +311,7 @@ export class EthereumTx {
       shortString.splitLongString(data.metadataUri)
     ]);
 
-    return `0x${poseidonHashMany(compiled.map(v => BigInt(v))).toString(16)}`;
+    return hash.computePoseidonHashOnElements(compiled);
   }
 
   async initializePropose(

--- a/packages/sx.js/src/clients/starknet/starknet-tx/index.ts
+++ b/packages/sx.js/src/clients/starknet/starknet-tx/index.ts
@@ -1,7 +1,6 @@
 import { Signer } from '@ethersproject/abstract-signer';
 import { Contract } from '@ethersproject/contracts';
 import { TransactionResponse } from '@ethersproject/providers';
-import { poseidonHashMany } from 'micro-starknet';
 import randomBytes from 'randombytes';
 import { Account, CallData, hash, shortString, uint256 } from 'starknet';
 import SpaceAbi from './abis/Space.json';
@@ -171,7 +170,7 @@ export class StarknetTx {
   }
 
   async getSalt({ sender, saltNonce }: { sender: string; saltNonce: string }) {
-    return poseidonHashMany([BigInt(sender), BigInt(saltNonce)]);
+    return BigInt(hash.computePoseidonHashOnElements([sender, saltNonce]));
   }
 
   async predictSpaceAddress({


### PR DESCRIPTION
### Summary

Replacing deprecated `micro-starknet` with already used `starknetjs`.