### PR TITLE
refactor: avoid implicit-any in queries

### DIFF
--- a/apps/ui/src/helpers/townhall/api.ts
+++ b/apps/ui/src/helpers/townhall/api.ts
@@ -1,4 +1,5 @@
 import { ApolloClient, InMemoryCache } from '@apollo/client/core';
+import { Receipt } from '@snapshot-labs/sx';
 import { HIGHLIGHT_URL } from '@/helpers/highlight';
 import { Category, Post, Vote } from '@/helpers/townhall/types';
 import { gql } from './gql';
@@ -309,6 +310,13 @@ export async function getResultsByRole(
     ...r,
     vote_count: Number(r.vote_count)
   }));
+}
+
+export function getEventData(receipt: Receipt, key: string) {
+  const event = receipt.result.events.find(event => event.key === key);
+  if (!event) throw new Error(`Event ${key} not found`);
+
+  return event.data;
 }
 
 export function newCategoryEventToEntry(event: NewCategoryEvent): Category {

--- a/apps/ui/src/queries/delegatees.ts
+++ b/apps/ui/src/queries/delegatees.ts
@@ -247,11 +247,15 @@ async function fetchSplitDelegationDelegatees(
     throw new Error('Failed to fetch delegatees');
   }
 
-  const body = await response.json();
+  const body: {
+    delegateTree: {
+      delegate: string;
+      delegatedPower: number;
+      weight: number;
+    }[];
+  } = await response.json();
 
-  const delegateesAddresses: string[] = body.delegateTree.map(
-    ({ delegate }) => delegate
-  );
+  const delegateesAddresses = body.delegateTree.map(({ delegate }) => delegate);
 
   const [names, ...delegatees] = await Promise.all([
     getNames(delegateesAddresses),

--- a/apps/ui/src/queries/townhall.ts
+++ b/apps/ui/src/queries/townhall.ts
@@ -12,6 +12,7 @@ import { SpaceType } from '@/composables/useTownhallSpace';
 import {
   getCategories,
   getCategory,
+  getEventData,
   getResultsByRole,
   getRoles,
   getSpace,
@@ -363,9 +364,7 @@ export function useCreateSpaceMutation() {
     onSuccess: data => {
       if (!data) return;
 
-      const { data: eventData } = data.result.events.find(
-        event => event.key === 'new_space'
-      );
+      const eventData = getEventData(data, 'new_space');
 
       const [spaceId]: [number] = eventData;
 
@@ -424,9 +423,7 @@ export function useCreateCategoryMutation({
     onSuccess: (data, variables) => {
       if (!data) return;
 
-      const { data: eventData } = data.result.events.find(
-        event => event.key === 'new_category'
-      );
+      const eventData = getEventData(data, 'new_category');
 
       const category = {
         ...newCategoryEventToEntry(eventData),
@@ -484,9 +481,7 @@ export function useEditCategoryMutation({
     onSuccess: (data, variables) => {
       if (!data) return;
 
-      const { data: eventData } = data.result.events.find(
-        event => event.key === 'edit_category'
-      );
+      const eventData = getEventData(data, 'edit_category');
 
       const category = {
         ...newCategoryEventToEntry(eventData),
@@ -603,9 +598,7 @@ export function useCreatePostMutation({
     onSuccess: async (data, body) => {
       if (!data) return;
 
-      const { data: eventData } = data.result.events.find(
-        event => event.key === 'new_post'
-      );
+      const eventData = getEventData(data, 'new_post');
 
       const post = { ...newPostEventToEntry(eventData), body };
 
@@ -729,9 +722,7 @@ export function useVoteMutation({
     onSuccess: async data => {
       if (!data) return;
 
-      const { data: event } = data.result.events.find(
-        event => event.key === 'new_vote'
-      );
+      const event = getEventData(data, 'new_vote');
 
       const vote = newVoteEventToEntry(event);
 

--- a/apps/ui/src/views/Townhall/Create.vue
+++ b/apps/ui/src/views/Townhall/Create.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getTopic } from '@/helpers/townhall/api';
+import { getEventData, getTopic } from '@/helpers/townhall/api';
 import { Space as TownhallSpace } from '@/helpers/townhall/types';
 import { getUserFacingErrorMessage, sleep } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
@@ -99,9 +99,7 @@ async function handleSubmit() {
     );
     if (!res) return;
 
-    const [spaceId, topicId] = res.result.events.find(
-      event => event.key === 'new_topic'
-    ).data;
+    const [spaceId, topicId] = getEventData(res, 'new_topic');
 
     while (true) {
       try {

--- a/packages/sx.js/src/clients/highlight/ethereum-sig.ts
+++ b/packages/sx.js/src/clients/highlight/ethereum-sig.ts
@@ -18,6 +18,7 @@ import {
   Envelope,
   HidePost,
   PinPost,
+  Receipt,
   RevokeRole,
   SetAlias,
   UnpinPost,
@@ -62,7 +63,7 @@ export class HighlightEthereumSigClient {
     return signer._signTypedData(domain, types, message);
   }
 
-  public async send(envelope: Envelope) {
+  public async send(envelope: Envelope): Promise<Receipt> {
     const { domain, message, primaryType, signer, signature } = envelope;
 
     const payload = {

--- a/packages/sx.js/src/clients/highlight/types.ts
+++ b/packages/sx.js/src/clients/highlight/types.ts
@@ -4,6 +4,12 @@ import { TOWNHALL_PERMISSIONS } from '../../highlightConstants';
 type PermissionLevel =
   (typeof TOWNHALL_PERMISSIONS)[keyof typeof TOWNHALL_PERMISSIONS];
 
+export type Receipt = {
+  result: {
+    events: { key: string; data: any }[];
+  };
+};
+
 export type Envelope = {
   type: 'HIGHLIGHT_ENVELOPE';
   domain: Required<TypedDataDomain>;

--- a/packages/sx.js/src/index.ts
+++ b/packages/sx.js/src/index.ts
@@ -6,3 +6,4 @@ export * from './strategies';
 export * from './networks';
 export * from './types';
 export * from './highlightConstants';
+export type { Receipt } from './clients/highlight/types';


### PR DESCRIPTION
### Summary

Fixes implicit any errors in src/queries.

The townhall errors came from `HighlightEthereumSigClient.send` in sx.js returning any. It now returns a Receipt type. Since find on typed events can return undefined, a small getEventData helper throws when the event is missing and replaces the inline lookups.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>