### PR TITLE
fix(ui): show active proposals count on sidebar org entries

### DIFF
--- a/apps/ui/src/components/App/SidebarItem.vue
+++ b/apps/ui/src/components/App/SidebarItem.vue
@@ -1,12 +1,33 @@
 <script setup lang="ts">
-import { resolveSpaceItem } from '@/helpers/organizations';
+import {
+  getOrganizationConfigBySpace,
+  resolveSpaceItem
+} from '@/helpers/organizations';
 import { Space } from '@/types';
 
 const props = defineProps<{
   space: Space;
 }>();
 
-const item = computed(() => resolveSpaceItem(props.space));
+const followedSpacesStore = useFollowedSpacesStore();
+
+const org = computed(() =>
+  getOrganizationConfigBySpace(`${props.space.network}:${props.space.id}`)
+);
+
+const item = computed(() => {
+  const resolved = resolveSpaceItem(props.space, org.value);
+
+  if (!org.value) return resolved;
+
+  const count = followedSpacesStore.orgActiveProposals[org.value.id];
+  if (count === undefined) return resolved;
+
+  return {
+    ...resolved,
+    avatarSpace: { ...resolved.avatarSpace, active_proposals: count }
+  };
+});
 </script>
 
 <template>

--- a/apps/ui/src/components/App/SidebarItem.vue
+++ b/apps/ui/src/components/App/SidebarItem.vue
@@ -20,12 +20,14 @@ const item = computed(() => {
 
   if (!org.value) return resolved;
 
-  const count = followedSpacesStore.orgActiveProposals[org.value.id];
-  if (count === undefined) return resolved;
-
+  // `resolveSpaceItem` can't know the org total, so it leaves a placeholder 0.
   return {
     ...resolved,
-    avatarSpace: { ...resolved.avatarSpace, active_proposals: count }
+    avatarSpace: {
+      ...resolved.avatarSpace,
+      active_proposals:
+        followedSpacesStore.orgActiveProposals[org.value.id] ?? 0
+    }
   };
 });
 </script>

--- a/apps/ui/src/networks/index.ts
+++ b/apps/ui/src/networks/index.ts
@@ -108,7 +108,9 @@ export const enabledReadWriteNetworks: NetworkID[] = enabledNetworks.filter(
 export const spaceCreationNetworks: NetworkID[] =
   enabledReadWriteNetworks.filter(id => !governorOnlyNetworks.includes(id));
 
-const onchainApiNetwork =
+// Every onchain network is served by the same sx-api, so any enabled one can
+// stand in for all of them when a request isn't scoped to a single indexer.
+export const onchainApiNetwork =
   enabledNetworks.find(network => !offchainNetworks.includes(network)) || 'eth';
 
 export const explorePageProtocols: Record<ExplorePageProtocol, ProtocolConfig> =

--- a/apps/ui/src/networks/index.ts
+++ b/apps/ui/src/networks/index.ts
@@ -108,8 +108,9 @@ export const enabledReadWriteNetworks: NetworkID[] = enabledNetworks.filter(
 export const spaceCreationNetworks: NetworkID[] =
   enabledReadWriteNetworks.filter(id => !governorOnlyNetworks.includes(id));
 
-// Every onchain network is served by the same sx-api, so any enabled one can
-// stand in for all of them when a request isn't scoped to a single indexer.
+// Onchain mainnets all point at `API_URL`, so any one of them can stand in for
+// the rest when a request isn't scoped to a single indexer. Testnets are served
+// by `API_TESTNET_URL` instead, so they are not interchangeable with these.
 export const onchainApiNetwork =
   enabledNetworks.find(network => !offchainNetworks.includes(network)) || 'eth';
 

--- a/apps/ui/src/queries/spaces.test.ts
+++ b/apps/ui/src/queries/spaces.test.ts
@@ -14,8 +14,9 @@ const ARBITRUM_ONCHAIN = [
 
 const ALL_NETWORKS = ['s', 'eth', 'arb1', 'sn'];
 
-// `enabledNetworks` is mutable so a test can simulate a build shipping without
-// the networks the organization configs point at.
+// `enabledNetworks` is mutable so a test can simulate an offchain-only build.
+// `onchainApiNetwork` is pinned to `eth` to match its `|| 'eth'` fallback,
+// which is what the real module resolves to when no onchain network is enabled.
 const { loadSpacesMock, enabledNetworks } = vi.hoisted(() => ({
   loadSpacesMock: vi.fn(),
   enabledNetworks: [] as string[]

--- a/apps/ui/src/queries/spaces.test.ts
+++ b/apps/ui/src/queries/spaces.test.ts
@@ -1,0 +1,254 @@
+// @vitest-environment happy-dom
+import { QueryClient, VUE_QUERY_CLIENT } from '@tanstack/vue-query';
+import { createPinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp, nextTick, ref } from 'vue';
+import { Space } from '@/types';
+import { useOrgsActiveProposalsQuery } from './spaces';
+
+const ENS_ONCHAIN = '0x323A76393544d5ecca80cd6ef2A560C6a395b7E3';
+const ARBITRUM_ONCHAIN = [
+  '0x789fC99093B09aD01C34DC7251D0C89ce743e5a4',
+  '0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9'
+];
+
+const ALL_NETWORKS = ['s', 'eth', 'arb1', 'sn'];
+
+// `enabledNetworks` is mutable so a test can simulate a build shipping without
+// the networks the organization configs point at.
+const { loadSpacesMock, enabledNetworks } = vi.hoisted(() => ({
+  loadSpacesMock: vi.fn(),
+  enabledNetworks: [] as string[]
+}));
+
+vi.mock('@/networks', () => ({
+  getNetwork: (id: string) => {
+    if (!enabledNetworks.includes(id)) {
+      throw new Error(`Network ${id} is not enabled`);
+    }
+
+    return {
+      api: { loadSpaces: (...args: any[]) => loadSpacesMock(id, ...args) }
+    };
+  },
+  enabledNetworks,
+  explorePageProtocols: {},
+  offchainNetworks: ['s', 's-tn'],
+  onchainApiNetwork: 'eth'
+}));
+
+function spaceOf(
+  network: Space['network'],
+  id: string,
+  active_proposals: number | null
+): Space {
+  return { network, id, active_proposals } as Space;
+}
+
+function callFor(networkId: string) {
+  return loadSpacesMock.mock.calls.find(([id]) => id === networkId);
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } }
+});
+
+let testApp: ReturnType<typeof createApp>;
+
+function withSetup<T>(composable: () => T): T {
+  let result!: T;
+  testApp = createApp({
+    setup() {
+      result = composable();
+      return () => null;
+    }
+  });
+  testApp.use(createPinia());
+  testApp.provide(VUE_QUERY_CLIENT, queryClient);
+  testApp.mount(document.createElement('div'));
+  return result;
+}
+
+beforeEach(() => {
+  queryClient.clear();
+  loadSpacesMock.mockReset();
+  enabledNetworks.splice(0, enabledNetworks.length, ...ALL_NETWORKS);
+});
+
+afterEach(() => {
+  testApp?.unmount();
+});
+
+describe('useOrgsActiveProposalsQuery', () => {
+  it('does not fetch when no followed space belongs to an org', async () => {
+    const { fetchStatus, data } = withSetup(() =>
+      useOrgsActiveProposalsQuery({
+        followedSpaces: ref([spaceOf('s', 'random.eth', 4)])
+      })
+    );
+
+    await nextTick();
+    await nextTick();
+
+    expect(fetchStatus.value).toBe('idle');
+    expect(loadSpacesMock).not.toHaveBeenCalled();
+    expect(data.value).toBeUndefined();
+  });
+
+  it('sums active proposals across every sibling of a followed org', async () => {
+    loadSpacesMock.mockImplementation(async (networkId: string) =>
+      networkId === 'eth'
+        ? [spaceOf('eth', ENS_ONCHAIN, 3)]
+        : [spaceOf('s', 'ens.eth', 2)]
+    );
+
+    const { data } = withSetup(() =>
+      useOrgsActiveProposalsQuery({
+        followedSpaces: ref([spaceOf('s', 'ens.eth', 2)])
+      })
+    );
+
+    await vi.waitFor(() => {
+      expect(data.value).toEqual({ ens: 5 });
+    });
+
+    expect(loadSpacesMock).toHaveBeenCalledTimes(2);
+    expect(loadSpacesMock).toHaveBeenCalledWith(
+      'eth',
+      { skip: 0, limit: 1000 },
+      { id_in: [ENS_ONCHAIN] }
+    );
+    expect(loadSpacesMock).toHaveBeenCalledWith(
+      's',
+      { skip: 0, limit: 1000 },
+      { id_in: ['ens.eth'] }
+    );
+  });
+
+  it('treats a missing or null count as zero', async () => {
+    loadSpacesMock.mockImplementation(async (networkId: string) =>
+      networkId === 'eth' ? [spaceOf('eth', ENS_ONCHAIN, null)] : []
+    );
+
+    const { data } = withSetup(() =>
+      useOrgsActiveProposalsQuery({
+        followedSpaces: ref([spaceOf('s', 'ens.eth', 0)])
+      })
+    );
+
+    await vi.waitFor(() => {
+      expect(data.value).toEqual({ ens: 0 });
+    });
+  });
+
+  it('batches the siblings of every followed org into one request per api', async () => {
+    loadSpacesMock.mockResolvedValue([]);
+
+    withSetup(() =>
+      useOrgsActiveProposalsQuery({
+        followedSpaces: ref([
+          spaceOf('s', 'ens.eth', 0),
+          spaceOf('s', 'arbitrumfoundation.eth', 0)
+        ])
+      })
+    );
+
+    await vi.waitFor(() => {
+      expect(loadSpacesMock).toHaveBeenCalledTimes(2);
+    });
+
+    // `arb1` siblings go through the `eth` api: both are served by the same
+    // sx-api, and the request isn't scoped to a single indexer.
+    expect(callFor('eth')?.[2].id_in).toEqual([
+      ENS_ONCHAIN,
+      ...ARBITRUM_ONCHAIN
+    ]);
+    expect(callFor('s')?.[2].id_in).toEqual([
+      'ens.eth',
+      'arbitrumfoundation.eth'
+    ]);
+  });
+
+  it('requests each sibling once when two spaces of one org are followed', async () => {
+    loadSpacesMock.mockResolvedValue([]);
+
+    withSetup(() =>
+      useOrgsActiveProposalsQuery({
+        followedSpaces: ref([
+          spaceOf('s', 'ens.eth', 0),
+          spaceOf('eth', ENS_ONCHAIN, 0)
+        ])
+      })
+    );
+
+    await vi.waitFor(() => {
+      expect(loadSpacesMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(callFor('eth')?.[2].id_in).toEqual([ENS_ONCHAIN]);
+    expect(callFor('s')?.[2].id_in).toEqual(['ens.eth']);
+  });
+
+  it('skips siblings on networks this build does not enable', async () => {
+    enabledNetworks.splice(0, enabledNetworks.length, 's');
+    loadSpacesMock.mockResolvedValue([spaceOf('s', 'ens.eth', 2)]);
+
+    const { data } = withSetup(() =>
+      useOrgsActiveProposalsQuery({
+        followedSpaces: ref([spaceOf('s', 'ens.eth', 2)])
+      })
+    );
+
+    await vi.waitFor(() => {
+      expect(data.value).toEqual({ ens: 2 });
+    });
+
+    expect(loadSpacesMock).toHaveBeenCalledTimes(1);
+    expect(callFor('s')?.[2].id_in).toEqual(['ens.eth']);
+  });
+
+  it('refetches when a new org is followed', async () => {
+    loadSpacesMock.mockResolvedValue([]);
+    const followedSpaces = ref([spaceOf('s', 'ens.eth', 0)]);
+
+    const { data } = withSetup(() =>
+      useOrgsActiveProposalsQuery({ followedSpaces })
+    );
+
+    await vi.waitFor(() => {
+      expect(data.value).toEqual({ ens: 0 });
+    });
+
+    followedSpaces.value = [
+      ...followedSpaces.value,
+      spaceOf('s', 'arbitrumfoundation.eth', 0)
+    ];
+
+    await vi.waitFor(() => {
+      expect(data.value).toEqual({ ens: 0, arbitrum: 0 });
+    });
+  });
+
+  it('does not refetch when the followed orgs are unchanged', async () => {
+    loadSpacesMock.mockResolvedValue([]);
+    const followedSpaces = ref([
+      spaceOf('s', 'ens.eth', 0),
+      spaceOf('s', 'arbitrumfoundation.eth', 0)
+    ]);
+
+    const { data } = withSetup(() =>
+      useOrgsActiveProposalsQuery({ followedSpaces })
+    );
+
+    await vi.waitFor(() => {
+      expect(data.value).toEqual({ ens: 0, arbitrum: 0 });
+    });
+
+    const callCount = loadSpacesMock.mock.calls.length;
+    followedSpaces.value = [...followedSpaces.value].reverse();
+    await nextTick();
+    await nextTick();
+
+    expect(loadSpacesMock).toHaveBeenCalledTimes(callCount);
+  });
+});

--- a/apps/ui/src/queries/spaces.ts
+++ b/apps/ui/src/queries/spaces.ts
@@ -284,8 +284,12 @@ export function useOrgsActiveProposalsQuery({
   return useQuery({
     queryKey: ['spaces', 'orgsActiveProposals', orgIds],
     queryFn: async (): Promise<Record<string, number>> => {
+      // Read once: `orgs` is reactive and can change while we're in flight,
+      // which would sum the new org set over the old set's results.
+      const currentOrgs = orgs.value;
+
       const results = await Promise.all(
-        [...siblingIdsByNetwork(orgs.value)].map(([networkId, ids]) =>
+        [...siblingIdsByNetwork(currentOrgs)].map(([networkId, ids]) =>
           getNetwork(networkId).api.loadSpaces(
             { skip: 0, limit: 1000 },
             { id_in: ids }
@@ -302,7 +306,7 @@ export function useOrgsActiveProposalsQuery({
       }
 
       const counts: Record<string, number> = {};
-      for (const org of orgs.value) {
+      for (const org of currentOrgs) {
         counts[org.id] = org.spaceIds.reduce((sum, space) => {
           const loaded = byId.get(getCompositeSpaceId(space));
           return sum + (loaded?.active_proposals ?? 0);

--- a/apps/ui/src/queries/spaces.ts
+++ b/apps/ui/src/queries/spaces.ts
@@ -7,7 +7,17 @@ import {
 } from '@tanstack/vue-query';
 import { MaybeRefOrGetter } from 'vue';
 import { SPACE_CATEGORIES } from '@/helpers/constants';
-import { enabledNetworks, explorePageProtocols, getNetwork } from '@/networks';
+import {
+  getOrganizationConfigBySpace,
+  OrganizationConfig
+} from '@/helpers/organizations';
+import {
+  enabledNetworks,
+  explorePageProtocols,
+  getNetwork,
+  offchainNetworks,
+  onchainApiNetwork
+} from '@/networks';
 import { ExplorePageProtocol, SpacesFilter } from '@/networks/types';
 import { NetworkID, Space } from '@/types';
 
@@ -208,5 +218,99 @@ export function useExploreSpacesQuery({
       return pages.length * protocolConfig.value.limit;
     },
     enabled: () => (controller ? toValue(controller) !== '' : true)
+  });
+}
+
+function getCompositeSpaceId(space: { network: NetworkID; id: string }) {
+  return `${space.network}:${space.id}`;
+}
+
+function uniqueOrgs(spaces: Space[]): OrganizationConfig[] {
+  const seen = new Set<string>();
+  const orgs: OrganizationConfig[] = [];
+
+  for (const space of spaces) {
+    const org = getOrganizationConfigBySpace(getCompositeSpaceId(space));
+    if (!org || seen.has(org.id)) continue;
+    seen.add(org.id);
+    orgs.push(org);
+  }
+
+  return orgs;
+}
+
+/**
+ * Groups every sibling space of `orgs` by the network whose API can resolve it.
+ * All onchain networks share the same sx-api, so their ids go in a single
+ * bucket (one request covering eth/arb1/sn); each offchain hub gets its own.
+ * Siblings on networks this build doesn't enable are dropped, both because
+ * `getNetwork` throws on them and because they are never rendered anyway.
+ */
+function siblingIdsByNetwork(orgs: OrganizationConfig[]) {
+  const buckets = new Map<NetworkID, string[]>();
+
+  for (const org of orgs) {
+    for (const space of org.spaceIds) {
+      if (!enabledNetworks.includes(space.network)) continue;
+
+      const networkId = offchainNetworks.includes(space.network)
+        ? space.network
+        : onchainApiNetwork;
+
+      const ids = buckets.get(networkId);
+      if (ids) ids.push(space.id);
+      else buckets.set(networkId, [space.id]);
+    }
+  }
+
+  return buckets;
+}
+
+/**
+ * Sums `active_proposals` across every space of each organization the user
+ * follows, so that a sidebar org entry shows the whole org's count rather than
+ * the count of the single space that got followed.
+ *
+ * Returns a map of org id → total (a `null` count is read as 0).
+ */
+export function useOrgsActiveProposalsQuery({
+  followedSpaces
+}: {
+  followedSpaces: MaybeRefOrGetter<Space[]>;
+}) {
+  const orgs = computed(() => uniqueOrgs(toValue(followedSpaces)));
+  const orgIds = computed(() => orgs.value.map(org => org.id).sort());
+
+  return useQuery({
+    queryKey: ['spaces', 'orgsActiveProposals', orgIds],
+    queryFn: async (): Promise<Record<string, number>> => {
+      const results = await Promise.all(
+        [...siblingIdsByNetwork(orgs.value)].map(([networkId, ids]) =>
+          getNetwork(networkId).api.loadSpaces(
+            { skip: 0, limit: 1000 },
+            { id_in: ids }
+          )
+        )
+      );
+
+      // NOTE: unlike the other queries here we don't prime the `spaces.detail`
+      // cache: spaces of every onchain network come back from a single api
+      // instance, so they are all formatted with that network's constants.
+      const byId = new Map<string, Space>();
+      for (const space of results.flat()) {
+        byId.set(getCompositeSpaceId(space), space);
+      }
+
+      const counts: Record<string, number> = {};
+      for (const org of orgs.value) {
+        counts[org.id] = org.spaceIds.reduce((sum, space) => {
+          const loaded = byId.get(getCompositeSpaceId(space));
+          return sum + (loaded?.active_proposals ?? 0);
+        }, 0);
+      }
+
+      return counts;
+    },
+    enabled: () => orgs.value.length > 0
   });
 }

--- a/apps/ui/src/queries/spaces.ts
+++ b/apps/ui/src/queries/spaces.ts
@@ -221,7 +221,7 @@ export function useExploreSpacesQuery({
   });
 }
 
-function getCompositeSpaceId(space: { network: NetworkID; id: string }) {
+function getCompositeSpaceId(space: Pick<Space, 'id' | 'network'>) {
   return `${space.network}:${space.id}`;
 }
 
@@ -240,11 +240,17 @@ function uniqueOrgs(spaces: Space[]): OrganizationConfig[] {
 }
 
 /**
- * Groups every sibling space of `orgs` by the network whose API can resolve it.
- * All onchain networks share the same sx-api, so their ids go in a single
- * bucket (one request covering eth/arb1/sn); each offchain hub gets its own.
- * Siblings on networks this build doesn't enable are dropped, both because
- * `getNetwork` throws on them and because they are never rendered anyway.
+ * Groups every sibling space of `orgs` into as few requests as possible.
+ * Onchain mainnets share one sx-api and `loadSpaces` only scopes to an indexer
+ * when given a `network` filter, so their ids go in a single bucket (one
+ * request covering eth/arb1/sn); each offchain hub gets its own.
+ *
+ * Siblings on networks this build doesn't enable are skipped: `getNetwork`
+ * rejects them, and in an offchain-only build `onchainApiNetwork` falls back to
+ * `eth`, which would then throw.
+ *
+ * Every org currently lists mainnet spaces only. If one ever lists a testnet
+ * space it would need its own bucket, since testnets use a different endpoint.
  */
 function siblingIdsByNetwork(orgs: OrganizationConfig[]) {
   const buckets = new Map<NetworkID, string[]>();
@@ -298,8 +304,8 @@ export function useOrgsActiveProposalsQuery({
       );
 
       // NOTE: unlike the other queries here we don't prime the `spaces.detail`
-      // cache: spaces of every onchain network come back from a single api
-      // instance, so they are all formatted with that network's constants.
+      // cache — these spaces are loaded only for their counts, and most of them
+      // are siblings the user doesn't follow and never opens.
       const byId = new Map<string, Space>();
       for (const space of results.flat()) {
         byId.set(getCompositeSpaceId(space), space);
@@ -315,6 +321,9 @@ export function useOrgsActiveProposalsQuery({
 
       return counts;
     },
+    // Following a space changes the key; without this every org badge would
+    // blank out until the refetch lands.
+    placeholderData: keepPreviousData,
     enabled: () => orgs.value.length > 0
   });
 }

--- a/apps/ui/src/stores/followedSpaces.ts
+++ b/apps/ui/src/stores/followedSpaces.ts
@@ -6,7 +6,10 @@ import {
   metadataNetwork,
   offchainNetworks
 } from '@/networks';
-import { useFollowedSpacesQuery } from '@/queries/spaces';
+import {
+  useFollowedSpacesQuery,
+  useOrgsActiveProposalsQuery
+} from '@/queries/spaces';
 import { NetworkID, Space } from '@/types';
 import pkg from '../../package.json';
 
@@ -76,6 +79,10 @@ export const useFollowedSpacesStore = defineStore('followedSpaces', () => {
       followedSpacesIdsByAccount.value[web3.value.account] =
         spaces.map(getCompositeSpaceId);
     }
+  });
+
+  const { data: orgActiveProposals } = useOrgsActiveProposalsQuery({
+    followedSpaces
   });
 
   const followedSpaceIdsByNetwork = computed(() =>
@@ -176,6 +183,7 @@ export const useFollowedSpacesStore = defineStore('followedSpaces', () => {
         hasSpaceDataLoaded.value
     ),
     followedSpaceLoading,
+    orgActiveProposals: computed(() => orgActiveProposals.value ?? {}),
     toggleSpaceFollow,
     isFollowed
   };


### PR DESCRIPTION
Closes #2205

## Problem

`resolveSpaceItem` returns a hardcoded `active_proposals: 0` for organizations:

https://github.com/snapshot-labs/sx-monorepo/blob/master/apps/ui/src/helpers/organizations/config.ts#L365

and `SpaceAvatar` only renders the badge when `showActiveProposals && space.active_proposals`, so an org entry in the sidebar never shows a count — even when its spaces have open proposals. A single space of that org would show one, which makes the org entry look like a regression to the user.

## Fix

Sum `active_proposals` across every space of each followed org (approach D from the issue).

Siblings are fetched with **one request per API**, not one per network. All onchain networks are served by the same sx-api and the request isn't scoped to an indexer, so a single call covers `eth`/`arb1`/`sn`; each offchain hub gets its own call. For the current org configs that's 2 requests total regardless of how many orgs are followed.

To pick that onchain network I exported the existing `onchainApiNetwork` from `@/networks` — it's the same value the explore page already uses for exactly this purpose, and it avoids hardcoding `eth`, which would throw `Network eth is not enabled` on a build that doesn't ship it.

Notes on the shape of the change:

- The query is wired **once** in the `followedSpaces` store. Wiring it inside `AppSidebarItem` would spawn one identical query per followed space.
- `resolveSpaceItem` is left pure; `AppSidebarItem` overrides the avatar's count at the call site, so the existing `helpers/organizations` tests are untouched.
- Siblings on networks the build doesn't enable are skipped — they're never rendered anyway, and `getNetwork` throws on them.
- The `spaces.detail` cache is deliberately **not** primed here, unlike the other queries in the file: these spaces are loaded only for their counts, and most are siblings the user doesn't follow and never opens.
- `placeholderData: keepPreviousData`, same as `useFollowedSpacesQuery` — following a space changes the query key, which would otherwise blank every org badge until the refetch lands.
- Per the caveat in the issue, only mainnets share `API_URL`; testnets use `API_TESTNET_URL`. No org config lists a testnet space today, and that's noted in the code where it would matter.

## Tests

New `apps/ui/src/queries/spaces.test.ts`, 8 cases: no fetch when no followed space belongs to an org, summing across siblings, `null`/missing counts read as 0, batching multiple orgs into one request per API, de-duplicating when two spaces of the same org are followed, skipping networks the build doesn't enable, refetching when a new org is followed, and *not* refetching when only the order changes.

Verified each guard is actually pinned: removing the org de-dup or the `enabledNetworks` filter fails the corresponding test.

Full `apps/ui` suite green (28 files / 288 tests), eslint + prettier + `vue-tsc` clean, and `turbo run build --filter=ui...` succeeds.

