### PR TITLE
fix(ui): point Get help and contact links to /contact-us

### DIFF
--- a/apps/ui/src/components/App/Footer.vue
+++ b/apps/ui/src/components/App/Footer.vue
@@ -27,7 +27,7 @@ const isSiteRoute = computed(() => {
         </UiButton>
       </UiTooltip>
       <UiTooltip title="Get help">
-        <UiButton :to="`${DOCS_URL}/faq/support-and-feedback`" uniform>
+        <UiButton :to="`${DOCS_URL}/contact-us`" uniform>
           <IH-chat />
         </UiButton>
       </UiTooltip>

--- a/apps/ui/src/components/ContentFlagable.vue
+++ b/apps/ui/src/components/ContentFlagable.vue
@@ -15,7 +15,7 @@ const isDMCA = computed(() => props.item.flag_code === FLAGS.DMCA);
   <UiAlert v-if="isDMCA" type="error" class="mb-3">
     This content has been removed in response to a DMCA request. If you have any
     questions or believe this was an error, please
-    <AppLink :to="`${DOCS_URL}/faq/support-and-feedback`">contact us</AppLink>.
+    <AppLink :to="`${DOCS_URL}/contact-us`">contact us</AppLink>.
   </UiAlert>
   <UiAlert v-else-if="item.flagged && isHidden" type="error" class="mb-3">
     <UiButton class="float-right ml-2" @click="isHidden = false">Show</UiButton>

--- a/apps/ui/src/components/Site/Footer.vue
+++ b/apps/ui/src/components/Site/Footer.vue
@@ -58,7 +58,7 @@ const SOCIALS = [
           <UiEyebrow>Resources</UiEyebrow>
           <div class="space-y-1">
             <div>
-              <AppLink :to="`${DOCS_URL}/faq/support-and-feedback`">
+              <AppLink :to="`${DOCS_URL}/contact-us`">
                 Helpdesk <IH-arrow-sm-right class="inline-block -rotate-45" />
               </AppLink>
             </div>
@@ -108,9 +108,7 @@ const SOCIALS = [
             <AppLink :to="{ name: 'site-policy' }">Privacy policy</AppLink>
           </div>
           <div>
-            <AppLink :to="`${DOCS_URL}/faq/support-and-feedback`"
-              >Contact us</AppLink
-            >
+            <AppLink :to="`${DOCS_URL}/contact-us`">Contact us</AppLink>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

`docs.snapshot.box/faq/support-and-feedback` has been retired in favor of a dedicated `/contact-us` page (#2313). The UI still linked to the old URL in four places: the floating "Get help" button, the site footer's "Helpdesk" and "Contact us" links, and the DMCA takedown notice. Point all of them at `/contact-us` instead.

## Verification

- `turbo run build lint typecheck --filter=ui` all pass