### PR TITLE
fix(ui): disable the edit button on raw execution transactions

### DIFF
--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -194,9 +194,22 @@ watch(
                 </template>
                 <template #right>
                   <div class="flex gap-3">
-                    <button type="button" @click="editTx(i)">
-                      <IH-pencil />
-                    </button>
+                    <UiTooltip
+                      :title="
+                        tx._type === 'raw'
+                          ? 'Editing raw transactions is not supported'
+                          : ''
+                      "
+                    >
+                      <button
+                        type="button"
+                        :disabled="tx._type === 'raw'"
+                        class="flex disabled:cursor-not-allowed disabled:opacity-40"
+                        @click="editTx(i)"
+                      >
+                        <IH-pencil />
+                      </button>
+                    </UiTooltip>
                     <button type="button" @click="removeTx(i)">
                       <IH-trash />
                     </button>


### PR DESCRIPTION
The pencil button on an execution transaction does nothing when the transaction is a raw one — no modal is bound to a `raw` state, so the click silently creates an unused property. It type-checks only because the app's tsconfig sets `noImplicitAny: false`, which suppresses the implicit-any index error (TS7053).

Raw transactions reach this list today by editing or duplicating a proposal whose osnap or safesnap execution decoded to raw. The button is disabled with an explanation rather than hidden, so on a list mixing raw and typed transactions the missing control does not read as a rendering glitch. Adding a raw-editing modal would be a feature rather than a fix.

## Test plan

1. Open http://localhost:8080/#/s:gnosis.eth/proposal/0x82c6f103d5fa8f12d8f60e377dd17f77fa5172ff6874f6cb7cae3dec833b7bf2 — its safeSnap batch on Ethereum holds 10 transactions with no `type`, so they decode as raw.
2. In the `...` menu, click **Duplicate proposal**.
3. The draft editor shows an Ethereum execution listing 10 `Raw transaction to …` rows. Their pencil is greyed out and hovering it explains why; on `master` the pencil looks active and clicking it does nothing.
4. Add a contract call from the execution toolbar and click its pencil: it is still active and the modal opens prefilled.
5. Reorder the rows by dragging, then hover the contract call's pencil — no tooltip, confirming the raw text is not carried over by node reuse.
