### PR TITLE
fix(sequencer): label brovider requests with client=sequencer

### DIFF
--- a/apps/sequencer/package.json
+++ b/apps/sequencer/package.json
@@ -29,7 +29,7 @@
     "@snapshot-labs/pineapple": "^1.2.1",
     "@snapshot-labs/snapshot-metrics": "^2.0.0",
     "@snapshot-labs/snapshot-sentry": "^3.1.0",
-    "@snapshot-labs/snapshot.js": "^0.17.0",
+    "@snapshot-labs/snapshot.js": "^0.17.1",
     "ajv": "8.11.0",
     "bluebird": "^3.7.2",
     "connection-string": "^1.0.1",

--- a/apps/sequencer/package.json
+++ b/apps/sequencer/package.json
@@ -22,7 +22,6 @@
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/bytes": "^5.6.1",
     "@ethersproject/hash": "^5.5.0",
-    "@ethersproject/providers": "^5.8.0",
     "@ethersproject/strings": "^5.7.0",
     "@ethersproject/wallet": "^5.6.2",
     "@shutter-network/shutter-crypto": "^1.0.0",

--- a/apps/sequencer/src/helpers/poke.ts
+++ b/apps/sequencer/src/helpers/poke.ts
@@ -1,7 +1,7 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import { addOrUpdateSpace } from './actions';
-import { PROVIDER_OPTIONS } from './provider';
+import { getSpaceUri } from './provider';
 
 type Space = Record<string, any>;
 
@@ -27,11 +27,7 @@ export default async function poke(id: string): Promise<Space> {
 async function getSpaceENS(id: string): Promise<Space> {
   let uri: string | null;
   try {
-    uri = await snapshot.utils.getSpaceUri(
-      id,
-      DEFAULT_NETWORK,
-      PROVIDER_OPTIONS
-    );
+    uri = await getSpaceUri(id, DEFAULT_NETWORK);
   } catch (err: any) {
     capture(err);
     return Promise.reject('unable to resolve space uri');

--- a/apps/sequencer/src/helpers/poke.ts
+++ b/apps/sequencer/src/helpers/poke.ts
@@ -1,7 +1,7 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import { addOrUpdateSpace } from './actions';
-import { BROVIDER_URL } from './provider';
+import { PROVIDER_OPTIONS } from './provider';
 
 type Space = Record<string, any>;
 
@@ -27,9 +27,11 @@ export default async function poke(id: string): Promise<Space> {
 async function getSpaceENS(id: string): Promise<Space> {
   let uri: string | null;
   try {
-    uri = await snapshot.utils.getSpaceUri(id, DEFAULT_NETWORK, {
-      broviderUrl: BROVIDER_URL
-    });
+    uri = await snapshot.utils.getSpaceUri(
+      id,
+      DEFAULT_NETWORK,
+      PROVIDER_OPTIONS
+    );
   } catch (err: any) {
     capture(err);
     return Promise.reject('unable to resolve space uri');

--- a/apps/sequencer/src/helpers/provider.ts
+++ b/apps/sequencer/src/helpers/provider.ts
@@ -1,39 +1,16 @@
-import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import snapshot from '@snapshot-labs/snapshot.js';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 
-export const BROVIDER_URL =
-  process.env.BROVIDER_URL ?? 'https://rpc.brovider.xyz';
-const providers = new Map<string, StaticJsonRpcProvider>();
+const BROVIDER_URL = process.env.BROVIDER_URL ?? 'https://rpc.brovider.xyz';
+
+// Shared by every snapshot.js call that ends up talking to brovider, so the
+// requests are attributed to `client=sequencer` instead of `client=none`.
+export const PROVIDER_OPTIONS = {
+  broviderUrl: BROVIDER_URL,
+  clientName: 'sequencer'
+};
 
 // Loose `any` return type matches snapshot.js: starknet networks return a
 // starknet RpcProvider, not a StaticJsonRpcProvider.
 export function getProvider(network: string | number): any {
-  const key = String(network);
-  const config = (
-    networks as Record<string, { starknet?: boolean } | undefined>
-  )[key];
-  if (!config) {
-    throw new Error(`Network '${key}' is not supported`);
-  }
-  // snapshot.js builds the RPC URL without a query string, so EVM providers are
-  // created locally to append ?client=sequencer. Starknet networks need
-  // snapshot.js (RpcProvider + broviderId mapping) and keep going through it.
-  if (config.starknet) {
-    return snapshot.utils.getProvider(network, { broviderUrl: BROVIDER_URL });
-  }
-
-  let provider = providers.get(key);
-  if (!provider) {
-    provider = new StaticJsonRpcProvider(
-      {
-        url: `${BROVIDER_URL}/${key}?client=sequencer`,
-        timeout: 25000,
-        allowGzip: true
-      },
-      Number(network)
-    );
-    providers.set(key, provider);
-  }
-  return provider;
+  return snapshot.utils.getProvider(network, PROVIDER_OPTIONS);
 }

--- a/apps/sequencer/src/helpers/provider.ts
+++ b/apps/sequencer/src/helpers/provider.ts
@@ -1,5 +1,13 @@
 import snapshot from '@snapshot-labs/snapshot.js';
 
+// snapshot.js types getProvider per network id but does not export the two
+// arms, so name them off a sample id of each kind rather than deep-importing
+// its internals.
+export type EvmProvider = ReturnType<typeof snapshot.utils.getProvider<'1'>>;
+export type StarknetProvider = ReturnType<
+  typeof snapshot.utils.getProvider<'0x534e5f4d41494e'>
+>;
+
 const BROVIDER_URL = process.env.BROVIDER_URL ?? 'https://rpc.brovider.xyz';
 
 // Shared by every snapshot.js call that ends up talking to brovider, so the
@@ -9,8 +17,24 @@ export const PROVIDER_OPTIONS = {
   clientName: 'sequencer'
 };
 
-// Generic so snapshot.js can resolve the return type per network: starknet
-// ones give an RpcProvider, everything else a StaticJsonRpcProvider.
-export function getProvider<T extends string | number>(network: T) {
+// Starknet spaces reach this too (proposal creation resolves the snapshot
+// block through it), so the return type stays the honest union; callers that
+// need an EVM-only API narrow it themselves.
+export function getProvider(
+  network: string | number
+): EvmProvider | StarknetProvider {
   return snapshot.utils.getProvider(network, PROVIDER_OPTIONS);
+}
+
+export function verify(
+  address: string,
+  sig: string | string[],
+  data: any,
+  network: string
+) {
+  return snapshot.utils.verify(address, sig, data, network, PROVIDER_OPTIONS);
+}
+
+export function getSpaceUri(id: string, network: string) {
+  return snapshot.utils.getSpaceUri(id, network, PROVIDER_OPTIONS);
 }

--- a/apps/sequencer/src/helpers/provider.ts
+++ b/apps/sequencer/src/helpers/provider.ts
@@ -9,8 +9,8 @@ export const PROVIDER_OPTIONS = {
   clientName: 'sequencer'
 };
 
-// Loose `any` return type matches snapshot.js: starknet networks return a
-// starknet RpcProvider, not a StaticJsonRpcProvider.
-export function getProvider(network: string | number): any {
+// Generic so snapshot.js can resolve the return type per network: starknet
+// ones give an RpcProvider, everything else a StaticJsonRpcProvider.
+export function getProvider<T extends string | number>(network: T) {
   return snapshot.utils.getProvider(network, PROVIDER_OPTIONS);
 }

--- a/apps/sequencer/src/helpers/provider.ts
+++ b/apps/sequencer/src/helpers/provider.ts
@@ -10,16 +10,11 @@ export type StarknetProvider = ReturnType<
 
 const BROVIDER_URL = process.env.BROVIDER_URL ?? 'https://rpc.brovider.xyz';
 
-// Shared by every snapshot.js call that ends up talking to brovider, so the
-// requests are attributed to `client=sequencer` instead of `client=none`.
 export const PROVIDER_OPTIONS = {
   broviderUrl: BROVIDER_URL,
   clientName: 'sequencer'
 };
 
-// Starknet spaces reach this too (proposal creation resolves the snapshot
-// block through it), so the return type stays the honest union; callers that
-// need an EVM-only API narrow it themselves.
 export function getProvider(
   network: string | number
 ): EvmProvider | StarknetProvider {
@@ -37,4 +32,8 @@ export function verify(
 
 export function getSpaceUri(id: string, network: string) {
   return snapshot.utils.getSpaceUri(id, network, PROVIDER_OPTIONS);
+}
+
+export function getSpaceController(space: string, network: string) {
+  return snapshot.utils.getSpaceController(space, network, PROVIDER_OPTIONS);
 }

--- a/apps/sequencer/src/helpers/turbo.ts
+++ b/apps/sequencer/src/helpers/turbo.ts
@@ -1,7 +1,7 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import db from './mysql';
-import { getProvider } from './provider';
+import { EvmProvider, getProvider } from './provider';
 import { fetchWithKeepAlive } from './utils';
 
 type Space = {
@@ -14,7 +14,8 @@ const NETWORK_PREFIX = process.env.NETWORK === 'mainnet' ? 's:' : 's-tn:';
 const EVM_INDEXER = process.env.NETWORK === 'mainnet' ? 'eth' : 'sep';
 const RUN_INTERVAL = 10 * 1e3; // 10 seconds
 
-const provider = getProvider(process.env.DEFAULT_NETWORK ?? '1');
+// DEFAULT_NETWORK is always an EVM chain, and block.number below is ethers-only.
+const provider = getProvider(process.env.DEFAULT_NETWORK ?? '1') as EvmProvider;
 
 // Periodically sync the turbo status of spaces with the schnaps-api
 export async function trackTurboStatuses() {

--- a/apps/sequencer/src/helpers/utils.ts
+++ b/apps/sequencer/src/helpers/utils.ts
@@ -7,7 +7,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import { Response } from 'express';
 import fetch from 'node-fetch';
-import { BROVIDER_URL, getProvider } from './provider';
+import { getProvider, PROVIDER_OPTIONS } from './provider';
 
 const MAINNET_NETWORK_ID_WHITELIST = [
   's',
@@ -349,9 +349,11 @@ export async function getSpaceController(space: string, network = NETWORK) {
   const networkId = tldMapping[tld]?.[network] ?? DEFAULT_NETWORK;
 
   try {
-    return await snapshot.utils.getSpaceController(space, networkId, {
-      broviderUrl: BROVIDER_URL
-    });
+    return await snapshot.utils.getSpaceController(
+      space,
+      networkId,
+      PROVIDER_OPTIONS
+    );
   } catch (err: any) {
     capture(err);
     return Promise.reject(

--- a/apps/sequencer/src/helpers/utils.ts
+++ b/apps/sequencer/src/helpers/utils.ts
@@ -7,7 +7,10 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import { Response } from 'express';
 import fetch from 'node-fetch';
-import { getProvider, PROVIDER_OPTIONS } from './provider';
+import {
+  getProvider,
+  getSpaceController as getSnapshotSpaceController
+} from './provider';
 
 const MAINNET_NETWORK_ID_WHITELIST = [
   's',
@@ -349,11 +352,7 @@ export async function getSpaceController(space: string, network = NETWORK) {
   const networkId = tldMapping[tld]?.[network] ?? DEFAULT_NETWORK;
 
   try {
-    return await snapshot.utils.getSpaceController(
-      space,
-      networkId,
-      PROVIDER_OPTIONS
-    );
+    return await getSnapshotSpaceController(space, networkId);
   } catch (err: any) {
     capture(err);
     return Promise.reject(

--- a/apps/sequencer/src/ingestor.ts
+++ b/apps/sequencer/src/ingestor.ts
@@ -11,7 +11,7 @@ import { doesMessageExist, storeMsg } from './helpers/highlight';
 import log from './helpers/log';
 import { timeIngestorProcess } from './helpers/metrics';
 import { flaggedIps } from './helpers/moderation';
-import { PROVIDER_OPTIONS } from './helpers/provider';
+import { verify } from './helpers/provider';
 import relayer, { issueReceipt } from './helpers/relayer';
 import { getIp, jsonParse, sha256 } from './helpers/utils';
 import writer from './writer';
@@ -130,12 +130,11 @@ export default async function ingestor(req) {
 
     // Check if signature is valid
     try {
-      const isValidSig = await snapshot.utils.verify(
+      const isValidSig = await verify(
         body.address,
         body.sig,
         body.data,
-        network,
-        PROVIDER_OPTIONS
+        network
       );
       if (!isValidSig) throw new Error('invalid signature');
     } catch (err: any) {

--- a/apps/sequencer/src/ingestor.ts
+++ b/apps/sequencer/src/ingestor.ts
@@ -11,7 +11,7 @@ import { doesMessageExist, storeMsg } from './helpers/highlight';
 import log from './helpers/log';
 import { timeIngestorProcess } from './helpers/metrics';
 import { flaggedIps } from './helpers/moderation';
-import { BROVIDER_URL } from './helpers/provider';
+import { PROVIDER_OPTIONS } from './helpers/provider';
 import relayer, { issueReceipt } from './helpers/relayer';
 import { getIp, jsonParse, sha256 } from './helpers/utils';
 import writer from './writer';
@@ -20,13 +20,11 @@ const NETWORK_METADATA = {
   evm: {
     name: 'snapshot',
     version: '0.1.4',
-    broviderUrl: BROVIDER_URL,
     defaultNetwork: process.env.DEFAULT_NETWORK ?? '1'
   },
   starknet: {
     name: 'sx-starknet',
     version: '0.1.0',
-    broviderUrl: BROVIDER_URL,
     defaultNetwork:
       process.env.NETWORK === 'testnet'
         ? '0x534e5f5345504f4c4941'
@@ -137,9 +135,7 @@ export default async function ingestor(req) {
         body.sig,
         body.data,
         network,
-        {
-          broviderUrl: networkMetadata.broviderUrl
-        }
+        PROVIDER_OPTIONS
       );
       if (!isValidSig) throw new Error('invalid signature');
     } catch (err: any) {

--- a/apps/sequencer/test/unit/helpers/provider.test.ts
+++ b/apps/sequencer/test/unit/helpers/provider.test.ts
@@ -1,0 +1,13 @@
+import { getProvider } from '../../../src/helpers/provider';
+
+describe('getProvider()', () => {
+  it('labels EVM requests with client=sequencer', () => {
+    expect(getProvider('1').connection.url).toContain('/1?client=sequencer');
+  });
+
+  it('labels Starknet requests with client=sequencer', () => {
+    expect(getProvider('0x534e5f4d41494e').channel.nodeUrl).toContain(
+      '/sn?client=sequencer'
+    );
+  });
+});

--- a/apps/sequencer/test/unit/helpers/provider.test.ts
+++ b/apps/sequencer/test/unit/helpers/provider.test.ts
@@ -1,13 +1,71 @@
-import { getProvider } from '../../../src/helpers/provider';
+const mockGetSpaceUri = jest.fn();
+const mockGetSpaceController = jest.fn();
+
+jest.mock('@snapshot-labs/snapshot.js', () => {
+  const originalModule = jest.requireActual('@snapshot-labs/snapshot.js');
+
+  return {
+    ...originalModule,
+    utils: {
+      ...originalModule.utils,
+      getSpaceUri: (...args: unknown[]) => mockGetSpaceUri(...args),
+      getSpaceController: (...args: unknown[]) =>
+        mockGetSpaceController(...args)
+    }
+  };
+});
+
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn()
+}));
+
+import poke from '../../../src/helpers/poke';
+import {
+  EvmProvider,
+  getProvider,
+  PROVIDER_OPTIONS,
+  StarknetProvider
+} from '../../../src/helpers/provider';
+import { getSpaceController } from '../../../src/helpers/utils';
 
 describe('getProvider()', () => {
   it('labels EVM requests with client=sequencer', () => {
-    expect(getProvider('1').connection.url).toContain('/1?client=sequencer');
+    expect((getProvider('1') as EvmProvider).connection.url).toContain(
+      '/1?client=sequencer'
+    );
   });
 
   it('labels Starknet requests with client=sequencer', () => {
-    expect(getProvider('0x534e5f4d41494e').channel.nodeUrl).toContain(
-      '/sn?client=sequencer'
+    expect(
+      (getProvider('0x534e5f4d41494e') as StarknetProvider).channel.nodeUrl
+    ).toContain('/sn?client=sequencer');
+  });
+});
+
+describe('PROVIDER_OPTIONS call sites', () => {
+  const DEFAULT_NETWORK = process.env.DEFAULT_NETWORK ?? '1';
+
+  it('poke() labels the ENS space URI lookup with client=sequencer', async () => {
+    mockGetSpaceUri.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(poke('test.eth')).rejects.toMatch(
+      'unable to resolve space uri'
+    );
+    expect(mockGetSpaceUri).toHaveBeenCalledWith(
+      'test.eth',
+      DEFAULT_NETWORK,
+      PROVIDER_OPTIONS
+    );
+  });
+
+  it('getSpaceController() labels the space controller lookup with client=sequencer', async () => {
+    mockGetSpaceController.mockResolvedValueOnce('0xcontroller');
+
+    await expect(getSpaceController('test.eth')).resolves.toBe('0xcontroller');
+    expect(mockGetSpaceController).toHaveBeenCalledWith(
+      'test.eth',
+      DEFAULT_NETWORK,
+      PROVIDER_OPTIONS
     );
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -271,7 +271,6 @@
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/hash": "^5.5.0",
-        "@ethersproject/providers": "^5.8.0",
         "@ethersproject/strings": "^5.7.0",
         "@ethersproject/wallet": "^5.6.2",
         "@shutter-network/shutter-crypto": "^1.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -278,7 +278,7 @@
         "@snapshot-labs/pineapple": "^1.2.1",
         "@snapshot-labs/snapshot-metrics": "^2.0.0",
         "@snapshot-labs/snapshot-sentry": "^3.1.0",
-        "@snapshot-labs/snapshot.js": "^0.17.0",
+        "@snapshot-labs/snapshot.js": "^0.17.1",
         "ajv": "8.11.0",
         "bluebird": "^3.7.2",
         "connection-string": "^1.0.1",
@@ -1894,7 +1894,7 @@
 
     "@snapshot-labs/snapshot-sentry": ["@snapshot-labs/snapshot-sentry@3.1.0", "", { "dependencies": { "@sentry/node": "^10.52.0" } }, "sha512-MIIQyW0GZisXa93JvDWFdMO0Ycu9JXBH0P3ca0qJ7HhbxfNrzqLOr1dzhKdhXT0e+sTWO7UCxdeQTGF3dV0l7w=="],
 
-    "@snapshot-labs/snapshot.js": ["@snapshot-labs/snapshot.js@0.17.0", "", { "dependencies": { "@ethersproject/abi": "^5.6.4", "@ethersproject/address": "^5.6.1", "@ethersproject/bignumber": "^5.7.0", "@ethersproject/bytes": "^5.6.1", "@ethersproject/contracts": "^5.6.2", "@ethersproject/hash": "^5.7.0", "@ethersproject/providers": "^5.6.8", "@ethersproject/units": "^5.7.0", "@ethersproject/wallet": "^5.6.2", "ajv": "8.11.0", "ajv-errors": "^3.0.0", "ajv-formats": "^2.1.1", "cross-fetch": "^3.1.6", "json-to-graphql-query": "^2.2.4", "lodash.set": "^4.3.2", "starknet": "^6.21.0", "viem": "^2.55.11" } }, "sha512-/c/0BTHhq9vGpsP600SUvGdCtnjggiZe8oCK2I117fudmpjF6Cd+bwD7PDUsrqUB7CklXfYmzRZ+ttahGZprmA=="],
+    "@snapshot-labs/snapshot.js": ["@snapshot-labs/snapshot.js@0.17.1", "", { "dependencies": { "@ethersproject/abi": "^5.6.4", "@ethersproject/address": "^5.6.1", "@ethersproject/bignumber": "^5.7.0", "@ethersproject/bytes": "^5.6.1", "@ethersproject/contracts": "^5.6.2", "@ethersproject/hash": "^5.7.0", "@ethersproject/providers": "^5.6.8", "@ethersproject/units": "^5.7.0", "@ethersproject/wallet": "^5.6.2", "ajv": "8.11.0", "ajv-errors": "^3.0.0", "ajv-formats": "^2.1.1", "cross-fetch": "^3.1.6", "json-to-graphql-query": "^2.2.4", "lodash.set": "^4.3.2", "starknet": "^6.21.0", "viem": "^2.55.11" } }, "sha512-S5YY+Q0fkISSveON8MfYS+5mV46B3gurwwsZXOLcAk7MU677w3GPuZjo8Qtzn5a7Y2n/QJu0PwQWCkiLiwz0Dw=="],
 
     "@snapshot-labs/sx": ["@snapshot-labs/sx@workspace:packages/sx.js"],
 


### PR DESCRIPTION
Fixes #2324

Attribute every sequencer RPC request to `client=sequencer` instead of `client=none`.

The issue names one unlabelled call site (the Starknet provider). There are four: signature verification, space controller resolution and space URI resolution also hand snapshot.js a `broviderUrl` with no client. `starknet_call` — the method the issue proposes to verify against — comes from signature verification, not from the provider helper, so labelling only the provider helper would have left that metric unchanged.

snapshot.js 0.17.1 applies `clientName` in the ethers, starknet.js and viem transports alike, so one shared options object covers all four. That also makes the locally built EVM provider redundant: no EVM network has a `broviderId`, and the timeout, gzip and chain-id arguments already match snapshot.js's own.

The lockfile resolved snapshot.js to 0.17.0, where `clientName` does not exist and would have been dropped silently.

## Test plan

- `bun run test:unit` in `apps/sequencer` — new test asserts both the EVM and Starknet provider URLs carry `?client=sequencer`
- After deploy, `sum by (client) (rate(rpc_request_count{client=~"sequencer|none"}[1h]))` should show `sequencer` rise and `none` fall by the same amount