### PR TITLE
refactor: avoid implicit-any in Vue files

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -110,6 +110,7 @@
     "@types/object-hash": "^3.0.6",
     "@types/qrcode": "^1.5.6",
     "@types/remarkable": "^2.0.4",
+    "@types/remove-markdown": "^0.3.4",
     "@types/turndown": "^5.0.6",
     "@vitejs/plugin-vue": "^6.0.0",
     "@vue/test-utils": "^2.4.5",

--- a/apps/ui/src/components/App/Sidebar.vue
+++ b/apps/ui/src/components/App/Sidebar.vue
@@ -19,7 +19,7 @@ const followedSpacesStore = useFollowedSpacesStore();
       :delay="100"
       :delay-on-touch-only="true"
       :touch-start-threshold="35"
-      :item-key="i => i"
+      item-key="id"
       v-bind="{ animation: 200 }"
       class="space-y-3 p-2 no-scrollbar overscroll-contain overflow-auto pb-3"
     >

--- a/apps/ui/src/components/App/Topnav.vue
+++ b/apps/ui/src/components/App/Topnav.vue
@@ -15,7 +15,15 @@ const { logout, web3 } = useWeb3();
 const { toggleTheme, currentTheme } = useTheme();
 const { isWhiteLabel } = useWhiteLabel();
 
-const SEARCH_CONFIG = {
+const SEARCH_CONFIG: Record<
+  string,
+  {
+    defaultRoute: string;
+    searchRoute: string;
+    placeholder: string;
+    exclude?: string[];
+  }
+> = {
   space: {
     defaultRoute: 'space-proposals',
     searchRoute: 'space-proposals',
@@ -48,8 +56,8 @@ const user = computed(
 const cb = computed(() => getCacheHash(user.value.avatar));
 
 const searchConfig = computed(() => {
-  const rootName = route.matched[0]?.name || '';
-  const subRootName = route.matched[1]?.name || '';
+  const rootName = String(route.matched[0]?.name || '');
+  const subRootName = String(route.matched[1]?.name || '');
   const exclusions = SEARCH_CONFIG[rootName]?.exclude || [];
 
   if (SEARCH_CONFIG[rootName] && !exclusions.includes(subRootName)) {

--- a/apps/ui/src/components/Combobox.vue
+++ b/apps/ui/src/components/Combobox.vue
@@ -115,8 +115,8 @@ function getDisplayValue(value: T | null) {
               :placeholder="definition.examples?.[0]"
               :display-value="item => getDisplayValue(item as T)"
               @keydown.enter="() => (query = '')"
-              @change="e => (query = e.target.value)"
-              @focus="event => handleFocus(event, open)"
+              @change="event => (query = event.target.value)"
+              @focus="(event: FocusEvent) => handleFocus(event, open)"
             />
           </ComboboxButton>
           <ComboboxButton v-if="!inline" class="absolute right-3 bottom-[14px]">

--- a/apps/ui/src/components/CreateDeploymentProgress.vue
+++ b/apps/ui/src/components/CreateDeploymentProgress.vue
@@ -58,7 +58,7 @@ const connectorModalOpen = ref(false);
 const connectorModalConnectors = ref([] as ConnectorType[]);
 const connectorCallbackFn: Ref<((value: Connector | false) => void) | null> =
   ref(null);
-const txIds = ref({});
+const txIds = ref<Record<string, string>>({});
 const deployedExecutionStrategies = ref([] as StrategyConfig[]);
 const executionStrategiesDestinations = ref([] as string[]);
 

--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -69,6 +69,7 @@ function openModal(
 
 function editTx(index: number) {
   const tx = model.value[index];
+  if (tx._type === 'raw') return;
 
   editedTx.value = index;
   modalState.value[tx._type] = tx._form;

--- a/apps/ui/src/components/EditorVotingType.vue
+++ b/apps/ui/src/components/EditorVotingType.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
 const modalOpen = ref(false);
 
 const activeVotingType = computed<VoteTypeInfo>(
-  () => VOTING_TYPES_INFO[proposal.value.type]
+  () => VOTING_TYPES_INFO[proposal.value.type as keyof typeof VOTING_TYPES_INFO]
 );
 
 const hasMultipleVotingType = computed<boolean>(

--- a/apps/ui/src/components/FormController.vue
+++ b/apps/ui/src/components/FormController.vue
@@ -47,11 +47,10 @@ watch(formErrors, value => emit('errors', value));
   <UiContainerSettings :title="title" :description="description">
     <div class="s-box">
       <UiInputAddress
-        :model-value="model"
+        v-model="model"
         :error="formErrors.controller"
         :definition="definition"
         :required="true"
-        @update:model-value="v => (model = v)"
       />
     </div>
   </UiContainerSettings>

--- a/apps/ui/src/components/FormSpaceProposal.vue
+++ b/apps/ui/src/components/FormSpaceProposal.vue
@@ -86,7 +86,11 @@ watchEffect(() => {
         @click="isSelectValidationModalOpen = true"
       >
         <div>
-          {{ VALIDATION_TYPES_INFO[proposalValidation.name].label }}
+          {{
+            VALIDATION_TYPES_INFO[
+              proposalValidation.name as keyof typeof VALIDATION_TYPES_INFO
+            ].label
+          }}
         </div>
         <IH-chevron-down />
       </button>

--- a/apps/ui/src/components/FormSpaceVoting.vue
+++ b/apps/ui/src/components/FormSpaceVoting.vue
@@ -239,7 +239,12 @@ watchEffect(() => {
           class="s-input !flex flex-row justify-between items-center"
           @click="isSelectVotingTypeModalOpen = true"
         >
-          <div>{{ VOTING_TYPES_INFO[votingType].label }}</div>
+          <div>
+            {{
+              VOTING_TYPES_INFO[votingType as keyof typeof VOTING_TYPES_INFO]
+                .label
+            }}
+          </div>
           <IH-chevron-down />
         </button>
       </UiWrapperInput>
@@ -274,9 +279,9 @@ watchEffect(() => {
           <div>
             {{
               VALIDATION_TYPES_INFO[
-                voteValidation.name === 'any'
+                (voteValidation.name === 'any'
                   ? 'any-voting'
-                  : voteValidation.name
+                  : voteValidation.name) as keyof typeof VALIDATION_TYPES_INFO
               ].label
             }}
           </div>

--- a/apps/ui/src/components/FormStrategiesStrategyActive.vue
+++ b/apps/ui/src/components/FormStrategiesStrategyActive.vue
@@ -1,12 +1,9 @@
 <script setup lang="ts">
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { networks, SnapshotNetwork } from '@/helpers/networks';
 import { getUrl, shorten } from '@/helpers/utils';
 import { getNetwork, offchainNetworks } from '@/networks';
 import { StrategyConfig } from '@/networks/types';
 import { NetworkID } from '@/types';
-
-type Networks = typeof networks;
-type NetworkDetails = Networks[keyof Networks];
 
 type Strategy = Pick<
   StrategyConfig,
@@ -34,7 +31,7 @@ defineEmits<{
 
 const network = computed(() => getNetwork(props.networkId));
 const hasAddress = computed(() => props.strategy.address.startsWith('0x'));
-const strategyNetworkDetails = computed<NetworkDetails>(() => {
+const strategyNetworkDetails = computed<SnapshotNetwork | null>(() => {
   if (!props.strategy.chainId) return null;
   if (!(props.strategy.chainId in networks)) return null;
 

--- a/apps/ui/src/components/MessagePropositionPower.vue
+++ b/apps/ui/src/components/MessagePropositionPower.vue
@@ -25,7 +25,8 @@ const offchainErrors = computed(() => ({
   basic: (strategy: Strategy) =>
     `You need at least ${_n(strategy.params.minScore, 'compact')} ${prettySymbolsList(
       strategy.params.strategies.map(
-        s => s.params.symbol || props.propositionPower.symbol
+        (s: { params: { symbol?: string } }) =>
+          s.params.symbol || props.propositionPower.symbol
       )
     )} to ${actionName.value}.`,
   'passport-gated': (strategy: Strategy) =>
@@ -34,22 +35,31 @@ const offchainErrors = computed(() => ({
     `You need to be attested by Karma EAS to ${actionName.value}.`
 }));
 
-const LINKS = {
+type OffchainValidationName = keyof typeof offchainErrors.value;
+
+const LINKS: Partial<
+  Record<OffchainValidationName, { label: string; url: string }>
+> = {
   'passport-gated': {
     label: 'Gitcoin Passport',
     url: 'https://passport.gitcoin.co/#/dashboard'
   }
-} as const;
+};
 
 const offchainStrategy = computed(() => {
-  const name = props.propositionPower.strategies[0].name;
+  const strategy = props.propositionPower.strategies[0];
+  const name = strategy.name as OffchainValidationName;
 
   if (offchainErrors.value[name]) {
-    return props.propositionPower.strategies[0];
+    return { ...strategy, name };
   }
 
   return null;
 });
+
+const offchainLink = computed(() =>
+  offchainStrategy.value ? LINKS[offchainStrategy.value.name] : undefined
+);
 
 function prettySymbolsList(symbols: string[]): string {
   return prettyConcat(Array.from(new Set(symbols)));
@@ -60,11 +70,8 @@ function prettySymbolsList(symbols: string[]): string {
   <UiAlert type="error" v-bind="$attrs">
     <template v-if="offchainStrategy">
       {{ offchainErrors[offchainStrategy.name](offchainStrategy) }}
-      <AppLink
-        v-if="LINKS[offchainStrategy.name]"
-        :to="LINKS[offchainStrategy.name].url"
-      >
-        {{ LINKS[offchainStrategy.name].label }}
+      <AppLink v-if="offchainLink" :to="offchainLink.url">
+        {{ offchainLink.label }}
         <IH-arrow-sm-right class="inline-block -rotate-45" />
       </AppLink>
     </template>

--- a/apps/ui/src/components/Modal/Delegate.vue
+++ b/apps/ui/src/components/Modal/Delegate.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { getAddress } from '@ethersproject/address';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { h, VNode } from 'vue';
 import { DELEGATE_REGISTRY_STRATEGIES } from '@/helpers/constants';
 import {
   isValidDelegation,
   ValidSpaceMetadataDelegation
 } from '@/helpers/delegation';
+import { networks } from '@/helpers/networks';
 import { clone, compareAddresses, getUrl } from '@/helpers/utils';
 import {
   EVM_CONNECTORS,
@@ -135,10 +135,12 @@ const chainIds = computed(() => {
     .flatMap(params => {
       return [
         params.network,
-        ...(params.params?.strategies?.flatMap(p => [
-          p.network,
-          p.params?.network
-        ]) || [])
+        ...(params.params?.strategies?.flatMap(
+          (p: { network?: unknown; params?: { network?: unknown } }) => [
+            p.network,
+            p.params?.network
+          ]
+        ) || [])
       ];
     })
     .filter(Boolean)

--- a/apps/ui/src/components/Modal/Deposit.vue
+++ b/apps/ui/src/components/Modal/Deposit.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import QRCode from 'qrcode';
 import { getGenericExplorerUrl } from '@/helpers/generic';
+import { networks } from '@/helpers/networks';
 import { formatAddress, getUrl } from '@/helpers/utils';
 
 const props = defineProps<{
@@ -11,7 +11,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'close');
+  (e: 'close'): void;
 }>();
 
 const { copy, copied } = useClipboard();

--- a/apps/ui/src/components/Modal/RoleConfig.vue
+++ b/apps/ui/src/components/Modal/RoleConfig.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'add', config: RoleConfig);
+  (e: 'add', config: RoleConfig): void;
   (e: 'close'): void;
 }>();
 

--- a/apps/ui/src/components/Modal/SelectValidation.vue
+++ b/apps/ui/src/components/Modal/SelectValidation.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+type EnumOption = { const: string; title: string };
+
 type ValidationDetails = {
   key:
     | 'any'
@@ -114,10 +116,10 @@ const definition = computed(() => {
 
     if (updated.properties[key].anyOf) {
       updated.properties[key].enum = updated.properties[key].anyOf.map(
-        item => item.const
+        (item: EnumOption) => item.const
       );
       updated.properties[key].options = updated.properties[key].anyOf.map(
-        item => ({
+        (item: EnumOption) => ({
           id: item.const,
           name: item.title
         })
@@ -128,9 +130,9 @@ const definition = computed(() => {
     if (updated.properties[key].items?.anyOf) {
       updated.properties[key].items.enum = updated.properties[
         key
-      ].items.anyOf.map(item => item.const);
+      ].items.anyOf.map((item: EnumOption) => item.const);
       updated.properties[key].options = updated.properties[key].items.anyOf.map(
-        item => ({
+        (item: EnumOption) => ({
           id: item.const,
           name: item.title
         })
@@ -188,14 +190,20 @@ function handleSelect(validationDetails: ValidationDetails) {
 
   if (selectedValidation.value.key === 'basic') {
     if (form.value.strategies) {
-      customStrategies.value = form.value.strategies.map(strategy => ({
-        id: crypto.randomUUID(),
-        chainId: strategy.network,
-        address: strategy.name,
-        name: strategy.name,
-        paramsDefinition: null,
-        params: clone(strategy.params)
-      }));
+      customStrategies.value = form.value.strategies.map(
+        (strategy: {
+          network: string;
+          name: string;
+          params: Record<string, any>;
+        }) => ({
+          id: crypto.randomUUID(),
+          chainId: strategy.network,
+          address: strategy.name,
+          name: strategy.name,
+          paramsDefinition: null,
+          params: clone(strategy.params)
+        })
+      );
     }
 
     form.value.strategies ??= [];
@@ -207,9 +215,15 @@ function handleSelect(validationDetails: ValidationDetails) {
     // Remove unsupported options
     form.value.stamps =
       definition.value.properties?.stamps?.options
-        ?.filter(option => form.value.stamps.includes(option.id))
-        ?.map(option => option.id) ?? form.value.stamps;
+        ?.filter((option: { id: string }) =>
+          form.value.stamps.includes(option.id)
+        )
+        ?.map((option: { id: string }) => option.id) ?? form.value.stamps;
   }
+}
+
+function getValidationInfo(key: ValidationDetails['key']) {
+  return VALIDATION_TYPES_INFO[key === 'any' ? 'any-voting' : key];
 }
 
 function handleApply() {
@@ -344,11 +358,7 @@ watch(
           <div class="flex items-center gap-2 overflow-hidden">
             <h4
               class="text-skin-link truncate"
-              v-text="
-                VALIDATION_TYPES_INFO[
-                  validation.key === 'any' ? `any-${type}` : validation.key
-                ].label
-              "
+              v-text="getValidationInfo(validation.key).label"
             />
             <UiPill
               v-if="validation.key === 'passport-gated'"
@@ -356,13 +366,7 @@ watch(
               label="Beta"
             />
           </div>
-          <div
-            v-text="
-              VALIDATION_TYPES_INFO[
-                validation.key === 'any' ? `any-${type}` : validation.key
-              ].description
-            "
-          />
+          <div v-text="getValidationInfo(validation.key).description" />
         </div>
       </UiSelector>
     </div>

--- a/apps/ui/src/components/Modal/SelectVotingType.vue
+++ b/apps/ui/src/components/Modal/SelectVotingType.vue
@@ -25,6 +25,10 @@ const availableVotingTypes = computed(() =>
   props.withAny ? (['any', ...props.votingTypes] as const) : props.votingTypes
 );
 
+function getVotingTypeInfo(type: AvailableVotingTypes) {
+  return VOTING_TYPES_INFO[type as keyof typeof VOTING_TYPES_INFO];
+}
+
 function handleSelect(type: AvailableVotingTypes) {
   emit('save', type);
   emit('close');
@@ -47,15 +51,15 @@ function handleSelect(type: AvailableVotingTypes) {
           <div class="flex items-center gap-2">
             <h4
               class="text-skin-link inline"
-              v-text="VOTING_TYPES_INFO[type].label"
+              v-text="getVotingTypeInfo(type).label"
             />
             <UiPill
-              v-if="VOTING_TYPES_INFO[type].isBeta"
+              v-if="getVotingTypeInfo(type).isBeta"
               variant="secondary"
               label="Beta"
             />
           </div>
-          <div v-text="VOTING_TYPES_INFO[type].description" />
+          <div v-text="getVotingTypeInfo(type).description" />
         </div>
       </UiSelector>
     </div>

--- a/apps/ui/src/components/Modal/StakeToken.vue
+++ b/apps/ui/src/components/Modal/StakeToken.vue
@@ -6,16 +6,17 @@ import { clone } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
 import { Transaction } from '@/types';
 
-const STAKING_CONTRACTS = {
-  1: {
-    address: '0xae7ab96520de3a18e5e111b5eaab095312d7fe84',
-    referral: '0x01e8CEC73B020AB9f822fD0dee3Aa4da2fe39e38'
-  },
-  11155111: {
-    address: '0x3e3FE7dBc6B4C189E7128855dD526361c49b40Af',
-    referral: '0x8C28Cf33d9Fd3D0293f963b1cd27e3FF422B425c'
-  }
-};
+const STAKING_CONTRACTS: Record<string, { address: string; referral: string }> =
+  {
+    1: {
+      address: '0xae7ab96520de3a18e5e111b5eaab095312d7fe84',
+      referral: '0x01e8CEC73B020AB9f822fD0dee3Aa4da2fe39e38'
+    },
+    11155111: {
+      address: '0x3e3FE7dBc6B4C189E7128855dD526361c49b40Af',
+      referral: '0x8C28Cf33d9Fd3D0293f963b1cd27e3FF422B425c'
+    }
+  };
 
 const DEFAULT_FORM_STATE = {
   to: '',

--- a/apps/ui/src/components/Modal/Transaction.vue
+++ b/apps/ui/src/components/Modal/Transaction.vue
@@ -14,7 +14,7 @@ const DEFAULT_FORM_STATE = {
   to: '',
   abi: [] as JsonFragment[],
   method: '',
-  args: {},
+  args: {} as Record<string, string>,
   amount: ''
 };
 
@@ -129,8 +129,7 @@ function handlePickerSelect(value: string) {
 
   if (!pickerField.value) return;
 
-  const isTopLevel = pickerField.value === 'to';
-  if (isTopLevel) form[pickerField.value] = value;
+  if (pickerField.value === 'to') form.to = value;
   else form.args[pickerField.value] = value;
 }
 

--- a/apps/ui/src/components/Modal/Vote.vue
+++ b/apps/ui/src/components/Modal/Vote.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { useQueryClient } from '@tanstack/vue-query';
 import { LocationQueryValue } from 'vue-router';
+import { networks } from '@/helpers/networks';
 import { _n, getChoiceText, getFormattedVotingPower } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
 import { getNetwork, offchainNetworks, starknetNetworks } from '@/networks';

--- a/apps/ui/src/components/PickerToken.vue
+++ b/apps/ui/src/components/PickerToken.vue
@@ -54,7 +54,7 @@ function handlePick(token: Token) {
   emit('pick', token.contractAddress);
 }
 
-async function fetchCustomToken(address) {
+async function fetchCustomToken(address: string) {
   if (props.assets.find(asset => asset.contractAddress === address)) return;
 
   if (getChainIdKind(props.network) !== 'evm') {

--- a/apps/ui/src/components/ProposalValidationConfigurator.vue
+++ b/apps/ui/src/components/ProposalValidationConfigurator.vue
@@ -46,13 +46,16 @@ const isSelectValidationModalOpen = ref(false);
 const initialValidation = ref<Validation>();
 
 const availableValidations = computed(() => {
-  return Object.keys(PROPOSAL_VALIDATIONS).reduce((acc, id) => {
-    acc[id] = {
-      ...VALIDATION_TYPES_INFO[id],
-      ...PROPOSAL_VALIDATIONS[id]
-    };
-    return acc;
-  }, {} as ValidationRecords);
+  return (Object.keys(PROPOSAL_VALIDATIONS) as ValidationDetailId[]).reduce(
+    (acc, id) => {
+      acc[id] = {
+        ...VALIDATION_TYPES_INFO[id],
+        ...PROPOSAL_VALIDATIONS[id]
+      };
+      return acc;
+    },
+    {} as ValidationRecords
+  );
 });
 
 function handleClick(validationId: string) {
@@ -61,7 +64,7 @@ function handleClick(validationId: string) {
     params: {}
   };
 
-  if (PROPOSAL_VALIDATIONS[validationId].withoutParams) {
+  if (PROPOSAL_VALIDATIONS[validationId as ValidationDetailId].withoutParams) {
     validation.value = selectedValidation;
     return;
   }

--- a/apps/ui/src/components/ProposalVote.vue
+++ b/apps/ui/src/components/ProposalVote.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { SUPPORTED_VOTING_TYPES } from '@/helpers/constants';
+import { networks } from '@/helpers/networks';
 import { _t, getChoiceText } from '@/helpers/utils';
 import { getNetwork, offchainNetworks } from '@/networks';
 import { Proposal as ProposalType } from '@/types';

--- a/apps/ui/src/components/TownhallTopicsList.vue
+++ b/apps/ui/src/components/TownhallTopicsList.vue
@@ -16,7 +16,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'endReached');
+  (e: 'endReached'): void;
 }>();
 
 const currentLimit = computed(() => {

--- a/apps/ui/src/components/Ui/BadgeNetwork.vue
+++ b/apps/ui/src/components/Ui/BadgeNetwork.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { networks } from '@/helpers/networks';
 import { getUrl } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
 import { ChainId, NetworkID } from '@/types';

--- a/apps/ui/src/components/Ui/InputAddress.vue
+++ b/apps/ui/src/components/Ui/InputAddress.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import snapshotJsNetworks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { networks as snapshotJsNetworks } from '@/helpers/networks';
 import { getUrl } from '@/helpers/utils';
 import { BaseDefinition } from '@/types';
 
@@ -9,6 +9,8 @@ type NetworkDetails = {
 };
 
 defineOptions({ inheritAttrs: false });
+
+const model = defineModel<string>();
 
 const props = defineProps<{
   path?: string;
@@ -57,6 +59,7 @@ const shouldShowPicker = computed(() => {
       />
     </UiTooltip>
     <UiInputString
+      v-model="model"
       :definition="definition"
       :required="required"
       v-bind="$attrs as any"

--- a/apps/ui/src/helpers/call.ts
+++ b/apps/ui/src/helpers/call.ts
@@ -1,7 +1,7 @@
 import { Interface } from '@ethersproject/abi';
 import { CallOverrides, Contract } from '@ethersproject/contracts';
 import { Provider } from '@ethersproject/providers';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { networks } from '@/helpers/networks';
 
 export type CallOptions = CallOverrides & { limit?: number };
 
@@ -35,7 +35,7 @@ export async function multicall(
   options?: CallOptions
 ) {
   const multi = new Contract(
-    networks[network as keyof typeof networks].multicall,
+    networks[network].multicall,
     MULTICALL_ABI,
     provider
   );

--- a/apps/ui/src/helpers/generic.ts
+++ b/apps/ui/src/helpers/generic.ts
@@ -1,5 +1,5 @@
 import { sanitizeUrl } from '@braintree/sanitize-url';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { networks } from '@/helpers/networks';
 import { getNetwork } from '@/networks';
 import { METADATA as EVM_NETWORKS_METADATA } from '@/networks/evm/metadata';
 import { METADATA as STARKNET_NETWORKS_METADATA } from '@/networks/starknet/metadata';
@@ -42,7 +42,7 @@ export function getGenericExplorerUrl(
       mappedType = 'token';
     }
 
-    const network = networks[chainId as keyof typeof networks];
+    const network = networks[chainId];
     if (!network) return null;
 
     return `${network.explorer.url}/${mappedType}/${address}`;

--- a/apps/ui/src/helpers/networks.ts
+++ b/apps/ui/src/helpers/networks.ts
@@ -1,0 +1,5 @@
+import networksJson from '@snapshot-labs/snapshot.js/src/networks.json';
+
+export type SnapshotNetwork = (typeof networksJson)[keyof typeof networksJson];
+
+export const networks: Record<string, SnapshotNetwork> = networksJson;

--- a/apps/ui/src/networks/evm/index.ts
+++ b/apps/ui/src/networks/evm/index.ts
@@ -1,5 +1,5 @@
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { getRelayerInfo } from '@/helpers/mana';
+import { networks } from '@/helpers/networks';
 import { pin } from '@/helpers/pin';
 import { getProvider } from '@/helpers/provider';
 import { formatAddress } from '@/helpers/utils';
@@ -99,8 +99,7 @@ export function createEvmNetwork(networkId: NetworkID): Network {
 
       if (dataType === 'address') id = formatAddress(id);
 
-      const network =
-        networks[(chainIdOverride ?? chainId) as keyof typeof networks];
+      const network = networks[chainIdOverride ?? chainId];
 
       return `${network.explorer.url}/${dataType}/${id}`;
     }

--- a/apps/ui/src/networks/offchain/index.ts
+++ b/apps/ui/src/networks/offchain/index.ts
@@ -1,4 +1,4 @@
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { networks } from '@/helpers/networks';
 import { pin } from '@/helpers/pin';
 import { getProvider } from '@/helpers/provider';
 import { formatAddress, getSpaceController } from '@/helpers/utils';
@@ -77,7 +77,7 @@ export function createOffchainNetwork(networkId: 's' | 's-tn'): Network {
       chainId?: ChainId
     ) => {
       chainId = chainId || l1ChainId;
-      const network = networks[chainId.toString() as keyof typeof networks];
+      const network = networks[chainId.toString()];
       const isStarknet = 'starknet' in network;
 
       switch (type) {

--- a/apps/ui/src/shims.d.ts
+++ b/apps/ui/src/shims.d.ts
@@ -3,3 +3,16 @@ declare module 'highlightjs-solidity' {
 
   export const solidity: LanguageFn;
 }
+
+declare module 'highlight.js/lib/core' {
+  import { LanguageFn } from 'lowlight';
+
+  const hljs: {
+    registerLanguage(name: string, language: LanguageFn): void;
+    getLanguage(name: string): unknown;
+    highlight(code: string, options: { language: string }): { value: string };
+    highlightAuto(code: string): { value: string };
+  };
+
+  export default hljs;
+}

--- a/apps/ui/src/views/My/Explore.vue
+++ b/apps/ui/src/views/My/Explore.vue
@@ -135,7 +135,7 @@ watch(
   ],
   ([searchQueryValue, protocolQuery, categoryQuery, networkQuery]) => {
     const _protocol = (
-      explorePageProtocols[protocolQuery] ? protocolQuery : DEFAULT_PROTOCOL
+      protocolQuery in explorePageProtocols ? protocolQuery : DEFAULT_PROTOCOL
     ) as ExplorePageProtocol;
 
     protocol.value = _protocol;

--- a/apps/ui/src/views/Network.vue
+++ b/apps/ui/src/views/Network.vue
@@ -22,7 +22,7 @@ const LINK = 'https://calendly.com/snapshotlabs/30min';
 
 const currentQuestion = ref();
 
-function toggleQuestion(id) {
+function toggleQuestion(id: number) {
   currentQuestion.value = currentQuestion.value === id ? '' : id;
 }
 </script>

--- a/apps/ui/src/views/Settings/Contacts.vue
+++ b/apps/ui/src/views/Settings/Contacts.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { shorten } from '@/helpers/utils';
+import { Contact } from '@/types';
 
 useTitle('Contacts');
 const contactsStore = useContactsStore();
@@ -16,7 +17,7 @@ function openModal(type: 'editContact') {
   modalState.value[type] = null;
 }
 
-function handleContactEdit(contact) {
+function handleContactEdit(contact: Contact) {
   modalState.value.editContact = contact;
   modalOpen.value.editContact = true;
 }

--- a/apps/ui/src/views/Settings/Spaces.vue
+++ b/apps/ui/src/views/Settings/Spaces.vue
@@ -37,7 +37,7 @@ watch(
   [() => route.query.p as string],
   ([protocolQuery]) => {
     protocol.value = (
-      explorePageProtocols[protocolQuery] ? protocolQuery : DEFAULT_PROTOCOL
+      protocolQuery in explorePageProtocols ? protocolQuery : DEFAULT_PROTOCOL
     ) as ExplorePageProtocol;
   },
   {

--- a/apps/ui/src/views/Space/Editor.vue
+++ b/apps/ui/src/views/Space/Editor.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { sanitizeUrl } from '@braintree/sanitize-url';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { useQueryClient } from '@tanstack/vue-query';
 import { LocationQueryValue } from 'vue-router';
 import { StrategyWithTreasury } from '@/composables/useTreasuries';
 import { BASIC_CHOICES, DOCS_URL, VERIFIED_URL } from '@/helpers/constants';
+import { networks } from '@/helpers/networks';
 import { getExecutionKey } from '@/helpers/ui';
 import { omit, prettyConcat } from '@/helpers/utils';
 import { validateForm } from '@/helpers/validation';

--- a/apps/ui/src/views/Space/Pro.vue
+++ b/apps/ui/src/views/Space/Pro.vue
@@ -319,13 +319,15 @@ onMounted(() => {
         class="max-w-[480px] w-full space-y-3"
       >
         <button
-          v-for="plan in Object.keys(PRO_MONTHLY_PRICES)"
+          v-for="plan in Object.keys(
+            PRO_MONTHLY_PRICES
+          ) as SubscriptionLength[]"
           :key="plan"
           :class="[
             'border rounded-lg px-4 py-3 flex gap-2 justify-between w-full',
             { 'border-skin-link': subscriptionLength === plan }
           ]"
-          @click="subscriptionLength = plan as SubscriptionLength"
+          @click="subscriptionLength = plan"
         >
           <div class="flex flex-1 items-center gap-x-2 flex-wrap">
             <h3 class="text-start">Pay {{ plan }}</h3>

--- a/apps/ui/src/views/SpaceUser/Statement.vue
+++ b/apps/ui/src/views/SpaceUser/Statement.vue
@@ -6,7 +6,7 @@ import ICAgora from '~icons/c/agora';
 import ICKarmahq from '~icons/c/karmahq';
 import ICTally from '~icons/c/tally';
 
-const SOURCE_ICONS = {
+const SOURCE_ICONS: Record<string, { icon: typeof ICAgora; link: string }> = {
   agora: { icon: ICAgora, link: 'https://www.agora.xyz' },
   karmahq: { icon: ICKarmahq, link: 'https://karmahq.xyz' },
   tally: { icon: ICTally, link: 'https://www.tally.xyz' }

--- a/bun.lock
+++ b/bun.lock
@@ -396,6 +396,7 @@
         "@types/object-hash": "^3.0.6",
         "@types/qrcode": "^1.5.6",
         "@types/remarkable": "^2.0.4",
+        "@types/remove-markdown": "^0.3.4",
         "@types/turndown": "^5.0.6",
         "@vitejs/plugin-vue": "^6.0.0",
         "@vue/test-utils": "^2.4.5",
@@ -2273,6 +2274,8 @@
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/remarkable": ["@types/remarkable@2.0.8", "", {}, "sha512-eKXqPZfpQl1kOADjdKchHrp2gwn9qMnGXhH/AtZe0UrklzhGJkawJo/Y/D0AlWcdWoWamFNIum8+/nkAISQVGg=="],
+
+    "@types/remove-markdown": ["@types/remove-markdown@0.3.4", "", {}, "sha512-i753EH/p02bw7bLlpfS/4CV1rdikbGiLabWyVsAvsFid3cA5RNU1frG7JycgY+NSnFwtoGlElvZVceCytecTDA=="],
 
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
 


### PR DESCRIPTION
### Summary

Fixes implicit any errors in components and views. Mostly small.

Notable:

- New `helpers/networks.ts` exports the snapshot.js networks JSON typed as a Record. It replaces direct JSON imports and the keyof typeof casts from earlier commits.
- Shim for `highlight.js/lib/core`. The app uses highlight.js v10 while lowlight bundles v11 types, and referencing the v10 types breaks lowlight registrations. Upgrading highlight.js would be the proper fix but touches the custom hljs stylesheets.
- Added `@types/remove-markdown`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>