### PR TITLE
refactor: avoid implicit-any in networks

### DIFF
--- a/apps/ui/src/helpers/osnap/transactions.ts
+++ b/apps/ui/src/helpers/osnap/transactions.ts
@@ -74,7 +74,7 @@ type OSnapRawTransaction = OSnapBaseTransaction & {
   type: 'raw';
 };
 
-type OSnapTransaction =
+export type OSnapTransaction =
   | OSnapTransferFundsTransaction
   | OSnapTransferNFTTransaction
   | OSnapContractInteractionTransaction

--- a/apps/ui/src/networks/common/graphqlApi/index.ts
+++ b/apps/ui/src/networks/common/graphqlApi/index.ts
@@ -165,7 +165,7 @@ function formatMetadataTreasury(treasury: string): SpaceMetadataTreasury {
     return {
       name,
       address,
-      chainId: String(CHAIN_IDS[network])
+      chainId: String(CHAIN_IDS[network as keyof typeof CHAIN_IDS])
     };
   }
 
@@ -196,7 +196,7 @@ function formatDelegation(delegation: string): SpaceMetadataDelegation {
       apiType: api_type,
       apiUrl: api_url,
       contractAddress: address === 'null' ? null : address,
-      chainId: String(CHAIN_IDS[network])
+      chainId: String(CHAIN_IDS[network as keyof typeof CHAIN_IDS])
     };
   }
 
@@ -228,7 +228,7 @@ function formatDelegations(
       apiType: 'governor-subgraph',
       apiUrl,
       contractAddress,
-      chainId: String(CHAIN_IDS[space._indexer])
+      chainId: String(CHAIN_IDS[space._indexer as keyof typeof CHAIN_IDS])
     }
   ];
 }

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -1139,11 +1139,11 @@ export function createActions(
         })
       );
     },
-    followSpace: () => {},
-    unfollowSpace: () => {},
-    updateUser: () => {},
-    updateStatement: () => {},
-    setAlias: () => {},
-    revokeAlias: () => {}
+    followSpace: async () => {},
+    unfollowSpace: async () => {},
+    updateUser: async () => {},
+    updateStatement: async () => {},
+    setAlias: async () => {},
+    revokeAlias: async () => {}
   };
 }

--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -100,7 +100,7 @@ export function createConstants(
       }
     };
 
-  const SUPPORTED_STRATEGIES = {
+  const SUPPORTED_STRATEGIES: Record<string, boolean> = {
     ...(config.Strategies.Vanilla && {
       [config.Strategies.Vanilla]: true
     }),
@@ -118,7 +118,7 @@ export function createConstants(
     })
   };
 
-  const SUPPORTED_EXECUTORS = {
+  const SUPPORTED_EXECUTORS: Record<string, boolean> = {
     ...(config.ExecutionStrategies.SimpleQuorumAvatar && {
       SimpleQuorumAvatar: true
     }),

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -3,8 +3,8 @@ import { getRelayerInfo } from '@/helpers/mana';
 import { pin } from '@/helpers/pin';
 import { getProvider } from '@/helpers/provider';
 import { formatAddress } from '@/helpers/utils';
-import { Network } from '@/networks/types';
-import { NetworkID, Space } from '@/types';
+import { ExplorerUrlType, Network } from '@/networks/types';
+import { ChainId, NetworkID, Space } from '@/types';
 import { createActions } from './actions';
 import { createConstants } from './constants';
 import { METADATA } from './metadata';
@@ -83,7 +83,11 @@ export function createEvmNetwork(networkId: NetworkID): Network {
           }
         }, interval);
       }),
-    getExplorerUrl: (id, type, chainIdOverride) => {
+    getExplorerUrl: (
+      id: string,
+      type: ExplorerUrlType,
+      chainIdOverride?: ChainId
+    ) => {
       let dataType: 'tx' | 'address' | 'token' | 'block' = 'tx';
       if (type === 'token') {
         dataType = 'token';
@@ -95,7 +99,10 @@ export function createEvmNetwork(networkId: NetworkID): Network {
 
       if (dataType === 'address') id = formatAddress(id);
 
-      return `${networks[chainIdOverride ?? chainId].explorer.url}/${dataType}/${id}`;
+      const network =
+        networks[(chainIdOverride ?? chainId) as keyof typeof networks];
+
+      return `${network.explorer.url}/${dataType}/${id}`;
     }
   };
 

--- a/apps/ui/src/networks/offchain/api/index.ts
+++ b/apps/ui/src/networks/offchain/api/index.ts
@@ -67,7 +67,9 @@ import {
   ApiSpace,
   ApiStatement,
   ApiStrategy,
-  ApiVote
+  ApiVote,
+  OSnapPlugin,
+  ReadOnlyExecutionPlugin
 } from './types';
 
 const DEFAULT_AUTHENTICATOR = 'OffchainAuthenticator';
@@ -310,9 +312,11 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
 
   if (proposal.plugins.oSnap) {
     try {
+      const oSnap: OSnapPlugin = proposal.plugins.oSnap;
+
       executions = [
         ...executions,
-        ...proposal.plugins.oSnap.safes.map(safe => {
+        ...oSnap.safes.map(safe => {
           const chainId = Number(safe.network);
 
           return {
@@ -374,9 +378,12 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
   }
 
   if (proposal.plugins.readOnlyExecution) {
+    const readOnlyExecution: ReadOnlyExecutionPlugin =
+      proposal.plugins.readOnlyExecution;
+
     executions = [
       ...executions,
-      ...proposal.plugins.readOnlyExecution.safes.map(safe => {
+      ...readOnlyExecution.safes.map(safe => {
         return {
           strategyType: 'ReadOnlyExecution',
           safeName: safe.safeName,
@@ -841,7 +848,8 @@ export function createApi(
         filter.hasOwnProperty('category') ||
         filter.hasOwnProperty('network')
       ) {
-        const where = {};
+        const where: { search?: string; category?: string; network?: string } =
+          {};
         if (filter?.searchQuery) where['search'] = filter.searchQuery;
         if (filter?.category) where['category'] = filter.category;
         if (filter?.network && filter.network !== 'all') {

--- a/apps/ui/src/networks/offchain/api/types.ts
+++ b/apps/ui/src/networks/offchain/api/types.ts
@@ -1,4 +1,11 @@
-import { DelegationType, SpaceMetadataLabel, Theme, VoteType } from '@/types';
+import { OSnapTransaction } from '@/helpers/osnap/transactions';
+import {
+  DelegationType,
+  SpaceMetadataLabel,
+  Theme,
+  Transaction,
+  VoteType
+} from '@/types';
 import {
   OffchainProposalFragmentFragment,
   OffchainRelatedSpaceFragmentFragment,
@@ -7,6 +14,24 @@ import {
   OffchainStrategyFragmentFragment,
   OffchainVoteFragmentFragment
 } from './gql/graphql';
+
+export type OSnapPlugin = {
+  safes: {
+    network: string;
+    safeName: string;
+    safeAddress: string;
+    transactions: OSnapTransaction[];
+  }[];
+};
+
+export type ReadOnlyExecutionPlugin = {
+  safes: {
+    safeName: string;
+    safeAddress: string;
+    chainId: number;
+    transactions: Transaction[];
+  }[];
+};
 
 type Override<
   T,

--- a/apps/ui/src/networks/offchain/index.ts
+++ b/apps/ui/src/networks/offchain/index.ts
@@ -77,7 +77,8 @@ export function createOffchainNetwork(networkId: 's' | 's-tn'): Network {
       chainId?: ChainId
     ) => {
       chainId = chainId || l1ChainId;
-      const network = networks[chainId.toString()];
+      const network = networks[chainId.toString() as keyof typeof networks];
+      const isStarknet = 'starknet' in network;
 
       switch (type) {
         case 'transaction':
@@ -85,7 +86,7 @@ export function createOffchainNetwork(networkId: 's' | 's-tn'): Network {
             return network ? `${network.explorer.url}/tx/${id}` : '';
           }
 
-          if (network.starknet) return '';
+          if (isStarknet) return '';
 
           return `https://signator.io/ipfs/${id}`;
         case 'strategy':
@@ -93,7 +94,7 @@ export function createOffchainNetwork(networkId: 's' | 's-tn'): Network {
         case 'contract':
         case 'address':
           return network
-            ? `${network.explorer.url}/${network.starknet ? 'contract' : 'address'}/${formatAddress(id)}`
+            ? `${network.explorer.url}/${isStarknet ? 'contract' : 'address'}/${formatAddress(id)}`
             : '';
         case 'block':
           return network ? `${network.explorer.url}/block/${id}` : '';

--- a/apps/ui/src/networks/offchain/plugins.ts
+++ b/apps/ui/src/networks/offchain/plugins.ts
@@ -3,19 +3,9 @@ import {
   SafeSnapExecutionData
 } from '@/helpers/safesnap/transactions';
 import { compareAddresses } from '@/helpers/utils';
-import { Proposal, Transaction } from '@/types';
+import { Proposal } from '@/types';
 import { ExecutionInfo } from '../types';
-
-type ReadOnlyExecutionSafe = {
-  safeName: string;
-  safeAddress: string;
-  chainId: number;
-  transactions: Transaction[];
-};
-
-type ReadOnlyExecutionPlugin = {
-  safes: ReadOnlyExecutionSafe[];
-};
+import { ReadOnlyExecutionPlugin } from './api/types';
 
 // Can hold shapes the editor never produces: UMA modules, multiple batches, or
 // a legacy top-level transaction list with no module address at all.

--- a/apps/ui/src/networks/starknet/actions.ts
+++ b/apps/ui/src/networks/starknet/actions.ts
@@ -640,7 +640,7 @@ export function createActions(
         }))
       });
     },
-    vetoProposal: () => null,
+    vetoProposal: async () => null,
     transferOwnership: async (
       web3: any,
       connectorType: ConnectorType,
@@ -864,12 +864,12 @@ export function createActions(
         })
       );
     },
-    followSpace: () => {},
-    unfollowSpace: () => {},
+    followSpace: async () => {},
+    unfollowSpace: async () => {},
     setAlias: async () => {},
     revokeAlias: async () => {},
-    updateUser: () => {},
-    updateStatement: () => {},
+    updateUser: async () => {},
+    updateStatement: async () => {},
     updateSettingsRaw: () => {
       throw new Error('Not implemented');
     },

--- a/apps/ui/src/networks/starknet/constants.ts
+++ b/apps/ui/src/networks/starknet/constants.ts
@@ -63,7 +63,7 @@ export function createConstants(
       }
     };
 
-  const SUPPORTED_STRATEGIES = {
+  const SUPPORTED_STRATEGIES: Record<string, boolean> = {
     [config.Strategies.MerkleWhitelist]: true,
     [config.Strategies.ERC20Votes]: true,
     [config.Strategies.EVMSlotValue]: true,
@@ -83,7 +83,7 @@ export function createConstants(
     config.Strategies.OZVotesTrace208StorageProofV2
   ];
 
-  const SUPPORTED_EXECUTORS = {
+  const SUPPORTED_EXECUTORS: Record<string, boolean> = {
     EthRelayer: true
   };
 

--- a/apps/ui/src/networks/starknet/index.ts
+++ b/apps/ui/src/networks/starknet/index.ts
@@ -2,7 +2,7 @@ import { LibraryError } from 'starknet';
 import { getRelayerInfo } from '@/helpers/mana';
 import { pin } from '@/helpers/pin';
 import { formatAddress } from '@/helpers/utils';
-import { Network } from '@/networks/types';
+import { ExplorerUrlType, Network } from '@/networks/types';
 import { NetworkID, Space } from '@/types';
 import { createActions } from './actions';
 import { createConstants } from './constants';
@@ -45,10 +45,10 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
       constants.SUPPORTED_EXECUTORS[executor],
     pin,
     getSpaceController: async (space: Space) => space.controller,
-    getTransaction: txId => provider.getTransactionReceipt(txId),
+    getTransaction: (txId: string) => provider.getTransactionReceipt(txId),
     getRelayerInfo: (space: string, network: NetworkID) =>
       getRelayerInfo(space, network, provider),
-    waitForTransaction: txId => {
+    waitForTransaction: (txId: string) => {
       let retries = 0;
 
       return new Promise((resolve, reject) => {
@@ -113,7 +113,7 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
           }
         }, interval);
       }),
-    getExplorerUrl: (id, type) => {
+    getExplorerUrl: (id: string, type: ExplorerUrlType) => {
       let dataType: 'tx' | 'contract' | 'token' | 'block' = 'tx';
       if (type === 'token') {
         dataType = 'token';

--- a/apps/ui/src/networks/types.ts
+++ b/apps/ui/src/networks/types.ts
@@ -28,6 +28,14 @@ import {
 } from '@/types';
 
 export type PaginationOpts = { limit: number; skip?: number };
+export type ExplorerUrlType =
+  | 'transaction'
+  | 'address'
+  | 'contract'
+  | 'strategy'
+  | 'token'
+  | 'block';
+
 export type SpacesFilter = {
   controller?: string;
   id_in?: string[];
@@ -186,13 +194,13 @@ export type ReadOnlyNetworkActions = {
     web3: Web3Provider | Wallet,
     account: string,
     proposal: Proposal
-  );
+  ): Promise<any>;
   cancelProposal(
     web3: Web3Provider | Wallet,
     connectorType: ConnectorType,
     account: string,
     proposal: Proposal
-  );
+  ): Promise<any>;
   vote(
     web3: Web3Provider | Wallet,
     connectorType: ConnectorType,
@@ -208,30 +216,42 @@ export type ReadOnlyNetworkActions = {
     networkId: NetworkID,
     spaceId: string,
     from?: string
-  );
+  ): Promise<any>;
   unfollowSpace(
     web3: Web3Provider | Wallet,
     networkId: NetworkID,
     spaceId: string,
     from?: string
-  );
-  setAlias(web3: Web3Provider, alias: string);
-  revokeAlias(web3: Web3Provider | Wallet, alias: string);
-  updateUser(web3: Web3Provider | Wallet, user: User, from?: string);
+  ): Promise<any>;
+  setAlias(web3: Web3Provider, alias: string): Promise<any>;
+  revokeAlias(web3: Web3Provider | Wallet, alias: string): Promise<any>;
+  updateUser(
+    web3: Web3Provider | Wallet,
+    user: User,
+    from?: string
+  ): Promise<any>;
   updateStatement(
     web3: Web3Provider | Wallet,
     statement: Statement,
     from?: string
-  );
+  ): Promise<any>;
   transferOwnership(
     web3: Web3Provider,
     connectorType: ConnectorType,
     space: Space,
     owner: string
-  );
-  updateSettingsRaw(web3: Web3Provider, space: Space, settings: string);
-  createSpaceRaw(web3: Web3Provider, id: string, settings: string);
-  deleteSpace(web3: Web3Provider, space: Space);
+  ): Promise<any>;
+  updateSettingsRaw(
+    web3: Web3Provider,
+    space: Space,
+    settings: string
+  ): Promise<any>;
+  createSpaceRaw(
+    web3: Web3Provider,
+    id: string,
+    settings: string
+  ): Promise<any>;
+  deleteSpace(web3: Web3Provider, space: Space): Promise<any>;
   send(envelope: any): Promise<any>;
 };
 
@@ -264,10 +284,10 @@ export type NetworkActions = ReadOnlyNetworkActions & {
       executionDestinations: string[];
       metadata: SpaceMetadata;
     }
-  );
-  executeTransactions(web3: Web3Provider, proposal: Proposal);
-  executeQueuedProposal(web3: Web3Provider, proposal: Proposal);
-  vetoProposal(web3: Web3Provider, proposal: Proposal);
+  ): Promise<any>;
+  executeTransactions(web3: Web3Provider, proposal: Proposal): Promise<any>;
+  executeQueuedProposal(web3: Web3Provider, proposal: Proposal): Promise<any>;
+  vetoProposal(web3: Web3Provider, proposal: Proposal): Promise<any>;
   updateSettings(
     web3: Web3Provider,
     connectorType: ConnectorType,
@@ -282,7 +302,7 @@ export type NetworkActions = ReadOnlyNetworkActions & {
     votingDelay: number | null,
     minVotingDuration: number | null,
     maxVotingDuration: number | null
-  );
+  ): Promise<any>;
   getUpdateSettingsTransaction(
     space: Space,
     metadata: SpaceMetadata,
@@ -305,7 +325,7 @@ export type NetworkActions = ReadOnlyNetworkActions & {
     delegationContract: string,
     chainIdOverride?: ChainId,
     delegateesMetadata?: Record<string, any>
-  );
+  ): Promise<any>;
   getDelegatee(
     delegation: SpaceMetadataDelegation,
     delegator: string
@@ -451,17 +471,7 @@ export type NetworkHelpers = {
   waitForTransaction(txId: string): Promise<any>;
   waitForIndexing(txId: string, timeout?: number): Promise<boolean>;
   waitForSpace(spaceAddress: string, interval?: number): Promise<Space>;
-  getExplorerUrl(
-    id: string,
-    type:
-      | 'transaction'
-      | 'address'
-      | 'contract'
-      | 'strategy'
-      | 'token'
-      | 'block',
-    chainId?: ChainId
-  ): string;
+  getExplorerUrl(id: string, type: ExplorerUrlType, chainId?: ChainId): string;
 };
 
 type BaseNetwork = {


### PR DESCRIPTION
### Summary

Fixes implicit any errors in src/networks. Mostly small.

Notable:

- Action methods in networks/types.ts without a return type now declare `Promise<any>`, matching vote and send in the same file. Stub implementations in EVM and Starknet became async to satisfy that.
- `OSnapPlugin` and `ReadOnlyExecutionPlugin` types live in offchain/api/types.ts.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>