### PR TITLE
chore: update misleading Inco results message

### DIFF
--- a/apps/ui/src/components/ProposalResults.vue
+++ b/apps/ui/src/components/ProposalResults.vue
@@ -153,7 +153,11 @@ onMounted(() => {
     "
     class="space-y-1"
   >
-    <div>
+    <div v-if="props.proposal.privacy === 'inco'">
+      Votes are encrypted and never revealed. The results will be decrypted
+      after the voting period is over.
+    </div>
+    <div v-else>
       All votes are encrypted and will be decrypted only after the voting period
       is over, making the results visible.
     </div>


### PR DESCRIPTION
### Summary

Inco votes are never revealed, just the results.

<img width="329" height="165" alt="image" src="https://github.com/user-attachments/assets/59a127b8-8411-4d29-b0bd-88d9441eb962" />
