### PR TITLE
refactor: remove deprecated micro-starknet from api and sx-starknet contracts

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,7 +25,6 @@
     "dotenv": "^16.0.1",
     "express": "^4.21.2",
     "graphql": "^16.11.0",
-    "micro-starknet": "^0.2.3",
     "pino": "^9.9.0",
     "pino-pretty": "^13.1.1",
     "starknet": "7.6.4",

--- a/apps/api/src/common/utils.ts
+++ b/apps/api/src/common/utils.ts
@@ -1,6 +1,5 @@
 import { faker } from '@faker-js/faker';
 import { getExecutionData, utils } from '@snapshot-labs/sx';
-import { poseidonHashMany } from 'micro-starknet';
 import { hash } from 'starknet';
 import { keccak256 } from 'viem';
 import { Network, Proposal, ScoresTick } from '../../.checkpoint/models';
@@ -132,7 +131,7 @@ export function getExecutionHash({
     return keccak256(data.executionParams[0] as `0x${string}`);
   }
 
-  return `0x${poseidonHashMany(data.executionParams.map(v => BigInt(v))).toString(16)}`;
+  return hash.computePoseidonHashOnElements(data.executionParams);
 }
 
 export function getSpaceDecimals(decimals: number[]) {

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,6 @@
         "dotenv": "^16.0.1",
         "express": "^4.21.2",
         "graphql": "^16.11.0",
-        "micro-starknet": "^0.2.3",
         "pino": "^9.9.0",
         "pino-pretty": "^13.1.1",
         "starknet": "7.6.4",
@@ -459,7 +458,6 @@
         "ethers": "^6.13.2",
         "forge-std": "github:foundry-rs/forge-std#v1.9.1",
         "hardhat": "^2.17.2",
-        "micro-starknet": "^0.2.3",
         "starknet": "7.6.4",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.6",
@@ -3880,8 +3878,6 @@
 
     "micro-packed": ["micro-packed@0.7.3", "", { "dependencies": { "@scure/base": "~1.2.5" } }, "sha512-2Milxs+WNC00TRlem41oRswvw31146GiSaoCT7s3Xi2gMUglW5QBeqlQaZeHr5tJx9nm3i57LNXPqxOOaWtTYg=="],
 
-    "micro-starknet": ["micro-starknet@0.2.3", "", { "dependencies": { "@noble/curves": "~1.0.0", "@noble/hashes": "~1.3.0" } }, "sha512-6XBcC+GerlwJSR4iA0VaeXtS2wrayWFcA4PEzrJPMuFmWCaUtuGIq5K/DB5F/XgnL54/zl2Bxo690Lj7mYVA8A=="],
-
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
@@ -5902,10 +5898,6 @@
 
     "micro-packed/@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
-    "micro-starknet/@noble/curves": ["@noble/curves@1.0.0", "", { "dependencies": { "@noble/hashes": "1.3.0" } }, "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw=="],
-
-    "micro-starknet/@noble/hashes": ["@noble/hashes@1.3.3", "", {}, "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA=="],
-
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "minipass-collect/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
@@ -6849,8 +6841,6 @@
     "mcp/express/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "mcp/express/type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
-
-    "micro-starknet/@noble/curves/@noble/hashes": ["@noble/hashes@1.3.0", "", {}, "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg=="],
 
     "mocha/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 

--- a/contracts/sx-starknet/package.json
+++ b/contracts/sx-starknet/package.json
@@ -41,7 +41,6 @@
     "ethers": "^6.13.2",
     "forge-std": "github:foundry-rs/forge-std#v1.9.1",
     "hardhat": "^2.17.2",
-    "micro-starknet": "^0.2.3",
     "starknet": "7.6.4",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6"

--- a/contracts/sx-starknet/tests/eth-tx-auth.test.ts
+++ b/contracts/sx-starknet/tests/eth-tx-auth.test.ts
@@ -4,10 +4,10 @@ import dotenv from 'dotenv';
 import { Contract as EthContract } from 'ethers';
 import { config, ethers } from 'hardhat';
 import { HttpNetworkConfig } from 'hardhat/types';
-import { poseidonHashMany } from 'micro-starknet';
 import {
   CairoCustomEnum,
   CallData,
+  hash,
   selector,
   Account as StarknetAccount,
   Contract as StarknetContract,
@@ -228,9 +228,9 @@ describe('Ethereum Transaction Authenticator', function () {
     });
 
     // Commit hash of payload to the Starknet Commit L1 contract
-    const proposalCommit = `0x${poseidonHashMany(
-      proposeCommitPreImage.map(v => BigInt(v))
-    ).toString(16)}`;
+    const proposalCommit = hash.computePoseidonHashOnElements(
+      proposeCommitPreImage
+    );
     console.log('Proposal commit: ', proposalCommit);
 
     console.log('Committing proposal on L1...');
@@ -274,9 +274,8 @@ describe('Ethereum Transaction Authenticator', function () {
     });
 
     // Commit hash of payload to the Starknet Commit L1 contract
-    const updateCommit = `0x${poseidonHashMany(
-      updateCommitPreImage.map(v => BigInt(v))
-    ).toString(16)}`;
+    const updateCommit =
+      hash.computePoseidonHashOnElements(updateCommitPreImage);
 
     console.log('Update commit: ', updateCommit);
 
@@ -319,9 +318,7 @@ describe('Ethereum Transaction Authenticator', function () {
     });
 
     // Commit hash of payload to the Starknet Commit L1 contract
-    const voteCommit = `0x${poseidonHashMany(
-      voteCommitPreImage.map(v => BigInt(v))
-    ).toString(16)}`;
+    const voteCommit = hash.computePoseidonHashOnElements(voteCommitPreImage);
 
     console.log('Vote commit: ', voteCommit);
 
@@ -373,9 +370,9 @@ describe('Ethereum Transaction Authenticator', function () {
     });
 
     // Commit hash of payload to the Starknet Commit L1 contract
-    const proposalCommit = `0x${poseidonHashMany(
-      proposeCommitPreImage.map(v => BigInt(v))
-    ).toString(16)}`;
+    const proposalCommit = hash.computePoseidonHashOnElements(
+      proposeCommitPreImage
+    );
 
     console.log('Proposal commit: ', proposalCommit);
 
@@ -438,9 +435,8 @@ describe('Ethereum Transaction Authenticator', function () {
     });
 
     // Commit hash of payload to the Starknet Commit L1 contract
-    const updateCommit = `0x${poseidonHashMany(
-      updateCommitPreImage.map(v => BigInt(v))
-    ).toString(16)}`;
+    const updateCommit =
+      hash.computePoseidonHashOnElements(updateCommitPreImage);
 
     console.log('Update commit: ', updateCommit);
 
@@ -501,9 +497,7 @@ describe('Ethereum Transaction Authenticator', function () {
     });
 
     // Commit hash of payload to the Starknet Commit L1 contract
-    const voteCommit = `0x${poseidonHashMany(
-      voteCommitPreImage.map(v => BigInt(v))
-    ).toString(16)}`;
+    const voteCommit = hash.computePoseidonHashOnElements(voteCommitPreImage);
 
     console.log('Vote commit: ', voteCommit);
 
@@ -575,9 +569,9 @@ describe('Ethereum Transaction Authenticator', function () {
     });
 
     // Commit hash of payload to the Starknet Commit L1 contract
-    const proposalCommit = `0x${poseidonHashMany(
-      proposeCommitPreImage.map(v => BigInt(v))
-    ).toString(16)}`;
+    const proposalCommit = hash.computePoseidonHashOnElements(
+      proposeCommitPreImage
+    );
     console.log('Proposal commit: ', proposalCommit);
 
     console.log('Committing proposal on L1...');
@@ -637,9 +631,9 @@ describe('Ethereum Transaction Authenticator', function () {
     });
 
     // Commit hash of payload to the Starknet Commit L1 contract
-    const proposalCommit = `0x${poseidonHashMany(
-      proposeCommitPreImage.map(v => BigInt(v))
-    ).toString(16)}`;
+    const proposalCommit = hash.computePoseidonHashOnElements(
+      proposeCommitPreImage
+    );
     console.log('Proposal commit: ', proposalCommit);
 
     console.log('Committing proposal on L1 from another signer...');
@@ -705,9 +699,9 @@ describe('Ethereum Transaction Authenticator', function () {
     });
 
     // Commit hash of payload to the Starknet Commit L1 contract
-    const proposalCommit = `0x${poseidonHashMany(
-      proposeCommitPreImage.map(v => BigInt(v))
-    ).toString(16)}`;
+    const proposalCommit = hash.computePoseidonHashOnElements(
+      proposeCommitPreImage
+    );
     console.log('Proposal commit: ', proposalCommit);
 
     console.log('Committing proposal on L1...');
@@ -775,9 +769,9 @@ describe('Ethereum Transaction Authenticator', function () {
     });
 
     // Commit hash of payload to the Starknet Commit L1 contract
-    const proposalCommit = `0x${poseidonHashMany(
-      proposeCommitPreImage.map(v => BigInt(v))
-    ).toString(16)}`;
+    const proposalCommit = hash.computePoseidonHashOnElements(
+      proposeCommitPreImage
+    );
     console.log('Proposal commit: ', proposalCommit);
 
     console.log('Committing proposal on L1 from the correct signer...');


### PR DESCRIPTION
### Summary

Follow-up to #2319. `apps/api` and `contracts/sx-starknet` still depended on the deprecated `micro-starknet`, so it stayed in `bun.lock`. This swaps the remaining call sites to `hash.computePoseidonHashOnElements` from `starknet` (already a dependency in both) and drops the package for good.

Output is identical: `starknet` implements it as `toHex(poseidonHashMany(...))` on `@scure/starknet`, which is `micro-starknet` under its new name. No indexer re-sync needed.

### How to test

1. `bun install --frozen-lockfile` — `grep micro-starknet bun.lock` returns nothing.
2. `cd apps/api && bun run codegen && bun run lint && bun run test` — green.
3. `cd contracts/sx-starknet && bun run lint && bun run typecheck` — green.
4. Old vs new hash compared on ~5k random inputs + 32 edge cases (empty, ≥ field prime, negatives, malformed strings, long arrays) — 0 differences, including error behavior.