### PR TITLE
docs: correct the API rate limits

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -353,7 +353,7 @@ Yes, however we encourage everyone to apply for a key as the limits for keyless 
 </Accordion>
 
 <Accordion title="Are there any limits for using the Hub GraphQL API?">
-Yes. Without an API Key: 100 requests per minute. With an API Key: 2 million requests per month. Learn how to apply in [API keys](/tools/api/api-keys).
+Yes. Without an API Key: 100 requests per minute. With an API Key: 200,000 requests per month. Learn how to apply in [API keys](/tools/api/api-keys).
 </Accordion>
 
 <Accordion title="How to add a webhook?">

--- a/docs/faq/im-a-developer.mdx
+++ b/docs/faq/im-a-developer.mdx
@@ -49,13 +49,11 @@ You can find more details about the process here: [api-keys](/tools/api/api-keys
 </Accordion>
 
 <Accordion title="Are there any limits for using the Hub GraphQL API?">
-Yes. Currently you can send 120 requests per every 20 seconds.
-
-After September 12th the limits will be updated:
+Yes.
 
 **🔓 No API Key:** 100 requests per minute.
 
-**🔑 With the API Key:** 2 million requests per month.\\
+**🔑 With the API Key:** 200,000 requests per month.\\
 
 Learn how to apply and generate your API Key here: [api-keys](/tools/api/api-keys)
 </Accordion>

--- a/docs/tools/api.mdx
+++ b/docs/tools/api.mdx
@@ -4,7 +4,7 @@ description: "You can use the Hub GraphQL API to create flexible queries for the
 ---
 
 <Info>
-There is a limit of 60 requests per minute with the API, to get higher limits please apply for an API Key by following this guide: [api-keys](/tools/api/api-keys)
+There is a limit of 100 requests per minute with the API, to get higher limits please apply for an API Key by following this guide: [api-keys](/tools/api/api-keys)
 </Info>
 
 ## Hub GraphQL API: Explorer

--- a/docs/tools/api/api-keys.mdx
+++ b/docs/tools/api/api-keys.mdx
@@ -13,10 +13,10 @@ You can use **the same API key** for different Snapshot APIs. Limits are **count
 
 **🔓 No API Key:** 100 requests per minute.
 
-**🔑 With the API Key:** 2 million requests per month.
+**🔑 With the API Key:** 200,000 requests per month.
 
 <Info>
-If you are getting **close to 2M requests a month** contact our support on [Help center](/faq/support-and-feedback)
+If you are getting **close to 200k requests a month** contact our support on [Help center](/faq/support-and-feedback)
 </Info>
 
 ## How can I get an API Key?
@@ -34,6 +34,8 @@ If you haven’t already please **fill in the below form** or submit it via [the
 We will review your submission and **whitelist the address** you provided in the form.
 
 Once whitelisted, you will **receive an email with your API key**. If you haven't received an email after 72 hours, please contact our support on [Help center](/faq/support-and-feedback).
+
+You can also see your key and its usage at any time under **Settings → API keys** in the Snapshot app, signed in with the whitelisted address.
 
 ## How to structure the query with my key?
 


### PR DESCRIPTION
The docs quote limits that haven't been true for a while. Every `429` from the hub links to `/tools/api/api-keys#limits`, so this is the page rate-limited callers land on.

## Changes

- **200,000 requests/month** with a key, not 2 million — that's tier 0 in keycard `config.json` (`2e5`, hub and score-api). Fixed in `api-keys.mdx`, `faq.mdx`, `im-a-developer.mdx`.
- **100 requests/minute** without a key, not 60 — hub `rateLimit.ts` is `max: 100` per minute. Fixed in `api.mdx`; the other pages already said 100.
- `api-keys.mdx`: one line pointing to **Settings → API keys** in the app, where a whitelisted address can see its key and usage.
- `im-a-developer.mdx`: dropped the stale "120 requests per 20 seconds / after September 12th" preamble.

## How to test

Open the four pages in the docs preview. Before: "2 million requests per month" and "60 requests per minute". After: 200,000 and 100, matching `keycard-api/src/config.json` and `snapshot-hub/src/helpers/rateLimit.ts`.
