### PR TITLE
fix(hub): export mysql pool metrics

### DIFF
--- a/apps/hub/src/helpers/metrics.ts
+++ b/apps/hub/src/helpers/metrics.ts
@@ -43,7 +43,8 @@ export default function initMetrics(app: Express) {
       ['^/graphql.*$', '/graphql']
     ],
     whitelistedPath,
-    errorHandler: (e: any) => capture(e)
+    errorHandler: (e: any) => capture(e),
+    db
   });
 
   app.use(instrumentRateLimitedRequests);


### PR DESCRIPTION
Fixes #2321

The hub never exported any `mysql_pool_*` metric: snapshot-metrics only instruments a connection pool when one is handed to its init, and the hub never handed one over. The Grafana MySQL panel for the hub is therefore empty, so pool saturation is invisible.

Caveat: the hub owns two pools (hub database and seq database) and the gauges carry no pool label, so only one can be instrumented. This wires up the hub pool; the seq-database pool stays unmonitored. Adding a pool label would mean changing snapshot-metrics, which is out of scope here.

## Test plan

Verified locally against the test database (`bun run test:setup`, then `PORT=3030 bun run start:test`):

- Before: `curl -s http://localhost:3030/metrics | grep -c mysql_pool` → `0`
- After: the five `mysql_pool_*` gauges are present, `mysql_pool_max_connections_count 25` matching `CONNECTION_LIMIT`.
