### PR TITLE
refactor: avoid implicit-any in composables

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -107,6 +107,7 @@
     "@types/lodash.kebabcase": "^4.1.9",
     "@types/lodash.set": "^4.3.9",
     "@types/node": "^24",
+    "@types/object-hash": "^3.0.6",
     "@types/qrcode": "^1.5.6",
     "@types/remarkable": "^2.0.4",
     "@types/turndown": "^5.0.6",

--- a/apps/ui/src/composables/useBalances.ts
+++ b/apps/ui/src/composables/useBalances.ts
@@ -52,7 +52,10 @@ export function useBalances({
         asset.contractAddress === ETH_CONTRACT
     );
 
-    const coingeckoAssetPlatform = COINGECKO_ASSET_PLATFORMS[chainId];
+    const coingeckoAssetPlatform =
+      COINGECKO_ASSET_PLATFORMS[
+        Number(chainId) as keyof typeof COINGECKO_ASSET_PLATFORMS
+      ];
 
     const coins = coingeckoAssetPlatform
       ? await getTokenPrices(

--- a/apps/ui/src/composables/useDelegates.ts
+++ b/apps/ui/src/composables/useDelegates.ts
@@ -18,7 +18,7 @@ type ApiDelegate = {
   id: string;
   user: string;
   delegatedVotes: string;
-  delegatedVotesRaw: string;
+  delegatedVotesRaw?: string;
   tokenHoldersRepresentedAmount: number;
 };
 
@@ -44,7 +44,7 @@ type DelegatesQueryFilter = {
   };
 };
 
-const DELEGATION_SUBGRAPHS = {
+const DELEGATION_SUBGRAPHS: Record<string, string> = {
   '1': 'https://subgrapher.snapshot.org/delegation/1',
   '10': 'https://subgrapher.snapshot.org/delegation/10',
   '56': 'https://subgrapher.snapshot.org/delegation/56',
@@ -251,7 +251,15 @@ export function useDelegates(
       throw new Error('Failed to fetch split delegation delegates');
     }
 
-    const body = await response.json();
+    const body: {
+      delegates: {
+        address: string;
+        votingPower: number;
+        delegatorCount: number;
+        percentOfDelegators: number;
+        percentOfVotingPower: number;
+      }[];
+    } = await response.json();
 
     return formatDelegates({
       delegates: body.delegates
@@ -296,7 +304,7 @@ export function useDelegates(
   async function getApeChainDelegationDelegates(
     filter: DelegatesQueryFilter
   ): Promise<Delegate[]> {
-    const CUSTOM_GOVERNANCES = {
+    const CUSTOM_GOVERNANCES: Record<string, string> = {
       33139: 'apechain',
       33111: 'curtis'
     };

--- a/apps/ui/src/composables/useMarkdownEditor.ts
+++ b/apps/ui/src/composables/useMarkdownEditor.ts
@@ -13,7 +13,7 @@ export function useMarkdownEditor(
   editorContainerRef: Ref<HTMLDivElement | null>,
   handler: ChangeHandler
 ) {
-  const shortcuts = {
+  const shortcuts: Record<string, () => void> = {
     b: bold,
     i: italic,
     k: link

--- a/apps/ui/src/composables/useNav/space.ts
+++ b/apps/ui/src/composables/useNav/space.ts
@@ -163,7 +163,7 @@ function getSpaceMainConfig(context: NavContext): NavConfig {
 
 export default {
   routeName: 'space',
-  isVisible: ({ route }) =>
+  isVisible: ({ route }: NavContext) =>
     !EXCLUDED_SUB_ROUTES.includes(String(route.matched[1]?.name)),
   getConfig(context: NavContext): NavConfig | null {
     if (!context.space) return null;

--- a/apps/ui/src/composables/useSettings.ts
+++ b/apps/ui/src/composables/useSettings.ts
@@ -70,9 +70,9 @@ export function useSettings() {
 
       result.forEach(({ name, value }) => {
         if (DEFAULT_LISTS_SETTINGS.hasOwnProperty(name)) {
-          lists.value[name] = value as string[];
+          lists.value[name as LISTS] = value as string[];
         } else if (DEFAULT_LIMITS_SETTINGS.hasOwnProperty(name)) {
-          limits.value[name] = Number(value);
+          limits.value[name as LIMITS] = Number(value);
         }
       });
 

--- a/apps/ui/src/composables/useSkin.ts
+++ b/apps/ui/src/composables/useSkin.ts
@@ -6,7 +6,7 @@ function hexToCssRgb(hex: string): string {
   return `${r},${g},${b}`;
 }
 
-const B64U_LOOKUP = {
+const B64U_LOOKUP: Record<string, string> = {
   '/': '_',
   _: '/',
   '+': '-',
@@ -38,7 +38,7 @@ export function useSkin() {
         acc[`--${colorName.replace('_color', '')}`] = hexToCssRgb(hex);
         return acc;
       },
-      {}
+      {} as Record<string, string>
     );
 
     if (colorVariables['--content']) {

--- a/apps/ui/src/composables/useSpaceAlerts.ts
+++ b/apps/ui/src/composables/useSpaceAlerts.ts
@@ -6,7 +6,7 @@ import {
 } from '@/helpers/constants';
 import { offchainNetworks } from '@/networks';
 import { useRelayerInfoQuery } from '@/queries/relayerInfo';
-import { Space } from '@/types';
+import { NetworkID, Space } from '@/types';
 
 const UPCOMING_PRO_ONLY_NETWORKS: readonly string[] = [
   '137' // Polygon
@@ -92,7 +92,9 @@ export function useSpaceAlerts(
       ),
       ...space.value.strategies_params.flatMap(strategy =>
         Array.isArray(strategy.params?.strategies)
-          ? strategy.params.strategies.map(param => String(param.network))
+          ? strategy.params.strategies.map((param: { network: unknown }) =>
+              String(param.network)
+            )
           : []
       )
     ]);
@@ -129,9 +131,11 @@ export function useSpaceAlerts(
   });
 
   const sigAuthenticatorAddresses = computed(() => {
-    const authenticators: Record<string, string | undefined> =
-      { ...evmNetworks, ...starknetNetworks }[space.value.network]
-        ?.Authenticators || {};
+    const networksConfig: Partial<
+      Record<NetworkID, { Authenticators: Record<string, string | undefined> }>
+    > = { ...evmNetworks, ...starknetNetworks };
+    const authenticators =
+      networksConfig[space.value.network]?.Authenticators || {};
 
     return [
       authenticators.EthSig,

--- a/apps/ui/src/composables/useSpaceSettings.ts
+++ b/apps/ui/src/composables/useSpaceSettings.ts
@@ -319,7 +319,7 @@ export function useSpaceSettings(space: Ref<Space>) {
 
   async function hasStrategyChanged(
     strategy: StrategyConfig,
-    previousParams: any,
+    previousParams: string[] | null,
     previousMetadata: any = {}
   ) {
     const metadata = strategy.generateMetadata
@@ -660,7 +660,9 @@ export function useSpaceSettings(space: Ref<Space>) {
     };
     const prunedSaveData: Partial<OffchainSpaceSettings> = clone(saveData);
     Object.entries(prunedSaveData).forEach(([key, value]) => {
-      if (value === null || value === '') delete prunedSaveData[key];
+      if (value === null || value === '') {
+        delete prunedSaveData[key as keyof OffchainSpaceSettings];
+      }
     });
     if (
       prunedSaveData.delegationPortal &&
@@ -681,7 +683,7 @@ export function useSpaceSettings(space: Ref<Space>) {
       } else {
         Object.entries(prunedSaveData.skinSettings).forEach(([key, value]) => {
           if (value === null || value === '') {
-            delete prunedSaveData.skinSettings?.[key];
+            delete prunedSaveData.skinSettings?.[key as keyof SkinSettings];
           }
         });
       }

--- a/apps/ui/src/composables/useWalletConnect.ts
+++ b/apps/ui/src/composables/useWalletConnect.ts
@@ -39,7 +39,10 @@ async function getConnector() {
 
 const connections: Ref<Record<string, ConnectionData | undefined>> = ref({});
 
-async function parseCall(chainId: number, call) {
+async function parseCall(
+  chainId: number,
+  call: { params: [{ to: string; data: string; value?: string }] }
+) {
   const params = call.params[0];
 
   const abi = await getABI(chainId, params.to);

--- a/apps/ui/src/composables/useWalletEns.ts
+++ b/apps/ui/src/composables/useWalletEns.ts
@@ -10,7 +10,7 @@ type ENSNames = Record<ENSName['name'], ENSName>;
 
 const MAX_ENS_NAME_LENGTH = 64;
 const DEFAULT_STATUS = 'AVAILABLE';
-const LOOKUP_CHAIN_IDS = {
+const LOOKUP_CHAIN_IDS: Partial<Record<NetworkID, string[]>> = {
   s: ['1', '109', '146'],
   's-tn': ['11155111', '157']
 };
@@ -105,7 +105,7 @@ export function useWalletEns(networkId: NetworkID) {
     const records: ENSNames = values.reduce((acc, name) => {
       acc[name] = { name, status: DEFAULT_STATUS };
       return acc;
-    }, {});
+    }, {} as ENSNames);
 
     validateNameLength(records);
     await validateUsedNames(records);
@@ -120,7 +120,7 @@ export function useWalletEns(networkId: NetworkID) {
 
     try {
       const records = await validateNames(
-        await getENSNames(web3.value.account, LOOKUP_CHAIN_IDS[networkId])
+        await getENSNames(web3.value.account, LOOKUP_CHAIN_IDS[networkId] ?? [])
       );
       ensNames.value.set(web3.value.account, records);
       hasError.value = false;

--- a/apps/ui/src/composables/useWeb3.ts
+++ b/apps/ui/src/composables/useWeb3.ts
@@ -1,6 +1,6 @@
 import { Web3Provider } from '@ethersproject/providers';
 import { formatUnits } from '@ethersproject/units';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import networksJson from '@snapshot-labs/snapshot.js/src/networks.json';
 import {
   LAST_USED_CONNECTOR_CACHE_KEY,
   RECENT_CONNECTOR
@@ -19,7 +19,12 @@ type Web3providerWithSafe = Web3Provider & {
   };
 };
 
-const defaultNetwork: any =
+const networks: Record<
+  string,
+  { chainId: ChainId; name: string; unknown?: boolean }
+> = networksJson;
+
+const defaultNetwork: string =
   import.meta.env.VITE_DEFAULT_NETWORK || Object.keys(networks)[0];
 
 const state = reactive({
@@ -106,7 +111,8 @@ export function useWeb3() {
 
     try {
       attachConnectorEvents(connector);
-      let network, accounts;
+      let network: { chainId: ChainId } | undefined;
+      let accounts: string[] = [];
       try {
         if (connector.id === 'gnosis' && web3.provider.safe) {
           const { chainId: safeChainId, safeAddress } = web3.provider.safe;
@@ -131,7 +137,7 @@ export function useWeb3() {
       }
       const acc = accounts.length > 0 ? accounts[0] : null;
 
-      if (acc) {
+      if (acc && network) {
         handleChainChanged(network.chainId);
         const usersStore = useUsersStore();
         try {
@@ -167,7 +173,7 @@ export function useWeb3() {
 
     if (!connector.provider.on) return;
 
-    connector.provider.on('accountsChanged', async accounts => {
+    connector.provider.on('accountsChanged', async (accounts: string[]) => {
       if (!accounts?.length) {
         logout(connector);
         return;
@@ -178,7 +184,7 @@ export function useWeb3() {
     });
 
     if (!STARKNET_CONNECTORS.includes(connector.type)) {
-      connector.provider.on('chainChanged', async chainId => {
+      connector.provider.on('chainChanged', async (chainId: string) => {
         handleChainChanged(parseInt(formatUnits(chainId, 0)));
       });
     }

--- a/apps/ui/src/composables/useWhiteLabel.ts
+++ b/apps/ui/src/composables/useWhiteLabel.ts
@@ -10,7 +10,7 @@ type WhiteLabelConfig = {
 
 // List of global paths, that should not be nested inside space scope
 // when redirecting from whitelabel to main app
-const GLOBAL_PATHS = { contacts: 'settings/contacts' };
+const GLOBAL_PATHS: Record<string, string> = { contacts: 'settings/contacts' };
 const DEFAULT_DOMAIN = import.meta.env.VITE_HOST || 'localhost';
 const WHITELABEL_MAPPING = import.meta.env.VITE_WHITELABEL_MAPPING;
 const domain = window.location.hostname;

--- a/apps/ui/src/shims.d.ts
+++ b/apps/ui/src/shims.d.ts
@@ -1,0 +1,5 @@
+declare module 'highlightjs-solidity' {
+  import { LanguageFn } from 'lowlight';
+
+  export const solidity: LanguageFn;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -393,6 +393,7 @@
         "@types/lodash.kebabcase": "^4.1.9",
         "@types/lodash.set": "^4.3.9",
         "@types/node": "^24",
+        "@types/object-hash": "^3.0.6",
         "@types/qrcode": "^1.5.6",
         "@types/remarkable": "^2.0.4",
         "@types/turndown": "^5.0.6",
@@ -2248,6 +2249,8 @@
     "@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
+
+    "@types/object-hash": ["@types/object-hash@3.0.6", "", {}, "sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w=="],
 
     "@types/pako": ["@types/pako@2.0.4", "", {}, "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw=="],
 


### PR DESCRIPTION
### Summary

Fixes implicit any errors in src/composables. Mostly small.

Notable:

- `useWeb3` types the snapshot.js networks map locally so it can add unknown chains.
- Split delegation delegates never had `delegatedVotesRaw`, so it is optional on `ApiDelegate` now.
- Added `@types/object-hash` and a shims.d.ts for `highlightjs-solidity`, which ships no types.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>