### PR TITLE
chore: disable Dependabot cooldown for Snapshot packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 0
     allow:
       - dependency-name: "@snapshot-labs/*"
     ignore:


### PR DESCRIPTION
### Summary

Dependabot detected `@snapshot-labs/snapshot.js@0.17.2` but skipped it because of the default three-day package cooldown ([update run](https://github.com/snapshot-labs/sx-monorepo/actions/runs/33976794057)). Set `cooldown.default-days: 0` for the existing Bun update configuration so new releases of allowed `@snapshot-labs/*` dependencies are eligible immediately.

The daily schedule, Snapshot dependency group, and checkpoint exclusion continue to apply. Once merged, the next Dependabot check can pick up newly published versions without waiting three days; this does not introduce a publish-triggered check.

### How to test

1. Parsed `.github/dependabot.yml` and verified the only configuration change is `cooldown.default-days: 0`.
2. `git diff --check` passed. Application tests are not applicable to this configuration-only change.
3. After merge, run a Dependabot update check and verify `snapshot.js@0.17.2` is no longer excluded by cooldown.

Reference: [GitHub cooldown options](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown).
