### PR TITLE
refactor: prepare for Inco execution

### DIFF
--- a/apps/api/src/evm/protocols/snapshot-x/config.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/config.ts
@@ -1,5 +1,5 @@
 import { CheckpointConfig } from '@snapshot-labs/checkpoint';
-import { evmNetworks } from '@snapshot-labs/sx';
+import { buildRegistry, evmNetworks } from '@snapshot-labs/sx';
 import L1AvatarExecutionStrategy from './abis/L1AvatarExecutionStrategy';
 import L1AvatarExecutionStrategyFactory from './abis/L1AvatarExecutionStrategyFactory';
 import ProxyFactory from './abis/ProxyFactory';
@@ -30,6 +30,12 @@ type Config = Pick<CheckpointConfig, 'sources' | 'templates' | 'abis'> & {
 
 export function createConfig(networkId: NetworkID): Config {
   const network = evmNetworks[networkId];
+  const {
+    SimpleQuorumAvatar,
+    IncoSimpleQuorumAvatar,
+    SimpleQuorumTimelock,
+    IncoSimpleQuorumTimelock
+  } = network.ExecutionStrategies;
 
   const sources = [
     {
@@ -212,12 +218,15 @@ export function createConfig(networkId: NetworkID): Config {
     protocolConfig: {
       chainId: network.Meta.eip712ChainId,
       manaRpcUrl: `${MANA_URL}/eth_rpc/${network.Meta.eip712ChainId}`,
-      masterSpace: network.Meta.masterSpace,
       incoMasterSpace: network.Meta.incoMasterSpace ?? null,
-      masterSimpleQuorumAvatar:
-        network.ExecutionStrategies.SimpleQuorumAvatar ?? null,
-      masterSimpleQuorumTimelock:
-        network.ExecutionStrategies.SimpleQuorumTimelock ?? null,
+      implementations: buildRegistry([
+        [network.Meta.masterSpace, 'Space'],
+        [network.Meta.incoMasterSpace, 'Space'],
+        [SimpleQuorumAvatar, 'SimpleQuorumAvatar'],
+        [IncoSimpleQuorumAvatar, 'SimpleQuorumAvatar'],
+        [SimpleQuorumTimelock, 'SimpleQuorumTimelock'],
+        [IncoSimpleQuorumTimelock, 'SimpleQuorumTimelock']
+      ]),
       propositionPowerValidationStrategyAddress:
         network.ProposalValidations.VotingPower ?? null,
       apeGasStrategy: network.Strategies.ApeGas ?? null,

--- a/apps/api/src/evm/protocols/snapshot-x/writers.ts
+++ b/apps/api/src/evm/protocols/snapshot-x/writers.ts
@@ -48,7 +48,7 @@ import {
   updateCounter,
   updateScoresTick
 } from '../../../common/utils';
-import { EVMConfig, SnapshotXConfig } from '../../types';
+import { EVMConfig, ImplementationType, SnapshotXConfig } from '../../types';
 import {
   getTimestampFromBlock as _getTimestampFromBlock,
   MULTICALL3_ADDRESS
@@ -78,12 +78,12 @@ export function createWriters(
   const incoMasterSpace = protocolConfig.incoMasterSpace
     ? getAddress(protocolConfig.incoMasterSpace)
     : null;
-  const masterSimpleQuorumTimelock = protocolConfig.masterSimpleQuorumTimelock
-    ? getAddress(protocolConfig.masterSimpleQuorumTimelock)
-    : null;
-  const masterSimpleQuorumAvatar = protocolConfig.masterSimpleQuorumAvatar
-    ? getAddress(protocolConfig.masterSimpleQuorumAvatar)
-    : null;
+  const implementations = new Map<string, ImplementationType>(
+    Object.entries(protocolConfig.implementations).map(([address, type]) => [
+      getAddress(address),
+      type
+    ])
+  );
 
   const handleProxyDeployed: evm.Writer<
     typeof ProxyFactoryAbi,
@@ -96,9 +96,8 @@ export function createWriters(
     const proxyAddress = getAddress(event.args.proxy);
     const implementationAddress = getAddress(event.args.implementation);
 
-    switch (implementationAddress) {
-      case getAddress(protocolConfig.masterSpace):
-      case incoMasterSpace: {
+    switch (implementations.get(implementationAddress)) {
+      case 'Space': {
         const spaceImplementation = new SpaceImplementation(
           proxyAddress,
           config.indexerName
@@ -113,15 +112,10 @@ export function createWriters(
         });
         break;
       }
-      case masterSimpleQuorumTimelock: {
-        const [type, quorum, timelockVetoGuardian, timelockDelay] =
+      case 'SimpleQuorumTimelock': {
+        const [quorum, timelockVetoGuardian, timelockDelay] =
           await client.multicall({
             contracts: [
-              {
-                address: proxyAddress,
-                abi: SimpleQuorumTimelockExecutionStrategyAbi,
-                functionName: 'getStrategyType'
-              },
               {
                 address: proxyAddress,
                 abi: SimpleQuorumTimelockExecutionStrategyAbi,
@@ -148,7 +142,7 @@ export function createWriters(
           config.indexerName
         );
         executionStrategy.address = proxyAddress;
-        executionStrategy.type = type;
+        executionStrategy.type = 'SimpleQuorumTimelock';
         executionStrategy.quorum = quorum.toString();
         executionStrategy.treasury_chain = protocolConfig.chainId;
         executionStrategy.treasury = proxyAddress;
@@ -165,14 +159,9 @@ export function createWriters(
 
         break;
       }
-      case masterSimpleQuorumAvatar: {
-        const [type, quorum, target] = await client.multicall({
+      case 'SimpleQuorumAvatar': {
+        const [quorum, target] = await client.multicall({
           contracts: [
-            {
-              address: proxyAddress,
-              abi: SimpleQuorumAvatarExecutionStrategyAbi,
-              functionName: 'getStrategyType'
-            },
             {
               address: proxyAddress,
               abi: SimpleQuorumAvatarExecutionStrategyAbi,
@@ -194,7 +183,7 @@ export function createWriters(
           config.indexerName
         );
         executionStrategy.address = proxyAddress;
-        executionStrategy.type = type;
+        executionStrategy.type = 'SimpleQuorumAvatar';
         executionStrategy.quorum = quorum.toString();
         executionStrategy.treasury_chain = protocolConfig.chainId;
         executionStrategy.treasury = getAddress(target);
@@ -963,32 +952,27 @@ export function createWriters(
       config.indexerName
     );
 
+    const space = await Space.loadEntity(spaceId, config.indexerName);
     const now = Number(block?.timestamp ?? getCurrentTimestamp());
 
-    if (executionStrategy) {
-      switch (executionStrategy.type) {
-        case 'SimpleQuorumAvatar':
-          proposal.execution_settled = true;
-          proposal.completed = true;
-          proposal.execution_tx = txId;
-          proposal.executed_at = BigInt(now);
-          proposal.executed_at_block_number = BigInt(blockNumber);
-          break;
-        case 'SimpleQuorumTimelock':
-          proposal.execution_time =
-            BigInt(now) + executionStrategy.timelock_delay;
-          break;
-      }
-    }
-
-    const space = await Space.loadEntity(spaceId, config.indexerName);
-
-    if (space?.protocol === 'snapshot-x-inco') {
+    const settle = () => {
       proposal.execution_settled = true;
       proposal.completed = true;
       proposal.execution_tx = txId;
       proposal.executed_at = BigInt(now);
       proposal.executed_at_block_number = BigInt(blockNumber);
+    };
+
+    switch (executionStrategy?.type) {
+      case 'SimpleQuorumAvatar':
+        settle();
+        break;
+      case 'SimpleQuorumTimelock':
+        proposal.execution_time =
+          BigInt(now) + executionStrategy.timelock_delay;
+        break;
+      default:
+        if (space?.protocol === 'snapshot-x-inco') settle();
     }
 
     await proposal.save();

--- a/apps/api/src/evm/types.ts
+++ b/apps/api/src/evm/types.ts
@@ -14,13 +14,16 @@ export type NetworkID =
   | 'curtis'
   | 'basesep';
 
+export type ImplementationType =
+  | 'Space'
+  | 'SimpleQuorumAvatar'
+  | 'SimpleQuorumTimelock';
+
 export type SnapshotXConfig = {
   chainId: number;
   manaRpcUrl: string;
-  masterSpace: string;
   incoMasterSpace: string | null;
-  masterSimpleQuorumAvatar: string | null;
-  masterSimpleQuorumTimelock: string | null;
+  implementations: Record<string, ImplementationType>;
   propositionPowerValidationStrategyAddress: string | null;
   apeGasStrategy: string | null;
   apeGasStrategyDelay: number;

--- a/apps/ui/src/networks/evm/actions.ts
+++ b/apps/ui/src/networks/evm/actions.ts
@@ -66,11 +66,8 @@ export function createActions(
   helpers: NetworkHelpers,
   networkId: NetworkID
 ): NetworkActions {
-  const networkConfig = createEvmConfig(
-    evmNetworks[networkId as keyof typeof evmNetworks]
-  );
-  const { incoProxyFactory, incoMasterSpace } =
-    evmNetworks[networkId as keyof typeof evmNetworks].Meta;
+  const network = evmNetworks[networkId as keyof typeof evmNetworks];
+  const networkConfig = createEvmConfig(network);
 
   const pickAuthenticatorAndStrategies = createStrategyPicker({
     helpers
@@ -84,15 +81,12 @@ export function createActions(
   };
 
   const client = new clients.EvmEthereumTx(clientOpts);
+  const { incoProxyFactory, incoMasterSpace } = network.Meta;
   const incoDeployClient =
     incoProxyFactory && incoMasterSpace
       ? new clients.EvmEthereumTx({
           ...clientOpts,
-          networkConfig: {
-            ...networkConfig,
-            proxyFactory: incoProxyFactory,
-            masterSpace: incoMasterSpace
-          }
+          networkConfig: createEvmConfig(network, 'snapshot-x-inco')
         })
       : null;
 

--- a/apps/ui/src/networks/evm/constants.ts
+++ b/apps/ui/src/networks/evm/constants.ts
@@ -1,6 +1,6 @@
 import { AbiCoder } from '@ethersproject/abi';
 import { Web3Provider } from '@ethersproject/providers';
-import { clients, evmNetworks } from '@snapshot-labs/sx';
+import { clients, evmNetworks, ProtocolID } from '@snapshot-labs/sx';
 import {
   APE_GAS_CONFIGS,
   DOCS_URL,
@@ -127,16 +127,21 @@ export function createConstants(
     })
   };
 
+  const avatarProtocols = [
+    config.ExecutionStrategies.SimpleQuorumAvatar && 'snapshot-x',
+    config.ExecutionStrategies.IncoSimpleQuorumAvatar && 'snapshot-x-inco'
+  ].filter(Boolean) as ProtocolID[];
+  const timelockProtocols = [
+    config.ExecutionStrategies.SimpleQuorumTimelock && 'snapshot-x',
+    config.ExecutionStrategies.IncoSimpleQuorumTimelock && 'snapshot-x-inco'
+  ].filter(Boolean) as ProtocolID[];
+
   const SUPPORTED_EXECUTORS: Record<string, boolean> = {
     ...(config.ExecutionStrategies.IncoSimpleQuorumVanilla && {
       SimpleQuorumVanilla: true
     }),
-    ...(config.ExecutionStrategies.SimpleQuorumAvatar && {
-      SimpleQuorumAvatar: true
-    }),
-    ...(config.ExecutionStrategies.SimpleQuorumTimelock && {
-      SimpleQuorumTimelock: true
-    }),
+    ...(avatarProtocols.length > 0 && { SimpleQuorumAvatar: true }),
+    ...(timelockProtocols.length > 0 && { SimpleQuorumTimelock: true }),
     // Governor Bravo
     GovernorBravoTimelock: true,
     // OpenZeppelin
@@ -737,6 +742,125 @@ export function createConstants(
         !([config.Strategies.ApeGas] as string[]).includes(strategy.address)
     );
 
+  const createAvatarExecutionStrategy = (protocols: ProtocolID[]) => ({
+    address: '',
+    protocols,
+    type: 'SimpleQuorumAvatar',
+    name: EXECUTORS.SimpleQuorumAvatar,
+    about:
+      'An execution strategy that allows proposals to execute transactions from a specified target Safe contract.',
+    icon: IHUserCircle,
+    generateSummary: (params: Record<string, any>) =>
+      `(${params.quorum}, ${shorten(params.contractAddress)})`,
+    deploy: async (
+      client: clients.EvmEthereumTx,
+      web3: Web3Provider,
+      controller: string,
+      spaceAddress: string,
+      params: Record<string, any>
+    ): Promise<{ address: string; txId: string }> => {
+      return client.deployAvatarExecution({
+        signer: web3.getSigner(),
+        params: {
+          controller: params.controller,
+          target: params.contractAddress,
+          spaces: [spaceAddress],
+          quorum: BigInt(params.quorum)
+        }
+      });
+    },
+    paramsDefinition: {
+      type: 'object',
+      title: 'Params',
+      additionalProperties: false,
+      required: ['controller', 'quorum', 'contractAddress'],
+      properties: {
+        controller: {
+          type: 'string',
+          format: 'address',
+          chainId: config.Meta.eip712ChainId,
+          title: 'Controller address',
+          examples: ['0x0000…']
+        },
+        quorum: {
+          type: 'integer',
+          title: 'Quorum',
+          examples: ['1']
+        },
+        contractAddress: {
+          type: 'string',
+          format: 'address',
+          chainId: config.Meta.eip712ChainId,
+          title: 'Safe address',
+          examples: ['0x0000…']
+        }
+      }
+    }
+  });
+
+  const createTimelockExecutionStrategy = (protocols: ProtocolID[]) => ({
+    address: '',
+    protocols,
+    type: 'SimpleQuorumTimelock',
+    name: EXECUTORS.SimpleQuorumTimelock,
+    about:
+      'Timelock implementation with a specified delay that queues proposal transactions for execution and includes an optional role to veto queued proposals.',
+    icon: IHClock,
+    generateSummary: (params: Record<string, any>) =>
+      `(${params.quorum}, ${params.timelockDelay})`,
+    deploy: async (
+      client: clients.EvmEthereumTx,
+      web3: Web3Provider,
+      controller: string,
+      spaceAddress: string,
+      params: Record<string, any>
+    ): Promise<{ address: string; txId: string }> => {
+      return client.deployTimelockExecution({
+        signer: web3.getSigner(),
+        params: {
+          controller: params.controller,
+          vetoGuardian:
+            params.vetoGuardian || '0x0000000000000000000000000000000000000000',
+          spaces: [spaceAddress],
+          timelockDelay: BigInt(params.timelockDelay),
+          quorum: BigInt(params.quorum)
+        }
+      });
+    },
+    paramsDefinition: {
+      type: 'object',
+      title: 'Params',
+      additionalProperties: false,
+      required: ['controller', 'quorum', 'timelockDelay'],
+      properties: {
+        controller: {
+          type: 'string',
+          format: 'address',
+          chainId: config.Meta.eip712ChainId,
+          title: 'Controller address',
+          examples: ['0x0000…']
+        },
+        quorum: {
+          type: 'integer',
+          title: 'Quorum',
+          examples: ['1']
+        },
+        vetoGuardian: {
+          type: 'string',
+          format: 'address',
+          chainId: config.Meta.eip712ChainId,
+          title: 'Veto guardian address',
+          examples: ['0x0000…']
+        },
+        timelockDelay: {
+          type: 'integer',
+          format: 'duration',
+          title: 'Timelock delay'
+        }
+      }
+    }
+  });
+
   const EDITOR_EXECUTION_STRATEGIES = [
     ...(config.ExecutionStrategies.IncoSimpleQuorumVanilla
       ? [
@@ -752,131 +876,11 @@ export function createConstants(
           }
         ]
       : []),
-    ...(config.ExecutionStrategies.SimpleQuorumAvatar
-      ? [
-          {
-            address: '',
-            protocols: ['snapshot-x' as const],
-            type: 'SimpleQuorumAvatar',
-            name: EXECUTORS.SimpleQuorumAvatar,
-            about:
-              'An execution strategy that allows proposals to execute transactions from a specified target Safe contract.',
-            icon: IHUserCircle,
-            generateSummary: (params: Record<string, any>) =>
-              `(${params.quorum}, ${shorten(params.contractAddress)})`,
-            deploy: async (
-              client: clients.EvmEthereumTx,
-              web3: Web3Provider,
-              controller: string,
-              spaceAddress: string,
-              params: Record<string, any>
-            ): Promise<{ address: string; txId: string }> => {
-              return client.deployAvatarExecution({
-                signer: web3.getSigner(),
-                params: {
-                  controller: params.controller,
-                  target: params.contractAddress,
-                  spaces: [spaceAddress],
-                  quorum: BigInt(params.quorum)
-                }
-              });
-            },
-            paramsDefinition: {
-              type: 'object',
-              title: 'Params',
-              additionalProperties: false,
-              required: ['controller', 'quorum', 'contractAddress'],
-              properties: {
-                controller: {
-                  type: 'string',
-                  format: 'address',
-                  chainId: config.Meta.eip712ChainId,
-                  title: 'Controller address',
-                  examples: ['0x0000…']
-                },
-                quorum: {
-                  type: 'integer',
-                  title: 'Quorum',
-                  examples: ['1']
-                },
-                contractAddress: {
-                  type: 'string',
-                  format: 'address',
-                  chainId: config.Meta.eip712ChainId,
-                  title: 'Safe address',
-                  examples: ['0x0000…']
-                }
-              }
-            }
-          }
-        ]
+    ...(avatarProtocols.length > 0
+      ? [createAvatarExecutionStrategy(avatarProtocols)]
       : []),
-    ...(config.ExecutionStrategies.SimpleQuorumTimelock
-      ? [
-          {
-            address: '',
-            protocols: ['snapshot-x' as const],
-            type: 'SimpleQuorumTimelock',
-            name: EXECUTORS.SimpleQuorumTimelock,
-            about:
-              'Timelock implementation with a specified delay that queues proposal transactions for execution and includes an optional role to veto queued proposals.',
-            icon: IHClock,
-            generateSummary: (params: Record<string, any>) =>
-              `(${params.quorum}, ${params.timelockDelay})`,
-            deploy: async (
-              client: clients.EvmEthereumTx,
-              web3: Web3Provider,
-              controller: string,
-              spaceAddress: string,
-              params: Record<string, any>
-            ): Promise<{ address: string; txId: string }> => {
-              return client.deployTimelockExecution({
-                signer: web3.getSigner(),
-                params: {
-                  controller: params.controller,
-                  vetoGuardian:
-                    params.vetoGuardian ||
-                    '0x0000000000000000000000000000000000000000',
-                  spaces: [spaceAddress],
-                  timelockDelay: BigInt(params.timelockDelay),
-                  quorum: BigInt(params.quorum)
-                }
-              });
-            },
-            paramsDefinition: {
-              type: 'object',
-              title: 'Params',
-              additionalProperties: false,
-              required: ['controller', 'quorum', 'timelockDelay'],
-              properties: {
-                controller: {
-                  type: 'string',
-                  format: 'address',
-                  chainId: config.Meta.eip712ChainId,
-                  title: 'Controller address',
-                  examples: ['0x0000…']
-                },
-                quorum: {
-                  type: 'integer',
-                  title: 'Quorum',
-                  examples: ['1']
-                },
-                vetoGuardian: {
-                  type: 'string',
-                  format: 'address',
-                  chainId: config.Meta.eip712ChainId,
-                  title: 'Veto guardian address',
-                  examples: ['0x0000…']
-                },
-                timelockDelay: {
-                  type: 'integer',
-                  format: 'duration',
-                  title: 'Timelock delay'
-                }
-              }
-            }
-          }
-        ]
+    ...(timelockProtocols.length > 0
+      ? [createTimelockExecutionStrategy(timelockProtocols)]
       : [])
   ];
 

--- a/packages/sx.js/src/evmNetworks.ts
+++ b/packages/sx.js/src/evmNetworks.ts
@@ -33,6 +33,8 @@ type Overrides = {
   };
   executionStrategies?: {
     IncoSimpleQuorumVanilla?: string;
+    IncoSimpleQuorumAvatar?: string;
+    IncoSimpleQuorumTimelock?: string;
     SimpleQuorumAvatar?: AddressOverride;
     SimpleQuorumTimelock?: AddressOverride;
   };
@@ -114,6 +116,8 @@ export function createStandardConfig(
     },
     ExecutionStrategies: {
       IncoSimpleQuorumVanilla: executionStrategies.IncoSimpleQuorumVanilla,
+      IncoSimpleQuorumAvatar: executionStrategies.IncoSimpleQuorumAvatar,
+      IncoSimpleQuorumTimelock: executionStrategies.IncoSimpleQuorumTimelock,
       SimpleQuorumAvatar: resolveAddress(
         executionStrategies.SimpleQuorumAvatar,
         '0xecE4f6b01a2d7FF5A9765cA44162D453fC455e42'
@@ -127,15 +131,28 @@ export function createStandardConfig(
 }
 
 export function createEvmConfig(
-  network: ReturnType<typeof createStandardConfig>
+  network: ReturnType<typeof createStandardConfig>,
+  protocol: ProtocolID = 'snapshot-x'
 ): EvmNetworkConfig {
+  const { Meta, ExecutionStrategies } = network;
+  const isInco = protocol === 'snapshot-x-inco';
+
+  const proxyFactory = isInco ? Meta.incoProxyFactory : Meta.proxyFactory;
+  const masterSpace = isInco ? Meta.incoMasterSpace : Meta.masterSpace;
+
+  if (!proxyFactory || !masterSpace) {
+    throw new Error(
+      `${protocol} is not available on chain ${Meta.eip712ChainId}`
+    );
+  }
+
   return {
-    eip712ChainId: network.Meta.eip712ChainId,
-    maxPriorityFeePerGas: network.Meta.maxPriorityFeePerGas,
-    blockTime: network.Meta.blockTime,
-    hasNonNativeBlockNumbers: network.Meta.hasNonNativeBlockNumbers,
-    proxyFactory: network.Meta.proxyFactory,
-    masterSpace: network.Meta.masterSpace,
+    eip712ChainId: Meta.eip712ChainId,
+    maxPriorityFeePerGas: Meta.maxPriorityFeePerGas,
+    blockTime: Meta.blockTime,
+    hasNonNativeBlockNumbers: Meta.hasNonNativeBlockNumbers,
+    proxyFactory,
+    masterSpace,
     authenticators: buildRegistry([
       [network.Authenticators.EthSig, { type: 'ethSig' }],
       [network.Authenticators.EthSigV2, { type: 'ethSigV2' }],
@@ -149,10 +166,15 @@ export function createEvmConfig(
       [network.Strategies.Whitelist, { type: 'whitelist' }],
       [network.Strategies.ApeGas, { type: 'apeGas' }]
     ]),
-    executionStrategiesImplementations: {
-      SimpleQuorumAvatar: network.ExecutionStrategies.SimpleQuorumAvatar,
-      SimpleQuorumTimelock: network.ExecutionStrategies.SimpleQuorumTimelock
-    }
+    executionStrategiesImplementations: isInco
+      ? {
+          SimpleQuorumAvatar: ExecutionStrategies.IncoSimpleQuorumAvatar,
+          SimpleQuorumTimelock: ExecutionStrategies.IncoSimpleQuorumTimelock
+        }
+      : {
+          SimpleQuorumAvatar: ExecutionStrategies.SimpleQuorumAvatar,
+          SimpleQuorumTimelock: ExecutionStrategies.SimpleQuorumTimelock
+        }
   };
 }
 

--- a/packages/sx.js/src/index.ts
+++ b/packages/sx.js/src/index.ts
@@ -4,4 +4,5 @@ export * as inco from './inco';
 export { getExecutionData } from './executors';
 export * from './strategies';
 export * from './networks';
+export { buildRegistry } from './registry';
 export * from './types';

--- a/packages/sx.js/test/unit/evmNetworks.test.ts
+++ b/packages/sx.js/test/unit/evmNetworks.test.ts
@@ -155,4 +155,35 @@ describe('createEvmConfig', () => {
       evmConfig.executionStrategiesImplementations.SimpleQuorumTimelock
     ).toBeUndefined();
   });
+
+  it('should use inco factory, master space and implementations', () => {
+    const config = createStandardConfig(84532, {
+      blockTime: 2,
+      incoProxyFactory: '0xfDe801CFc7f9a931eB1CF026e60B08a366B13494',
+      incoMasterSpace: '0x3F31D742D3158b07434A041e26B47e9EB94e010C',
+      executionStrategies: {
+        IncoSimpleQuorumAvatar: '0x1111111111111111111111111111111111111111',
+        IncoSimpleQuorumTimelock: '0x2222222222222222222222222222222222222222'
+      }
+    });
+
+    const evmConfig = createEvmConfig(config, 'snapshot-x-inco');
+
+    expect(evmConfig.proxyFactory).toBe(
+      '0xfDe801CFc7f9a931eB1CF026e60B08a366B13494'
+    );
+    expect(evmConfig.masterSpace).toBe(
+      '0x3F31D742D3158b07434A041e26B47e9EB94e010C'
+    );
+    expect(evmConfig.executionStrategiesImplementations).toEqual({
+      SimpleQuorumAvatar: '0x1111111111111111111111111111111111111111',
+      SimpleQuorumTimelock: '0x2222222222222222222222222222222222222222'
+    });
+  });
+
+  it('should throw when inco is not available', () => {
+    expect(() => createEvmConfig(evmNetworks.eth, 'snapshot-x-inco')).toThrow(
+      'snapshot-x-inco is not available on chain 1'
+    );
+  });
 });


### PR DESCRIPTION
### Summary

Currently there are no contracts for Inco execution other than existing IncoSimpleQuorumVanilla.

To make it easier in the future to add those this is prepwork so when contracts are deployed it will be just matter of adding IncoSimpleQuorumTimelock and IncoSimpleQuorumAvatar entries in executionStrategies in evmNetworks.

### How to test

1. Interacting with Inco spaces still works.