### PR TITLE
fix(ui): keep execution rows collapsed on delete and edit

### DIFF
--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -178,11 +178,7 @@ watch(
       <template v-if="model.length > 0 && treasury">
         <UiSectionHeader label="Transactions" class="border-t" />
         <div>
-          <Draggable
-            v-model="model"
-            handle=".handle"
-            :item-key="() => undefined"
-          >
+          <Draggable v-model="model" handle=".handle" :item-key="tx => tx">
             <template #item="{ element: tx, index: i }">
               <TransactionsListItem :tx="tx" :chain-id="treasury.network">
                 <template v-if="model.length > 1" #left>
@@ -205,12 +201,12 @@ watch(
                         type="button"
                         :disabled="tx._type === 'raw'"
                         class="flex disabled:cursor-not-allowed disabled:opacity-40"
-                        @click="editTx(i)"
+                        @click.stop="editTx(i)"
                       >
                         <IH-pencil />
                       </button>
                     </UiTooltip>
-                    <button type="button" @click="removeTx(i)">
+                    <button type="button" @click.stop="removeTx(i)">
                       <IH-trash />
                     </button>
                   </div>


### PR DESCRIPTION
Fixes #2347

Acting on a transaction row in the proposal editor left the wrong row expanded.

Editing a transaction was expanding it
Deleting a transaction was expanding the next transaction

Rows are now keyed by transaction identity rather than `salt`, which is empty on SafeSnap- and oSnap-parsed transactions.

## Test plan

1. Open [s:gnosis.eth/proposal/0x82c6f103d5fa8f12d8f60e377dd17f77fa5172ff6874f6cb7cae3dec833b7bf2](http://localhost:8080/#/s:gnosis.eth/proposal/0x82c6f103d5fa8f12d8f60e377dd17f77fa5172ff6874f6cb7cae3dec833b7bf2) and duplicate the proposal
2. Delete an transaction
3. It should not expand the next transaction
4. Add some editable transaction (send token)
5. Edit the transaction
6. It should not expand the transaction

