### PR TITLE
fix(ui): type item-key callback in execution editor

### DIFF
--- a/apps/ui/src/components/EditorExecution.vue
+++ b/apps/ui/src/components/EditorExecution.vue
@@ -179,7 +179,11 @@ watch(
       <template v-if="model.length > 0 && treasury">
         <UiSectionHeader label="Transactions" class="border-t" />
         <div>
-          <Draggable v-model="model" handle=".handle" :item-key="tx => tx">
+          <Draggable
+            v-model="model"
+            handle=".handle"
+            :item-key="(tx: TransactionType) => tx"
+          >
             <template #item="{ element: tx, index: i }">
               <TransactionsListItem :tx="tx" :chain-id="treasury.network">
                 <template v-if="model.length > 1" #left>


### PR DESCRIPTION
Master fails the UI typecheck, so CI is red on every open PR regardless of its contents.

Two PRs that were each green in isolation conflicted: one tightened the UI TypeScript config to reject implicit `any`, the other added an untyped callback parameter and had its CI run against master before the config change landed. Once both merged, master no longer typechecks.

This annotates the parameter with its existing type. UI typecheck and lint pass again.
