### PR TITLE
fix(ui): clear a leftover allowance before approving a new amount

### DIFF
--- a/apps/ui/src/helpers/token.test.ts
+++ b/apps/ui/src/helpers/token.test.ts
@@ -104,6 +104,15 @@ describe('approve', () => {
     expect(approveMock).toHaveBeenCalledTimes(1);
   });
 
+  it('rethrows a non-object rejection untouched', async () => {
+    allowanceMock.mockResolvedValue(allowanceOf(50n));
+    waitMock.mockRejectedValue(undefined);
+
+    await expect(approve(web3, TOKEN, SPENDER, 200n)).rejects.toBeUndefined();
+
+    expect(approveMock).toHaveBeenCalledTimes(1);
+  });
+
   it('does not read the allowance when revoking', async () => {
     await approve(web3, TOKEN, SPENDER, 0n);
 

--- a/apps/ui/src/helpers/token.test.ts
+++ b/apps/ui/src/helpers/token.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { approve } from './token';
+
+const TOKEN = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+const SPENDER = '0xE40BfEB5a3014c9b98597088cA71eccdc27Ca410';
+const OWNER = '0xC2339fcbB6481C2Dc1f509b7A8cD7CE815f8FEC2';
+
+// `approve` reads the current allowance and may send a reset transaction before
+// the real one, so stub the contract rather than faking encoded responses.
+const { allowanceMock, approveMock, waitMock } = vi.hoisted(() => ({
+  allowanceMock: vi.fn(),
+  approveMock: vi.fn(),
+  waitMock: vi.fn()
+}));
+
+vi.mock('@ethersproject/contracts', () => ({
+  Contract: vi.fn(() => ({
+    allowance: allowanceMock,
+    approve: approveMock
+  }))
+}));
+
+function allowanceOf(value: bigint) {
+  return { toBigInt: () => value };
+}
+
+const web3 = {
+  getSigner: () => ({ getAddress: async () => OWNER })
+} as any;
+
+beforeEach(() => {
+  allowanceMock.mockReset().mockResolvedValue(allowanceOf(0n));
+  waitMock.mockReset().mockResolvedValue(undefined);
+  approveMock.mockReset().mockResolvedValue({ hash: '0x1', wait: waitMock });
+});
+
+describe('approve', () => {
+  it('approves directly when there is no leftover allowance', async () => {
+    await approve(web3, TOKEN, SPENDER, 200n);
+
+    expect(approveMock).toHaveBeenCalledTimes(1);
+    expect(approveMock).toHaveBeenCalledWith(SPENDER, 200n);
+  });
+
+  it('clears a leftover allowance before approving a new amount', async () => {
+    allowanceMock.mockResolvedValue(allowanceOf(50n));
+
+    await approve(web3, TOKEN, SPENDER, 200n);
+
+    expect(approveMock).toHaveBeenCalledTimes(2);
+    expect(approveMock).toHaveBeenNthCalledWith(1, SPENDER, 0n);
+    expect(approveMock).toHaveBeenNthCalledWith(2, SPENDER, 200n);
+  });
+
+  it('waits for the reset to be mined before approving', async () => {
+    allowanceMock.mockResolvedValue(allowanceOf(50n));
+
+    await approve(web3, TOKEN, SPENDER, 200n);
+
+    expect(waitMock).toHaveBeenCalledTimes(1);
+    expect(waitMock.mock.invocationCallOrder[0]).toBeLessThan(
+      approveMock.mock.invocationCallOrder[1]
+    );
+  });
+
+  it('returns the transaction of the requested amount', async () => {
+    allowanceMock.mockResolvedValue(allowanceOf(50n));
+    approveMock
+      .mockResolvedValueOnce({ hash: '0xreset', wait: waitMock })
+      .mockResolvedValueOnce({ hash: '0xapprove', wait: waitMock });
+
+    const tx = await approve(web3, TOKEN, SPENDER, 200n);
+
+    expect(tx.hash).toBe('0xapprove');
+  });
+
+  it('continues when the reset is sped up rather than cancelled', async () => {
+    allowanceMock.mockResolvedValue(allowanceOf(50n));
+    waitMock.mockRejectedValue(
+      Object.assign(new Error('transaction was replaced'), {
+        code: 'TRANSACTION_REPLACED',
+        cancelled: false
+      })
+    );
+
+    await expect(approve(web3, TOKEN, SPENDER, 200n)).resolves.toBeDefined();
+
+    expect(approveMock).toHaveBeenNthCalledWith(2, SPENDER, 200n);
+  });
+
+  it('fails when the reset is cancelled, leaving the allowance set', async () => {
+    allowanceMock.mockResolvedValue(allowanceOf(50n));
+    waitMock.mockRejectedValue(
+      Object.assign(new Error('transaction was cancelled'), {
+        code: 'TRANSACTION_REPLACED',
+        cancelled: true
+      })
+    );
+
+    await expect(approve(web3, TOKEN, SPENDER, 200n)).rejects.toThrow(
+      'transaction was cancelled'
+    );
+
+    expect(approveMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not read the allowance when revoking', async () => {
+    await approve(web3, TOKEN, SPENDER, 0n);
+
+    expect(allowanceMock).not.toHaveBeenCalled();
+    expect(approveMock).toHaveBeenCalledTimes(1);
+    expect(approveMock).toHaveBeenCalledWith(SPENDER, 0n);
+  });
+});

--- a/apps/ui/src/helpers/token.ts
+++ b/apps/ui/src/helpers/token.ts
@@ -57,8 +57,8 @@ export async function approve(
 
       // Speeding a transaction up rejects `wait` even though the replacement
       // was mined; only a cancellation leaves the allowance in place.
-      await reset.wait().catch((e: any) => {
-        if (e.code !== 'TRANSACTION_REPLACED' || e.cancelled) throw e;
+      await reset.wait().catch((err: any) => {
+        if (err?.code !== 'TRANSACTION_REPLACED' || err.cancelled) throw err;
       });
     }
   }

--- a/apps/ui/src/helpers/token.ts
+++ b/apps/ui/src/helpers/token.ts
@@ -43,6 +43,26 @@ export async function approve(
 ) {
   const contract = new Contract(tokenAddress, abis.erc20, web3.getSigner());
 
+  // Mainnet USDT, and any other token carrying the same legacy guard, reverts
+  // when a non-zero allowance is overwritten with another non-zero value.
+  if (amount > 0n) {
+    const allowance = await getTokenAllowance(
+      web3,
+      tokenAddress,
+      spenderAddress
+    );
+
+    if (allowance > 0n) {
+      const reset = await contract.approve(spenderAddress, 0n);
+
+      // Speeding a transaction up rejects `wait` even though the replacement
+      // was mined; only a cancellation leaves the allowance in place.
+      await reset.wait().catch((e: any) => {
+        if (e.code !== 'TRANSACTION_REPLACED' || e.cancelled) throw e;
+      });
+    }
+  }
+
   return contract.approve(spenderAddress, amount);
 }
 


### PR DESCRIPTION
Closes #2083

## Problem

Mainnet USDT keeps the legacy approve guard:

```solidity
function approve(address _spender, uint _value) public {
    if ((_value != 0) && (allowed[msg.sender][_spender] != 0)) revert();
```

`approve` in `helpers/token.ts` passes the new amount straight through, so replacing a non-zero allowance with another non-zero value reverts.

It needs a leftover allowance that is non-zero but insufficient — approve 100, pay 50, then try to pay 200. `getIsApproved` sees `50 < 200` and returns false, the flow moves to the approve step, and the guard rejects it. The happy path is unaffected because `payWithERC20Token` consumes exactly the approved amount; cancelling mid-flow or changing quantity between attempts is what leaves the remainder behind.

## Fix

Option (b) from the issue: when an allowance is already set, send `approve(0)` and wait for it before approving the new amount.

- applied generically rather than special-casing the USDT address, so any token with the same guard is covered — including the Sepolia USDT entry in `TOKENS`, which an address check would miss
- revocations (`amount === 0`) skip the allowance read entirely, since the guard only trips on non-zero over non-zero
- kept inside the helper, so it still resolves to the transaction of the requested amount and `usePaymentFactory`'s step machine is unchanged
- `wait()` rejects with `TRANSACTION_REPLACED` when the user speeds the reset up, even though the replacement was mined, so only a cancellation is treated as a failure

## Trade-offs

- adds one `allowance` read per approve, including for well-behaved tokens. It felt better than threading the value read moments earlier by `getIsApproved`, which would couple the two and let the value go stale — happy to change it if you prefer
- a user in this state now signs twice within the "Setting token allowance" step, and only the second transaction reaches `addPendingTransaction`, so the reset does not appear in the pending list

## Testing

New `token.test.ts` covering the reset, its ordering, the returned transaction, the replaced/cancelled cases and the revocation path. Five of the seven fail against the current code. Full `apps/ui` suite, eslint, prettier and `vue-tsc` all pass.

## Out of scope

`apps/auction/src/helpers/token.ts` carries the same `approve` and would need the same treatment, but the app is excluded from build, lint and typecheck at the root, so I left it untouched. Glad to include it if you would like.