### PR TITLE
fix(ui): update network page calendar link

### DIFF
--- a/apps/ui/src/views/Network.vue
+++ b/apps/ui/src/views/Network.vue
@@ -18,7 +18,7 @@ const FAQ = [
   }
 ];
 
-const LINK = 'https://calendly.com/snapshot-labs/network-plan';
+const LINK = 'https://calendly.com/snapshotlabs/30min';
 
 const currentQuestion = ref();
 


### PR DESCRIPTION
### Summary

The "book a call" link on the network page (`/network`) still pointed to an old, no-longer-used Calendly link. Point it to the shared Snapshot Labs Calendly instead.

### How to test

1. Go to `/network` on the UI.
2. Click the calendar link/button and confirm it opens https://calendly.com/snapshotlabs/30min.