### PR TITLE
refactor(sequencer): drop overlord call, value strategies at 0

### DIFF
--- a/apps/sequencer/.env.example
+++ b/apps/sequencer/.env.example
@@ -18,5 +18,4 @@ BROVIDER_URL=https://rpc.brovider.xyz # optional
 AUTH_SECRET=1dfd84a695705665668c260222ded178d1f1d62d251d7bee8148428dac6d0487 # optional
 WALLETCONNECT_PROJECT_ID=e6454bd61aba40b786e866a69bd4c5c6
 REOWN_SECRET= # optional
-OVERLORD_URL=https://overlord.snapshot.box
 LAST_CB=1

--- a/apps/sequencer/docs/cb-flow.md
+++ b/apps/sequencer/docs/cb-flow.md
@@ -4,13 +4,13 @@
 
 | Value | Constant | Proposals | Votes |
 |------:|----------|-----------|-------|
-| 0 | `PENDING_SYNC` | Default. Waiting for strategy values from Overlord | N/A |
+| 0 | `PENDING_SYNC` | Default. Waiting for strategy values | N/A |
 | -1 | `PENDING_COMPUTE` | Strategy values synced. Waiting for `scores_total_value` computation | Default. Waiting for `vp_value` computation |
 | -2 | `PENDING_FINAL` | Score value computed, but proposal still active | Value computed, but `vp_state` not final |
 | 1 | `FINAL` | Fully computed | Fully computed |
 | -3 | `PENDING_DELETE` | N/A | Proposal deleted, vote awaiting async cleanup |
 | -10 | `INELIGIBLE` | Invalid payload format, cannot compute (permanent) | Invalid data, cannot compute (permanent) |
-| -11 | `ERROR_SYNC` | Overlord sync failed, will be retried | N/A |
+| -11 | `ERROR_SYNC` | Strategy value sync failed, will be retried | N/A |
 
 > 🟦 Blue = user action &nbsp;&nbsp; 🟧 Orange = async background script
 
@@ -19,7 +19,7 @@
 ```mermaid
 flowchart TD
     A([Proposal Created]):::user --> B["cb = 0<br>PENDING_SYNC"]
-    B -->|proposalStrategiesValue.ts<br>fetches USD values from Overlord| C{Success?}
+    B -->|proposalStrategiesValue.ts<br>assigns strategy values| C{Success?}
     C -->|Yes| D["cb = -1<br>PENDING_COMPUTE"]
     C -->|No, status 400| G
     C -->|No, other error| E["cb = -11<br>ERROR_SYNC"]

--- a/apps/sequencer/src/constants.ts
+++ b/apps/sequencer/src/constants.ts
@@ -1,9 +1,9 @@
 export const CB = {
   FINAL: 1,
-  PENDING_SYNC: 0, // Default db value, waiting from value from overlord
+  PENDING_SYNC: 0, // Default db value, waiting for strategy values
   PENDING_COMPUTE: -1,
   PENDING_FINAL: -2,
   PENDING_DELETE: -3,
   INELIGIBLE: -10, // Payload format, can not compute
-  ERROR_SYNC: -11 // Sync error from overlord, waiting for retry
+  ERROR_SYNC: -11 // Strategy value sync error, waiting for retry
 };

--- a/apps/sequencer/src/helpers/entityValue.ts
+++ b/apps/sequencer/src/helpers/entityValue.ts
@@ -1,35 +1,10 @@
-import { jsonRpcRequest } from './utils';
-
 type Proposal = {
-  network: string;
   strategies: any[];
-  start: number;
 };
 
-const OVERLORD_URL =
-  process.env.OVERLORD_URL ?? 'https://overlord.snapshot.box';
-// Round strategy values to 9 decimal places
-const STRATEGIES_VALUE_PRECISION = 9;
-
+// Overlord pricing service is retired; every strategy is valued at 0 until a replacement exists.
 export async function getVpValueByStrategy(
   proposal: Proposal
 ): Promise<number[]> {
-  const result: number[] = await jsonRpcRequest(
-    OVERLORD_URL,
-    'get_value_by_strategy',
-    {
-      network: proposal.network,
-      strategies: proposal.strategies,
-      snapshot: proposal.start // Expecting timestamp and not block number
-    }
-  );
-
-  // Handle unlikely case where strategies value array length does not match strategies length
-  if (result.length !== proposal.strategies.length) {
-    throw new Error('Strategies value length mismatch');
-  }
-
-  return result.map(value =>
-    parseFloat(value.toFixed(STRATEGIES_VALUE_PRECISION))
-  );
+  return proposal.strategies.map(() => 0);
 }

--- a/apps/sequencer/src/helpers/proposalStrategiesValue.ts
+++ b/apps/sequencer/src/helpers/proposalStrategiesValue.ts
@@ -94,11 +94,8 @@ async function refreshVpByStrategy(proposals: Proposal[]) {
 }
 
 export default async function run() {
-  if (!process.env.OVERLORD_URL) return;
   while (true) {
-    log.info(
-      '[proposalStrategiesValue] Fetching proposals values from overlord'
-    );
+    log.info('[proposalStrategiesValue] Fetching proposals values');
     const proposals = await getProposals();
     log.info(`[proposalStrategiesValue] Found ${proposals.length} proposals`);
 


### PR DESCRIPTION
Fix https://github.com/snapshot-labs/workflow/issues/849

Stops the sequencer from calling the Overlord pricing service, which is being retired.

Remove all overlord reference, but keep the loop logic, so instead of calling overlord to return the strategie's fiat price, we always return 0.

This is the minimal changes needed to disable overlord, without refactoring to remove the whole strategies values loop

## Test plan

- Start the sequencer without `OVERLORD_URL` set and create a proposal
- Proposal row moves from `cb = 0` to `cb = -1` within ~10s with `vp_value_by_strategy` set to an all-zero array matching the strategy count
- After a vote, proposal reaches `cb = 1` (or `-2` while active) with `scores_total_value = 0`
