### PR TITLE
feat(api): use random selector with public nodes

### DIFF
--- a/apps/api/src/evm/index.ts
+++ b/apps/api/src/evm/index.ts
@@ -4,6 +4,7 @@ import { registerIndexer } from '../register';
 import { createWriters as createGovernorBravoWriters } from './protocols/governor-bravo/writers';
 import { createWriters as createOpenZeppelinWriters } from './protocols/openzeppelin/writers';
 import { createWriters as createSnapshotXWriters } from './protocols/snapshot-x/writers';
+import { createRpcSelector } from './rpc';
 import { EVMConfig } from './types';
 import { applyProtocolPrefixToWriters } from './utils';
 
@@ -49,22 +50,29 @@ function createWriters(config: EVMConfig) {
   return writers;
 }
 
-const ethIndexer = new evm.EvmIndexer(createWriters(ethConfig));
-const sepIndexer = new evm.EvmIndexer(createWriters(sepConfig));
-const oethIndexer = new evm.EvmIndexer(createWriters(oethConfig));
-const maticIndexer = new evm.EvmIndexer(createWriters(maticConfig));
+function createIndexer(config: EVMConfig) {
+  return new evm.EvmIndexer(createWriters(config), {
+    rpcSelector: createRpcSelector(config)
+  });
+}
+
+const ethIndexer = createIndexer(ethConfig);
+const sepIndexer = createIndexer(sepConfig);
+const oethIndexer = createIndexer(oethConfig);
+const maticIndexer = createIndexer(maticConfig);
 const arb1Indexer = process.env.HYPERSYNC_API_TOKEN
   ? new evm.HyperSyncEvmIndexer(createWriters(arb1Config), {
-      apiToken: process.env.HYPERSYNC_API_TOKEN
+      apiToken: process.env.HYPERSYNC_API_TOKEN,
+      rpcSelector: createRpcSelector(arb1Config)
     })
-  : new evm.EvmIndexer(createWriters(arb1Config));
-const baseIndexer = new evm.EvmIndexer(createWriters(baseConfig));
-const mntIndexer = new evm.EvmIndexer(createWriters(mntConfig));
-const bnbIndexer = new evm.EvmIndexer(createWriters(bnbConfig));
-const bnbtIndexer = new evm.EvmIndexer(createWriters(bnbtConfig));
-const apeIndexer = new evm.EvmIndexer(createWriters(apeConfig));
-const curtisIndexer = new evm.EvmIndexer(createWriters(curtisConfig));
-const basesepIndexer = new evm.EvmIndexer(createWriters(basesepConfig));
+  : createIndexer(arb1Config);
+const baseIndexer = createIndexer(baseConfig);
+const mntIndexer = createIndexer(mntConfig);
+const bnbIndexer = createIndexer(bnbConfig);
+const bnbtIndexer = createIndexer(bnbtConfig);
+const apeIndexer = createIndexer(apeConfig);
+const curtisIndexer = createIndexer(curtisConfig);
+const basesepIndexer = createIndexer(basesepConfig);
 
 export function addEvmIndexers(checkpoint: Checkpoint) {
   registerIndexer(checkpoint, ethConfig.indexerName, ethConfig, ethIndexer);

--- a/apps/api/src/evm/rpc.ts
+++ b/apps/api/src/evm/rpc.ts
@@ -1,0 +1,99 @@
+import { RpcSelector } from '@snapshot-labs/checkpoint';
+import { EVMConfig, NetworkID } from './types';
+
+const HISTORICAL_BLOCKS = 1000;
+const HEAD_MAX_AGE = 15 * 60 * 1000;
+
+type LatestBlock = Parameters<RpcSelector>[0]['latestBlock'];
+
+const PUBLIC_RPC_URLS: Partial<Record<NetworkID, string[]>> = {
+  eth: [
+    'https://ethereum-rpc.publicnode.com',
+    'https://0xrpc.io/eth',
+    'https://ethereum.public.blockpi.network/v1/rpc/public',
+    'https://eth-mainnet.public.blastapi.io'
+  ],
+  oeth: [
+    'https://optimism-rpc.publicnode.com',
+    'https://public-op-mainnet.fastnode.io',
+    'https://mainnet.optimism.io',
+    'https://op.api.pocket.network'
+  ],
+  base: [
+    'https://base-rpc.publicnode.com',
+    'https://base.public.blockpi.network/v1/rpc/public',
+    'https://mainnet.base.org',
+    'https://base.rpc.sentio.xyz'
+  ],
+  bnb: [
+    'https://bsc-rpc.publicnode.com',
+    'https://0.48.club',
+    'https://rpc-bsc.48.club',
+    'https://bsc.blockrazor.xyz'
+  ],
+  arb1: [
+    'https://arbitrum-one-rpc.publicnode.com',
+    'https://arb1.arbitrum.io/rpc',
+    'https://arbitrum-one.public.blastapi.io',
+    'https://arbitrum-one.rpc.sentio.xyz'
+  ],
+  mnt: [
+    'https://mantle-rpc.publicnode.com',
+    'https://mantle.api.pocket.network',
+    'https://rpc.mantle.xyz'
+  ],
+  ape: ['https://rpc.apechain.com'],
+  sep: [
+    'https://ethereum-sepolia-rpc.publicnode.com',
+    'https://0xrpc.io/sep',
+    'https://rpc.sepolia.ethpandaops.io'
+  ],
+  bnbt: ['https://bsc-testnet-rpc.publicnode.com'],
+  basesep: [
+    'https://base-sepolia-rpc.publicnode.com',
+    'https://base-testnet.api.pocket.network',
+    'https://sepolia.base.org'
+  ],
+  curtis: [
+    'https://curtis.rpc.caldera.xyz/http',
+    'https://rpc.curtis.apechain.com'
+  ]
+};
+
+/**
+ * Live sync goes to public nodes, everything else to default node.
+ * Requests for the same block always hit the same node so getBlock and
+ * getLogs see a consistent view of the chain head.
+ */
+export function createRpcSelector(config: EVMConfig): RpcSelector {
+  const defaultUrl = config.network_node_url;
+  const publicUrls = PUBLIC_RPC_URLS[config.indexerName] ?? [];
+  let counter = 0;
+
+  const pickPublic = (index: number) =>
+    publicUrls[index % publicUrls.length] ?? defaultUrl;
+
+  const pickForBlock = (blockNumber: number, latestBlock: LatestBlock) => {
+    const isFresh =
+      latestBlock !== null && Date.now() - latestBlock.updatedAt < HEAD_MAX_AGE;
+    if (!isFresh) return defaultUrl;
+
+    return latestBlock.number - blockNumber > HISTORICAL_BLOCKS
+      ? defaultUrl
+      : pickPublic(blockNumber);
+  };
+
+  return context => {
+    switch (context.type) {
+      case 'getChainId':
+      case 'getBlockNumber':
+        return pickPublic(counter++);
+      case 'getBlock':
+        return pickForBlock(context.blockNumber, context.latestBlock);
+      case 'getLogs':
+        return context.fromBlock === context.toBlock
+          ? pickForBlock(context.toBlock, context.latestBlock)
+          : defaultUrl;
+    }
+  };
+}


### PR DESCRIPTION
### Summary

Depends on https://github.com/snapshot-labs/checkpoint/pull/412
Closes: https://github.com/snapshot-labs/workflow/issues/845

Adds random picker for public nodes for live block requests.

### How to test

1. Apply diff from below.
2. Run `bun run dev:interactive`.
3. It works.

```diff
diff --git a/apps/api/src/evm/config.ts b/apps/api/src/evm/config.ts
index 437b96d1d..55e54297d 100644
--- a/apps/api/src/evm/config.ts
+++ b/apps/api/src/evm/config.ts
@@ -11,6 +11,22 @@ const MAX_BLOCKS_PER_REQUEST: Partial<Record<NetworkID, number>> = {
   base: 1000
 };
 
+// Dev only: chain head minus 10k blocks as of 2026-09-09
+const MIN_START_BLOCKS: Record<NetworkID, number> = {
+  eth: 25930690,
+  sep: 11658798,
+  oeth: 156674339,
+  matic: 93498169,
+  arb1: 503397568,
+  base: 51079054,
+  mnt: 100408571,
+  bnb: 120891697,
+  bnbt: 130036518,
+  ape: 48765249,
+  curtis: 35438240,
+  basesep: 46589584
+};
+
 export function createConfig(indexerName: NetworkID): EVMConfig {
   const network = evmNetworks[indexerName];
 
@@ -42,6 +58,11 @@ export function createConfig(indexerName: NetworkID): EVMConfig {
     );
   }
 
+  partialConfig.sources = partialConfig.sources.map(source => ({
+    ...source,
+    start: Math.max(source.start, MIN_START_BLOCKS[indexerName])
+  }));
+
   return {
     indexerName,
     network_node_url: getRpcUrl(network.Meta.eip712ChainId),
diff --git a/scripts/dev-interactive.ts b/scripts/dev-interactive.ts
index 0e8c12114..0ee612d6e 100644
--- a/scripts/dev-interactive.ts
+++ b/scripts/dev-interactive.ts
@@ -14,7 +14,8 @@ const SERVICES: Record<ServiceType, Service> = {
   api: {
     env: {
       UI_URL: 'http://localhost:8080',
-      ENABLED_NETWORKS: 'sep,sn-sep',
+      ENABLED_NETWORKS:
+        'eth,sep,oeth,matic,arb1,base,mnt,bnb,bnbt,ape,curtis,basesep',
       VITE_ENABLED_NETWORKS: 's-tn,sep,sn-sep',
       VITE_METADATA_NETWORK: 's-tn',
       VITE_API_TESTNET_URL: 'http://localhost:3000'
@@ -85,7 +86,7 @@ async function run() {
       message: 'Select services to run locally',
       choices: [
         { name: 'UI', value: 'ui' as const },
-        { name: 'API (only sep and sn-sep)', value: 'api' as const },
+        { name: 'API (EVM networks only)', value: 'api' as const },
         { name: 'Mana', value: 'mana' as const },
         { name: 'Hub', value: 'hub' as const },
         { name: 'Sequencer', value: 'sequencer' as const },

```

### To-Do

- [ ]

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
