### PR TITLE
fix(ui): don't flash the ENS owner notice while the owner check is pending

### DIFF
--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -116,6 +116,7 @@ export function useSpaceSettings(space: Ref<Space>) {
 
   const loading = ref(true);
   const isModifiedEvaluating = ref(false);
+  const isOwnerEvaluating = ref(false);
 
   const network = computed(() => getNetwork(space.value.network));
 
@@ -136,7 +137,7 @@ export function useSpaceSettings(space: Ref<Space>) {
       return compareAddresses(owner, account);
     },
     false,
-    { lazy: true }
+    { lazy: true, evaluating: isOwnerEvaluating }
   );
   const isAdmin = computed(() => {
     if (!offchainNetworks.includes(space.value.network)) return false;
@@ -1106,6 +1107,7 @@ export function useSpaceSettings(space: Ref<Space>) {
     ),
     isController,
     isOwner,
+    isOwnerEvaluating,
     isAdmin,
     canModifySettings,
     form,

--- a/apps/ui/src/views/Space/Settings.vue
+++ b/apps/ui/src/views/Space/Settings.vue
@@ -22,6 +22,7 @@ const {
   isModified,
   isController,
   isOwner,
+  isOwnerEvaluating,
   isAdmin,
   canModifySettings,
   form,
@@ -638,7 +639,9 @@ watchEffect(() => setTitle(`Edit settings - ${props.space.name}`));
           the name's owner
         </UiMessage>
         <UiMessage
-          v-else-if="isOffchainNetwork && isController && !isOwner"
+          v-else-if="
+            isOffchainNetwork && isController && !isOwner && !isOwnerEvaluating
+          "
           type="danger"
           class="mb-3"
         >


### PR DESCRIPTION
### Summary

Open **Settings → Controller** on a space you own and a red warning flashes for about a second, then disappears on its own:

> Controller can only be edited by the ENS owner

You *are* the ENS owner — that's why it goes away.

The owner check is an on-chain ENS lookup, and while it's in flight the app treats the answer as "no". The controller check finishes much earlier, so there's a brief window where the app thinks "controller, but not owner" — exactly the condition that shows the warning.

It now waits for the lookup to finish before deciding. Permissions are unchanged: the edit button was already disabled while the check runs.

### How to test

Same page, same space, both links. `?as=` signs you in as the controller in guest mode, so you don't need the wallet.

**Before** → https://testnet.snapshot.org/#/s-tn:%E2%9A%A1space.eth/settings/controller?as=0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6

**After** → https://deploy-preview-2332--snapshot-testnet.netlify.app/#/s-tn:%E2%9A%A1space.eth/settings/controller?as=0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6

Hard-reload each and watch the space just above the controller address:

- **Before** — red warning appears, then vanishes on its own (~820ms).
- **After** — nothing appears; the page settles identically.

Throttle to Slow 3G if you miss it. A genuine non-owner still gets the warning — it just waits for the check, then stays.

### Screenshots

**Before** — shown to the ENS owner while the lookup is still in flight:

<img width="1440" height="900" alt="0-BEFORE-real-timing-724ms-window" src="https://github.com/user-attachments/assets/83330621-7a82-404f-8e6f-985e10d3fba5" />
